### PR TITLE
[codex] fix stalled Codex stream timeout

### DIFF
--- a/console/src/api/apps.ts
+++ b/console/src/api/apps.ts
@@ -1,0 +1,96 @@
+import { requestJson } from './client';
+
+export type AppCategory =
+  | 'apps'
+  | 'documents'
+  | 'games'
+  | 'productivity'
+  | 'creative'
+  | 'quiz'
+  | 'scratch';
+
+export type AppVisibility = 'private' | 'public';
+
+export interface AppSummary {
+  id: string;
+  title: string;
+  description: string | null;
+  category: AppCategory;
+  prompt: string | null;
+  agentId: string | null;
+  sessionId: string | null;
+  visibility: AppVisibility;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AppDetail extends AppSummary {
+  html: string;
+}
+
+export interface AppsListResponse {
+  apps: AppSummary[];
+  total: number;
+}
+
+export interface GenerateAppRequest {
+  description: string;
+  category?: AppCategory;
+  sessionId?: string;
+  agentId?: string;
+  model?: string;
+  chatbotId?: string;
+}
+
+export interface AppMutationResponse {
+  app: AppDetail;
+}
+
+export function fetchApps(
+  token: string,
+  options: { category?: string; search?: string } = {},
+): Promise<AppsListResponse> {
+  const params = new URLSearchParams();
+  if (options.category && options.category !== 'all') {
+    params.set('category', options.category);
+  }
+  if (options.search?.trim()) params.set('q', options.search.trim());
+  const query = params.toString();
+  return requestJson<AppsListResponse>(`/api/apps${query ? `?${query}` : ''}`, {
+    token,
+  });
+}
+
+export function fetchApp(
+  token: string,
+  id: string,
+): Promise<AppMutationResponse> {
+  return requestJson<AppMutationResponse>(
+    `/api/apps/${encodeURIComponent(id)}`,
+    { token },
+  );
+}
+
+export function generateApp(
+  token: string,
+  request: GenerateAppRequest,
+): Promise<AppMutationResponse> {
+  return requestJson<AppMutationResponse>('/api/apps/generate', {
+    token,
+    method: 'POST',
+    body: request,
+  });
+}
+
+export function deleteApp(token: string, id: string): Promise<{ ok: boolean }> {
+  return requestJson<{ ok: boolean }>(`/api/apps/${encodeURIComponent(id)}`, {
+    token,
+    method: 'DELETE',
+  });
+}
+
+/** Token-bearing URL for embedding a generated app in a sandboxed iframe. */
+export function appViewUrl(id: string, token: string): string {
+  const params = new URLSearchParams({ token });
+  return `/api/apps/${encodeURIComponent(id)}/view?${params.toString()}`;
+}

--- a/console/src/api/apps.ts
+++ b/console/src/api/apps.ts
@@ -11,14 +11,18 @@ export type AppCategory =
 
 export type AppVisibility = 'private' | 'public';
 
+export type AppKind = 'web' | 'live';
+
 export interface AppSummary {
   id: string;
   title: string;
   description: string | null;
   category: AppCategory;
+  kind: AppKind;
   prompt: string | null;
   agentId: string | null;
   sessionId: string | null;
+  sourceKey: string | null;
   visibility: AppVisibility;
   createdAt: string;
   updatedAt: string;

--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -148,6 +148,7 @@ export interface ChatStreamResult {
   model?: string;
   provider?: string;
   artifacts?: ChatArtifact[];
+  apps?: Array<{ id: string; title: string; kind: 'web' | 'live' }>;
   toolsUsed?: string[];
 }
 

--- a/console/src/lib/app-seed.test.ts
+++ b/console/src/lib/app-seed.test.ts
@@ -9,13 +9,11 @@ describe('stripAppBuildDirective', () => {
   it('shows only the briefing, hiding the build directive', () => {
     const seed = buildAppSeed('productivity tool', 'A churn dashboard');
     const shown = stripAppBuildDirective(seed);
-    // Briefing is visible…
     expect(shown).toContain('A churn dashboard');
-    // …but the build instructions are not shown.
-    expect(shown).not.toMatch(/before building/i);
+    expect(shown).not.toMatch(/best-practice defaults/i);
     expect(shown).not.toMatch(/default to react/i);
     // The full seed still carries the directive for the model.
-    expect(seed).toMatch(/before building/i);
+    expect(seed).toMatch(/best-practice defaults/i);
     expect(seed).toMatch(/default to react/i);
   });
 
@@ -25,29 +23,32 @@ describe('stripAppBuildDirective', () => {
 });
 
 describe('buildAppSeed', () => {
-  it('refines a provided idea and does not suggest alternatives', () => {
+  it('builds immediately with best-practice defaults instead of interrogating', () => {
     const seed = buildAppSeed('productivity tool', 'A churn dashboard');
-    expect(seed).toMatch(/refine this briefing/i);
-    expect(seed).toMatch(/don't suggest a different app/i);
-    expect(seed).toMatch(/propose a short plan/i);
+    expect(seed).toMatch(/best-practice defaults/i);
+    expect(seed).toMatch(/don't ask me a list of questions/i);
+    expect(seed).toMatch(/build it now/i);
+    expect(seed).not.toMatch(/wait for my ok/i);
   });
 });
 
 describe('buildLiveAppSeed', () => {
-  it('uses MCP connectors directly and does not suggest alternatives when given an idea', () => {
+  it('uses MCP connectors directly and builds now when given an idea', () => {
     const seed = buildLiveAppSeed('A dashboard of open PRs for hybridclaw');
     expect(stripAppBuildDirective(seed)).toContain(
       'A dashboard of open PRs for hybridclaw',
     );
-    expect(seed).toMatch(/connected MCP servers \/ tools are the data source/i);
     expect(seed).toMatch(/do not ask me which data source/i);
+    expect(seed).toMatch(/best-practice defaults/i);
+    expect(seed).toMatch(/build it now/i);
     expect(seed).not.toMatch(/suggest a few useful live apps/i);
+    expect(seed).not.toMatch(/wait for my ok/i);
     expect(seed).toMatch(/embeds the latest data/i);
   });
 
-  it('suggests options when no idea is given', () => {
+  it('recommends an option when no idea is given', () => {
     const seed = buildLiveAppSeed('');
-    expect(seed).toMatch(/suggest a few useful live apps/i);
+    expect(seed).toMatch(/suggest the most useful live app/i);
     expect(seed).toMatch(/data source/i);
   });
 });

--- a/console/src/lib/app-seed.test.ts
+++ b/console/src/lib/app-seed.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { buildAppSeed, buildLiveAppSeed } from './app-seed';
+
+describe('buildAppSeed', () => {
+  it('includes the category and idea, plus a plan-then-build flow', () => {
+    const seed = buildAppSeed('productivity tool', 'A churn dashboard');
+    expect(seed).toContain('productivity tool');
+    expect(seed).toContain('A churn dashboard');
+    expect(seed).toMatch(/propose a short plan/i);
+    expect(seed).toMatch(/self-contained/i);
+    expect(seed).toMatch(/frontend-design skill/i);
+  });
+
+  it('works with no category and no idea', () => {
+    const seed = buildAppSeed(null, '');
+    expect(seed).toMatch(/web app/i);
+    expect(seed).toMatch(/propose a short plan/i);
+  });
+});
+
+describe('buildLiveAppSeed', () => {
+  it('inspects connectors, suggests, plans, then builds with embedded data', () => {
+    const seed = buildLiveAppSeed('A dashboard of github review requests');
+    expect(seed).toContain('A dashboard of github review requests');
+    expect(seed).toMatch(/connectors \/ MCP servers/i);
+    expect(seed).toMatch(/suggest/i);
+    expect(seed).toMatch(/propose a short plan/i);
+    expect(seed).toMatch(/embeds the latest data/i);
+    expect(seed).toMatch(/refresh/i);
+  });
+});

--- a/console/src/lib/app-seed.test.ts
+++ b/console/src/lib/app-seed.test.ts
@@ -23,26 +23,25 @@ describe('stripAppBuildDirective', () => {
 });
 
 describe('buildAppSeed', () => {
-  it('builds immediately with best-practice defaults instead of interrogating', () => {
+  it('proposes a plan first, decides with best practices, and does not interrogate', () => {
     const seed = buildAppSeed('productivity tool', 'A churn dashboard');
     expect(seed).toMatch(/best-practice defaults/i);
     expect(seed).toMatch(/don't ask me a list of questions/i);
-    expect(seed).toMatch(/build it now/i);
-    expect(seed).not.toMatch(/wait for my ok/i);
+    expect(seed).toMatch(/propose a short plan/i);
+    expect(seed).toMatch(/wait for my ok/i);
   });
 });
 
 describe('buildLiveAppSeed', () => {
-  it('uses MCP connectors directly and builds now when given an idea', () => {
+  it('uses MCP directly, plans first, and does not suggest alternatives when given an idea', () => {
     const seed = buildLiveAppSeed('A dashboard of open PRs for hybridclaw');
     expect(stripAppBuildDirective(seed)).toContain(
       'A dashboard of open PRs for hybridclaw',
     );
     expect(seed).toMatch(/do not ask me which data source/i);
-    expect(seed).toMatch(/best-practice defaults/i);
-    expect(seed).toMatch(/build it now/i);
+    expect(seed).toMatch(/propose a short plan/i);
+    expect(seed).toMatch(/wait for my ok/i);
     expect(seed).not.toMatch(/suggest a few useful live apps/i);
-    expect(seed).not.toMatch(/wait for my ok/i);
     expect(seed).toMatch(/embeds the latest data/i);
   });
 

--- a/console/src/lib/app-seed.test.ts
+++ b/console/src/lib/app-seed.test.ts
@@ -1,42 +1,53 @@
 import { describe, expect, it } from 'vitest';
-import { buildAppSeed, buildLiveAppSeed } from './app-seed';
+import {
+  buildAppSeed,
+  buildLiveAppSeed,
+  stripAppBuildDirective,
+} from './app-seed';
 
-describe('buildAppSeed', () => {
-  it('refines a provided idea (no alternative suggestions) and defaults to React', () => {
+describe('stripAppBuildDirective', () => {
+  it('shows only the briefing, hiding the build directive', () => {
     const seed = buildAppSeed('productivity tool', 'A churn dashboard');
-    expect(seed).toContain('productivity tool');
-    expect(seed).toContain('A churn dashboard');
-    expect(seed).toMatch(/refine this briefing/i);
-    expect(seed).toMatch(/don't suggest a different app/i);
-    expect(seed).toMatch(/propose a short plan/i);
-    expect(seed).toMatch(/self-contained/i);
+    const shown = stripAppBuildDirective(seed);
+    // Briefing is visible…
+    expect(shown).toContain('A churn dashboard');
+    // …but the build instructions are not shown.
+    expect(shown).not.toMatch(/before building/i);
+    expect(shown).not.toMatch(/default to react/i);
+    // The full seed still carries the directive for the model.
+    expect(seed).toMatch(/before building/i);
     expect(seed).toMatch(/default to react/i);
   });
 
-  it('asks what to build when no idea is given', () => {
-    const seed = buildAppSeed(null, '');
-    expect(seed).toMatch(/web app/i);
-    expect(seed).toMatch(/ask me/i);
+  it('returns content unchanged when there is no directive', () => {
+    expect(stripAppBuildDirective('just a message')).toBe('just a message');
+  });
+});
+
+describe('buildAppSeed', () => {
+  it('refines a provided idea and does not suggest alternatives', () => {
+    const seed = buildAppSeed('productivity tool', 'A churn dashboard');
+    expect(seed).toMatch(/refine this briefing/i);
+    expect(seed).toMatch(/don't suggest a different app/i);
     expect(seed).toMatch(/propose a short plan/i);
   });
 });
 
 describe('buildLiveAppSeed', () => {
-  it('with an idea: confirms connectors, refines, and does not suggest alternatives', () => {
+  it('uses MCP connectors directly and does not suggest alternatives when given an idea', () => {
     const seed = buildLiveAppSeed('A dashboard of open PRs for hybridclaw');
-    expect(seed).toContain('A dashboard of open PRs for hybridclaw');
-    expect(seed).toMatch(/connectors \/ MCP servers/i);
-    expect(seed).toMatch(/confirm the ones this app needs/i);
-    expect(seed).toMatch(/don't suggest a different app/i);
+    expect(stripAppBuildDirective(seed)).toContain(
+      'A dashboard of open PRs for hybridclaw',
+    );
+    expect(seed).toMatch(/connected MCP servers \/ tools are the data source/i);
+    expect(seed).toMatch(/do not ask me which data source/i);
     expect(seed).not.toMatch(/suggest a few useful live apps/i);
     expect(seed).toMatch(/embeds the latest data/i);
-    expect(seed).toMatch(/refresh/i);
-    expect(seed).toMatch(/default to react/i);
   });
 
-  it('without an idea: suggests connector-powered options', () => {
+  it('suggests options when no idea is given', () => {
     const seed = buildLiveAppSeed('');
     expect(seed).toMatch(/suggest a few useful live apps/i);
-    expect(seed).toMatch(/embeds the latest data/i);
+    expect(seed).toMatch(/data source/i);
   });
 });

--- a/console/src/lib/app-seed.test.ts
+++ b/console/src/lib/app-seed.test.ts
@@ -2,30 +2,41 @@ import { describe, expect, it } from 'vitest';
 import { buildAppSeed, buildLiveAppSeed } from './app-seed';
 
 describe('buildAppSeed', () => {
-  it('includes the category and idea, plus a plan-then-build flow', () => {
+  it('refines a provided idea (no alternative suggestions) and defaults to React', () => {
     const seed = buildAppSeed('productivity tool', 'A churn dashboard');
     expect(seed).toContain('productivity tool');
     expect(seed).toContain('A churn dashboard');
+    expect(seed).toMatch(/refine this briefing/i);
+    expect(seed).toMatch(/don't suggest a different app/i);
     expect(seed).toMatch(/propose a short plan/i);
     expect(seed).toMatch(/self-contained/i);
-    expect(seed).toMatch(/frontend-design skill/i);
+    expect(seed).toMatch(/default to react/i);
   });
 
-  it('works with no category and no idea', () => {
+  it('asks what to build when no idea is given', () => {
     const seed = buildAppSeed(null, '');
     expect(seed).toMatch(/web app/i);
+    expect(seed).toMatch(/ask me/i);
     expect(seed).toMatch(/propose a short plan/i);
   });
 });
 
 describe('buildLiveAppSeed', () => {
-  it('inspects connectors, suggests, plans, then builds with embedded data', () => {
-    const seed = buildLiveAppSeed('A dashboard of github review requests');
-    expect(seed).toContain('A dashboard of github review requests');
+  it('with an idea: confirms connectors, refines, and does not suggest alternatives', () => {
+    const seed = buildLiveAppSeed('A dashboard of open PRs for hybridclaw');
+    expect(seed).toContain('A dashboard of open PRs for hybridclaw');
     expect(seed).toMatch(/connectors \/ MCP servers/i);
-    expect(seed).toMatch(/suggest/i);
-    expect(seed).toMatch(/propose a short plan/i);
+    expect(seed).toMatch(/confirm the ones this app needs/i);
+    expect(seed).toMatch(/don't suggest a different app/i);
+    expect(seed).not.toMatch(/suggest a few useful live apps/i);
     expect(seed).toMatch(/embeds the latest data/i);
     expect(seed).toMatch(/refresh/i);
+    expect(seed).toMatch(/default to react/i);
+  });
+
+  it('without an idea: suggests connector-powered options', () => {
+    const seed = buildLiveAppSeed('');
+    expect(seed).toMatch(/suggest a few useful live apps/i);
+    expect(seed).toMatch(/embeds the latest data/i);
   });
 });

--- a/console/src/lib/app-seed.ts
+++ b/console/src/lib/app-seed.ts
@@ -44,15 +44,15 @@ export function buildAppSeed(
       ? `Let's build a ${categoryNoun} web app. Here's my idea: ${desc}`
       : `Let's build a web app. Here's my idea: ${desc}`;
     return compose(briefing, [
-      "Don't ask me a list of questions and don't wait for confirmation. Use best-practice defaults for anything I didn't specify, and don't suggest a different app — I already know what I want.",
-      `Briefly note the key decisions you're making, then build it now. ${BUILD_NOTE}`,
+      "Don't ask me a list of questions — use best-practice defaults for anything I didn't specify, and don't suggest a different app (I already know what I want).",
+      `First propose a short plan (your key decisions, a few bullets), then wait for my OK and build it. ${BUILD_NOTE}`,
     ]);
   }
   const briefing = categoryNoun
     ? `Let's build a ${categoryNoun} web app.`
     : "Let's build a web app.";
   return compose(briefing, [
-    'Ask me one quick question about what I want, then use best-practice defaults and build it now.',
+    'Ask me one quick question about what I want, then propose a short plan, wait for my OK, and build it.',
     BUILD_NOTE,
   ]);
 }
@@ -65,7 +65,7 @@ export function buildAppSeed(
  */
 export function buildLiveAppSeed(description: string): string {
   const desc = description.trim();
-  const liveTail = `Build it now as a live app that embeds the latest data pulled from those connectors, with a refresh action. ${BUILD_NOTE}`;
+  const liveTail = `build it as a live app that embeds the latest data pulled from those connectors, with a refresh action. ${BUILD_NOTE}`;
   const mcpRule =
     'Assume my connected MCP servers / tools are the data source: if a relevant connector is available, use it directly to fetch the data — do not ask me which data source or connector to use.';
   if (desc) {
@@ -73,14 +73,14 @@ export function buildLiveAppSeed(description: string): string {
       `I want to create a live app that uses my connected tools. Here's my idea: ${desc}`,
       [
         mcpRule,
-        "Don't ask me a list of questions and don't wait for confirmation. Use best-practice defaults for anything I didn't specify (scope, fields, sorting, refresh), and don't suggest a different app — I already know what I want. Tell me only if something essential is missing.",
-        `Briefly note the key decisions you're making, then ${liveTail}`,
+        "Don't ask me a list of questions — use best-practice defaults for anything I didn't specify (scope, fields, sorting, refresh), and don't suggest a different app (I already know what I want). Tell me only if something essential is missing.",
+        `First propose a short plan (your key decisions, a few bullets), then wait for my OK and ${liveTail}`,
       ],
     );
   }
   return compose('I want to create a live app that uses my connected tools.', [
     mcpRule,
     'Suggest the most useful live app or dashboard you can build with my connectors (briefly list a couple of options and recommend one).',
-    `Once I pick, use best-practice defaults and ${liveTail}`,
+    `Once I pick, propose a short plan, wait for my OK, and ${liveTail}`,
   ]);
 }

--- a/console/src/lib/app-seed.ts
+++ b/console/src/lib/app-seed.ts
@@ -22,3 +22,22 @@ export function buildAppSeed(
   }
   return `Let's build a small self-contained web app. ${tail}`;
 }
+
+/**
+ * Seed for a "live app": the agent first inspects the user's connected tools
+ * (MCP / connectors), suggests connector-powered apps, then builds one that
+ * embeds the latest data so it can be refreshed later.
+ */
+export function buildLiveAppSeed(description: string): string {
+  const desc = description.trim();
+  const intro = desc
+    ? `I want to create a live app that uses my connected tools. Here's my idea: ${desc}`
+    : 'I want to create a live app that uses my connected tools.';
+  return [
+    intro,
+    '',
+    'First, check which connectors / MCP servers I have set up.',
+    'Then suggest a few useful live apps or dashboards that use them, and ask me which to build.',
+    'Build the one I pick as a single self-contained web app that embeds the latest data pulled from those connectors, so I can preview it and refresh it later.',
+  ].join('\n');
+}

--- a/console/src/lib/app-seed.ts
+++ b/console/src/lib/app-seed.ts
@@ -1,57 +1,82 @@
-// The build flow mirrors the reference artifact experience: gather
-// requirements, propose a short plan and wait for confirmation, design with
-// care, then ship a single self-contained HTML file (which the gallery serves
-// in a sandboxed iframe — so it must be fully client-side).
+// The build flow mirrors the reference artifact experience: refine the
+// briefing, propose a short plan and wait for confirmation, then build. Output
+// is one self-contained HTML file (the gallery serves it in a sandboxed iframe,
+// so it must be fully client-side), defaulting to React via CDN.
+const CLIENT_NOTE =
+  'Build one self-contained, fully client-side HTML file (no backend).';
+
+const STACK_NOTE =
+  'Default to React via CDN — load React, ReactDOM, and Babel standalone from a CDN and put your JSX in an inline <script type="text/babel"> so it stays a single HTML file. Use a different stack only if I ask.';
+
 const DESIGN_NOTE =
   'Design it with care — if you have a frontend-design skill, use it; otherwise apply strong fundamentals (clear layout, sensible typography, responsive, accessible, modern).';
 
-const WEB_BUILD_STEPS = [
-  'Before building:',
-  '1. Ask me a couple of quick questions about the purpose and who it is for.',
-  '2. Propose a short plan — what it does, how it works, and how it looks — and wait for my OK.',
-  `Then build it as a single, self-contained, polished HTML file (inline CSS and JS, CDN libraries allowed, fully client-side with no backend) that I can preview. ${DESIGN_NOTE}`,
-].join('\n');
-
-const LIVE_BUILD_STEPS = [
-  'Before building:',
-  '1. Check which connectors / MCP servers I have set up.',
-  '2. Suggest a few useful live apps or dashboards that use them, and ask me which to build.',
-  '3. Propose a short plan and wait for my OK.',
-  `Then build the one I pick as a single, self-contained, polished HTML file that embeds the latest data pulled from those connectors, so I can preview it and refresh it later. ${DESIGN_NOTE}`,
-].join('\n');
+const BUILD_NOTE = `${CLIENT_NOTE} ${STACK_NOTE} ${DESIGN_NOTE}`;
 
 /**
  * Build the first chat message that kicks off an app-building conversation.
- * Selecting a category (or running `/app <idea>`) starts a normal chat seeded
- * with this message, so the agent gathers requirements, plans, then builds.
+ * When the user provides an idea, the agent refines that briefing and clarifies
+ * open points (it does NOT suggest different apps); otherwise it asks what to
+ * build. Either way it proposes a plan, waits for confirmation, then builds.
  */
 export function buildAppSeed(
   categoryNoun: string | null,
   description: string,
 ): string {
   const desc = description.trim();
-  let intro: string;
-  if (categoryNoun && desc) {
-    intro = `Let's build a ${categoryNoun} as a web app. Here's the idea: ${desc}`;
-  } else if (desc) {
-    intro = `Let's build a web app. Here's the idea: ${desc}`;
-  } else if (categoryNoun) {
-    intro = `Let's build a ${categoryNoun}.`;
-  } else {
-    intro = "Let's build a small web app.";
+  if (desc) {
+    const intro = categoryNoun
+      ? `Let's build a ${categoryNoun} web app. Here's my idea: ${desc}`
+      : `Let's build a web app. Here's my idea: ${desc}`;
+    return [
+      intro,
+      '',
+      'Before building:',
+      "1. Refine this briefing with me — clarify any open points and fill the gaps. Don't suggest a different app; I already know what I want.",
+      '2. Propose a short plan and wait for my OK.',
+      `Then build it. ${BUILD_NOTE}`,
+    ].join('\n');
   }
-  return `${intro}\n\n${WEB_BUILD_STEPS}`;
+  const intro = categoryNoun
+    ? `Let's build a ${categoryNoun} web app.`
+    : "Let's build a web app.";
+  return [
+    intro,
+    '',
+    'Before building:',
+    '1. Ask me a couple of quick questions about what I want, the purpose, and who it is for.',
+    '2. Propose a short plan and wait for my OK.',
+    `Then build it. ${BUILD_NOTE}`,
+  ].join('\n');
 }
 
 /**
- * Seed for a "live app": the agent first inspects the user's connected tools
- * (MCP / connectors), suggests connector-powered apps, plans, then builds one
- * that embeds the latest data so it can be refreshed later.
+ * Seed for a "live app". With an idea, the agent confirms the needed connectors
+ * are available and refines the briefing (no alternative-app suggestions);
+ * without one, it suggests connector-powered options. It then plans, confirms,
+ * and builds an app that embeds live connector data and can be refreshed.
  */
 export function buildLiveAppSeed(description: string): string {
   const desc = description.trim();
-  const intro = desc
-    ? `I want to create a live app that uses my connected tools. Here's my idea: ${desc}`
-    : 'I want to create a live app that uses my connected tools.';
-  return `${intro}\n\n${LIVE_BUILD_STEPS}`;
+  const liveTail = `Then build it as a live app that embeds the latest data pulled from those connectors, with a refresh action. ${BUILD_NOTE}`;
+  if (desc) {
+    return [
+      `I want to create a live app that uses my connected tools. Here's my idea: ${desc}`,
+      '',
+      'Before building:',
+      '1. Check which connectors / MCP servers I have set up, and confirm the ones this app needs are available — tell me if something is missing or will not work.',
+      "2. Refine this briefing with me and clarify any open points (which data source, which connector, scope). Don't suggest a different app; I already know what I want.",
+      '3. Propose a short plan and wait for my OK.',
+      liveTail,
+    ].join('\n');
+  }
+  return [
+    'I want to create a live app that uses my connected tools.',
+    '',
+    'Before building:',
+    '1. Check which connectors / MCP servers I have set up.',
+    '2. Suggest a few useful live apps or dashboards that use them, and ask me which to build.',
+    '3. Refine the idea with me and propose a short plan; wait for my OK.',
+    liveTail,
+  ].join('\n');
 }

--- a/console/src/lib/app-seed.ts
+++ b/console/src/lib/app-seed.ts
@@ -1,43 +1,57 @@
+// The build flow mirrors the reference artifact experience: gather
+// requirements, propose a short plan and wait for confirmation, design with
+// care, then ship a single self-contained HTML file (which the gallery serves
+// in a sandboxed iframe — so it must be fully client-side).
+const DESIGN_NOTE =
+  'Design it with care — if you have a frontend-design skill, use it; otherwise apply strong fundamentals (clear layout, sensible typography, responsive, accessible, modern).';
+
+const WEB_BUILD_STEPS = [
+  'Before building:',
+  '1. Ask me a couple of quick questions about the purpose and who it is for.',
+  '2. Propose a short plan — what it does, how it works, and how it looks — and wait for my OK.',
+  `Then build it as a single, self-contained, polished HTML file (inline CSS and JS, CDN libraries allowed, fully client-side with no backend) that I can preview. ${DESIGN_NOTE}`,
+].join('\n');
+
+const LIVE_BUILD_STEPS = [
+  'Before building:',
+  '1. Check which connectors / MCP servers I have set up.',
+  '2. Suggest a few useful live apps or dashboards that use them, and ask me which to build.',
+  '3. Propose a short plan and wait for my OK.',
+  `Then build the one I pick as a single, self-contained, polished HTML file that embeds the latest data pulled from those connectors, so I can preview it and refresh it later. ${DESIGN_NOTE}`,
+].join('\n');
+
 /**
  * Build the first chat message that kicks off an app-building conversation.
  * Selecting a category (or running `/app <idea>`) starts a normal chat seeded
- * with this message, so the agent gathers requirements and then builds a
- * self-contained web app — rather than one-shotting from a form.
+ * with this message, so the agent gathers requirements, plans, then builds.
  */
 export function buildAppSeed(
   categoryNoun: string | null,
   description: string,
 ): string {
   const desc = description.trim();
-  const tail =
-    'Ask me any clarifying questions you need, then build it as a single self-contained web app and show me a preview.';
+  let intro: string;
   if (categoryNoun && desc) {
-    return `Let's build a ${categoryNoun} as a self-contained web app. Here's the idea: ${desc}\n\n${tail}`;
+    intro = `Let's build a ${categoryNoun} as a web app. Here's the idea: ${desc}`;
+  } else if (desc) {
+    intro = `Let's build a web app. Here's the idea: ${desc}`;
+  } else if (categoryNoun) {
+    intro = `Let's build a ${categoryNoun}.`;
+  } else {
+    intro = "Let's build a small web app.";
   }
-  if (desc) {
-    return `Let's build this as a self-contained web app: ${desc}\n\n${tail}`;
-  }
-  if (categoryNoun) {
-    return `Let's build a ${categoryNoun}. Ask me a few quick questions about what I want, what it's for, and who it's for — then build it as a single self-contained web app I can preview.`;
-  }
-  return `Let's build a small self-contained web app. ${tail}`;
+  return `${intro}\n\n${WEB_BUILD_STEPS}`;
 }
 
 /**
  * Seed for a "live app": the agent first inspects the user's connected tools
- * (MCP / connectors), suggests connector-powered apps, then builds one that
- * embeds the latest data so it can be refreshed later.
+ * (MCP / connectors), suggests connector-powered apps, plans, then builds one
+ * that embeds the latest data so it can be refreshed later.
  */
 export function buildLiveAppSeed(description: string): string {
   const desc = description.trim();
   const intro = desc
     ? `I want to create a live app that uses my connected tools. Here's my idea: ${desc}`
     : 'I want to create a live app that uses my connected tools.';
-  return [
-    intro,
-    '',
-    'First, check which connectors / MCP servers I have set up.',
-    'Then suggest a few useful live apps or dashboards that use them, and ask me which to build.',
-    'Build the one I pick as a single self-contained web app that embeds the latest data pulled from those connectors, so I can preview it and refresh it later.',
-  ].join('\n');
+  return `${intro}\n\n${LIVE_BUILD_STEPS}`;
 }

--- a/console/src/lib/app-seed.ts
+++ b/console/src/lib/app-seed.ts
@@ -44,20 +44,16 @@ export function buildAppSeed(
       ? `Let's build a ${categoryNoun} web app. Here's my idea: ${desc}`
       : `Let's build a web app. Here's my idea: ${desc}`;
     return compose(briefing, [
-      'Before building:',
-      "1. Refine this briefing with me — clarify any open points and fill the gaps. Don't suggest a different app; I already know what I want.",
-      '2. Propose a short plan and wait for my OK.',
-      `Then build it. ${BUILD_NOTE}`,
+      "Don't ask me a list of questions and don't wait for confirmation. Use best-practice defaults for anything I didn't specify, and don't suggest a different app — I already know what I want.",
+      `Briefly note the key decisions you're making, then build it now. ${BUILD_NOTE}`,
     ]);
   }
   const briefing = categoryNoun
     ? `Let's build a ${categoryNoun} web app.`
     : "Let's build a web app.";
   return compose(briefing, [
-    'Before building:',
-    '1. Ask me a couple of quick questions about what I want, the purpose, and who it is for.',
-    '2. Propose a short plan and wait for my OK.',
-    `Then build it. ${BUILD_NOTE}`,
+    'Ask me one quick question about what I want, then use best-practice defaults and build it now.',
+    BUILD_NOTE,
   ]);
 }
 
@@ -69,7 +65,7 @@ export function buildAppSeed(
  */
 export function buildLiveAppSeed(description: string): string {
   const desc = description.trim();
-  const liveTail = `Then build it as a live app that embeds the latest data pulled from those connectors, with a refresh action. ${BUILD_NOTE}`;
+  const liveTail = `Build it now as a live app that embeds the latest data pulled from those connectors, with a refresh action. ${BUILD_NOTE}`;
   const mcpRule =
     'Assume my connected MCP servers / tools are the data source: if a relevant connector is available, use it directly to fetch the data — do not ask me which data source or connector to use.';
   if (desc) {
@@ -77,22 +73,14 @@ export function buildLiveAppSeed(description: string): string {
       `I want to create a live app that uses my connected tools. Here's my idea: ${desc}`,
       [
         mcpRule,
-        '',
-        'Before building:',
-        '1. Check which connectors / MCP servers I have set up, and confirm the ones this app needs are available — tell me only if something required is missing.',
-        '2. Refine this briefing with me on genuinely open points (scope, fields, sorting). Do not suggest a different app; I already know what I want.',
-        '3. Propose a short plan and wait for my OK.',
-        liveTail,
+        "Don't ask me a list of questions and don't wait for confirmation. Use best-practice defaults for anything I didn't specify (scope, fields, sorting, refresh), and don't suggest a different app — I already know what I want. Tell me only if something essential is missing.",
+        `Briefly note the key decisions you're making, then ${liveTail}`,
       ],
     );
   }
   return compose('I want to create a live app that uses my connected tools.', [
     mcpRule,
-    '',
-    'Before building:',
-    '1. Check which connectors / MCP servers I have set up.',
-    '2. Suggest a few useful live apps or dashboards that use them, and ask me which to build.',
-    '3. Refine the idea with me and propose a short plan; wait for my OK.',
-    liveTail,
+    'Suggest the most useful live app or dashboard you can build with my connectors (briefly list a couple of options and recommend one).',
+    `Once I pick, use best-practice defaults and ${liveTail}`,
   ]);
 }

--- a/console/src/lib/app-seed.ts
+++ b/console/src/lib/app-seed.ts
@@ -1,7 +1,15 @@
-// The build flow mirrors the reference artifact experience: refine the
-// briefing, propose a short plan and wait for confirmation, then build. Output
-// is one self-contained HTML file (the gallery serves it in a sandboxed iframe,
-// so it must be fully client-side), defaulting to React via CDN.
+// An app-build seed is one chat message, but only the briefing (the part
+// before the marker) is shown in the chat — the build directive after it is
+// sent to the model as input but hidden from the bubble (see
+// stripAppBuildDirective + message-block). The model still receives everything.
+export const APP_BUILD_DIRECTIVE_MARKER = '\n\n<<<APP_BUILD_DIRECTIVE>>>\n';
+
+/** Display helper: show only the briefing, hide the build directive. */
+export function stripAppBuildDirective(content: string): string {
+  const idx = content.indexOf(APP_BUILD_DIRECTIVE_MARKER);
+  return idx === -1 ? content : content.slice(0, idx).trimEnd();
+}
+
 const CLIENT_NOTE =
   'Build one self-contained, fully client-side HTML file (no backend).';
 
@@ -16,11 +24,15 @@ const PUBLISH_NOTE =
 
 const BUILD_NOTE = `${CLIENT_NOTE} ${STACK_NOTE} ${DESIGN_NOTE} ${PUBLISH_NOTE}`;
 
+function compose(briefing: string, directiveLines: string[]): string {
+  return `${briefing}${APP_BUILD_DIRECTIVE_MARKER}${directiveLines.join('\n')}`;
+}
+
 /**
  * Build the first chat message that kicks off an app-building conversation.
- * When the user provides an idea, the agent refines that briefing and clarifies
- * open points (it does NOT suggest different apps); otherwise it asks what to
- * build. Either way it proposes a plan, waits for confirmation, then builds.
+ * Only the briefing is shown; the directive (everything after the marker) is
+ * input for the model. When the user gives an idea, the agent refines that
+ * briefing rather than suggesting other apps.
  */
 export function buildAppSeed(
   categoryNoun: string | null,
@@ -28,58 +40,59 @@ export function buildAppSeed(
 ): string {
   const desc = description.trim();
   if (desc) {
-    const intro = categoryNoun
+    const briefing = categoryNoun
       ? `Let's build a ${categoryNoun} web app. Here's my idea: ${desc}`
       : `Let's build a web app. Here's my idea: ${desc}`;
-    return [
-      intro,
-      '',
+    return compose(briefing, [
       'Before building:',
       "1. Refine this briefing with me — clarify any open points and fill the gaps. Don't suggest a different app; I already know what I want.",
       '2. Propose a short plan and wait for my OK.',
       `Then build it. ${BUILD_NOTE}`,
-    ].join('\n');
+    ]);
   }
-  const intro = categoryNoun
+  const briefing = categoryNoun
     ? `Let's build a ${categoryNoun} web app.`
     : "Let's build a web app.";
-  return [
-    intro,
-    '',
+  return compose(briefing, [
     'Before building:',
     '1. Ask me a couple of quick questions about what I want, the purpose, and who it is for.',
     '2. Propose a short plan and wait for my OK.',
     `Then build it. ${BUILD_NOTE}`,
-  ].join('\n');
+  ]);
 }
 
 /**
- * Seed for a "live app". With an idea, the agent confirms the needed connectors
- * are available and refines the briefing (no alternative-app suggestions);
- * without one, it suggests connector-powered options. It then plans, confirms,
- * and builds an app that embeds live connector data and can be refreshed.
+ * Seed for a "live app". Live apps assume the available MCP connectors / tools
+ * and use them directly (no "which data source?" questions). With an idea the
+ * agent confirms the needed connectors and refines the briefing; without one it
+ * suggests connector-powered options.
  */
 export function buildLiveAppSeed(description: string): string {
   const desc = description.trim();
   const liveTail = `Then build it as a live app that embeds the latest data pulled from those connectors, with a refresh action. ${BUILD_NOTE}`;
+  const mcpRule =
+    'Assume my connected MCP servers / tools are the data source: if a relevant connector is available, use it directly to fetch the data — do not ask me which data source or connector to use.';
   if (desc) {
-    return [
+    return compose(
       `I want to create a live app that uses my connected tools. Here's my idea: ${desc}`,
-      '',
-      'Before building:',
-      '1. Check which connectors / MCP servers I have set up, and confirm the ones this app needs are available — tell me if something is missing or will not work.',
-      "2. Refine this briefing with me and clarify any open points (which data source, which connector, scope). Don't suggest a different app; I already know what I want.",
-      '3. Propose a short plan and wait for my OK.',
-      liveTail,
-    ].join('\n');
+      [
+        mcpRule,
+        '',
+        'Before building:',
+        '1. Check which connectors / MCP servers I have set up, and confirm the ones this app needs are available — tell me only if something required is missing.',
+        '2. Refine this briefing with me on genuinely open points (scope, fields, sorting). Do not suggest a different app; I already know what I want.',
+        '3. Propose a short plan and wait for my OK.',
+        liveTail,
+      ],
+    );
   }
-  return [
-    'I want to create a live app that uses my connected tools.',
+  return compose('I want to create a live app that uses my connected tools.', [
+    mcpRule,
     '',
     'Before building:',
     '1. Check which connectors / MCP servers I have set up.',
     '2. Suggest a few useful live apps or dashboards that use them, and ask me which to build.',
     '3. Refine the idea with me and propose a short plan; wait for my OK.',
     liveTail,
-  ].join('\n');
+  ]);
 }

--- a/console/src/lib/app-seed.ts
+++ b/console/src/lib/app-seed.ts
@@ -11,7 +11,10 @@ const STACK_NOTE =
 const DESIGN_NOTE =
   'Design it with care — if you have a frontend-design skill, use it; otherwise apply strong fundamentals (clear layout, sensible typography, responsive, accessible, modern).';
 
-const BUILD_NOTE = `${CLIENT_NOTE} ${STACK_NOTE} ${DESIGN_NOTE}`;
+const PUBLISH_NOTE =
+  'When you finish, the app is automatically published to my Apps gallery and opened as a preview with its own link — no external hosting needed, so just build it.';
+
+const BUILD_NOTE = `${CLIENT_NOTE} ${STACK_NOTE} ${DESIGN_NOTE} ${PUBLISH_NOTE}`;
 
 /**
  * Build the first chat message that kicks off an app-building conversation.

--- a/console/src/lib/app-seed.ts
+++ b/console/src/lib/app-seed.ts
@@ -1,0 +1,24 @@
+/**
+ * Build the first chat message that kicks off an app-building conversation.
+ * Selecting a category (or running `/app <idea>`) starts a normal chat seeded
+ * with this message, so the agent gathers requirements and then builds a
+ * self-contained web app — rather than one-shotting from a form.
+ */
+export function buildAppSeed(
+  categoryNoun: string | null,
+  description: string,
+): string {
+  const desc = description.trim();
+  const tail =
+    'Ask me any clarifying questions you need, then build it as a single self-contained web app and show me a preview.';
+  if (categoryNoun && desc) {
+    return `Let's build a ${categoryNoun} as a self-contained web app. Here's the idea: ${desc}\n\n${tail}`;
+  }
+  if (desc) {
+    return `Let's build this as a self-contained web app: ${desc}\n\n${tail}`;
+  }
+  if (categoryNoun) {
+    return `Let's build a ${categoryNoun}. Ask me a few quick questions about what I want, what it's for, and who it's for — then build it as a single self-contained web app I can preview.`;
+  }
+  return `Let's build a small self-contained web app. ${tail}`;
+}

--- a/console/src/lib/app-seed.ts
+++ b/console/src/lib/app-seed.ts
@@ -11,7 +11,7 @@ export function stripAppBuildDirective(content: string): string {
 }
 
 const CLIENT_NOTE =
-  'Build one self-contained, fully client-side HTML file (no backend).';
+  'Build one self-contained, fully client-side HTML file (no backend), and save it into the workspace `apps/` folder (e.g. apps/<short-name>.html).';
 
 const STACK_NOTE =
   'Default to React via CDN — load React, ReactDOM, and Babel standalone from a CDN and put your JSX in an inline <script type="text/babel"> so it stays a single HTML file. Use a different stack only if I ask.';

--- a/console/src/router.tsx
+++ b/console/src/router.tsx
@@ -313,6 +313,18 @@ const secretsRoute = createRoute({
 const chatRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/chat',
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { prompt?: string; send?: string; agent?: string } => {
+    const prompt = optionalStringSearchValue(search.prompt);
+    const send = optionalStringSearchValue(search.send);
+    const agent = optionalStringSearchValue(search.agent);
+    return {
+      ...(prompt ? { prompt } : {}),
+      ...(send ? { send } : {}),
+      ...(agent ? { agent } : {}),
+    };
+  },
   component: ChatRouteComponent,
 });
 
@@ -324,18 +336,6 @@ const chatSessionRoute = createRoute({
 const appsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/apps',
-  validateSearch: (
-    search: Record<string, unknown>,
-  ): { build?: string; prompt?: string; category?: string } => {
-    const build = optionalStringSearchValue(search.build);
-    const prompt = optionalStringSearchValue(search.prompt);
-    const category = optionalStringSearchValue(search.category);
-    return {
-      ...(build ? { build } : {}),
-      ...(prompt ? { prompt } : {}),
-      ...(category ? { category } : {}),
-    };
-  },
   component: AppsRouteComponent,
 });
 

--- a/console/src/router.tsx
+++ b/console/src/router.tsx
@@ -321,18 +321,21 @@ const chatRoute = createRoute({
     agent?: string;
     app?: string;
     category?: string;
+    kind?: string;
   } => {
     const prompt = optionalStringSearchValue(search.prompt);
     const send = optionalStringSearchValue(search.send);
     const agent = optionalStringSearchValue(search.agent);
     const app = optionalStringSearchValue(search.app);
     const category = optionalStringSearchValue(search.category);
+    const kind = optionalStringSearchValue(search.kind);
     return {
       ...(prompt ? { prompt } : {}),
       ...(send ? { send } : {}),
       ...(agent ? { agent } : {}),
       ...(app ? { app } : {}),
       ...(category ? { category } : {}),
+      ...(kind ? { kind } : {}),
     };
   },
   component: ChatRouteComponent,

--- a/console/src/router.tsx
+++ b/console/src/router.tsx
@@ -64,6 +64,19 @@ function ChatRouteComponent() {
   );
 }
 
+const LazyAppsPage = lazy(async () => {
+  const mod = await import('./routes/apps');
+  return { default: mod.AppsPage };
+});
+
+function AppsRouteComponent() {
+  return (
+    <Suspense fallback={<div className="empty-state">Loading apps…</div>}>
+      <LazyAppsPage />
+    </Suspense>
+  );
+}
+
 function optionalStringSearchValue(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
@@ -308,6 +321,24 @@ const chatSessionRoute = createRoute({
   path: '$sessionId',
 });
 
+const appsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/apps',
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { build?: string; prompt?: string; category?: string } => {
+    const build = optionalStringSearchValue(search.build);
+    const prompt = optionalStringSearchValue(search.prompt);
+    const category = optionalStringSearchValue(search.category);
+    return {
+      ...(build ? { build } : {}),
+      ...(prompt ? { prompt } : {}),
+      ...(category ? { category } : {}),
+    };
+  },
+  component: AppsRouteComponent,
+});
+
 const routeTree = rootRoute.addChildren([
   adminLayoutRoute.addChildren([
     dashboardRoute,
@@ -342,6 +373,7 @@ const routeTree = rootRoute.addChildren([
   ]),
   agentsOverviewRoute,
   chatRoute.addChildren([chatSessionRoute]),
+  appsRoute,
 ]);
 
 export const router = createRouter({

--- a/console/src/router.tsx
+++ b/console/src/router.tsx
@@ -315,14 +315,24 @@ const chatRoute = createRoute({
   path: '/chat',
   validateSearch: (
     search: Record<string, unknown>,
-  ): { prompt?: string; send?: string; agent?: string } => {
+  ): {
+    prompt?: string;
+    send?: string;
+    agent?: string;
+    app?: string;
+    category?: string;
+  } => {
     const prompt = optionalStringSearchValue(search.prompt);
     const send = optionalStringSearchValue(search.send);
     const agent = optionalStringSearchValue(search.agent);
+    const app = optionalStringSearchValue(search.app);
+    const category = optionalStringSearchValue(search.category);
     return {
       ...(prompt ? { prompt } : {}),
       ...(send ? { send } : {}),
       ...(agent ? { agent } : {}),
+      ...(app ? { app } : {}),
+      ...(category ? { category } : {}),
     };
   },
   component: ChatRouteComponent,

--- a/console/src/routes/apps-chat-sidebar.tsx
+++ b/console/src/routes/apps-chat-sidebar.tsx
@@ -1,0 +1,121 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { useRef, useState } from 'react';
+import { fetchChatRecent } from '../api/chat';
+import type { ChatRecentSession } from '../api/chat-types';
+import { deleteSession } from '../api/client';
+import { isAuthReadyForApi, useAuth } from '../auth';
+import { Button } from '../components/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../components/dialog';
+import { useToast } from '../components/toast';
+import { readStoredUserId } from '../lib/chat-helpers';
+import { CHAT_UI_CONFIG } from '../lib/chat-ui-config';
+import { getErrorMessage } from '../lib/error-message';
+import { ChatSidebarPanel } from './chat/chat-sidebar';
+
+/**
+ * The chat recents sidebar, wired for the Apps page. It reuses the chat
+ * conversation list so the left rail is continuous between /chat and /apps;
+ * opening a conversation or starting a new one navigates back into chat.
+ */
+export function AppsChatSidebar() {
+  const auth = useAuth();
+  const toast = useToast();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const userId = useRef(readStoredUserId()).current;
+
+  const [search, setSearch] = useState('');
+  const [scope, setScope] = useState<'user' | 'all'>('user');
+  const [deleteTarget, setDeleteTarget] = useState<ChatRecentSession | null>(
+    null,
+  );
+  const trimmed = search.trim();
+
+  const recentQuery = useQuery({
+    queryKey: ['apps-chat-recent', auth.token, userId, trimmed, scope],
+    queryFn: () =>
+      fetchChatRecent(
+        auth.token,
+        userId,
+        'web',
+        trimmed
+          ? CHAT_UI_CONFIG.maxSearchResults
+          : CHAT_UI_CONFIG.maxRecentSessions,
+        trimmed || undefined,
+        scope,
+      ),
+    staleTime: 10_000,
+    enabled: isAuthReadyForApi(auth),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteSession(auth.token, id),
+    onSuccess: async () => {
+      setDeleteTarget(null);
+      await queryClient.invalidateQueries({ queryKey: ['apps-chat-recent'] });
+      toast.success('Conversation deleted.');
+    },
+    onError: (error) => {
+      toast.error(`Delete failed: ${getErrorMessage(error)}`);
+    },
+  });
+
+  return (
+    <>
+      <ChatSidebarPanel
+        sessions={recentQuery.data?.sessions ?? []}
+        activeSessionId=""
+        onNewChat={() => navigate({ to: '/chat' })}
+        onOpenSession={(sessionId) =>
+          navigate({ to: '/chat/$sessionId', params: { sessionId } })
+        }
+        onRequestDeleteSession={(session) => setDeleteTarget(session)}
+        deleteDisabled={deleteMutation.isPending}
+        searchQuery={search}
+        onSearchQueryChange={setSearch}
+        recentScope={scope}
+        onRecentScopeChange={setScope}
+        isLoading={recentQuery.isFetching}
+        onRefreshRecent={() => {
+          void recentQuery.refetch();
+        }}
+      />
+      <Dialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+      >
+        <DialogContent size="sm" role="alertdialog">
+          <DialogHeader>
+            <DialogTitle>Delete conversation?</DialogTitle>
+            <DialogDescription>
+              “{deleteTarget?.title || 'Untitled'}” will be permanently removed.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose>Cancel</DialogClose>
+            <Button
+              variant="danger"
+              disabled={deleteMutation.isPending}
+              onClick={() =>
+                deleteTarget && deleteMutation.mutate(deleteTarget.sessionId)
+              }
+            >
+              {deleteMutation.isPending ? 'Deleting…' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/console/src/routes/apps-icons.tsx
+++ b/console/src/routes/apps-icons.tsx
@@ -35,6 +35,16 @@ export function AppsGridIcon(props: IconProps) {
   );
 }
 
+/** Circular arrow — refresh a live app with the latest connector data. */
+export function RefreshIcon(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="M20 11a8 8 0 1 0-2.3 5.7" />
+      <path d="M20 5v6h-6" />
+    </Svg>
+  );
+}
+
 function AppsWebsitesIcon(props: IconProps) {
   return (
     <Svg {...props}>

--- a/console/src/routes/apps-icons.tsx
+++ b/console/src/routes/apps-icons.tsx
@@ -1,0 +1,123 @@
+import type { ReactNode, SVGProps } from 'react';
+import type { AppCategory } from '../api/apps';
+
+type IconProps = SVGProps<SVGSVGElement>;
+
+function Svg(props: IconProps & { children: ReactNode }) {
+  const { children, ...rest } = props;
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.6}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      width="100%"
+      height="100%"
+      aria-hidden="true"
+      {...rest}
+    >
+      {children}
+    </svg>
+  );
+}
+
+/** 2x2 grid — the "Apps" launcher icon used in the chat sidebar nav. */
+export function AppsGridIcon(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <rect x="4" y="4" width="7" height="7" rx="1.5" />
+      <rect x="13" y="4" width="7" height="7" rx="1.5" />
+      <rect x="4" y="13" width="7" height="7" rx="1.5" />
+      <rect x="13" y="13" width="7" height="7" rx="1.5" />
+    </Svg>
+  );
+}
+
+function AppsWebsitesIcon(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <rect x="3.5" y="5" width="17" height="14" rx="2" />
+      <path d="M3.5 9h17" />
+      <path d="M6.5 7h.01M8.5 7h.01" />
+    </Svg>
+  );
+}
+
+function DocumentsIcon(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="M7 3h7l4 4v14H7z" />
+      <path d="M14 3v4h4" />
+      <path d="M9.5 12h5M9.5 15h5M9.5 9h2" />
+    </Svg>
+  );
+}
+
+function GamesIcon(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <rect x="3" y="8" width="18" height="9" rx="4.5" />
+      <path d="M7 11.5v3M5.5 13h3" />
+      <path d="M15.5 12h.01M17.5 14h.01" />
+    </Svg>
+  );
+}
+
+function ProductivityIcon(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="M13 3 5 13h6l-1 8 8-10h-6z" />
+    </Svg>
+  );
+}
+
+function CreativeIcon(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="M3 21c0-3 2-4 4-4 1.5 0 2.5 1 2.5 2.5S8 21 6 21z" />
+      <path d="M9 17 19.5 6.5a2.1 2.1 0 0 0-3-3L6 14" />
+    </Svg>
+  );
+}
+
+function QuizIcon(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <rect x="5" y="4" width="14" height="17" rx="2" />
+      <path d="M9 4.5h6V7H9z" />
+      <path d="m8.5 12 1.5 1.5 2.5-3" />
+      <path d="M14.5 12.5h2" />
+    </Svg>
+  );
+}
+
+function ScratchIcon(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="M12 4v6M9 7h6" />
+      <path
+        d="M6 16.5 7 19l2.5 1L7 21l-1 2.5L5 21l-2.5-1L5 19z"
+        transform="translate(0 -3)"
+      />
+      <path d="M17 13l.7 1.8 1.8.7-1.8.7L17 18l-.7-1.8-1.8-.7 1.8-.7z" />
+    </Svg>
+  );
+}
+
+const CATEGORY_ICONS: Record<AppCategory, (props: IconProps) => ReactNode> = {
+  apps: AppsWebsitesIcon,
+  documents: DocumentsIcon,
+  games: GamesIcon,
+  productivity: ProductivityIcon,
+  creative: CreativeIcon,
+  quiz: QuizIcon,
+  scratch: ScratchIcon,
+};
+
+export function CategoryIcon(props: { category: AppCategory } & IconProps) {
+  const { category, ...rest } = props;
+  const Icon = CATEGORY_ICONS[category] ?? AppsWebsitesIcon;
+  return <Icon {...rest} />;
+}

--- a/console/src/routes/apps.module.css
+++ b/console/src/routes/apps.module.css
@@ -1,0 +1,432 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 28px 24px 48px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.topbarLeft {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.backLink {
+  border: none;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 0.875rem;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 6px;
+}
+
+.backLink:hover {
+  color: var(--foreground);
+  background: var(--nav-hover);
+}
+
+.title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--foreground);
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.searchWrap {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
+.searchIcon {
+  position: absolute;
+  left: 14px;
+  width: 18px;
+  height: 18px;
+  color: var(--muted-foreground);
+  pointer-events: none;
+}
+
+.searchInput {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 12px 14px 12px 42px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--card);
+  color: var(--foreground);
+  font-size: 0.9375rem;
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: var(--ring);
+  box-shadow: var(--shadow-focus);
+}
+
+.filterTrigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--card);
+  color: var(--foreground);
+  font-size: 0.875rem;
+  white-space: nowrap;
+}
+
+.filterTrigger svg {
+  width: 16px;
+  height: 16px;
+  color: var(--muted-foreground);
+}
+
+.grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.card {
+  position: relative;
+  display: flex;
+  height: 100%;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--card);
+  box-shadow: var(--shadow-card);
+  transition:
+    border-color 120ms ease,
+    transform 120ms ease;
+}
+
+.card:hover {
+  border-color: var(--border-strong);
+  transform: translateY(-2px);
+}
+
+.cardMain {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  border: none;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  border-radius: 14px;
+}
+
+.cardGlyph {
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.cardBody {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.cardTitle {
+  font-size: 1rem;
+  font-weight: 650;
+  color: var(--foreground);
+  line-height: 1.3;
+}
+
+.cardDesc {
+  font-size: 0.8125rem;
+  color: var(--muted-foreground);
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.cardMeta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 0.75rem;
+  color: var(--muted-foreground);
+}
+
+.cardCategory {
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.cardDot {
+  opacity: 0.5;
+}
+
+.cardDelete {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.card:hover .cardDelete,
+.cardDelete:focus-visible {
+  opacity: 1;
+}
+
+.cardDelete:hover {
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.cardDeleteIcon {
+  width: 16px;
+  height: 16px;
+}
+
+.buildingBanner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--accent-soft, var(--card));
+  color: var(--foreground);
+  font-size: 0.875rem;
+}
+
+.buildingSpinner {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid var(--border-strong);
+  border-top-color: var(--primary);
+  animation: appsSpin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes appsSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Empty state */
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+  padding: 64px 24px;
+  border: 1px dashed var(--border);
+  border-radius: 16px;
+  background: var(--card);
+}
+
+.emptyGlyph {
+  font-size: 2.5rem;
+}
+
+.emptyTitle {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 650;
+  color: var(--foreground);
+}
+
+.emptyText {
+  margin: 0 0 8px;
+  max-width: 420px;
+  color: var(--muted-foreground);
+  font-size: 0.9375rem;
+}
+
+/* New App dialog */
+.newDialog {
+  width: min(720px, 94vw);
+  max-width: min(720px, 94vw);
+}
+
+.categoryGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.categoryTile {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--card);
+  cursor: pointer;
+  text-align: left;
+  min-height: 110px;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease;
+}
+
+.categoryTile:hover {
+  border-color: var(--border-strong);
+  background: var(--nav-hover);
+}
+
+.categoryGlyph {
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.categoryLabel {
+  font-size: 0.9375rem;
+  font-weight: 650;
+  color: var(--foreground);
+}
+
+.categoryHint {
+  font-size: 0.75rem;
+  color: var(--muted-foreground);
+  line-height: 1.4;
+}
+
+.promptInput {
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 8px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--input, var(--card));
+  color: var(--foreground);
+  font-size: 0.9375rem;
+  font-family: inherit;
+  resize: vertical;
+  min-height: 120px;
+}
+
+.promptInput:focus {
+  outline: none;
+  border-color: var(--ring);
+  box-shadow: var(--shadow-focus);
+}
+
+.secondaryButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--card);
+  color: var(--foreground);
+  font-size: 0.875rem;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.secondaryButton:hover {
+  border-color: var(--border-strong);
+  background: var(--nav-hover);
+}
+
+.secondaryButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Viewer */
+.viewerDialog {
+  width: min(1100px, 95vw);
+  max-width: min(1100px, 95vw);
+  height: 86vh;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+
+.viewerHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.viewerTitle {
+  font-size: 1rem;
+  font-weight: 650;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.viewerActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.viewerFrame {
+  flex: 1;
+  width: 100%;
+  border: none;
+  background: #fff;
+}
+
+@media (max-width: 640px) {
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/console/src/routes/apps.module.css
+++ b/console/src/routes/apps.module.css
@@ -1,3 +1,9 @@
+.scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
 .page {
   display: flex;
   flex-direction: column;
@@ -19,22 +25,11 @@
 .topbarLeft {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 10px;
 }
 
-.backLink {
-  border: none;
-  background: transparent;
-  color: var(--muted-foreground);
-  font-size: 0.875rem;
-  cursor: pointer;
-  padding: 4px 6px;
-  border-radius: 6px;
-}
-
-.backLink:hover {
-  color: var(--foreground);
-  background: var(--nav-hover);
+.mobileTrigger {
+  flex-shrink: 0;
 }
 
 .title {
@@ -145,8 +140,19 @@
 }
 
 .cardGlyph {
-  font-size: 1.5rem;
-  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.cardGlyph svg {
+  width: 22px;
+  height: 22px;
 }
 
 .cardBody {
@@ -267,7 +273,19 @@
 }
 
 .emptyGlyph {
-  font-size: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: var(--muted);
+  color: var(--muted-foreground);
+}
+
+.emptyGlyph svg {
+  width: 26px;
+  height: 26px;
 }
 
 .emptyTitle {
@@ -300,7 +318,7 @@
 .categoryTile {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
   padding: 16px;
   border: 1px solid var(--border);
   border-radius: 12px;
@@ -319,8 +337,79 @@
 }
 
 .categoryGlyph {
-  font-size: 1.5rem;
-  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.categoryGlyph svg {
+  width: 23px;
+  height: 23px;
+}
+
+.dialogTitleIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: -5px;
+  width: 22px;
+  height: 22px;
+  margin-right: 8px;
+  color: var(--foreground);
+}
+
+.dialogTitleIcon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.examples {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.examplesLabel {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted-foreground);
+}
+
+.exampleChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.exampleChip {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--card);
+  color: var(--foreground);
+  font-size: 0.8125rem;
+  padding: 6px 12px;
+  cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease;
+}
+
+.exampleChip:hover {
+  border-color: var(--border-strong);
+  background: var(--nav-hover);
+}
+
+.exampleChip:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .categoryLabel {

--- a/console/src/routes/apps.module.css
+++ b/console/src/routes/apps.module.css
@@ -98,6 +98,43 @@
   color: var(--muted-foreground);
 }
 
+.newAppTrigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 14px;
+  border: none;
+  border-radius: var(--radius-sm, 10px);
+  background: var(--foreground);
+  color: var(--background);
+  font-size: 0.875rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.newAppTrigger svg {
+  width: 15px;
+  height: 15px;
+}
+
+.newAppItem {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  text-align: left;
+}
+
+.newAppItemTitle {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.newAppItemHint {
+  font-size: 0.75rem;
+  color: var(--muted-foreground);
+}
+
 .grid {
   list-style: none;
   margin: 0;
@@ -139,6 +176,13 @@
   border-radius: 14px;
 }
 
+.cardTop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .cardGlyph {
   display: inline-flex;
   align-items: center;
@@ -148,6 +192,69 @@
   border-radius: 10px;
   background: var(--muted);
   color: var(--foreground);
+}
+
+.kindBadge,
+.kindBadgeLive {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--muted-foreground);
+  background: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.kindBadgeLive {
+  color: var(--accent-foreground, var(--foreground));
+  background: var(--accent-soft, var(--accent));
+  border-color: var(--accent, var(--border-strong));
+}
+
+.cardActions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.card:hover .cardActions,
+.cardActions:focus-within {
+  opacity: 1;
+}
+
+.cardAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: none;
+  border-radius: 8px;
+  background: var(--card);
+  color: var(--muted-foreground);
+  cursor: pointer;
+}
+
+.cardAction:hover {
+  background: var(--nav-hover);
+  color: var(--foreground);
+}
+
+.cardActionIcon {
+  width: 16px;
+  height: 16px;
+}
+
+.inlineIcon {
+  width: 15px;
+  height: 15px;
+  vertical-align: -2px;
 }
 
 .cardGlyph svg {

--- a/console/src/routes/apps.tsx
+++ b/console/src/routes/apps.tsx
@@ -1,0 +1,554 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate, useSearch } from '@tanstack/react-router';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  type AppCategory,
+  type AppDetail,
+  type AppSummary,
+  appViewUrl,
+  deleteApp,
+  fetchApp,
+  fetchApps,
+  generateApp,
+} from '../api/apps';
+import { useAuth } from '../auth';
+import { Button } from '../components/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../components/dialog';
+import {
+  Dropdown,
+  DropdownContent,
+  DropdownItem,
+  DropdownTrigger,
+} from '../components/dropdown';
+import { ChevronDown, Search, Trash } from '../components/icons';
+import { useToast } from '../components/toast';
+import { getErrorMessage } from '../lib/error-message';
+import { formatRelativeTime } from '../lib/format';
+import styles from './apps.module.css';
+
+interface CategoryMeta {
+  slug: AppCategory;
+  label: string;
+  hint: string;
+  glyph: string;
+}
+
+const CATEGORIES: CategoryMeta[] = [
+  {
+    slug: 'apps',
+    label: 'Apps & Websites',
+    hint: 'Interactive web apps and landing pages',
+    glyph: '🌐',
+  },
+  {
+    slug: 'documents',
+    label: 'Documents & Templates',
+    hint: 'Reports, docs, printable templates',
+    glyph: '📄',
+  },
+  {
+    slug: 'games',
+    label: 'Games',
+    hint: 'Playable browser games',
+    glyph: '🎮',
+  },
+  {
+    slug: 'productivity',
+    label: 'Productivity Tools',
+    hint: 'Calculators, trackers, dashboards',
+    glyph: '⚡',
+  },
+  {
+    slug: 'creative',
+    label: 'Creative Projects',
+    hint: 'Visual, generative, artistic pieces',
+    glyph: '🎨',
+  },
+  {
+    slug: 'quiz',
+    label: 'Quiz or Survey',
+    hint: 'Quizzes, surveys, interactive forms',
+    glyph: '📝',
+  },
+  {
+    slug: 'scratch',
+    label: 'Start from scratch',
+    hint: 'Describe anything you can imagine',
+    glyph: '✨',
+  },
+];
+
+const CATEGORY_BY_SLUG = new Map(CATEGORIES.map((c) => [c.slug, c]));
+
+function categoryLabel(slug: string): string {
+  return CATEGORY_BY_SLUG.get(slug as AppCategory)?.label ?? 'App';
+}
+
+function categoryGlyph(slug: string): string {
+  return CATEGORY_BY_SLUG.get(slug as AppCategory)?.glyph ?? '🌐';
+}
+
+export function AppsPage() {
+  const { token } = useAuth();
+  const toast = useToast();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const searchParams = useSearch({ strict: false }) as {
+    build?: string;
+    prompt?: string;
+    category?: string;
+  };
+  const deepLinkHandled = useRef(false);
+
+  const [search, setSearch] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState<'all' | AppCategory>(
+    'all',
+  );
+  const [newOpen, setNewOpen] = useState(false);
+  const [seedPrompt, setSeedPrompt] = useState('');
+  const [seedCategory, setSeedCategory] = useState<AppCategory | null>(null);
+  const [viewer, setViewer] = useState<AppDetail | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<AppSummary | null>(null);
+
+  const query = useQuery({
+    queryKey: ['apps', token],
+    queryFn: () => fetchApps(token),
+    retry: false,
+  });
+
+  const generateMutation = useMutation({
+    mutationFn: (vars: { description: string; category: AppCategory }) =>
+      generateApp(token, {
+        description: vars.description,
+        category: vars.category,
+      }),
+    onSuccess: async (result) => {
+      await queryClient.invalidateQueries({ queryKey: ['apps'] });
+      setNewOpen(false);
+      setSeedPrompt('');
+      setSeedCategory(null);
+      toast.success(`Built “${result.app.title}”.`);
+      setViewer(result.app);
+    },
+    onError: (error) => {
+      toast.error(`Build failed: ${getErrorMessage(error)}`);
+    },
+  });
+
+  // Deep-link from the chat "/app <description>" slash command:
+  // /apps?build=1&prompt=...&category=... immediately builds the app. Without
+  // `build`, a `prompt` just pre-fills the builder dialog.
+  useEffect(() => {
+    if (deepLinkHandled.current) return;
+    const prompt = searchParams.prompt?.trim();
+    if (!prompt && searchParams.build !== '1') return;
+    deepLinkHandled.current = true;
+    const category =
+      searchParams.category &&
+      CATEGORY_BY_SLUG.has(searchParams.category as AppCategory)
+        ? (searchParams.category as AppCategory)
+        : 'scratch';
+    // Clear the params so a refresh doesn't rebuild.
+    void navigate({ to: '/apps', replace: true });
+    if (searchParams.build === '1' && prompt) {
+      generateMutation.mutate({ description: prompt, category });
+      return;
+    }
+    if (prompt) {
+      setSeedPrompt(prompt);
+      setSeedCategory(category);
+      setNewOpen(true);
+    }
+  }, [searchParams, navigate, generateMutation]);
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteApp(token, id),
+    onSuccess: async (_, id) => {
+      await queryClient.invalidateQueries({ queryKey: ['apps'] });
+      if (viewer?.id === id) setViewer(null);
+      setConfirmDelete(null);
+      toast.success('App deleted.');
+    },
+    onError: (error) => {
+      toast.error(`Delete failed: ${getErrorMessage(error)}`);
+    },
+  });
+
+  const apps = query.data?.apps ?? [];
+
+  const filtered = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    return apps.filter((app) => {
+      if (categoryFilter !== 'all' && app.category !== categoryFilter) {
+        return false;
+      }
+      if (!needle) return true;
+      return (
+        app.title.toLowerCase().includes(needle) ||
+        (app.description ?? '').toLowerCase().includes(needle)
+      );
+    });
+  }, [apps, search, categoryFilter]);
+
+  async function openApp(summary: AppSummary) {
+    try {
+      const result = await fetchApp(token, summary.id);
+      setViewer(result.app);
+    } catch (error) {
+      toast.error(`Could not open app: ${getErrorMessage(error)}`);
+    }
+  }
+
+  const filterLabel =
+    categoryFilter === 'all' ? 'All' : categoryLabel(categoryFilter);
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.topbar}>
+        <div className={styles.topbarLeft}>
+          <button
+            type="button"
+            className={styles.backLink}
+            onClick={() => navigate({ to: '/chat' })}
+          >
+            ← Chat
+          </button>
+          <h1 className={styles.title}>Apps</h1>
+        </div>
+        <Button
+          onClick={() => {
+            setSeedPrompt('');
+            setSeedCategory(null);
+            setNewOpen(true);
+          }}
+        >
+          + New App
+        </Button>
+      </header>
+
+      <div className={styles.toolbar}>
+        <div className={styles.searchWrap}>
+          <Search className={styles.searchIcon} aria-hidden="true" />
+          <input
+            type="search"
+            className={styles.searchInput}
+            placeholder="Search apps…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            aria-label="Search apps"
+          />
+        </div>
+        <Dropdown>
+          <DropdownTrigger className={styles.filterTrigger}>
+            <span>
+              Filter: <strong>{filterLabel}</strong>
+            </span>
+            <ChevronDown aria-hidden="true" />
+          </DropdownTrigger>
+          <DropdownContent align="end">
+            <DropdownItem
+              active={categoryFilter === 'all'}
+              onSelect={() => setCategoryFilter('all')}
+            >
+              All
+            </DropdownItem>
+            {CATEGORIES.map((category) => (
+              <DropdownItem
+                key={category.slug}
+                active={categoryFilter === category.slug}
+                onSelect={() => setCategoryFilter(category.slug)}
+              >
+                {category.glyph} {category.label}
+              </DropdownItem>
+            ))}
+          </DropdownContent>
+        </Dropdown>
+      </div>
+
+      {generateMutation.isPending && !newOpen ? (
+        <div className={styles.buildingBanner} role="status">
+          <span className={styles.buildingSpinner} aria-hidden="true" />
+          Building your app… this can take a moment.
+        </div>
+      ) : null}
+
+      {query.isPending ? (
+        <div className="empty-state">Loading apps…</div>
+      ) : query.isError ? (
+        <div className="empty-state">
+          Failed to load apps: {getErrorMessage(query.error)}
+        </div>
+      ) : filtered.length === 0 ? (
+        <EmptyState
+          hasApps={apps.length > 0}
+          onCreate={() => setNewOpen(true)}
+        />
+      ) : (
+        <ul className={styles.grid}>
+          {filtered.map((app) => (
+            <li key={app.id}>
+              <AppCard
+                app={app}
+                onOpen={() => openApp(app)}
+                onDelete={() => setConfirmDelete(app)}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <NewAppDialog
+        open={newOpen}
+        onOpenChange={(open) => {
+          if (!generateMutation.isPending) setNewOpen(open);
+        }}
+        seedPrompt={seedPrompt}
+        seedCategory={seedCategory}
+        isGenerating={generateMutation.isPending}
+        onSubmit={(description, category) =>
+          generateMutation.mutate({ description, category })
+        }
+      />
+
+      <AppViewer app={viewer} token={token} onClose={() => setViewer(null)} />
+
+      <Dialog
+        open={confirmDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmDelete(null);
+        }}
+      >
+        <DialogContent size="sm" role="alertdialog">
+          <DialogHeader>
+            <DialogTitle>Delete app?</DialogTitle>
+            <DialogDescription>
+              “{confirmDelete?.title}” will be permanently removed from the
+              gallery.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose className={styles.secondaryButton}>Cancel</DialogClose>
+            <Button
+              variant="danger"
+              disabled={deleteMutation.isPending}
+              onClick={() =>
+                confirmDelete && deleteMutation.mutate(confirmDelete.id)
+              }
+            >
+              {deleteMutation.isPending ? 'Deleting…' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function EmptyState(props: { hasApps: boolean; onCreate: () => void }) {
+  return (
+    <div className={styles.empty}>
+      <div className={styles.emptyGlyph} aria-hidden="true">
+        ✨
+      </div>
+      <h2 className={styles.emptyTitle}>
+        {props.hasApps ? 'No matching apps' : 'No apps yet'}
+      </h2>
+      <p className={styles.emptyText}>
+        {props.hasApps
+          ? 'Try a different search or filter.'
+          : 'Describe an app, document, game, or tool and HybridClaw builds it for you.'}
+      </p>
+      {!props.hasApps ? (
+        <Button onClick={props.onCreate}>+ New App</Button>
+      ) : null}
+    </div>
+  );
+}
+
+function AppCard(props: {
+  app: AppSummary;
+  onOpen: () => void;
+  onDelete: () => void;
+}) {
+  const { app } = props;
+  return (
+    <div className={styles.card}>
+      <button type="button" className={styles.cardMain} onClick={props.onOpen}>
+        <div className={styles.cardGlyph} aria-hidden="true">
+          {categoryGlyph(app.category)}
+        </div>
+        <div className={styles.cardBody}>
+          <span className={styles.cardTitle}>{app.title}</span>
+          {app.description ? (
+            <span className={styles.cardDesc}>{app.description}</span>
+          ) : null}
+        </div>
+        <div className={styles.cardMeta}>
+          <span className={styles.cardCategory}>
+            {categoryLabel(app.category)}
+          </span>
+          <span className={styles.cardDot}>·</span>
+          <span>{formatRelativeTime(app.createdAt)}</span>
+          <span className={styles.cardDot}>·</span>
+          <span>{app.visibility === 'public' ? 'Public' : 'Private'}</span>
+        </div>
+      </button>
+      <button
+        type="button"
+        className={styles.cardDelete}
+        aria-label={`Delete ${app.title}`}
+        title="Delete"
+        onClick={props.onDelete}
+      >
+        <Trash className={styles.cardDeleteIcon} />
+      </button>
+    </div>
+  );
+}
+
+function NewAppDialog(props: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  seedPrompt: string;
+  seedCategory: AppCategory | null;
+  isGenerating: boolean;
+  onSubmit: (description: string, category: AppCategory) => void;
+}) {
+  const [category, setCategory] = useState<AppCategory | null>(null);
+  const [description, setDescription] = useState('');
+
+  // Reset / seed each time the dialog opens.
+  useEffect(() => {
+    if (!props.open) return;
+    setCategory(props.seedCategory);
+    setDescription(props.seedPrompt);
+  }, [props.open, props.seedCategory, props.seedPrompt]);
+
+  const activeCategory = category ? CATEGORY_BY_SLUG.get(category) : undefined;
+
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent className={styles.newDialog}>
+        {category === null ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Create a new app</DialogTitle>
+              <DialogDescription>
+                Pick a category to get started, or start from scratch with your
+                own idea.
+              </DialogDescription>
+            </DialogHeader>
+            <div className={styles.categoryGrid}>
+              {CATEGORIES.map((meta) => (
+                <button
+                  key={meta.slug}
+                  type="button"
+                  className={styles.categoryTile}
+                  onClick={() => setCategory(meta.slug)}
+                >
+                  <span className={styles.categoryGlyph} aria-hidden="true">
+                    {meta.glyph}
+                  </span>
+                  <span className={styles.categoryLabel}>{meta.label}</span>
+                  <span className={styles.categoryHint}>{meta.hint}</span>
+                </button>
+              ))}
+            </div>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>
+                {activeCategory?.glyph} {activeCategory?.label}
+              </DialogTitle>
+              <DialogDescription>
+                Describe what you want. HybridClaw builds a self-contained app
+                and saves it to your gallery.
+              </DialogDescription>
+            </DialogHeader>
+            <textarea
+              className={styles.promptInput}
+              value={description}
+              autoFocus
+              disabled={props.isGenerating}
+              placeholder="e.g. A pomodoro timer with a circular progress ring and sound when it finishes"
+              onChange={(e) => setDescription(e.target.value)}
+              rows={5}
+            />
+            <DialogFooter>
+              <button
+                type="button"
+                className={styles.secondaryButton}
+                disabled={props.isGenerating}
+                onClick={() => setCategory(null)}
+              >
+                ← Back
+              </button>
+              <Button
+                disabled={props.isGenerating || description.trim().length === 0}
+                onClick={() => props.onSubmit(description.trim(), category)}
+              >
+                {props.isGenerating ? 'Building…' : 'Build app'}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AppViewer(props: {
+  app: AppDetail | null;
+  token: string;
+  onClose: () => void;
+}) {
+  const { app } = props;
+  return (
+    <Dialog
+      open={app !== null}
+      onOpenChange={(open) => {
+        if (!open) props.onClose();
+      }}
+    >
+      <DialogContent className={styles.viewerDialog} aria-label="App preview">
+        <div className={styles.viewerHeader}>
+          <DialogTitle className={styles.viewerTitle}>{app?.title}</DialogTitle>
+          <div className={styles.viewerActions}>
+            {app ? (
+              <a
+                className={styles.secondaryButton}
+                href={appViewUrl(app.id, props.token)}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Open in new tab ↗
+              </a>
+            ) : null}
+            <DialogClose className={styles.secondaryButton}>Close</DialogClose>
+          </div>
+        </div>
+        {app ? (
+          <iframe
+            key={app.id}
+            className={styles.viewerFrame}
+            title={app.title}
+            src={appViewUrl(app.id, props.token)}
+            // AI-generated HTML is served from the gateway origin, so it runs in
+            // an opaque sandbox origin (no allow-same-origin) and cannot reach
+            // gateway cookies or APIs.
+            sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads allow-popups-to-escape-sandbox"
+          />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/console/src/routes/apps.tsx
+++ b/console/src/routes/apps.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import {
   type AppCategory,
   type AppDetail,
+  type AppKind,
   type AppSummary,
   appViewUrl,
   deleteApp,
@@ -30,12 +31,12 @@ import {
 import { ChevronDown, Search, Trash } from '../components/icons';
 import { MobileTopbarTrigger } from '../components/sidebar/index';
 import { useToast } from '../components/toast';
-import { buildAppSeed } from '../lib/app-seed';
+import { buildAppSeed, buildLiveAppSeed } from '../lib/app-seed';
 import { getErrorMessage } from '../lib/error-message';
 import { formatRelativeTime } from '../lib/format';
 import styles from './apps.module.css';
 import { AppsChatSidebar } from './apps-chat-sidebar';
-import { CategoryIcon } from './apps-icons';
+import { CategoryIcon, RefreshIcon as Refresh } from './apps-icons';
 import chatCss from './chat/chat-page.module.css';
 import { ChatSidebarProvider } from './chat/chat-sidebar';
 
@@ -140,7 +141,7 @@ export function AppsPage() {
   const [categoryFilter, setCategoryFilter] = useState<'all' | AppCategory>(
     'all',
   );
-  const [newOpen, setNewOpen] = useState(false);
+  const [newKind, setNewKind] = useState<AppKind | null>(null);
   const [viewer, setViewer] = useState<AppDetail | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<AppSummary | null>(null);
 
@@ -150,18 +151,51 @@ export function AppsPage() {
     retry: false,
   });
 
-  // Selecting a category starts an app-building conversation in chat, seeded
-  // with the category and any idea the user typed.
-  function startBuild(category: AppCategory, description: string) {
+  // Starting a build opens a chat conversation seeded for the chosen kind:
+  // web apps are category-driven; live apps inspect the user's connectors first.
+  function startWebBuild(category: AppCategory, description: string) {
     const seedNoun = CATEGORY_BY_SLUG.get(category)?.seedNoun ?? null;
-    setNewOpen(false);
+    setNewKind(null);
     void navigate({
       to: '/chat',
       search: {
         prompt: buildAppSeed(seedNoun, description),
         send: '1',
         app: '1',
+        kind: 'web',
         ...(category !== 'scratch' ? { category } : {}),
+      },
+    });
+  }
+
+  function startLiveBuild(description: string) {
+    setNewKind(null);
+    void navigate({
+      to: '/chat',
+      search: {
+        prompt: buildLiveAppSeed(description),
+        send: '1',
+        app: '1',
+        kind: 'live',
+      },
+    });
+  }
+
+  function refreshApp(app: AppSummary) {
+    if (!app.sessionId) {
+      toast.error('This app has no conversation to refresh.');
+      return;
+    }
+    setViewer(null);
+    void navigate({
+      to: '/chat/$sessionId',
+      params: { sessionId: app.sessionId },
+      search: {
+        prompt:
+          'Refresh this live app with the latest data from my connectors and rebuild it as a single self-contained web app.',
+        send: '1',
+        app: '1',
+        kind: 'live',
       },
     });
   }
@@ -219,7 +253,30 @@ export function AppsPage() {
                   <MobileTopbarTrigger className={styles.mobileTrigger} />
                   <h1 className={styles.title}>Apps</h1>
                 </div>
-                <Button onClick={() => setNewOpen(true)}>+ New app</Button>
+                <Dropdown>
+                  <DropdownTrigger className={styles.newAppTrigger}>
+                    + New app
+                    <ChevronDown aria-hidden="true" />
+                  </DropdownTrigger>
+                  <DropdownContent align="end">
+                    <DropdownItem onSelect={() => setNewKind('web')}>
+                      <span className={styles.newAppItem}>
+                        <span className={styles.newAppItemTitle}>Web app</span>
+                        <span className={styles.newAppItemHint}>
+                          Self-contained app, document, game, or tool
+                        </span>
+                      </span>
+                    </DropdownItem>
+                    <DropdownItem onSelect={() => setNewKind('live')}>
+                      <span className={styles.newAppItem}>
+                        <span className={styles.newAppItemTitle}>Live app</span>
+                        <span className={styles.newAppItemHint}>
+                          Uses your connectors and can be refreshed
+                        </span>
+                      </span>
+                    </DropdownItem>
+                  </DropdownContent>
+                </Dropdown>
               </header>
 
               <div className={styles.toolbar}>
@@ -270,7 +327,7 @@ export function AppsPage() {
               ) : filtered.length === 0 ? (
                 <EmptyState
                   hasApps={apps.length > 0}
-                  onCreate={() => setNewOpen(true)}
+                  onCreate={() => setNewKind('web')}
                 />
               ) : (
                 <ul className={styles.grid}>
@@ -280,6 +337,7 @@ export function AppsPage() {
                         app={app}
                         onOpen={() => openApp(app)}
                         onDelete={() => setConfirmDelete(app)}
+                        onRefresh={() => refreshApp(app)}
                       />
                     </li>
                   ))}
@@ -291,12 +349,18 @@ export function AppsPage() {
       </div>
 
       <NewAppDialog
-        open={newOpen}
-        onOpenChange={setNewOpen}
-        onStart={startBuild}
+        kind={newKind}
+        onClose={() => setNewKind(null)}
+        onStartWeb={startWebBuild}
+        onStartLive={startLiveBuild}
       />
 
-      <AppViewer app={viewer} token={token} onClose={() => setViewer(null)} />
+      <AppViewer
+        app={viewer}
+        token={token}
+        onClose={() => setViewer(null)}
+        onRefresh={viewer ? () => refreshApp(viewer) : undefined}
+      />
 
       <Dialog
         open={confirmDelete !== null}
@@ -355,13 +419,23 @@ function AppCard(props: {
   app: AppSummary;
   onOpen: () => void;
   onDelete: () => void;
+  onRefresh: () => void;
 }) {
   const { app } = props;
+  const isLive = app.kind === 'live';
   return (
     <div className={styles.card}>
       <button type="button" className={styles.cardMain} onClick={props.onOpen}>
-        <div className={styles.cardGlyph} aria-hidden="true">
-          <CategoryIcon category={app.category} />
+        <div className={styles.cardTop}>
+          <div className={styles.cardGlyph} aria-hidden="true">
+            <CategoryIcon category={app.category} />
+          </div>
+          <span
+            className={isLive ? styles.kindBadgeLive : styles.kindBadge}
+            title={isLive ? 'Connector-aware, refreshable' : undefined}
+          >
+            {isLive ? 'Live' : 'Web'}
+          </span>
         </div>
         <div className={styles.cardBody}>
           <span className={styles.cardTitle}>{app.title}</span>
@@ -379,43 +453,65 @@ function AppCard(props: {
           <span>{app.visibility === 'public' ? 'Public' : 'Private'}</span>
         </div>
       </button>
-      <button
-        type="button"
-        className={styles.cardDelete}
-        aria-label={`Delete ${app.title}`}
-        title="Delete"
-        onClick={props.onDelete}
-      >
-        <Trash className={styles.cardDeleteIcon} />
-      </button>
+      <div className={styles.cardActions}>
+        {isLive ? (
+          <button
+            type="button"
+            className={styles.cardAction}
+            aria-label={`Refresh ${app.title}`}
+            title="Refresh with latest data"
+            onClick={props.onRefresh}
+          >
+            <Refresh className={styles.cardActionIcon} />
+          </button>
+        ) : null}
+        <button
+          type="button"
+          className={styles.cardAction}
+          aria-label={`Delete ${app.title}`}
+          title="Delete"
+          onClick={props.onDelete}
+        >
+          <Trash className={styles.cardActionIcon} />
+        </button>
+      </div>
     </div>
   );
 }
 
 function NewAppDialog(props: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onStart: (category: AppCategory, description: string) => void;
+  kind: AppKind | null;
+  onClose: () => void;
+  onStartWeb: (category: AppCategory, description: string) => void;
+  onStartLive: (description: string) => void;
 }) {
   const [category, setCategory] = useState<AppCategory | null>(null);
   const [description, setDescription] = useState('');
+  const open = props.kind !== null;
 
   // Reset each time the dialog opens.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset on open/kind change
   useEffect(() => {
-    if (!props.open) return;
+    if (!open) return;
     setCategory(null);
     setDescription('');
-  }, [props.open]);
+  }, [open, props.kind]);
 
   const activeCategory = category ? CATEGORY_BY_SLUG.get(category) : undefined;
+  const showCategoryGrid = props.kind === 'web' && category === null;
 
   return (
-    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) props.onClose();
+      }}
+    >
       <DialogContent className={styles.newDialog}>
-        {category === null ? (
+        {showCategoryGrid ? (
           <>
             <DialogHeader>
-              <DialogTitle>Create a new app</DialogTitle>
+              <DialogTitle>Create a web app</DialogTitle>
               <DialogDescription>
                 Pick a category to get started, or start from scratch with your
                 own idea.
@@ -438,7 +534,38 @@ function NewAppDialog(props: {
               ))}
             </div>
           </>
-        ) : (
+        ) : props.kind === 'live' ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Create a live app</DialogTitle>
+              <DialogDescription>
+                HybridClaw checks your connected tools (MCP), suggests apps that
+                use them, then builds one you can refresh. Add a starting idea
+                (optional).
+              </DialogDescription>
+            </DialogHeader>
+            <textarea
+              className={styles.promptInput}
+              value={description}
+              autoFocus
+              placeholder="e.g. A dashboard of my upcoming meetings and unread priority emails"
+              onChange={(e) => setDescription(e.target.value)}
+              rows={4}
+            />
+            <DialogFooter>
+              <button
+                type="button"
+                className={styles.secondaryButton}
+                onClick={props.onClose}
+              >
+                Cancel
+              </button>
+              <Button onClick={() => props.onStartLive(description.trim())}>
+                Start building →
+              </Button>
+            </DialogFooter>
+          </>
+        ) : category ? (
           <>
             <DialogHeader>
               <DialogTitle>
@@ -486,13 +613,13 @@ function NewAppDialog(props: {
                 ← Back
               </button>
               <Button
-                onClick={() => props.onStart(category, description.trim())}
+                onClick={() => props.onStartWeb(category, description.trim())}
               >
                 Start building →
               </Button>
             </DialogFooter>
           </>
-        )}
+        ) : null}
       </DialogContent>
     </Dialog>
   );
@@ -502,6 +629,7 @@ function AppViewer(props: {
   app: AppDetail | null;
   token: string;
   onClose: () => void;
+  onRefresh?: () => void;
 }) {
   const { app } = props;
   return (
@@ -515,6 +643,15 @@ function AppViewer(props: {
         <div className={styles.viewerHeader}>
           <DialogTitle className={styles.viewerTitle}>{app?.title}</DialogTitle>
           <div className={styles.viewerActions}>
+            {app && app.kind === 'live' && props.onRefresh ? (
+              <button
+                type="button"
+                className={styles.secondaryButton}
+                onClick={props.onRefresh}
+              >
+                <Refresh className={styles.inlineIcon} /> Refresh
+              </button>
+            ) : null}
             {app ? (
               <a
                 className={styles.secondaryButton}

--- a/console/src/routes/apps.tsx
+++ b/console/src/routes/apps.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useNavigate, useSearch } from '@tanstack/react-router';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { useEffect, useMemo, useState } from 'react';
 import {
   type AppCategory,
   type AppDetail,
@@ -9,7 +9,6 @@ import {
   deleteApp,
   fetchApp,
   fetchApps,
-  generateApp,
 } from '../api/apps';
 import { useAuth } from '../auth';
 import { Button } from '../components/button';
@@ -31,6 +30,7 @@ import {
 import { ChevronDown, Search, Trash } from '../components/icons';
 import { MobileTopbarTrigger } from '../components/sidebar/index';
 import { useToast } from '../components/toast';
+import { buildAppSeed } from '../lib/app-seed';
 import { getErrorMessage } from '../lib/error-message';
 import { formatRelativeTime } from '../lib/format';
 import styles from './apps.module.css';
@@ -43,6 +43,8 @@ interface CategoryMeta {
   slug: AppCategory;
   label: string;
   hint: string;
+  /** Noun phrase used to seed the build conversation; null = freeform. */
+  seedNoun: string | null;
   examples: string[];
 }
 
@@ -51,6 +53,7 @@ const CATEGORIES: CategoryMeta[] = [
     slug: 'apps',
     label: 'Apps & websites',
     hint: 'Internal tools, portals, landing pages',
+    seedNoun: 'web app or website',
     examples: [
       'A client onboarding portal with step-by-step progress',
       'A SaaS pricing page with a monthly/annual toggle',
@@ -61,6 +64,7 @@ const CATEGORIES: CategoryMeta[] = [
     slug: 'documents',
     label: 'Documents & templates',
     hint: 'Proposals, reports, printable templates',
+    seedNoun: 'document or template',
     examples: [
       'A consulting invoice with line items and totals',
       'A quarterly business review one-pager',
@@ -71,6 +75,7 @@ const CATEGORIES: CategoryMeta[] = [
     slug: 'games',
     label: 'Games',
     hint: 'Playable browser games',
+    seedNoun: 'browser game',
     examples: [
       'A product-knowledge quiz game for new hires',
       'A typing-speed trainer',
@@ -81,6 +86,7 @@ const CATEGORIES: CategoryMeta[] = [
     slug: 'productivity',
     label: 'Productivity tools',
     hint: 'Calculators, trackers, dashboards',
+    seedNoun: 'productivity tool',
     examples: [
       'A SaaS MRR and churn dashboard',
       'A meeting-cost calculator',
@@ -91,6 +97,7 @@ const CATEGORIES: CategoryMeta[] = [
     slug: 'creative',
     label: 'Creative projects',
     hint: 'Brand assets, mockups, visuals',
+    seedNoun: 'creative project',
     examples: [
       'A branded social media post mockup',
       'A pitch-deck cover slide',
@@ -101,6 +108,7 @@ const CATEGORIES: CategoryMeta[] = [
     slug: 'quiz',
     label: 'Quiz or survey',
     hint: 'Lead capture, feedback, assessments',
+    seedNoun: 'quiz or survey',
     examples: [
       'A lead-qualification survey with scoring',
       'An employee eNPS survey',
@@ -111,6 +119,7 @@ const CATEGORIES: CategoryMeta[] = [
     slug: 'scratch',
     label: 'Start from scratch',
     hint: 'Describe anything you can imagine',
+    seedNoun: null,
     examples: [],
   },
 ];
@@ -126,20 +135,12 @@ export function AppsPage() {
   const toast = useToast();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const searchParams = useSearch({ strict: false }) as {
-    build?: string;
-    prompt?: string;
-    category?: string;
-  };
-  const deepLinkHandled = useRef(false);
 
   const [search, setSearch] = useState('');
   const [categoryFilter, setCategoryFilter] = useState<'all' | AppCategory>(
     'all',
   );
   const [newOpen, setNewOpen] = useState(false);
-  const [seedPrompt, setSeedPrompt] = useState('');
-  const [seedCategory, setSeedCategory] = useState<AppCategory | null>(null);
   const [viewer, setViewer] = useState<AppDetail | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<AppSummary | null>(null);
 
@@ -149,50 +150,16 @@ export function AppsPage() {
     retry: false,
   });
 
-  const generateMutation = useMutation({
-    mutationFn: (vars: { description: string; category: AppCategory }) =>
-      generateApp(token, {
-        description: vars.description,
-        category: vars.category,
-      }),
-    onSuccess: async (result) => {
-      await queryClient.invalidateQueries({ queryKey: ['apps'] });
-      setNewOpen(false);
-      setSeedPrompt('');
-      setSeedCategory(null);
-      toast.success(`Built “${result.app.title}”.`);
-      setViewer(result.app);
-    },
-    onError: (error) => {
-      toast.error(`Build failed: ${getErrorMessage(error)}`);
-    },
-  });
-
-  // Deep-link from the chat "/app <description>" slash command:
-  // /apps?build=1&prompt=...&category=... immediately builds the app. Without
-  // `build`, a `prompt` just pre-fills the builder dialog.
-  useEffect(() => {
-    if (deepLinkHandled.current) return;
-    const prompt = searchParams.prompt?.trim();
-    if (!prompt && searchParams.build !== '1') return;
-    deepLinkHandled.current = true;
-    const category =
-      searchParams.category &&
-      CATEGORY_BY_SLUG.has(searchParams.category as AppCategory)
-        ? (searchParams.category as AppCategory)
-        : 'scratch';
-    // Clear the params so a refresh doesn't rebuild.
-    void navigate({ to: '/apps', replace: true });
-    if (searchParams.build === '1' && prompt) {
-      generateMutation.mutate({ description: prompt, category });
-      return;
-    }
-    if (prompt) {
-      setSeedPrompt(prompt);
-      setSeedCategory(category);
-      setNewOpen(true);
-    }
-  }, [searchParams, navigate, generateMutation]);
+  // Selecting a category starts an app-building conversation in chat, seeded
+  // with the category and any idea the user typed.
+  function startBuild(category: AppCategory, description: string) {
+    const seedNoun = CATEGORY_BY_SLUG.get(category)?.seedNoun ?? null;
+    setNewOpen(false);
+    void navigate({
+      to: '/chat',
+      search: { prompt: buildAppSeed(seedNoun, description), send: '1' },
+    });
+  }
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => deleteApp(token, id),
@@ -247,15 +214,7 @@ export function AppsPage() {
                   <MobileTopbarTrigger className={styles.mobileTrigger} />
                   <h1 className={styles.title}>Apps</h1>
                 </div>
-                <Button
-                  onClick={() => {
-                    setSeedPrompt('');
-                    setSeedCategory(null);
-                    setNewOpen(true);
-                  }}
-                >
-                  + New app
-                </Button>
+                <Button onClick={() => setNewOpen(true)}>+ New app</Button>
               </header>
 
               <div className={styles.toolbar}>
@@ -297,13 +256,6 @@ export function AppsPage() {
                 </Dropdown>
               </div>
 
-              {generateMutation.isPending && !newOpen ? (
-                <div className={styles.buildingBanner} role="status">
-                  <span className={styles.buildingSpinner} aria-hidden="true" />
-                  Building your app… this can take a moment.
-                </div>
-              ) : null}
-
               {query.isPending ? (
                 <div className="empty-state">Loading apps…</div>
               ) : query.isError ? (
@@ -335,15 +287,8 @@ export function AppsPage() {
 
       <NewAppDialog
         open={newOpen}
-        onOpenChange={(open) => {
-          if (!generateMutation.isPending) setNewOpen(open);
-        }}
-        seedPrompt={seedPrompt}
-        seedCategory={seedCategory}
-        isGenerating={generateMutation.isPending}
-        onSubmit={(description, category) =>
-          generateMutation.mutate({ description, category })
-        }
+        onOpenChange={setNewOpen}
+        onStart={startBuild}
       />
 
       <AppViewer app={viewer} token={token} onClose={() => setViewer(null)} />
@@ -445,20 +390,17 @@ function AppCard(props: {
 function NewAppDialog(props: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  seedPrompt: string;
-  seedCategory: AppCategory | null;
-  isGenerating: boolean;
-  onSubmit: (description: string, category: AppCategory) => void;
+  onStart: (category: AppCategory, description: string) => void;
 }) {
   const [category, setCategory] = useState<AppCategory | null>(null);
   const [description, setDescription] = useState('');
 
-  // Reset / seed each time the dialog opens.
+  // Reset each time the dialog opens.
   useEffect(() => {
     if (!props.open) return;
-    setCategory(props.seedCategory);
-    setDescription(props.seedPrompt);
-  }, [props.open, props.seedCategory, props.seedPrompt]);
+    setCategory(null);
+    setDescription('');
+  }, [props.open]);
 
   const activeCategory = category ? CATEGORY_BY_SLUG.get(category) : undefined;
 
@@ -501,18 +443,17 @@ function NewAppDialog(props: {
                 {activeCategory?.label}
               </DialogTitle>
               <DialogDescription>
-                Describe what you want. HybridClaw builds a self-contained app
-                and saves it to your gallery.
+                Add a starting idea (optional). HybridClaw opens a chat, asks a
+                few questions, then builds it for you.
               </DialogDescription>
             </DialogHeader>
             <textarea
               className={styles.promptInput}
               value={description}
               autoFocus
-              disabled={props.isGenerating}
               placeholder="e.g. A client onboarding portal that tracks setup steps and shows progress"
               onChange={(e) => setDescription(e.target.value)}
-              rows={5}
+              rows={4}
             />
             {activeCategory && activeCategory.examples.length > 0 ? (
               <div className={styles.examples}>
@@ -523,7 +464,6 @@ function NewAppDialog(props: {
                       key={example}
                       type="button"
                       className={styles.exampleChip}
-                      disabled={props.isGenerating}
                       onClick={() => setDescription(example)}
                     >
                       {example}
@@ -536,16 +476,14 @@ function NewAppDialog(props: {
               <button
                 type="button"
                 className={styles.secondaryButton}
-                disabled={props.isGenerating}
                 onClick={() => setCategory(null)}
               >
                 ← Back
               </button>
               <Button
-                disabled={props.isGenerating || description.trim().length === 0}
-                onClick={() => props.onSubmit(description.trim(), category)}
+                onClick={() => props.onStart(category, description.trim())}
               >
-                {props.isGenerating ? 'Building…' : 'Build app'}
+                Start building →
               </Button>
             </DialogFooter>
           </>

--- a/console/src/routes/apps.tsx
+++ b/console/src/routes/apps.tsx
@@ -29,60 +29,89 @@ import {
   DropdownTrigger,
 } from '../components/dropdown';
 import { ChevronDown, Search, Trash } from '../components/icons';
+import { MobileTopbarTrigger } from '../components/sidebar/index';
 import { useToast } from '../components/toast';
 import { getErrorMessage } from '../lib/error-message';
 import { formatRelativeTime } from '../lib/format';
 import styles from './apps.module.css';
+import { AppsChatSidebar } from './apps-chat-sidebar';
+import { CategoryIcon } from './apps-icons';
+import chatCss from './chat/chat-page.module.css';
+import { ChatSidebarProvider } from './chat/chat-sidebar';
 
 interface CategoryMeta {
   slug: AppCategory;
   label: string;
   hint: string;
-  glyph: string;
+  examples: string[];
 }
 
 const CATEGORIES: CategoryMeta[] = [
   {
     slug: 'apps',
-    label: 'Apps & Websites',
-    hint: 'Interactive web apps and landing pages',
-    glyph: '🌐',
+    label: 'Apps & websites',
+    hint: 'Internal tools, portals, landing pages',
+    examples: [
+      'A client onboarding portal with step-by-step progress',
+      'A SaaS pricing page with a monthly/annual toggle',
+      'An internal team directory with search',
+    ],
   },
   {
     slug: 'documents',
-    label: 'Documents & Templates',
-    hint: 'Reports, docs, printable templates',
-    glyph: '📄',
+    label: 'Documents & templates',
+    hint: 'Proposals, reports, printable templates',
+    examples: [
+      'A consulting invoice with line items and totals',
+      'A quarterly business review one-pager',
+      'A statement-of-work proposal template',
+    ],
   },
   {
     slug: 'games',
     label: 'Games',
     hint: 'Playable browser games',
-    glyph: '🎮',
+    examples: [
+      'A product-knowledge quiz game for new hires',
+      'A typing-speed trainer',
+      'A memory match game',
+    ],
   },
   {
     slug: 'productivity',
-    label: 'Productivity Tools',
+    label: 'Productivity tools',
     hint: 'Calculators, trackers, dashboards',
-    glyph: '⚡',
+    examples: [
+      'A SaaS MRR and churn dashboard',
+      'A meeting-cost calculator',
+      'A project ROI calculator',
+    ],
   },
   {
     slug: 'creative',
-    label: 'Creative Projects',
-    hint: 'Visual, generative, artistic pieces',
-    glyph: '🎨',
+    label: 'Creative projects',
+    hint: 'Brand assets, mockups, visuals',
+    examples: [
+      'A branded social media post mockup',
+      'A pitch-deck cover slide',
+      'A simple drawing canvas',
+    ],
   },
   {
     slug: 'quiz',
-    label: 'Quiz or Survey',
-    hint: 'Quizzes, surveys, interactive forms',
-    glyph: '📝',
+    label: 'Quiz or survey',
+    hint: 'Lead capture, feedback, assessments',
+    examples: [
+      'A lead-qualification survey with scoring',
+      'An employee eNPS survey',
+      'A customer CSAT form',
+    ],
   },
   {
     slug: 'scratch',
     label: 'Start from scratch',
     hint: 'Describe anything you can imagine',
-    glyph: '✨',
+    examples: [],
   },
 ];
 
@@ -90,10 +119,6 @@ const CATEGORY_BY_SLUG = new Map(CATEGORIES.map((c) => [c.slug, c]));
 
 function categoryLabel(slug: string): string {
   return CATEGORY_BY_SLUG.get(slug as AppCategory)?.label ?? 'App';
-}
-
-function categoryGlyph(slug: string): string {
-  return CATEGORY_BY_SLUG.get(slug as AppCategory)?.glyph ?? '🌐';
 }
 
 export function AppsPage() {
@@ -211,99 +236,102 @@ export function AppsPage() {
     categoryFilter === 'all' ? 'All' : categoryLabel(categoryFilter);
 
   return (
-    <div className={styles.page}>
-      <header className={styles.topbar}>
-        <div className={styles.topbarLeft}>
-          <button
-            type="button"
-            className={styles.backLink}
-            onClick={() => navigate({ to: '/chat' })}
-          >
-            ← Chat
-          </button>
-          <h1 className={styles.title}>Apps</h1>
-        </div>
-        <Button
-          onClick={() => {
-            setSeedPrompt('');
-            setSeedCategory(null);
-            setNewOpen(true);
-          }}
-        >
-          + New App
-        </Button>
-      </header>
+    <ChatSidebarProvider>
+      <div className={chatCss.chatPage}>
+        <AppsChatSidebar />
+        <div className={chatCss.chatMain}>
+          <div className={styles.scroll}>
+            <div className={styles.page}>
+              <header className={styles.topbar}>
+                <div className={styles.topbarLeft}>
+                  <MobileTopbarTrigger className={styles.mobileTrigger} />
+                  <h1 className={styles.title}>Apps</h1>
+                </div>
+                <Button
+                  onClick={() => {
+                    setSeedPrompt('');
+                    setSeedCategory(null);
+                    setNewOpen(true);
+                  }}
+                >
+                  + New app
+                </Button>
+              </header>
 
-      <div className={styles.toolbar}>
-        <div className={styles.searchWrap}>
-          <Search className={styles.searchIcon} aria-hidden="true" />
-          <input
-            type="search"
-            className={styles.searchInput}
-            placeholder="Search apps…"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            aria-label="Search apps"
-          />
+              <div className={styles.toolbar}>
+                <div className={styles.searchWrap}>
+                  <Search className={styles.searchIcon} aria-hidden="true" />
+                  <input
+                    type="search"
+                    className={styles.searchInput}
+                    placeholder="Search apps…"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    aria-label="Search apps"
+                  />
+                </div>
+                <Dropdown>
+                  <DropdownTrigger className={styles.filterTrigger}>
+                    <span>
+                      Filter: <strong>{filterLabel}</strong>
+                    </span>
+                    <ChevronDown aria-hidden="true" />
+                  </DropdownTrigger>
+                  <DropdownContent align="end">
+                    <DropdownItem
+                      active={categoryFilter === 'all'}
+                      onSelect={() => setCategoryFilter('all')}
+                    >
+                      All
+                    </DropdownItem>
+                    {CATEGORIES.map((category) => (
+                      <DropdownItem
+                        key={category.slug}
+                        active={categoryFilter === category.slug}
+                        onSelect={() => setCategoryFilter(category.slug)}
+                      >
+                        {category.label}
+                      </DropdownItem>
+                    ))}
+                  </DropdownContent>
+                </Dropdown>
+              </div>
+
+              {generateMutation.isPending && !newOpen ? (
+                <div className={styles.buildingBanner} role="status">
+                  <span className={styles.buildingSpinner} aria-hidden="true" />
+                  Building your app… this can take a moment.
+                </div>
+              ) : null}
+
+              {query.isPending ? (
+                <div className="empty-state">Loading apps…</div>
+              ) : query.isError ? (
+                <div className="empty-state">
+                  Failed to load apps: {getErrorMessage(query.error)}
+                </div>
+              ) : filtered.length === 0 ? (
+                <EmptyState
+                  hasApps={apps.length > 0}
+                  onCreate={() => setNewOpen(true)}
+                />
+              ) : (
+                <ul className={styles.grid}>
+                  {filtered.map((app) => (
+                    <li key={app.id}>
+                      <AppCard
+                        app={app}
+                        onOpen={() => openApp(app)}
+                        onDelete={() => setConfirmDelete(app)}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
         </div>
-        <Dropdown>
-          <DropdownTrigger className={styles.filterTrigger}>
-            <span>
-              Filter: <strong>{filterLabel}</strong>
-            </span>
-            <ChevronDown aria-hidden="true" />
-          </DropdownTrigger>
-          <DropdownContent align="end">
-            <DropdownItem
-              active={categoryFilter === 'all'}
-              onSelect={() => setCategoryFilter('all')}
-            >
-              All
-            </DropdownItem>
-            {CATEGORIES.map((category) => (
-              <DropdownItem
-                key={category.slug}
-                active={categoryFilter === category.slug}
-                onSelect={() => setCategoryFilter(category.slug)}
-              >
-                {category.glyph} {category.label}
-              </DropdownItem>
-            ))}
-          </DropdownContent>
-        </Dropdown>
       </div>
-
-      {generateMutation.isPending && !newOpen ? (
-        <div className={styles.buildingBanner} role="status">
-          <span className={styles.buildingSpinner} aria-hidden="true" />
-          Building your app… this can take a moment.
-        </div>
-      ) : null}
-
-      {query.isPending ? (
-        <div className="empty-state">Loading apps…</div>
-      ) : query.isError ? (
-        <div className="empty-state">
-          Failed to load apps: {getErrorMessage(query.error)}
-        </div>
-      ) : filtered.length === 0 ? (
-        <EmptyState
-          hasApps={apps.length > 0}
-          onCreate={() => setNewOpen(true)}
-        />
-      ) : (
-        <ul className={styles.grid}>
-          {filtered.map((app) => (
-            <li key={app.id}>
-              <AppCard
-                app={app}
-                onOpen={() => openApp(app)}
-                onDelete={() => setConfirmDelete(app)}
-              />
-            </li>
-          ))}
-        </ul>
-      )}
 
       <NewAppDialog
         open={newOpen}
@@ -348,7 +376,7 @@ export function AppsPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </ChatSidebarProvider>
   );
 }
 
@@ -356,7 +384,7 @@ function EmptyState(props: { hasApps: boolean; onCreate: () => void }) {
   return (
     <div className={styles.empty}>
       <div className={styles.emptyGlyph} aria-hidden="true">
-        ✨
+        <CategoryIcon category="scratch" />
       </div>
       <h2 className={styles.emptyTitle}>
         {props.hasApps ? 'No matching apps' : 'No apps yet'}
@@ -364,10 +392,10 @@ function EmptyState(props: { hasApps: boolean; onCreate: () => void }) {
       <p className={styles.emptyText}>
         {props.hasApps
           ? 'Try a different search or filter.'
-          : 'Describe an app, document, game, or tool and HybridClaw builds it for you.'}
+          : 'Describe an app, document, tool, or report and HybridClaw builds it for you.'}
       </p>
       {!props.hasApps ? (
-        <Button onClick={props.onCreate}>+ New App</Button>
+        <Button onClick={props.onCreate}>+ New app</Button>
       ) : null}
     </div>
   );
@@ -383,7 +411,7 @@ function AppCard(props: {
     <div className={styles.card}>
       <button type="button" className={styles.cardMain} onClick={props.onOpen}>
         <div className={styles.cardGlyph} aria-hidden="true">
-          {categoryGlyph(app.category)}
+          <CategoryIcon category={app.category} />
         </div>
         <div className={styles.cardBody}>
           <span className={styles.cardTitle}>{app.title}</span>
@@ -455,7 +483,7 @@ function NewAppDialog(props: {
                   onClick={() => setCategory(meta.slug)}
                 >
                   <span className={styles.categoryGlyph} aria-hidden="true">
-                    {meta.glyph}
+                    <CategoryIcon category={meta.slug} />
                   </span>
                   <span className={styles.categoryLabel}>{meta.label}</span>
                   <span className={styles.categoryHint}>{meta.hint}</span>
@@ -467,7 +495,10 @@ function NewAppDialog(props: {
           <>
             <DialogHeader>
               <DialogTitle>
-                {activeCategory?.glyph} {activeCategory?.label}
+                <span className={styles.dialogTitleIcon} aria-hidden="true">
+                  <CategoryIcon category={category} />
+                </span>
+                {activeCategory?.label}
               </DialogTitle>
               <DialogDescription>
                 Describe what you want. HybridClaw builds a self-contained app
@@ -479,10 +510,28 @@ function NewAppDialog(props: {
               value={description}
               autoFocus
               disabled={props.isGenerating}
-              placeholder="e.g. A pomodoro timer with a circular progress ring and sound when it finishes"
+              placeholder="e.g. A client onboarding portal that tracks setup steps and shows progress"
               onChange={(e) => setDescription(e.target.value)}
               rows={5}
             />
+            {activeCategory && activeCategory.examples.length > 0 ? (
+              <div className={styles.examples}>
+                <span className={styles.examplesLabel}>Examples</span>
+                <div className={styles.exampleChips}>
+                  {activeCategory.examples.map((example) => (
+                    <button
+                      key={example}
+                      type="button"
+                      className={styles.exampleChip}
+                      disabled={props.isGenerating}
+                      onClick={() => setDescription(example)}
+                    >
+                      {example}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : null}
             <DialogFooter>
               <button
                 type="button"

--- a/console/src/routes/apps.tsx
+++ b/console/src/routes/apps.tsx
@@ -157,7 +157,12 @@ export function AppsPage() {
     setNewOpen(false);
     void navigate({
       to: '/chat',
-      search: { prompt: buildAppSeed(seedNoun, description), send: '1' },
+      search: {
+        prompt: buildAppSeed(seedNoun, description),
+        send: '1',
+        app: '1',
+        ...(category !== 'scratch' ? { category } : {}),
+      },
     });
   }
 

--- a/console/src/routes/chat/__test-utils/router-mock.ts
+++ b/console/src/routes/chat/__test-utils/router-mock.ts
@@ -11,6 +11,7 @@ export interface TestRouter {
 export interface RouterMockModule {
   useNavigate: () => TestRouter['navigate'];
   useParams: () => { sessionId: string | null };
+  useSearch: () => Record<string, string | undefined>;
   __testRouter: TestRouter;
 }
 
@@ -65,6 +66,8 @@ export async function createRouterMock(
   };
   return {
     useNavigate: () => navigate,
+    useSearch: () =>
+      Object.fromEntries(new URLSearchParams(window.location.search)),
     useParams: () =>
       React.useSyncExternalStore(
         (cb) => {

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -89,6 +89,66 @@
   height: 18px;
 }
 
+.appPreviewDialog {
+  width: min(1100px, 95vw);
+  max-width: min(1100px, 95vw);
+  height: 86vh;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+
+.appPreviewHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.appPreviewTitle {
+  font-size: 1rem;
+  font-weight: 650;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.appPreviewActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.appPreviewLink {
+  display: inline-flex;
+  align-items: center;
+  padding: 7px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--card);
+  color: var(--foreground);
+  font-size: 0.8125rem;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.appPreviewLink:hover {
+  border-color: var(--border-strong);
+  background: var(--chat-hover-bg);
+}
+
+.appPreviewFrame {
+  flex: 1;
+  width: 100%;
+  border: none;
+  background: #fff;
+}
+
 .sidebarLabel {
   margin: 12px 0 4px;
   padding: 0 6px;

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -79,6 +79,16 @@
   justify-content: center;
 }
 
+.navLinkIcon {
+  align-items: center;
+  color: var(--muted-foreground);
+}
+
+.navLinkIcon svg {
+  width: 18px;
+  height: 18px;
+}
+
 .sidebarLabel {
   margin: 12px 0 4px;
   padding: 0 6px;

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -143,6 +143,34 @@ function chatContextQueryKey(token: string, sessionId: string) {
   return ['chat-context', token, sessionId] as const;
 }
 
+type AppBuildSessionInfo = { category?: string; kind?: 'web' | 'live' };
+const APP_BUILD_SESSIONS_KEY = 'hybridclaw.appBuildSessions';
+
+// App-build session tags are persisted so follow-up build turns (and the
+// finished-build popup) keep working after a page reload.
+function loadAppBuildSessions(): Map<string, AppBuildSessionInfo> {
+  try {
+    const raw = localStorage.getItem(APP_BUILD_SESSIONS_KEY);
+    if (!raw) return new Map();
+    return new Map(
+      Object.entries(JSON.parse(raw) as Record<string, AppBuildSessionInfo>),
+    );
+  } catch {
+    return new Map();
+  }
+}
+
+function saveAppBuildSessions(map: Map<string, AppBuildSessionInfo>): void {
+  try {
+    localStorage.setItem(
+      APP_BUILD_SESSIONS_KEY,
+      JSON.stringify(Object.fromEntries(map)),
+    );
+  } catch {
+    // ignore storage failures (private mode, quota)
+  }
+}
+
 export function ChatPage() {
   const auth = useAuth();
   const navigate = useNavigate();
@@ -164,9 +192,15 @@ export function ChatPage() {
     };
   }, []);
   // Sessions started as app builds: each app-build turn is tagged so the
-  // gateway captures the produced HTML into the Apps gallery.
-  const appBuildSessionsRef = useRef(
-    new Map<string, { category?: string; kind?: 'web' | 'live' }>(),
+  // gateway captures the produced HTML into the Apps gallery. Persisted so a
+  // reload mid-conversation doesn't drop the tag.
+  const appBuildSessionsRef = useRef(loadAppBuildSessions());
+  const markAppBuildSession = useCallback(
+    (sessionId: string, info: AppBuildSessionInfo) => {
+      appBuildSessionsRef.current.set(sessionId, info);
+      saveAppBuildSessions(appBuildSessionsRef.current);
+    },
+    [],
   );
   const initialComposerPrompt = initialChatSeed.autoSend
     ? ''
@@ -829,7 +863,7 @@ export function ChatPage() {
           return;
         }
         const sid = ensureSessionForSend();
-        appBuildSessionsRef.current.set(sid, { kind: 'web' });
+        markAppBuildSession(sid, { kind: 'web' });
         jumpToBottom();
         void stream.sendMessage(buildAppSeed(null, description), [], {
           appBuild: true,
@@ -853,7 +887,13 @@ export function ChatPage() {
       }
       void stream.sendMessage(content, media);
     },
-    [ensureSessionForSend, jumpToBottom, navigate, stream.sendMessage],
+    [
+      ensureSessionForSend,
+      jumpToBottom,
+      navigate,
+      markAppBuildSession,
+      stream.sendMessage,
+    ],
   );
 
   // Auto-send a seeded conversation (Apps builder / `/app`): when arriving at
@@ -873,7 +913,7 @@ export function ChatPage() {
     window.history.replaceState(null, '', window.location.pathname);
     if (initialChatSeed.appBuild) {
       const sid = ensureSessionForSend();
-      appBuildSessionsRef.current.set(sid, {
+      markAppBuildSession(sid, {
         category: initialChatSeed.appCategory,
         kind: initialChatSeed.appKind,
       });
@@ -884,6 +924,7 @@ export function ChatPage() {
     chatApiReady,
     historyQuery.isFetched,
     ensureSessionForSend,
+    markAppBuildSession,
     handleSendMessage,
   ]);
 

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -154,8 +154,13 @@ export function ChatPage() {
     return {
       prompt: sp.get('prompt') || '',
       autoSend: sp.get('send') === '1',
+      appBuild: sp.get('app') === '1',
+      appCategory: sp.get('category') || undefined,
     };
   }, []);
+  // Sessions started as app builds: each app-build turn is tagged so the
+  // gateway captures the produced HTML into the Apps gallery.
+  const appBuildSessionsRef = useRef(new Map<string, string | undefined>());
   const initialComposerPrompt = initialChatSeed.autoSend
     ? ''
     : initialChatSeed.prompt;
@@ -808,16 +813,27 @@ export function ChatPage() {
           void navigate({ to: '/apps' });
           return;
         }
-        ensureSessionForSend();
+        const sid = ensureSessionForSend();
+        appBuildSessionsRef.current.set(sid, undefined);
         jumpToBottom();
-        void stream.sendMessage(buildAppSeed(null, description), []);
+        void stream.sendMessage(buildAppSeed(null, description), [], {
+          appBuild: true,
+        });
         return;
       }
-      ensureSessionForSend();
+      const sid = ensureSessionForSend();
       // Sending re-engages the user with the live conversation — snap back so
       // their bubble and the incoming stream are visible without the "↓ Latest"
       // chip getting in the way.
       jumpToBottom();
+      if (appBuildSessionsRef.current.has(sid)) {
+        const appCategory = appBuildSessionsRef.current.get(sid);
+        void stream.sendMessage(content, media, {
+          appBuild: true,
+          ...(appCategory ? { appCategory } : {}),
+        });
+        return;
+      }
       void stream.sendMessage(content, media);
     },
     [ensureSessionForSend, jumpToBottom, navigate, stream.sendMessage],
@@ -835,8 +851,12 @@ export function ChatPage() {
     autoSentSeedRef.current = true;
     // Drop the params so a refresh doesn't resend.
     window.history.replaceState(null, '', window.location.pathname);
+    if (initialChatSeed.appBuild) {
+      const sid = ensureSessionForSend();
+      appBuildSessionsRef.current.set(sid, initialChatSeed.appCategory);
+    }
     handleSendMessage(seed, []);
-  }, [initialChatSeed, chatApiReady, handleSendMessage]);
+  }, [initialChatSeed, chatApiReady, ensureSessionForSend, handleSendMessage]);
 
   const appendLocalCommandResult = useCallback(
     (targetSessionId: string, content: string) => {

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -49,6 +49,7 @@ import {
   useConfiguredViewSwitchItems,
   ViewSwitchNav,
 } from '../../components/view-switch';
+import { buildAppSeed } from '../../lib/app-seed';
 import {
   type ApprovalAction,
   buildApprovalCommand,
@@ -146,10 +147,18 @@ export function ChatPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const userId = useRef(readStoredUserId()).current;
-  const initialComposerPrompt = useMemo(
-    () => new URLSearchParams(window.location.search).get('prompt') || '',
-    [],
-  );
+  // A `?prompt=` seed prefills the composer. When paired with `?send=1` (used
+  // by the Apps builder and `/app`), it is auto-sent instead of prefilled.
+  const initialChatSeed = useMemo(() => {
+    const sp = new URLSearchParams(window.location.search);
+    return {
+      prompt: sp.get('prompt') || '',
+      autoSend: sp.get('send') === '1',
+    };
+  }, []);
+  const initialComposerPrompt = initialChatSeed.autoSend
+    ? ''
+    : initialChatSeed.prompt;
   const launchAgentId = useMemo(readLaunchAgentId, []);
 
   const [errorState, setErrorState] = useState({ message: '', version: 0 });
@@ -789,16 +798,19 @@ export function ChatPage() {
 
   const handleSendMessage = useCallback(
     (content: string, media: MediaItem[]) => {
-      // `/app <description>` (or `/apps ...`) is handled client-side: it opens
-      // the Apps gallery and builds the artifact there rather than sending a
-      // chat turn. Bare `/app` just opens the gallery.
+      // `/app <idea>` starts an app-building conversation: the message is
+      // reframed as a build request so the agent gathers requirements and then
+      // builds a self-contained web app. Bare `/app` opens the Apps gallery.
       const appCommand = /^\/apps?\b[ \t]*([\s\S]*)$/i.exec(content.trim());
       if (appCommand && media.length === 0) {
         const description = appCommand[1].trim();
-        void navigate({
-          to: '/apps',
-          search: description ? { build: '1', prompt: description } : {},
-        });
+        if (!description) {
+          void navigate({ to: '/apps' });
+          return;
+        }
+        ensureSessionForSend();
+        jumpToBottom();
+        void stream.sendMessage(buildAppSeed(null, description), []);
         return;
       }
       ensureSessionForSend();
@@ -810,6 +822,21 @@ export function ChatPage() {
     },
     [ensureSessionForSend, jumpToBottom, navigate, stream.sendMessage],
   );
+
+  // Auto-send a seeded conversation (Apps builder / `/app`): when arriving at
+  // `/chat?prompt=…&send=1`, fire the first message once the chat API is ready.
+  const autoSentSeedRef = useRef(false);
+  useEffect(() => {
+    if (autoSentSeedRef.current) return;
+    if (!initialChatSeed.autoSend) return;
+    const seed = initialChatSeed.prompt.trim();
+    if (!seed) return;
+    if (!chatApiReady) return;
+    autoSentSeedRef.current = true;
+    // Drop the params so a refresh doesn't resend.
+    window.history.replaceState(null, '', window.location.pathname);
+    handleSendMessage(seed, []);
+  }, [initialChatSeed, chatApiReady, handleSendMessage]);
 
   const appendLocalCommandResult = useCallback(
     (targetSessionId: string, content: string) => {

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -151,16 +151,22 @@ export function ChatPage() {
   // by the Apps builder and `/app`), it is auto-sent instead of prefilled.
   const initialChatSeed = useMemo(() => {
     const sp = new URLSearchParams(window.location.search);
+    const kind = sp.get('kind');
+    const appKind: 'web' | 'live' | undefined =
+      kind === 'live' ? 'live' : kind === 'web' ? 'web' : undefined;
     return {
       prompt: sp.get('prompt') || '',
       autoSend: sp.get('send') === '1',
       appBuild: sp.get('app') === '1',
       appCategory: sp.get('category') || undefined,
+      appKind,
     };
   }, []);
   // Sessions started as app builds: each app-build turn is tagged so the
   // gateway captures the produced HTML into the Apps gallery.
-  const appBuildSessionsRef = useRef(new Map<string, string | undefined>());
+  const appBuildSessionsRef = useRef(
+    new Map<string, { category?: string; kind?: 'web' | 'live' }>(),
+  );
   const initialComposerPrompt = initialChatSeed.autoSend
     ? ''
     : initialChatSeed.prompt;
@@ -814,10 +820,11 @@ export function ChatPage() {
           return;
         }
         const sid = ensureSessionForSend();
-        appBuildSessionsRef.current.set(sid, undefined);
+        appBuildSessionsRef.current.set(sid, { kind: 'web' });
         jumpToBottom();
         void stream.sendMessage(buildAppSeed(null, description), [], {
           appBuild: true,
+          appKind: 'web',
         });
         return;
       }
@@ -826,11 +833,12 @@ export function ChatPage() {
       // their bubble and the incoming stream are visible without the "↓ Latest"
       // chip getting in the way.
       jumpToBottom();
-      if (appBuildSessionsRef.current.has(sid)) {
-        const appCategory = appBuildSessionsRef.current.get(sid);
+      const appBuild = appBuildSessionsRef.current.get(sid);
+      if (appBuild) {
         void stream.sendMessage(content, media, {
           appBuild: true,
-          ...(appCategory ? { appCategory } : {}),
+          ...(appBuild.category ? { appCategory: appBuild.category } : {}),
+          ...(appBuild.kind ? { appKind: appBuild.kind } : {}),
         });
         return;
       }
@@ -853,7 +861,10 @@ export function ChatPage() {
     window.history.replaceState(null, '', window.location.pathname);
     if (initialChatSeed.appBuild) {
       const sid = ensureSessionForSend();
-      appBuildSessionsRef.current.set(sid, initialChatSeed.appCategory);
+      appBuildSessionsRef.current.set(sid, {
+        category: initialChatSeed.appCategory,
+        kind: initialChatSeed.appKind,
+      });
     }
     handleSendMessage(seed, []);
   }, [initialChatSeed, chatApiReady, ensureSessionForSend, handleSendMessage]);

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 import {
   type SetStateAction,
   useCallback,
@@ -142,6 +143,7 @@ function chatContextQueryKey(token: string, sessionId: string) {
 
 export function ChatPage() {
   const auth = useAuth();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const userId = useRef(readStoredUserId()).current;
   const initialComposerPrompt = useMemo(
@@ -787,6 +789,18 @@ export function ChatPage() {
 
   const handleSendMessage = useCallback(
     (content: string, media: MediaItem[]) => {
+      // `/app <description>` (or `/apps ...`) is handled client-side: it opens
+      // the Apps gallery and builds the artifact there rather than sending a
+      // chat turn. Bare `/app` just opens the gallery.
+      const appCommand = /^\/apps?\b[ \t]*([\s\S]*)$/i.exec(content.trim());
+      if (appCommand && media.length === 0) {
+        const description = appCommand[1].trim();
+        void navigate({
+          to: '/apps',
+          search: description ? { build: '1', prompt: description } : {},
+        });
+        return;
+      }
       ensureSessionForSend();
       // Sending re-engages the user with the live conversation — snap back so
       // their bubble and the incoming stream are visible without the "↓ Latest"
@@ -794,7 +808,7 @@ export function ChatPage() {
       jumpToBottom();
       void stream.sendMessage(content, media);
     },
-    [ensureSessionForSend, jumpToBottom, stream.sendMessage],
+    [ensureSessionForSend, jumpToBottom, navigate, stream.sendMessage],
   );
 
   const appendLocalCommandResult = useCallback(

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useSearch } from '@tanstack/react-router';
 import {
   type SetStateAction,
   useCallback,
@@ -178,19 +178,27 @@ export function ChatPage() {
   const userId = useRef(readStoredUserId()).current;
   // A `?prompt=` seed prefills the composer. When paired with `?send=1` (used
   // by the Apps builder and `/app`), it is auto-sent instead of prefilled.
-  const initialChatSeed = useMemo(() => {
-    const sp = new URLSearchParams(window.location.search);
-    const kind = sp.get('kind');
+  // Read from router state (not window.location) — the URL lags client-side
+  // navigation, so window.location.search can be empty at first render.
+  const chatSearch = useSearch({ strict: false }) as {
+    prompt?: string;
+    send?: string;
+    app?: string;
+    category?: string;
+    kind?: string;
+  };
+  const [initialChatSeed] = useState(() => {
+    const kind = chatSearch.kind;
     const appKind: 'web' | 'live' | undefined =
       kind === 'live' ? 'live' : kind === 'web' ? 'web' : undefined;
     return {
-      prompt: sp.get('prompt') || '',
-      autoSend: sp.get('send') === '1',
-      appBuild: sp.get('app') === '1',
-      appCategory: sp.get('category') || undefined,
+      prompt: chatSearch.prompt ?? '',
+      autoSend: chatSearch.send === '1',
+      appBuild: chatSearch.app === '1',
+      appCategory: chatSearch.category,
       appKind,
     };
-  }, []);
+  });
   // Sessions started as app builds: each app-build turn is tagged so the
   // gateway captures the produced HTML into the Apps gallery. Persisted so a
   // reload mid-conversation doesn't drop the tag.

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -856,6 +856,9 @@ export function ChatPage() {
     const seed = initialChatSeed.prompt.trim();
     if (!seed) return;
     if (!chatApiReady) return;
+    // Wait for the session's initial (empty) history to settle first — sending
+    // before it resolves lets the empty fetch clobber the optimistic message.
+    if (!historyQuery.isFetched) return;
     autoSentSeedRef.current = true;
     // Drop the params so a refresh doesn't resend.
     window.history.replaceState(null, '', window.location.pathname);
@@ -867,7 +870,13 @@ export function ChatPage() {
       });
     }
     handleSendMessage(seed, []);
-  }, [initialChatSeed, chatApiReady, ensureSessionForSend, handleSendMessage]);
+  }, [
+    initialChatSeed,
+    chatApiReady,
+    historyQuery.isFetched,
+    ensureSessionForSend,
+    handleSendMessage,
+  ]);
 
   const appendLocalCommandResult = useCallback(
     (targetSessionId: string, content: string) => {

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { appViewUrl } from '../../api/apps';
 import {
   cleanupNoUserChatSessions,
   createChatBranch,
@@ -400,6 +401,12 @@ export function ChatPage() {
   );
   const modelOptions = modelsQuery.data?.models ?? EMPTY_MODELS;
 
+  const [previewApp, setPreviewApp] = useState<{
+    id: string;
+    title: string;
+    kind: 'web' | 'live';
+  } | null>(null);
+
   const stream = useChatStream({
     token: auth.token,
     userId,
@@ -408,6 +415,8 @@ export function ChatPage() {
     refreshRecent,
     onSessionIdCorrection: handleSessionIdCorrection,
     onModelResolved: setSelectedModelId,
+    // When a build is captured into the gallery, pop it open as a preview.
+    onAppsCaptured: (apps) => setPreviewApp(apps[apps.length - 1] ?? null),
     resolveAddressedAgentPresentation,
   });
 
@@ -1349,6 +1358,56 @@ export function ChatPage() {
                 {deleteSessionMutation.isPending ? 'Deleting...' : 'Delete'}
               </button>
             </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        <Dialog
+          open={previewApp !== null}
+          onOpenChange={(open) => {
+            if (!open) setPreviewApp(null);
+          }}
+        >
+          <DialogContent
+            className={css.appPreviewDialog}
+            aria-label="App preview"
+          >
+            <div className={css.appPreviewHeader}>
+              <DialogTitle className={css.appPreviewTitle}>
+                {previewApp?.title}
+              </DialogTitle>
+              <div className={css.appPreviewActions}>
+                <button
+                  type="button"
+                  className={css.appPreviewLink}
+                  onClick={() => {
+                    setPreviewApp(null);
+                    void navigate({ to: '/apps' });
+                  }}
+                >
+                  View in Apps
+                </button>
+                {previewApp ? (
+                  <a
+                    className={css.appPreviewLink}
+                    href={appViewUrl(previewApp.id, auth.token)}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Open in new tab ↗
+                  </a>
+                ) : null}
+                <DialogClose className={css.appPreviewLink}>Close</DialogClose>
+              </div>
+            </div>
+            {previewApp ? (
+              <iframe
+                key={previewApp.id}
+                className={css.appPreviewFrame}
+                title={previewApp.title}
+                src={appViewUrl(previewApp.id, auth.token)}
+                sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads allow-popups-to-escape-sandbox"
+              />
+            ) : null}
           </DialogContent>
         </Dialog>
       </div>

--- a/console/src/routes/chat/chat-sidebar.tsx
+++ b/console/src/routes/chat/chat-sidebar.tsx
@@ -19,6 +19,7 @@ import sidebarStyles from '../../components/sidebar/index.module.css';
 import { ThemeToggle } from '../../components/theme-toggle';
 import { cx } from '../../lib/cx';
 import { formatRelativeTime } from '../../lib/format';
+import { AppsGridIcon } from '../apps-icons';
 import css from './chat-page.module.css';
 
 export { SidebarProvider as ChatSidebarProvider } from '../../components/sidebar/index';
@@ -71,7 +72,9 @@ export function ChatSidebarPanel(props: ChatSidebarProps) {
           className={css.newChatButton}
           onClick={() => navigate({ to: '/apps' })}
         >
-          <span aria-hidden="true">▦</span>
+          <span aria-hidden="true" className={css.navLinkIcon}>
+            <AppsGridIcon />
+          </span>
           <span>Apps</span>
         </button>
         <div className={css.sidebarSearchWrap}>

--- a/console/src/routes/chat/chat-sidebar.tsx
+++ b/console/src/routes/chat/chat-sidebar.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from '@tanstack/react-router';
 import { useEffect } from 'react';
 import type { ChatRecentSession } from '../../api/chat-types';
 import { useAuth } from '../../auth';
@@ -42,6 +43,7 @@ export interface ChatSidebarProps {
 export function ChatSidebarPanel(props: ChatSidebarProps) {
   const auth = useAuth();
   const sidebar = useSidebar();
+  const navigate = useNavigate();
   const isSearching = props.searchQuery.trim().length > 0;
 
   useEffect(() => {
@@ -63,6 +65,14 @@ export function ChatSidebarPanel(props: ChatSidebarProps) {
         >
           <span aria-hidden="true">+</span>
           <span>New Conversation</span>
+        </button>
+        <button
+          type="button"
+          className={css.newChatButton}
+          onClick={() => navigate({ to: '/apps' })}
+        >
+          <span aria-hidden="true">▦</span>
+          <span>Apps</span>
         </button>
         <div className={css.sidebarSearchWrap}>
           <input

--- a/console/src/routes/chat/message-block.tsx
+++ b/console/src/routes/chat/message-block.tsx
@@ -16,6 +16,7 @@ import type {
 } from '../../api/chat-types';
 import { Button } from '../../components/button';
 import { ThumbsDown, ThumbsUp } from '../../components/icons';
+import { stripAppBuildDirective } from '../../lib/app-seed';
 import { type ApprovalAction, copyToClipboard } from '../../lib/chat-helpers';
 import { cx } from '../../lib/cx';
 import { renderMarkdown } from '../../lib/markdown';
@@ -506,7 +507,7 @@ export const MessageBlock = memo(function MessageBlock(props: {
             />
           ) : isUser ? (
             <UserMessageContent
-              content={msg.content}
+              content={stripAppBuildDirective(msg.content)}
               presentation={msg.addressedAgentPresentation}
               skillInvocationTargets={props.skillInvocationTargets}
               token={token}

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -73,7 +73,7 @@ export interface UseChatStreamReturn {
   sendMessage: (
     content: string,
     media: MediaItem[],
-    opts?: { hideUser?: boolean },
+    opts?: { hideUser?: boolean; appBuild?: boolean; appCategory?: string },
   ) => Promise<boolean>;
   stopRequest: () => Promise<void>;
   isStreaming: boolean;
@@ -135,7 +135,7 @@ export function useChatStream(
     async (
       content: string,
       media: MediaItem[],
-      opts?: { hideUser?: boolean },
+      opts?: { hideUser?: boolean; appBuild?: boolean; appCategory?: string },
     ) => {
       if (activeRequestRef.current) {
         setError(
@@ -262,6 +262,8 @@ export function useChatStream(
             content,
             stream: true,
             ...(media.length > 0 ? { media } : {}),
+            ...(opts?.appBuild ? { appBuild: true } : {}),
+            ...(opts?.appCategory ? { appCategory: opts.appCategory } : {}),
           },
           signal: req.controller.signal,
           callbacks: {

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -36,6 +36,9 @@ interface UseChatStreamOptions {
   refreshRecent: () => void;
   onSessionIdCorrection: (serverSessionId: string) => void;
   onModelResolved?: (modelId: string) => void;
+  onAppsCaptured?: (
+    apps: Array<{ id: string; title: string; kind: 'web' | 'live' }>,
+  ) => void;
   resolveAddressedAgentPresentation?: (
     content: string,
   ) => AssistantPresentation | null;
@@ -100,6 +103,7 @@ export function useChatStream(
     refreshRecent,
     onSessionIdCorrection,
     onModelResolved,
+    onAppsCaptured,
     resolveAddressedAgentPresentation,
   } = options;
 
@@ -306,6 +310,12 @@ export function useChatStream(
           onModelResolved?.(resolvedModel);
         }
 
+        // Only pop the preview for explicit app builds/refreshes — regular
+        // chats still capture HTML to the gallery, just without interrupting.
+        if (opts?.appBuild && result.apps && result.apps.length > 0) {
+          onAppsCaptured?.(result.apps);
+        }
+
         flushRender();
 
         const finalText = result.result ?? req.assistantText ?? '';
@@ -456,6 +466,7 @@ export function useChatStream(
       writeMessages,
       onSessionIdCorrection,
       onModelResolved,
+      onAppsCaptured,
       resolveAddressedAgentPresentation,
       queryClient,
       setError,

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -73,7 +73,12 @@ export interface UseChatStreamReturn {
   sendMessage: (
     content: string,
     media: MediaItem[],
-    opts?: { hideUser?: boolean; appBuild?: boolean; appCategory?: string },
+    opts?: {
+      hideUser?: boolean;
+      appBuild?: boolean;
+      appCategory?: string;
+      appKind?: 'web' | 'live';
+    },
   ) => Promise<boolean>;
   stopRequest: () => Promise<void>;
   isStreaming: boolean;
@@ -135,7 +140,12 @@ export function useChatStream(
     async (
       content: string,
       media: MediaItem[],
-      opts?: { hideUser?: boolean; appBuild?: boolean; appCategory?: string },
+      opts?: {
+        hideUser?: boolean;
+        appBuild?: boolean;
+        appCategory?: string;
+        appKind?: 'web' | 'live';
+      },
     ) => {
       if (activeRequestRef.current) {
         setError(
@@ -264,6 +274,7 @@ export function useChatStream(
             ...(media.length > 0 ? { media } : {}),
             ...(opts?.appBuild ? { appBuild: true } : {}),
             ...(opts?.appCategory ? { appCategory: opts.appCategory } : {}),
+            ...(opts?.appKind ? { appKind: opts.appKind } : {}),
           },
           signal: req.controller.signal,
           callbacks: {

--- a/container/src/providers/openai-codex.ts
+++ b/container/src/providers/openai-codex.ts
@@ -19,6 +19,7 @@ import {
   type NormalizedStreamCallArgs,
   ProviderRequestError,
 } from './shared.js';
+import { readWithIdleTimeout, STREAM_IDLE_TIMEOUT_MS } from './stream-utils.js';
 
 interface CodexAccumulatedContentPart {
   type: string;
@@ -836,7 +837,10 @@ export async function callOpenAICodexProviderStream(
 
   try {
     while (!streamDone) {
-      const { done, value } = await reader.read();
+      const { done, value } = await readWithIdleTimeout(
+        reader,
+        STREAM_IDLE_TIMEOUT_MS,
+      );
       if (done) break;
 
       buffer += decoder.decode(value, { stream: true });

--- a/src/apps/app-generator.ts
+++ b/src/apps/app-generator.ts
@@ -1,0 +1,131 @@
+import type { AppCategory } from '../memory/apps.js';
+import { normalizeAppCategory } from '../memory/apps.js';
+import { callAuxiliaryModel } from '../providers/auxiliary.js';
+
+const APP_TITLE_MAX_CHARS = 80;
+const APP_GENERATION_MAX_TOKENS = 16000;
+
+const CATEGORY_GUIDANCE: Record<AppCategory, string> = {
+  apps: 'an interactive web app or website',
+  documents: 'a polished, well-typeset document or template',
+  games: 'a playable browser game with clear controls and win/lose feedback',
+  productivity:
+    'a focused productivity tool (calculator, tracker, planner, dashboard)',
+  creative: 'a creative, visually striking interactive piece',
+  quiz: 'an interactive quiz or survey that scores or summarizes responses',
+  scratch: 'whatever the user describes',
+};
+
+const SYSTEM_PROMPT = [
+  'You are an expert front-end engineer that builds single-file web artifacts.',
+  'Return ONE complete, self-contained HTML document and nothing else.',
+  'Rules:',
+  '- Output ONLY raw HTML. No markdown, no code fences, no commentary before or after.',
+  '- The document MUST start with `<!DOCTYPE html>` and contain `<html>`, `<head>`, and `<body>`.',
+  '- Inline all CSS in a <style> tag and all JavaScript in a <script> tag. No external build steps.',
+  '- You MAY load libraries only from a public CDN (e.g. cdnjs, jsDelivr, unpkg) via <script>/<link>.',
+  '- Do NOT call backend APIs, local files, or anything requiring secrets. It must work fully client-side, offline if possible.',
+  '- Make it responsive, accessible, and visually polished. Include a clear <title>.',
+  '- Keep everything in the single returned document.',
+].join('\n');
+
+export interface GenerateAppParams {
+  description: string;
+  category?: string | null;
+  agentId?: string;
+  model?: string;
+  chatbotId?: string | null;
+}
+
+export interface GeneratedApp {
+  title: string;
+  html: string;
+  category: AppCategory;
+}
+
+/**
+ * Pull a complete HTML document out of a raw model response that may be wrapped
+ * in markdown fences, prefixed with prose, or include `<think>` reasoning.
+ */
+export function extractHtmlDocument(raw: string): string | null {
+  let text = String(raw || '').replace(/<think>[\s\S]*?<\/think>/gi, '');
+
+  // Prefer a fenced ```html block (take the largest such block).
+  const fenceRe = /```(?:html|HTML)?\s*\n?([\s\S]*?)```/g;
+  let best: string | null = null;
+  for (const match of text.matchAll(fenceRe)) {
+    const body = match[1]?.trim();
+    if (body && (!best || body.length > best.length)) best = body;
+  }
+  if (best) text = best;
+
+  const lower = text.toLowerCase();
+  const docStart = lower.indexOf('<!doctype html');
+  const htmlStart = lower.indexOf('<html');
+  const start = docStart !== -1 ? docStart : htmlStart;
+  if (start === -1) return null;
+  const htmlEnd = lower.lastIndexOf('</html>');
+  const end = htmlEnd !== -1 ? htmlEnd + '</html>'.length : text.length;
+  const doc = text.slice(start, end).trim();
+  return doc.length > 0 ? doc : null;
+}
+
+export function deriveAppTitle(html: string, description: string): string {
+  const titleMatch = html.match(/<title>([\s\S]*?)<\/title>/i);
+  const fromTitle = titleMatch?.[1]?.replace(/\s+/g, ' ').trim();
+  const candidate =
+    fromTitle ||
+    description
+      .replace(/<think>[\s\S]*?<\/think>/gi, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+  const cleaned = candidate.replace(/^["'`]+|["'`]+$/g, '').trim();
+  if (!cleaned) return 'Untitled App';
+  return cleaned.length > APP_TITLE_MAX_CHARS
+    ? `${cleaned.slice(0, APP_TITLE_MAX_CHARS).trimEnd()}…`
+    : cleaned;
+}
+
+export async function generateApp(
+  params: GenerateAppParams,
+): Promise<GeneratedApp> {
+  const description = params.description.trim();
+  if (!description) {
+    throw new Error('An app description is required.');
+  }
+  const category = normalizeAppCategory(params.category);
+  const userPrompt = [
+    `Build ${CATEGORY_GUIDANCE[category]} based on this request:`,
+    '',
+    description,
+    '',
+    'Return the complete HTML document now.',
+  ].join('\n');
+
+  const result = await callAuxiliaryModel({
+    // App generation reuses the general-purpose `second_opinion` auxiliary task
+    // for model routing rather than introducing a dedicated config key.
+    task: 'second_opinion',
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    ...(params.model ? { fallbackModel: params.model } : {}),
+    ...(params.chatbotId ? { fallbackChatbotId: params.chatbotId } : {}),
+    fallbackEnableRag: false,
+    maxTokens: APP_GENERATION_MAX_TOKENS,
+    messages: [
+      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'user', content: userPrompt },
+    ],
+  });
+
+  const html = extractHtmlDocument(result.content);
+  if (!html) {
+    throw new Error(
+      'The model did not return a valid HTML document. Try refining the request.',
+    );
+  }
+  return {
+    title: deriveAppTitle(html, description),
+    html,
+    category,
+  };
+}

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -709,6 +709,26 @@ function buildSlashCommandCatalogDefinitions(
       description: 'Show HybridClaw runtime status (only visible to you)',
     },
     {
+      // Web-console only: handled client-side by the chat composer, which opens
+      // the Apps gallery and builds the artifact there (see chat-page.tsx).
+      name: 'app',
+      description:
+        'Build a web app, document, game, or tool and save it to your Apps gallery',
+      localSurfaces: ['web'],
+      tuiMenu: {
+        label: '/app <description>',
+        insertText: '/app ',
+      },
+      options: [
+        {
+          kind: 'string',
+          name: 'description',
+          description: 'What to build',
+          required: true,
+        },
+      ],
+    },
+    {
       name: 'btw',
       description: BTW_COMMAND_DESCRIPTION,
       options: [

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -714,6 +714,7 @@ function buildSlashCommandCatalogDefinitions(
       name: 'app',
       description:
         'Build a web app, document, game, or tool and save it to your Apps gallery',
+      tuiOnly: true,
       localSurfaces: ['web'],
       tuiMenu: {
         label: '/app <description>',

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -7146,6 +7146,11 @@ async function handleApiAppGenerate(
  * the assistant text and tag the entry with category / kind.
  * Best-effort: never throws into the chat response path.
  */
+/** Workspace folder the Apps builder asks the agent to write app files into. */
+const APP_BUILD_OUTPUT_DIR = 'apps';
+/** Only auto-capture app files written around this turn, not stale ones. */
+const APP_BUILD_FRESHNESS_MS = 15 * 60 * 1000;
+
 async function maybeCaptureChatArtifacts(
   chatRequest: GatewayChatRequest,
   result: GatewayChatResult,
@@ -7185,13 +7190,75 @@ async function maybeCaptureChatArtifacts(
         'Captured HTML artifact into Apps gallery',
       );
     }
-    // App-builder turns often write the HTML to a workspace file and only
-    // reference it in the reply (e.g. "apps/dashboard.html"). Resolve those
-    // references inside the agent workspace and capture them.
-    if (captured.length === 0 && chatRequest.appBuild) {
-      const workspaceDir = agentWorkspaceDir(
-        agentId || resolveDefaultAgentId(getRuntimeConfig()),
+    const workspaceDir =
+      captured.length === 0 && chatRequest.appBuild
+        ? agentWorkspaceDir(
+            agentId || resolveDefaultAgentId(getRuntimeConfig()),
+          )
+        : null;
+
+    const captureWorkspaceHtml = async (
+      ref: string,
+      filePath: string,
+    ): Promise<void> => {
+      let content: string;
+      try {
+        content = await fs.promises.readFile(filePath, 'utf8');
+      } catch {
+        return;
+      }
+      const html = extractHtmlDocument(content) ?? content;
+      if (!/<html|<!doctype html/i.test(html)) return;
+      const app = upsertAppArtifact({
+        sessionId,
+        sourceKey: ref,
+        title: deriveAppTitle(html, path.basename(ref)),
+        html,
+        category,
+        kind,
+        agentId,
+      });
+      captured.push({ id: app.id, title: app.title, kind: app.kind });
+      logger.debug(
+        { sessionId, appId: app.id, title: app.title, kind, ref },
+        'Captured workspace HTML file into Apps gallery',
       );
+    };
+
+    // App-builder turns write the HTML to a file in the `apps/` folder (per the
+    // build instructions). Capture the newest .html there — even if the agent
+    // never names the file in its reply.
+    if (workspaceDir) {
+      const appsDir = path.join(workspaceDir, APP_BUILD_OUTPUT_DIR);
+      try {
+        const entries = await fs.promises.readdir(appsDir, {
+          withFileTypes: true,
+        });
+        let newest: { ref: string; path: string; mtime: number } | null = null;
+        for (const entry of entries) {
+          if (!entry.isFile()) continue;
+          if (!entry.name.toLowerCase().endsWith('.html')) continue;
+          const filePath = path.join(appsDir, entry.name);
+          const stat = await fs.promises.stat(filePath);
+          // Skip files that weren't written around this turn (e.g. a plan turn
+          // that didn't build anything shouldn't re-capture an old app).
+          if (Date.now() - stat.mtimeMs > APP_BUILD_FRESHNESS_MS) continue;
+          if (!newest || stat.mtimeMs > newest.mtime) {
+            newest = {
+              ref: `${APP_BUILD_OUTPUT_DIR}/${entry.name}`,
+              path: filePath,
+              mtime: stat.mtimeMs,
+            };
+          }
+        }
+        if (newest) await captureWorkspaceHtml(newest.ref, newest.path);
+      } catch {
+        // No apps/ folder this turn — fall through to the other strategies.
+      }
+    }
+
+    // Otherwise, resolve any *.html paths referenced in the reply.
+    if (workspaceDir && captured.length === 0) {
       const seen = new Set<string>();
       for (const match of (result.result ?? '').matchAll(
         /([A-Za-z0-9_][A-Za-z0-9_./-]*\.html)\b/g,
@@ -7200,29 +7267,7 @@ async function maybeCaptureChatArtifacts(
         if (seen.has(ref)) continue;
         seen.add(ref);
         const filePath = resolveWorkspaceRelativePath(workspaceDir, ref);
-        if (!filePath) continue;
-        let content: string;
-        try {
-          content = await fs.promises.readFile(filePath, 'utf8');
-        } catch {
-          continue;
-        }
-        const html = extractHtmlDocument(content) ?? content;
-        if (!/<html|<!doctype html/i.test(html)) continue;
-        const app = upsertAppArtifact({
-          sessionId,
-          sourceKey: ref,
-          title: deriveAppTitle(html, path.basename(ref)),
-          html,
-          category,
-          kind,
-          agentId,
-        });
-        captured.push({ id: app.id, title: app.title, kind: app.kind });
-        logger.debug(
-          { sessionId, appId: app.id, title: app.title, kind, ref },
-          'Captured workspace HTML file into Apps gallery',
-        );
+        if (filePath) await captureWorkspaceHtml(ref, filePath);
       }
     }
     // Or the HTML may be inlined in the reply instead of a file.

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -112,7 +112,7 @@ import {
   deleteApp,
   getApp,
   listApps,
-  upsertAppForSession,
+  upsertAppArtifact,
 } from '../memory/apps.js';
 import {
   claimQueuedProactiveMessages,
@@ -2973,6 +2973,9 @@ async function handleApiChat(
     ...(typeof body.appCategory === 'string'
       ? { appCategory: body.appCategory }
       : {}),
+    ...(body.appKind === 'live' || body.appKind === 'web'
+      ? { appKind: body.appKind }
+      : {}),
   };
   logger.debug(
     {
@@ -3005,7 +3008,7 @@ async function handleApiChat(
     processedResult.sessionId || chatRequest.sessionId,
     processedResult,
   );
-  await maybeCaptureAppBuild(chatRequest, result);
+  await maybeCaptureChatArtifacts(chatRequest, result);
   sendJson(res, result.status === 'success' ? 200 : 500, result);
 }
 
@@ -3311,7 +3314,7 @@ async function handleApiChatStream(
       type: 'result',
       result: filteredResult,
     });
-    await maybeCaptureAppBuild(chatRequest, filteredResult);
+    await maybeCaptureChatArtifacts(chatRequest, filteredResult);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     sendEvent({
@@ -7125,45 +7128,72 @@ async function handleApiAppGenerate(
 }
 
 /**
- * For app-build conversations, persist a self-contained HTML result into the
- * Apps gallery (one entry per session, updated as the conversation iterates).
+ * Persist self-contained HTML produced in a chat turn into the Apps gallery.
+ * Runs for every chat (not just the Apps builder): each HTML artifact file
+ * becomes a gallery entry keyed by (session, filename), updated in place as the
+ * conversation iterates. App-builder turns additionally capture HTML inlined in
+ * the assistant text and tag the entry with category / kind.
  * Best-effort: never throws into the chat response path.
  */
-async function maybeCaptureAppBuild(
+async function maybeCaptureChatArtifacts(
   chatRequest: GatewayChatRequest,
   result: GatewayChatResult,
 ): Promise<void> {
-  if (!chatRequest.appBuild) return;
   if (result.status !== 'success') return;
   const sessionId = result.sessionId || chatRequest.sessionId;
   if (!sessionId) return;
+  const kind = chatRequest.appKind === 'live' ? 'live' : 'web';
+  const category = chatRequest.appBuild
+    ? (chatRequest.appCategory ?? null)
+    : null;
+  const agentId = result.agentId ?? chatRequest.agentId ?? null;
   try {
-    let html: string | null = null;
-    const htmlArtifact = result.artifacts?.find((artifact) =>
-      artifact.mimeType?.toLowerCase().includes('html'),
-    );
-    if (htmlArtifact?.path) {
+    let capturedFromArtifact = false;
+    for (const artifact of result.artifacts ?? []) {
+      if (!artifact.mimeType?.toLowerCase().includes('html')) continue;
+      if (!artifact.path) continue;
+      let html: string;
       try {
-        const content = await fs.promises.readFile(htmlArtifact.path, 'utf8');
+        const content = await fs.promises.readFile(artifact.path, 'utf8');
         html = extractHtmlDocument(content) ?? content;
       } catch {
-        // Fall back to extracting from the assistant text below.
+        continue;
       }
+      const app = upsertAppArtifact({
+        sessionId,
+        sourceKey: artifact.filename || artifact.path,
+        title: deriveAppTitle(html, artifact.filename || ''),
+        html,
+        category,
+        kind,
+        agentId,
+      });
+      capturedFromArtifact = true;
+      logger.debug(
+        { sessionId, appId: app.id, title: app.title, kind },
+        'Captured HTML artifact into Apps gallery',
+      );
     }
-    if (!html) html = extractHtmlDocument(result.result ?? '');
-    if (!html) return;
-    const app = upsertAppForSession(sessionId, {
-      title: deriveAppTitle(html, ''),
-      html,
-      category: chatRequest.appCategory ?? null,
-      agentId: result.agentId ?? chatRequest.agentId ?? null,
-    });
-    logger.debug(
-      { sessionId, appId: app.id, title: app.title },
-      'Captured app build into Apps gallery',
-    );
+    // App-builder turns may inline the HTML in the reply instead of a file.
+    if (!capturedFromArtifact && chatRequest.appBuild) {
+      const html = extractHtmlDocument(result.result ?? '');
+      if (!html) return;
+      const app = upsertAppArtifact({
+        sessionId,
+        sourceKey: 'inline',
+        title: deriveAppTitle(html, ''),
+        html,
+        category,
+        kind,
+        agentId,
+      });
+      logger.debug(
+        { sessionId, appId: app.id, title: app.title, kind },
+        'Captured inline app build into Apps gallery',
+      );
+    }
   } catch (err) {
-    logger.warn({ err, sessionId }, 'Failed to capture app build');
+    logger.warn({ err, sessionId }, 'Failed to capture chat artifacts');
   }
 }
 

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -25,7 +25,11 @@ import {
   normalizeAgentProxyConfig,
   resolveSnakeCamelAlias,
 } from '../agents/agent-types.js';
-import { generateApp } from '../apps/app-generator.js';
+import {
+  deriveAppTitle,
+  extractHtmlDocument,
+  generateApp,
+} from '../apps/app-generator.js';
 import { getHybridAIApiKey } from '../auth/hybridai-auth.js';
 import { getBoardBudgetSummaries } from '../board/budget-chip.js';
 import {
@@ -103,7 +107,13 @@ import {
   UPLOADED_MEDIA_CACHE_ROOT_DISPLAY,
   writeUploadedMediaCacheFile,
 } from '../media/uploaded-media-cache.js';
-import { createApp, deleteApp, getApp, listApps } from '../memory/apps.js';
+import {
+  createApp,
+  deleteApp,
+  getApp,
+  listApps,
+  upsertAppForSession,
+} from '../memory/apps.js';
 import {
   claimQueuedProactiveMessages,
   enqueueProactiveMessage,
@@ -2959,6 +2969,10 @@ async function handleApiChat(
     chatbotId: body.chatbotId,
     enableRag: body.enableRag,
     model: body.model,
+    ...(body.appBuild ? { appBuild: true } : {}),
+    ...(typeof body.appCategory === 'string'
+      ? { appCategory: body.appCategory }
+      : {}),
   };
   logger.debug(
     {
@@ -2991,6 +3005,7 @@ async function handleApiChat(
     processedResult.sessionId || chatRequest.sessionId,
     processedResult,
   );
+  await maybeCaptureAppBuild(chatRequest, result);
   sendJson(res, result.status === 'success' ? 200 : 500, result);
 }
 
@@ -3296,6 +3311,7 @@ async function handleApiChatStream(
       type: 'result',
       result: filteredResult,
     });
+    await maybeCaptureAppBuild(chatRequest, filteredResult);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     sendEvent({
@@ -7106,6 +7122,49 @@ async function handleApiAppGenerate(
       typeof body.sessionId === 'string' ? body.sessionId.trim() || null : null,
   });
   sendJson(res, 201, { app });
+}
+
+/**
+ * For app-build conversations, persist a self-contained HTML result into the
+ * Apps gallery (one entry per session, updated as the conversation iterates).
+ * Best-effort: never throws into the chat response path.
+ */
+async function maybeCaptureAppBuild(
+  chatRequest: GatewayChatRequest,
+  result: GatewayChatResult,
+): Promise<void> {
+  if (!chatRequest.appBuild) return;
+  if (result.status !== 'success') return;
+  const sessionId = result.sessionId || chatRequest.sessionId;
+  if (!sessionId) return;
+  try {
+    let html: string | null = null;
+    const htmlArtifact = result.artifacts?.find((artifact) =>
+      artifact.mimeType?.toLowerCase().includes('html'),
+    );
+    if (htmlArtifact?.path) {
+      try {
+        const content = await fs.promises.readFile(htmlArtifact.path, 'utf8');
+        html = extractHtmlDocument(content) ?? content;
+      } catch {
+        // Fall back to extracting from the assistant text below.
+      }
+    }
+    if (!html) html = extractHtmlDocument(result.result ?? '');
+    if (!html) return;
+    const app = upsertAppForSession(sessionId, {
+      title: deriveAppTitle(html, ''),
+      html,
+      category: chatRequest.appCategory ?? null,
+      agentId: result.agentId ?? chatRequest.agentId ?? null,
+    });
+    logger.debug(
+      { sessionId, appId: app.id, title: app.title },
+      'Captured app build into Apps gallery',
+    );
+  } catch (err) {
+    logger.warn({ err, sessionId }, 'Failed to capture app build');
+  }
 }
 
 async function handleApiAdminTerminal(

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -7146,11 +7146,6 @@ async function handleApiAppGenerate(
  * the assistant text and tag the entry with category / kind.
  * Best-effort: never throws into the chat response path.
  */
-/** Workspace folder the Apps builder asks the agent to write app files into. */
-const APP_BUILD_OUTPUT_DIR = 'apps';
-/** Only auto-capture app files written around this turn, not stale ones. */
-const APP_BUILD_FRESHNESS_MS = 15 * 60 * 1000;
-
 async function maybeCaptureChatArtifacts(
   chatRequest: GatewayChatRequest,
   result: GatewayChatResult,
@@ -7226,39 +7221,10 @@ async function maybeCaptureChatArtifacts(
     };
 
     // App-builder turns write the HTML to a file in the `apps/` folder (per the
-    // build instructions). Capture the newest .html there — even if the agent
-    // never names the file in its reply.
+    // build instructions) and reference it in the reply (e.g.
+    // "apps/dashboard.html"). Resolve those *.html references inside the agent
+    // workspace and capture them.
     if (workspaceDir) {
-      const appsDir = path.join(workspaceDir, APP_BUILD_OUTPUT_DIR);
-      try {
-        const entries = await fs.promises.readdir(appsDir, {
-          withFileTypes: true,
-        });
-        let newest: { ref: string; path: string; mtime: number } | null = null;
-        for (const entry of entries) {
-          if (!entry.isFile()) continue;
-          if (!entry.name.toLowerCase().endsWith('.html')) continue;
-          const filePath = path.join(appsDir, entry.name);
-          const stat = await fs.promises.stat(filePath);
-          // Skip files that weren't written around this turn (e.g. a plan turn
-          // that didn't build anything shouldn't re-capture an old app).
-          if (Date.now() - stat.mtimeMs > APP_BUILD_FRESHNESS_MS) continue;
-          if (!newest || stat.mtimeMs > newest.mtime) {
-            newest = {
-              ref: `${APP_BUILD_OUTPUT_DIR}/${entry.name}`,
-              path: filePath,
-              mtime: stat.mtimeMs,
-            };
-          }
-        }
-        if (newest) await captureWorkspaceHtml(newest.ref, newest.path);
-      } catch {
-        // No apps/ folder this turn — fall through to the other strategies.
-      }
-    }
-
-    // Otherwise, resolve any *.html paths referenced in the reply.
-    if (workspaceDir && captured.length === 0) {
       const seen = new Set<string>();
       for (const match of (result.result ?? '').matchAll(
         /([A-Za-z0-9_][A-Za-z0-9_./-]*\.html)\b/g,

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -2353,13 +2353,19 @@ function isConsoleSpaPath(pathname: string): boolean {
     pathname === '/admin' ||
     pathname.startsWith('/admin/') ||
     pathname === '/chat' ||
-    pathname.startsWith('/chat/')
+    pathname.startsWith('/chat/') ||
+    pathname === '/apps' ||
+    pathname.startsWith('/apps/')
   );
 }
 
 function resolveConsolePageTitle(pathname: string): string {
   if (pathname === '/chat' || pathname.startsWith('/chat/')) {
     return 'HybridClaw Chat';
+  }
+
+  if (pathname === '/apps' || pathname.startsWith('/apps/')) {
+    return 'HybridClaw Apps';
   }
 
   if (pathname === '/agents' || pathname.startsWith('/agents/')) {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -7185,7 +7185,47 @@ async function maybeCaptureChatArtifacts(
         'Captured HTML artifact into Apps gallery',
       );
     }
-    // App-builder turns may inline the HTML in the reply instead of a file.
+    // App-builder turns often write the HTML to a workspace file and only
+    // reference it in the reply (e.g. "apps/dashboard.html"). Resolve those
+    // references inside the agent workspace and capture them.
+    if (captured.length === 0 && chatRequest.appBuild) {
+      const workspaceDir = agentWorkspaceDir(
+        agentId || resolveDefaultAgentId(getRuntimeConfig()),
+      );
+      const seen = new Set<string>();
+      for (const match of (result.result ?? '').matchAll(
+        /([A-Za-z0-9_][A-Za-z0-9_./-]*\.html)\b/g,
+      )) {
+        const ref = match[1];
+        if (seen.has(ref)) continue;
+        seen.add(ref);
+        const filePath = resolveWorkspaceRelativePath(workspaceDir, ref);
+        if (!filePath) continue;
+        let content: string;
+        try {
+          content = await fs.promises.readFile(filePath, 'utf8');
+        } catch {
+          continue;
+        }
+        const html = extractHtmlDocument(content) ?? content;
+        if (!/<html|<!doctype html/i.test(html)) continue;
+        const app = upsertAppArtifact({
+          sessionId,
+          sourceKey: ref,
+          title: deriveAppTitle(html, path.basename(ref)),
+          html,
+          category,
+          kind,
+          agentId,
+        });
+        captured.push({ id: app.id, title: app.title, kind: app.kind });
+        logger.debug(
+          { sessionId, appId: app.id, title: app.title, kind, ref },
+          'Captured workspace HTML file into Apps gallery',
+        );
+      }
+    }
+    // Or the HTML may be inlined in the reply instead of a file.
     if (captured.length === 0 && chatRequest.appBuild) {
       const html = extractHtmlDocument(result.result ?? '');
       if (!html) return captured;

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -3008,7 +3008,8 @@ async function handleApiChat(
     processedResult.sessionId || chatRequest.sessionId,
     processedResult,
   );
-  await maybeCaptureChatArtifacts(chatRequest, result);
+  const capturedApps = await maybeCaptureChatArtifacts(chatRequest, result);
+  if (capturedApps.length > 0) result.apps = capturedApps;
   sendJson(res, result.status === 'success' ? 200 : 500, result);
 }
 
@@ -3310,11 +3311,15 @@ async function handleApiChatStream(
     if (pendingApproval && pendingApproval.approvalId !== streamedApprovalId) {
       sendEvent(pendingApproval);
     }
+    const capturedApps = await maybeCaptureChatArtifacts(
+      chatRequest,
+      filteredResult,
+    );
+    if (capturedApps.length > 0) filteredResult.apps = capturedApps;
     sendEvent({
       type: 'result',
       result: filteredResult,
     });
-    await maybeCaptureChatArtifacts(chatRequest, filteredResult);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     sendEvent({
@@ -7138,17 +7143,17 @@ async function handleApiAppGenerate(
 async function maybeCaptureChatArtifacts(
   chatRequest: GatewayChatRequest,
   result: GatewayChatResult,
-): Promise<void> {
-  if (result.status !== 'success') return;
+): Promise<NonNullable<GatewayChatResult['apps']>> {
+  const captured: NonNullable<GatewayChatResult['apps']> = [];
+  if (result.status !== 'success') return captured;
   const sessionId = result.sessionId || chatRequest.sessionId;
-  if (!sessionId) return;
+  if (!sessionId) return captured;
   const kind = chatRequest.appKind === 'live' ? 'live' : 'web';
   const category = chatRequest.appBuild
     ? (chatRequest.appCategory ?? null)
     : null;
   const agentId = result.agentId ?? chatRequest.agentId ?? null;
   try {
-    let capturedFromArtifact = false;
     for (const artifact of result.artifacts ?? []) {
       if (!artifact.mimeType?.toLowerCase().includes('html')) continue;
       if (!artifact.path) continue;
@@ -7168,16 +7173,16 @@ async function maybeCaptureChatArtifacts(
         kind,
         agentId,
       });
-      capturedFromArtifact = true;
+      captured.push({ id: app.id, title: app.title, kind: app.kind });
       logger.debug(
         { sessionId, appId: app.id, title: app.title, kind },
         'Captured HTML artifact into Apps gallery',
       );
     }
     // App-builder turns may inline the HTML in the reply instead of a file.
-    if (!capturedFromArtifact && chatRequest.appBuild) {
+    if (captured.length === 0 && chatRequest.appBuild) {
       const html = extractHtmlDocument(result.result ?? '');
-      if (!html) return;
+      if (!html) return captured;
       const app = upsertAppArtifact({
         sessionId,
         sourceKey: 'inline',
@@ -7187,6 +7192,7 @@ async function maybeCaptureChatArtifacts(
         kind,
         agentId,
       });
+      captured.push({ id: app.id, title: app.title, kind: app.kind });
       logger.debug(
         { sessionId, appId: app.id, title: app.title, kind },
         'Captured inline app build into Apps gallery',
@@ -7195,6 +7201,7 @@ async function maybeCaptureChatArtifacts(
   } catch (err) {
     logger.warn({ err, sessionId }, 'Failed to capture chat artifacts');
   }
+  return captured;
 }
 
 async function handleApiAdminTerminal(

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -25,6 +25,7 @@ import {
   normalizeAgentProxyConfig,
   resolveSnakeCamelAlias,
 } from '../agents/agent-types.js';
+import { generateApp } from '../apps/app-generator.js';
 import { getHybridAIApiKey } from '../auth/hybridai-auth.js';
 import { getBoardBudgetSummaries } from '../board/budget-chip.js';
 import {
@@ -102,6 +103,7 @@ import {
   UPLOADED_MEDIA_CACHE_ROOT_DISPLAY,
   writeUploadedMediaCacheFile,
 } from '../media/uploaded-media-cache.js';
+import { createApp, deleteApp, getApp, listApps } from '../memory/apps.js';
 import {
   claimQueuedProactiveMessages,
   enqueueProactiveMessage,
@@ -6978,6 +6980,134 @@ async function handleApiArtifact(
   });
 }
 
+/**
+ * Parse `/api/apps/<id>` (or `/api/apps/<id><suffix>`, e.g. `/view`) into the
+ * app id. Returns null for non-matching paths or malformed ids rather than
+ * throwing, so it is safe to call from the pre-auth dispatch section.
+ */
+function parseApiAppId(pathname: string, suffix = ''): string | null {
+  const prefix = '/api/apps/';
+  if (!pathname.startsWith(prefix)) return null;
+  let rest = pathname.slice(prefix.length);
+  if (suffix) {
+    if (!rest.endsWith(suffix)) return null;
+    rest = rest.slice(0, rest.length - suffix.length);
+  }
+  if (!rest || rest.includes('/')) return null;
+  try {
+    return decodeURIComponent(rest);
+  } catch {
+    return null;
+  }
+}
+
+async function handleApiAppView(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+  id: string,
+): Promise<void> {
+  if (
+    !hasApiAuth(req, url, {
+      allowLocalWebSession: true,
+      allowQueryToken: true,
+      allowSessionCookie: true,
+    })
+  ) {
+    sendJson(res, 401, {
+      error:
+        'Unauthorized. Set `Authorization: Bearer <WEB_API_TOKEN>` or pass `?token=<WEB_API_TOKEN>`.',
+    });
+    return;
+  }
+  const app = getApp(id);
+  if (!app) {
+    sendJson(res, 404, { error: 'App not found.' });
+    return;
+  }
+  res.writeHead(200, {
+    'Content-Type': 'text/html; charset=utf-8',
+    'Cache-Control': 'no-store',
+    'X-Content-Type-Options': 'nosniff',
+  });
+  res.end(app.html);
+}
+
+function handleApiAppsList(res: ServerResponse, url: URL): void {
+  const category = url.searchParams.get('category') ?? undefined;
+  const search =
+    url.searchParams.get('q') ?? url.searchParams.get('search') ?? undefined;
+  const apps = listApps({
+    ...(category ? { category } : {}),
+    ...(search ? { search } : {}),
+  });
+  sendJson(res, 200, { apps, total: apps.length });
+}
+
+function handleApiAppDetail(res: ServerResponse, id: string): void {
+  const app = getApp(id);
+  if (!app) {
+    sendJson(res, 404, { error: 'App not found.' });
+    return;
+  }
+  sendJson(res, 200, { app });
+}
+
+function handleApiAppDelete(res: ServerResponse, id: string): void {
+  if (!deleteApp(id)) {
+    sendJson(res, 404, { error: 'App not found.' });
+    return;
+  }
+  sendJson(res, 200, { ok: true });
+}
+
+async function handleApiAppGenerate(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const body = (await readJsonBody(req)) as {
+    description?: unknown;
+    category?: unknown;
+    agentId?: unknown;
+    model?: unknown;
+    sessionId?: unknown;
+    chatbotId?: unknown;
+  };
+  const description =
+    typeof body.description === 'string' ? body.description.trim() : '';
+  if (!description) {
+    throw new GatewayRequestError(
+      400,
+      'A non-empty `description` is required.',
+    );
+  }
+  const agentId =
+    (typeof body.agentId === 'string' && body.agentId.trim()) ||
+    resolveDefaultAgentId(getRuntimeConfig());
+  const generated = await generateApp({
+    description,
+    ...(typeof body.category === 'string' ? { category: body.category } : {}),
+    agentId,
+    ...(typeof body.model === 'string' && body.model.trim()
+      ? { model: body.model.trim() }
+      : {}),
+    ...(typeof body.chatbotId === 'string' && body.chatbotId.trim()
+      ? { chatbotId: body.chatbotId.trim() }
+      : {}),
+  });
+  const app = createApp({
+    title: generated.title,
+    html: generated.html,
+    category: generated.category,
+    description,
+    prompt: description,
+    agentId,
+    sessionId:
+      typeof body.sessionId === 'string' ? body.sessionId.trim() || null : null,
+  });
+  sendJson(res, 201, { app });
+}
+
 async function handleApiAdminTerminal(
   req: IncomingMessage,
   res: ServerResponse,
@@ -7348,6 +7478,25 @@ export function startGatewayHttpServer(): GatewayHttpServer {
         });
         return;
       }
+      {
+        // App viewer renders generated HTML inline in a (sandboxed) browser
+        // frame, so — like /api/artifact — it accepts query-token / cookie auth
+        // instead of requiring an Authorization header.
+        const appViewId = parseApiAppId(pathname, '/view');
+        if (appViewId !== null && method === 'GET') {
+          void handleApiAppView(req, res, url, appViewId).catch(
+            (err: unknown) => {
+              if (res.writableEnded) return;
+              const errorText =
+                err instanceof Error ? err.message : String(err);
+              const statusCode =
+                err instanceof GatewayRequestError ? err.statusCode : 500;
+              sendJson(res, statusCode, { error: errorText });
+            },
+          );
+          return;
+        }
+      }
       if (pathname === '/api/mcp/oauth/callback' && method === 'GET') {
         // Public by design: the OAuth provider redirects the user's browser
         // here without gateway credentials. The flow is bound to a
@@ -7425,6 +7574,29 @@ export function startGatewayHttpServer(): GatewayHttpServer {
           if (pathname === '/api/admin/overview' && method === 'GET') {
             await handleApiAdminOverview(res);
             return;
+          }
+          if (pathname === '/api/apps' && method === 'GET') {
+            handleApiAppsList(res, url);
+            return;
+          }
+          if (pathname === '/api/apps/generate' && method === 'POST') {
+            await handleApiAppGenerate(req, res);
+            return;
+          }
+          {
+            const appId = parseApiAppId(pathname);
+            if (appId !== null) {
+              if (method === 'GET') {
+                handleApiAppDetail(res, appId);
+                return;
+              }
+              if (method === 'DELETE') {
+                handleApiAppDelete(res, appId);
+                return;
+              }
+              sendMethodNotAllowed(res);
+              return;
+            }
           }
           if (pathname === '/api/admin/secrets' && method === 'GET') {
             handleApiAdminSecrets(req, res);

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -166,9 +166,17 @@ export interface GatewayChatRequestBody {
   chatbotId?: string | null;
   model?: string | null;
   enableRag?: boolean;
+  /**
+   * When true, a self-contained HTML result from this turn is captured into the
+   * Apps gallery (used by the Apps builder conversation). `appCategory` tags it.
+   */
+  appBuild?: boolean;
+  appCategory?: string | null;
 }
 
 export interface GatewayChatRequest {
+  appBuild?: boolean;
+  appCategory?: string | null;
   sessionId: GatewayChatRequestBody['sessionId'];
   executionSessionId?: string;
   executorModeOverride?: 'host' | 'container';

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -107,6 +107,8 @@ export interface GatewayChatResult {
     filename: string;
     mimeType: string;
   }>;
+  /** Apps captured into the gallery from this turn (Apps builder / artifacts). */
+  apps?: Array<{ id: string; title: string; kind: 'web' | 'live' }>;
   toolExecutions?: ToolExecution[];
   pendingApproval?: PendingApproval;
   tokenUsage?: TokenUsageStats;

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -167,16 +167,19 @@ export interface GatewayChatRequestBody {
   model?: string | null;
   enableRag?: boolean;
   /**
-   * When true, a self-contained HTML result from this turn is captured into the
-   * Apps gallery (used by the Apps builder conversation). `appCategory` tags it.
+   * Marks an Apps-builder conversation. HTML artifacts are captured into the
+   * gallery for every chat, but `appBuild` also captures inline HTML from the
+   * assistant text and tags the entry with `appCategory` / `appKind`.
    */
   appBuild?: boolean;
   appCategory?: string | null;
+  appKind?: 'web' | 'live';
 }
 
 export interface GatewayChatRequest {
   appBuild?: boolean;
   appCategory?: string | null;
+  appKind?: 'web' | 'live';
   sessionId: GatewayChatRequestBody['sessionId'];
   executionSessionId?: string;
   executorModeOverride?: 'host' | 'container';

--- a/src/memory/apps.ts
+++ b/src/memory/apps.ts
@@ -20,15 +20,24 @@ export type AppCategory = (typeof APP_CATEGORIES)[number];
 
 export type AppVisibility = 'private' | 'public';
 
+/** A `live` app is connector-aware and can be refreshed; `web` is static. */
+export type AppKind = 'web' | 'live';
+
+export function normalizeAppKind(raw: string | null | undefined): AppKind {
+  return raw === 'live' ? 'live' : 'web';
+}
+
 export interface StoredApp {
   id: string;
   title: string;
   description: string | null;
   category: AppCategory;
+  kind: AppKind;
   html: string;
   prompt: string | null;
   agentId: string | null;
   sessionId: string | null;
+  sourceKey: string | null;
   visibility: AppVisibility;
   createdAt: string;
   updatedAt: string;
@@ -42,9 +51,11 @@ export interface CreateAppInput {
   html: string;
   description?: string | null;
   category?: string | null;
+  kind?: AppKind;
   prompt?: string | null;
   agentId?: string | null;
   sessionId?: string | null;
+  sourceKey?: string | null;
   visibility?: AppVisibility;
 }
 
@@ -53,16 +64,18 @@ interface AppRow {
   title: string;
   description: string | null;
   category: string;
+  kind: string;
   html: string;
   prompt: string | null;
   agent_id: string | null;
   session_id: string | null;
+  source_key: string | null;
   visibility: string;
   created_at: string;
   updated_at: string;
 }
 
-const SUMMARY_COLUMNS = `id, title, description, category, prompt, agent_id, session_id, visibility, created_at, updated_at`;
+const SUMMARY_COLUMNS = `id, title, description, category, kind, prompt, agent_id, session_id, source_key, visibility, created_at, updated_at`;
 
 export function normalizeAppCategory(
   raw: string | null | undefined,
@@ -85,9 +98,11 @@ function appSummaryFromRow(row: Omit<AppRow, 'html'>): AppSummary {
     title: row.title,
     description: row.description,
     category: normalizeAppCategory(row.category),
+    kind: normalizeAppKind(row.kind),
     prompt: row.prompt,
     agentId: row.agent_id,
     sessionId: row.session_id,
+    sourceKey: row.source_key,
     visibility: normalizeVisibility(row.visibility),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -105,22 +120,25 @@ export function createApp(input: CreateAppInput): StoredApp {
   return withMemoryDatabase((database: Database.Database) => {
     const id = randomUUID();
     const category = normalizeAppCategory(input.category);
+    const kind = normalizeAppKind(input.kind);
     const visibility = normalizeVisibility(input.visibility);
     database
       .prepare(
         `INSERT INTO apps
-          (id, title, description, category, html, prompt, agent_id, session_id, visibility, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`,
+          (id, title, description, category, kind, html, prompt, agent_id, session_id, source_key, visibility, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`,
       )
       .run(
         id,
         input.title.trim() || 'Untitled App',
         input.description?.trim() || null,
         category,
+        kind,
         input.html,
         input.prompt?.trim() || null,
         input.agentId?.trim() || null,
         input.sessionId?.trim() || null,
+        input.sourceKey?.trim() || null,
         visibility,
       );
     const row = database
@@ -166,40 +184,43 @@ export function listApps(query: ListAppsQuery = {}): AppSummary[] {
   });
 }
 
-export interface UpsertAppForSessionInput {
+export interface UpsertAppArtifactInput {
+  sessionId: string;
+  /** Stable identity within a session (artifact filename, or 'inline'). */
+  sourceKey: string;
   title: string;
   html: string;
   category?: string | null;
+  kind?: AppKind;
   description?: string | null;
   prompt?: string | null;
   agentId?: string | null;
 }
 
 /**
- * Create or update the app attached to a chat session. App-build conversations
- * call this on each turn that produces HTML, so the gallery entry evolves with
- * the conversation instead of creating duplicates.
+ * Create or update the gallery entry for one artifact within a chat session,
+ * identified by (session_id, source_key). Capturing the same artifact again as
+ * a conversation iterates updates the entry in place instead of duplicating.
  */
-export function upsertAppForSession(
-  sessionId: string,
-  input: UpsertAppForSessionInput,
-): StoredApp {
+export function upsertAppArtifact(input: UpsertAppArtifactInput): StoredApp {
   return withMemoryDatabase((database: Database.Database) => {
-    const session = sessionId.trim();
+    const session = input.sessionId.trim();
+    const sourceKey = input.sourceKey.trim() || 'inline';
     const category = normalizeAppCategory(input.category);
+    const kind = normalizeAppKind(input.kind);
     const title = input.title.trim() || 'Untitled App';
     const existing = session
       ? (database
           .prepare<unknown[], { id: string }>(
-            `SELECT id FROM apps WHERE session_id = ? ORDER BY created_at DESC LIMIT 1`,
+            `SELECT id FROM apps WHERE session_id = ? AND source_key = ? ORDER BY created_at DESC LIMIT 1`,
           )
-          .get(session) ?? null)
+          .get(session, sourceKey) ?? null)
       : null;
     if (existing) {
       database
         .prepare(
           `UPDATE apps
-             SET title = ?, html = ?, category = ?,
+             SET title = ?, html = ?, category = ?, kind = ?,
                  description = COALESCE(?, description),
                  updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
            WHERE id = ?`,
@@ -208,23 +229,26 @@ export function upsertAppForSession(
           title,
           input.html,
           category,
+          kind,
           input.description?.trim() || null,
           existing.id,
         );
       const row = database
         .prepare<unknown[], AppRow>(`SELECT * FROM apps WHERE id = ?`)
         .get(existing.id);
-      if (!row) throw new Error('Failed to update app for session.');
+      if (!row) throw new Error('Failed to update app artifact.');
       return appFromRow(row);
     }
     return createApp({
       title,
       html: input.html,
       category,
+      kind,
       description: input.description ?? null,
       prompt: input.prompt ?? null,
       agentId: input.agentId ?? null,
       sessionId: session || null,
+      sourceKey,
     });
   });
 }

--- a/src/memory/apps.ts
+++ b/src/memory/apps.ts
@@ -166,6 +166,69 @@ export function listApps(query: ListAppsQuery = {}): AppSummary[] {
   });
 }
 
+export interface UpsertAppForSessionInput {
+  title: string;
+  html: string;
+  category?: string | null;
+  description?: string | null;
+  prompt?: string | null;
+  agentId?: string | null;
+}
+
+/**
+ * Create or update the app attached to a chat session. App-build conversations
+ * call this on each turn that produces HTML, so the gallery entry evolves with
+ * the conversation instead of creating duplicates.
+ */
+export function upsertAppForSession(
+  sessionId: string,
+  input: UpsertAppForSessionInput,
+): StoredApp {
+  return withMemoryDatabase((database: Database.Database) => {
+    const session = sessionId.trim();
+    const category = normalizeAppCategory(input.category);
+    const title = input.title.trim() || 'Untitled App';
+    const existing = session
+      ? (database
+          .prepare<unknown[], { id: string }>(
+            `SELECT id FROM apps WHERE session_id = ? ORDER BY created_at DESC LIMIT 1`,
+          )
+          .get(session) ?? null)
+      : null;
+    if (existing) {
+      database
+        .prepare(
+          `UPDATE apps
+             SET title = ?, html = ?, category = ?,
+                 description = COALESCE(?, description),
+                 updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+           WHERE id = ?`,
+        )
+        .run(
+          title,
+          input.html,
+          category,
+          input.description?.trim() || null,
+          existing.id,
+        );
+      const row = database
+        .prepare<unknown[], AppRow>(`SELECT * FROM apps WHERE id = ?`)
+        .get(existing.id);
+      if (!row) throw new Error('Failed to update app for session.');
+      return appFromRow(row);
+    }
+    return createApp({
+      title,
+      html: input.html,
+      category,
+      description: input.description ?? null,
+      prompt: input.prompt ?? null,
+      agentId: input.agentId ?? null,
+      sessionId: session || null,
+    });
+  });
+}
+
 export function getApp(id: string): StoredApp | null {
   return withMemoryDatabase((database: Database.Database) => {
     const normalized = id.trim();

--- a/src/memory/apps.ts
+++ b/src/memory/apps.ts
@@ -1,0 +1,200 @@
+import { randomUUID } from 'node:crypto';
+import type Database from 'better-sqlite3';
+import { withMemoryDatabase } from './db.js';
+
+/**
+ * Slugs for the artifact/app categories surfaced in the gallery "New App"
+ * picker. `scratch` ("Von Grund auf neu beginnen") is the freeform option.
+ */
+export const APP_CATEGORIES = [
+  'apps',
+  'documents',
+  'games',
+  'productivity',
+  'creative',
+  'quiz',
+  'scratch',
+] as const;
+
+export type AppCategory = (typeof APP_CATEGORIES)[number];
+
+export type AppVisibility = 'private' | 'public';
+
+export interface StoredApp {
+  id: string;
+  title: string;
+  description: string | null;
+  category: AppCategory;
+  html: string;
+  prompt: string | null;
+  agentId: string | null;
+  sessionId: string | null;
+  visibility: AppVisibility;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Gallery list rows omit the (potentially large) HTML body. */
+export type AppSummary = Omit<StoredApp, 'html'>;
+
+export interface CreateAppInput {
+  title: string;
+  html: string;
+  description?: string | null;
+  category?: string | null;
+  prompt?: string | null;
+  agentId?: string | null;
+  sessionId?: string | null;
+  visibility?: AppVisibility;
+}
+
+interface AppRow {
+  id: string;
+  title: string;
+  description: string | null;
+  category: string;
+  html: string;
+  prompt: string | null;
+  agent_id: string | null;
+  session_id: string | null;
+  visibility: string;
+  created_at: string;
+  updated_at: string;
+}
+
+const SUMMARY_COLUMNS = `id, title, description, category, prompt, agent_id, session_id, visibility, created_at, updated_at`;
+
+export function normalizeAppCategory(
+  raw: string | null | undefined,
+): AppCategory {
+  const value = String(raw || '')
+    .trim()
+    .toLowerCase();
+  return (APP_CATEGORIES as readonly string[]).includes(value)
+    ? (value as AppCategory)
+    : 'apps';
+}
+
+function normalizeVisibility(raw: string | null | undefined): AppVisibility {
+  return raw === 'public' ? 'public' : 'private';
+}
+
+function appSummaryFromRow(row: Omit<AppRow, 'html'>): AppSummary {
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description,
+    category: normalizeAppCategory(row.category),
+    prompt: row.prompt,
+    agentId: row.agent_id,
+    sessionId: row.session_id,
+    visibility: normalizeVisibility(row.visibility),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function appFromRow(row: AppRow): StoredApp {
+  return {
+    ...appSummaryFromRow(row),
+    html: row.html,
+  };
+}
+
+export function createApp(input: CreateAppInput): StoredApp {
+  return withMemoryDatabase((database: Database.Database) => {
+    const id = randomUUID();
+    const category = normalizeAppCategory(input.category);
+    const visibility = normalizeVisibility(input.visibility);
+    database
+      .prepare(
+        `INSERT INTO apps
+          (id, title, description, category, html, prompt, agent_id, session_id, visibility, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`,
+      )
+      .run(
+        id,
+        input.title.trim() || 'Untitled App',
+        input.description?.trim() || null,
+        category,
+        input.html,
+        input.prompt?.trim() || null,
+        input.agentId?.trim() || null,
+        input.sessionId?.trim() || null,
+        visibility,
+      );
+    const row = database
+      .prepare<unknown[], AppRow>(`SELECT * FROM apps WHERE id = ?`)
+      .get(id);
+    if (!row) {
+      throw new Error('Failed to persist generated app.');
+    }
+    return appFromRow(row);
+  });
+}
+
+export interface ListAppsQuery {
+  category?: string;
+  search?: string;
+  limit?: number;
+}
+
+export function listApps(query: ListAppsQuery = {}): AppSummary[] {
+  return withMemoryDatabase((database: Database.Database) => {
+    const clauses: string[] = [];
+    const params: unknown[] = [];
+    if (query.category && query.category !== 'all') {
+      clauses.push('category = ?');
+      params.push(normalizeAppCategory(query.category));
+    }
+    const search = query.search?.trim().toLowerCase();
+    if (search) {
+      clauses.push('(LOWER(title) LIKE ? OR LOWER(description) LIKE ?)');
+      params.push(`%${search}%`, `%${search}%`);
+    }
+    const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
+    const limit =
+      typeof query.limit === 'number' && Number.isFinite(query.limit)
+        ? Math.min(Math.max(Math.floor(query.limit), 1), 500)
+        : 200;
+    const rows = database
+      .prepare<unknown[], Omit<AppRow, 'html'>>(
+        `SELECT ${SUMMARY_COLUMNS} FROM apps ${where} ORDER BY created_at DESC LIMIT ?`,
+      )
+      .all(...params, limit);
+    return rows.map(appSummaryFromRow);
+  });
+}
+
+export function getApp(id: string): StoredApp | null {
+  return withMemoryDatabase((database: Database.Database) => {
+    const normalized = id.trim();
+    if (!normalized) return null;
+    const row = database
+      .prepare<unknown[], AppRow>(`SELECT * FROM apps WHERE id = ?`)
+      .get(normalized);
+    return row ? appFromRow(row) : null;
+  });
+}
+
+export function deleteApp(id: string): boolean {
+  return withMemoryDatabase((database: Database.Database) => {
+    const normalized = id.trim();
+    if (!normalized) return false;
+    const result = database
+      .prepare(`DELETE FROM apps WHERE id = ?`)
+      .run(normalized);
+    return result.changes > 0;
+  });
+}
+
+export function countApps(): number {
+  return withMemoryDatabase((database: Database.Database) => {
+    const row = database
+      .prepare<unknown[], { count: number }>(
+        `SELECT COUNT(*) AS count FROM apps`,
+      )
+      .get();
+    return row?.count ?? 0;
+  });
+}

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -162,7 +162,7 @@ let databaseInitialized = false;
 let usageEventBatchInsertStatement: Database.Statement | null = null;
 const usageRecordSubscribers = new Set<UsageRecordSubscriber>();
 
-export const DATABASE_SCHEMA_VERSION = 46;
+export const DATABASE_SCHEMA_VERSION = 47;
 const AGENT_CANONICAL_ID_COLLISION_LIMIT = 20;
 const DEFAULT_LOCAL_OWNER_USER_ID = formatLocalOwnerUserId('');
 const STRUCTURED_AUDIT_SESSION_LIMIT = 10_000;
@@ -3120,6 +3120,40 @@ function migrateV46(database: Database.Database): void {
   recordMigration(database, 46, 'Persist generated apps (artifacts gallery)');
 }
 
+function appsKindNeedMigration(database: Database.Database): boolean {
+  return (
+    tableExists(database, 'apps') && !columnExists(database, 'apps', 'kind')
+  );
+}
+
+function migrateV47(
+  database: Database.Database,
+  opts?: InitDatabaseOptions,
+): void {
+  const quiet = opts?.quiet === true;
+  addColumnIfMissing({
+    database,
+    table: 'apps',
+    column: 'kind',
+    ddl: "kind TEXT NOT NULL DEFAULT 'web'",
+    quiet,
+  });
+  addColumnIfMissing({
+    database,
+    table: 'apps',
+    column: 'source_key',
+    ddl: 'source_key TEXT',
+    quiet,
+  });
+  if (tableExists(database, 'apps')) {
+    database.exec(`
+      CREATE INDEX IF NOT EXISTS idx_apps_session_source
+        ON apps(session_id, source_key);
+    `);
+  }
+  recordMigration(database, 47, 'Add app kind (web/live) and source key');
+}
+
 function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -3236,6 +3270,9 @@ function runMigrations(
     migrateV45(database, opts);
   }
   if (currentVersion < 46) migrateV46(database);
+  if (currentVersion < 47 || appsKindNeedMigration(database)) {
+    migrateV47(database, opts);
+  }
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);
   if (!quiet && currentVersion < DATABASE_SCHEMA_VERSION) {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -162,7 +162,7 @@ let databaseInitialized = false;
 let usageEventBatchInsertStatement: Database.Statement | null = null;
 const usageRecordSubscribers = new Set<UsageRecordSubscriber>();
 
-export const DATABASE_SCHEMA_VERSION = 45;
+export const DATABASE_SCHEMA_VERSION = 46;
 const AGENT_CANONICAL_ID_COLLISION_LIMIT = 20;
 const DEFAULT_LOCAL_OWNER_USER_ID = formatLocalOwnerUserId('');
 const STRUCTURED_AUDIT_SESSION_LIMIT = 10_000;
@@ -3099,6 +3099,27 @@ function migrateV45(
   recordMigration(database, 45, 'Persist per-agent empty chat header');
 }
 
+function migrateV46(database: Database.Database): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS apps (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      description TEXT,
+      category TEXT NOT NULL DEFAULT 'apps',
+      html TEXT NOT NULL,
+      prompt TEXT,
+      agent_id TEXT,
+      session_id TEXT,
+      visibility TEXT NOT NULL DEFAULT 'private' CHECK (visibility IN ('private', 'public')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_apps_created_at ON apps(created_at);
+    CREATE INDEX IF NOT EXISTS idx_apps_category ON apps(category);
+  `);
+  recordMigration(database, 46, 'Persist generated apps (artifacts gallery)');
+}
+
 function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -3214,6 +3235,7 @@ function runMigrations(
   if (currentVersion < 45 || agentEmptyChatHeaderNeedMigration(database)) {
     migrateV45(database, opts);
   }
+  if (currentVersion < 46) migrateV46(database);
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);
   if (!quiet && currentVersion < DATABASE_SCHEMA_VERSION) {

--- a/tests/app-generator.test.ts
+++ b/tests/app-generator.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from 'vitest';
+import {
+  deriveAppTitle,
+  extractHtmlDocument,
+} from '../src/apps/app-generator.ts';
+
+test('extractHtmlDocument returns a clean full document as-is', () => {
+  const doc = '<!DOCTYPE html><html><head><title>X</title></head><body>1</body></html>';
+  expect(extractHtmlDocument(doc)).toBe(doc);
+});
+
+test('extractHtmlDocument unwraps a fenced ```html block and strips prose', () => {
+  const raw = [
+    'Sure, here is your app:',
+    '```html',
+    '<!DOCTYPE html><html><body>game</body></html>',
+    '```',
+    'Hope you like it!',
+  ].join('\n');
+  expect(extractHtmlDocument(raw)).toBe(
+    '<!DOCTYPE html><html><body>game</body></html>',
+  );
+});
+
+test('extractHtmlDocument strips <think> reasoning and leading text', () => {
+  const raw =
+    '<think>I will build...</think>Here:\n<html><body>ok</body></html>\nDone.';
+  expect(extractHtmlDocument(raw)).toBe('<html><body>ok</body></html>');
+});
+
+test('extractHtmlDocument returns null when no html is present', () => {
+  expect(extractHtmlDocument('I cannot do that.')).toBeNull();
+});
+
+test('deriveAppTitle prefers the document <title>', () => {
+  const html = '<html><head><title>Budget Tracker</title></head></html>';
+  expect(deriveAppTitle(html, 'make me a money app')).toBe('Budget Tracker');
+});
+
+test('deriveAppTitle falls back to the description', () => {
+  expect(deriveAppTitle('<html></html>', '  a snake game  ')).toBe(
+    'a snake game',
+  );
+});
+
+test('deriveAppTitle truncates very long titles', () => {
+  const long = 'a'.repeat(200);
+  const title = deriveAppTitle('<html></html>', long);
+  expect(title.length).toBeLessThanOrEqual(81);
+  expect(title.endsWith('…')).toBe(true);
+});

--- a/tests/apps-store.test.ts
+++ b/tests/apps-store.test.ts
@@ -75,6 +75,34 @@ test('unknown category normalizes to apps', async () => {
   expect(created.category).toBe('apps');
 });
 
+test('upsertAppForSession creates then updates the same session entry', async () => {
+  const { upsertAppForSession, listApps, getApp } = await setup();
+  const first = upsertAppForSession('sess-app-1', {
+    title: 'Draft',
+    html: '<html><body>v1</body></html>',
+    category: 'productivity',
+  });
+  expect(listApps()).toHaveLength(1);
+
+  const second = upsertAppForSession('sess-app-1', {
+    title: 'Final Dashboard',
+    html: '<html><body>v2</body></html>',
+    category: 'productivity',
+  });
+  // Same row updated in place, not a duplicate.
+  expect(second.id).toBe(first.id);
+  expect(listApps()).toHaveLength(1);
+  expect(getApp(first.id)?.html).toContain('v2');
+  expect(getApp(first.id)?.title).toBe('Final Dashboard');
+
+  // A different session makes a separate entry.
+  upsertAppForSession('sess-app-2', {
+    title: 'Other',
+    html: '<html></html>',
+  });
+  expect(listApps()).toHaveLength(2);
+});
+
 test('deleteApp removes the record', async () => {
   const { createApp, deleteApp, getApp } = await setup();
   const created = createApp({ title: 'Temp', html: '<html></html>' });

--- a/tests/apps-store.test.ts
+++ b/tests/apps-store.test.ts
@@ -1,0 +1,84 @@
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
+
+const ORIGINAL_HOME = process.env.HOME;
+
+const makeTempHome = useTempDir('hybridclaw-apps-store-');
+
+useCleanMocks({
+  cleanup: () => {
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+    else process.env.HOME = ORIGINAL_HOME;
+  },
+  resetModules: true,
+});
+
+async function setup() {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const store = await import('../src/memory/apps.ts');
+  initDatabase({ quiet: true });
+  return store;
+}
+
+test('createApp persists and getApp returns the stored html', async () => {
+  const { createApp, getApp } = await setup();
+  const created = createApp({
+    title: 'Pomodoro Timer',
+    html: '<!DOCTYPE html><html><body>hi</body></html>',
+    description: 'A focus timer',
+    category: 'productivity',
+    prompt: 'build a pomodoro timer',
+  });
+  expect(created.id).toBeTruthy();
+  expect(created.category).toBe('productivity');
+  expect(created.visibility).toBe('private');
+
+  const fetched = getApp(created.id);
+  expect(fetched?.html).toContain('<body>hi</body>');
+  expect(fetched?.title).toBe('Pomodoro Timer');
+});
+
+test('listApps omits html, filters by category and search, newest first', async () => {
+  const { createApp, listApps } = await setup();
+  createApp({ title: 'Snake Game', html: '<html></html>', category: 'games' });
+  createApp({
+    title: 'Invoice Doc',
+    html: '<html></html>',
+    category: 'documents',
+    description: 'monthly invoice',
+  });
+
+  const all = listApps();
+  expect(all).toHaveLength(2);
+  // Summary rows do not carry the html body.
+  expect((all[0] as unknown as { html?: string }).html).toBeUndefined();
+
+  const games = listApps({ category: 'games' });
+  expect(games).toHaveLength(1);
+  expect(games[0].title).toBe('Snake Game');
+
+  const bySearch = listApps({ search: 'invoice' });
+  expect(bySearch).toHaveLength(1);
+  expect(bySearch[0].title).toBe('Invoice Doc');
+});
+
+test('unknown category normalizes to apps', async () => {
+  const { createApp } = await setup();
+  const created = createApp({
+    title: 'Mystery',
+    html: '<html></html>',
+    category: 'not-a-real-category',
+  });
+  expect(created.category).toBe('apps');
+});
+
+test('deleteApp removes the record', async () => {
+  const { createApp, deleteApp, getApp } = await setup();
+  const created = createApp({ title: 'Temp', html: '<html></html>' });
+  expect(deleteApp(created.id)).toBe(true);
+  expect(getApp(created.id)).toBeNull();
+  expect(deleteApp(created.id)).toBe(false);
+});

--- a/tests/apps-store.test.ts
+++ b/tests/apps-store.test.ts
@@ -75,19 +75,26 @@ test('unknown category normalizes to apps', async () => {
   expect(created.category).toBe('apps');
 });
 
-test('upsertAppForSession creates then updates the same session entry', async () => {
-  const { upsertAppForSession, listApps, getApp } = await setup();
-  const first = upsertAppForSession('sess-app-1', {
+test('upsertAppArtifact creates then updates the same (session, source) entry', async () => {
+  const { upsertAppArtifact, listApps, getApp } = await setup();
+  const first = upsertAppArtifact({
+    sessionId: 'sess-app-1',
+    sourceKey: 'app.html',
     title: 'Draft',
     html: '<html><body>v1</body></html>',
     category: 'productivity',
+    kind: 'live',
   });
   expect(listApps()).toHaveLength(1);
+  expect(first.kind).toBe('live');
 
-  const second = upsertAppForSession('sess-app-1', {
+  const second = upsertAppArtifact({
+    sessionId: 'sess-app-1',
+    sourceKey: 'app.html',
     title: 'Final Dashboard',
     html: '<html><body>v2</body></html>',
     category: 'productivity',
+    kind: 'live',
   });
   // Same row updated in place, not a duplicate.
   expect(second.id).toBe(first.id);
@@ -95,12 +102,23 @@ test('upsertAppForSession creates then updates the same session entry', async ()
   expect(getApp(first.id)?.html).toContain('v2');
   expect(getApp(first.id)?.title).toBe('Final Dashboard');
 
-  // A different session makes a separate entry.
-  upsertAppForSession('sess-app-2', {
-    title: 'Other',
+  // A different artifact in the same session is a separate entry.
+  upsertAppArtifact({
+    sessionId: 'sess-app-1',
+    sourceKey: 'report.html',
+    title: 'Report',
     html: '<html></html>',
   });
   expect(listApps()).toHaveLength(2);
+
+  // A different session is also separate.
+  upsertAppArtifact({
+    sessionId: 'sess-app-2',
+    sourceKey: 'app.html',
+    title: 'Other',
+    html: '<html></html>',
+  });
+  expect(listApps()).toHaveLength(3);
 });
 
 test('deleteApp removes the record', async () => {

--- a/tests/openai-codex-provider.test.ts
+++ b/tests/openai-codex-provider.test.ts
@@ -41,6 +41,7 @@ const baseArgs = {
 };
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -121,6 +122,46 @@ describe('OpenAI Codex provider', () => {
     });
 
     expect(result.choices[0]?.message.content).toBe('ls -la');
+  });
+
+  test('times out a stalled streaming response after the first event', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        const encoder = new TextEncoder();
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  'event: response.created\r\n' +
+                    'data: {"type":"response.created","response":{"id":"resp_4","model":"gpt-5.4"}}\r\n\r\n',
+                ),
+              );
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+          },
+        );
+      }),
+    );
+
+    const resultPromise = callOpenAICodexProviderStream({
+      ...baseArgs,
+      onTextDelta: () => undefined,
+    });
+    const assertion = expect(resultPromise).rejects.toThrow(
+      'Stream idle timeout after 90000ms',
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(90_000);
+
+    await assertion;
   });
 
   test('fails explicitly when Codex returns no output at all', async () => {


### PR DESCRIPTION
## Summary

Fixes a silent hang in the OpenAI Codex streaming provider. The Codex SSE reader now uses the same idle-timeout wrapper as the other streaming providers, so a stream that emits an initial event and then stalls surfaces a retryable timeout instead of leaving the gateway turn open indefinitely.

## Root Cause

`container/src/providers/openai-codex.ts` called `reader.read()` directly. If the upstream SSE connection emitted `response.created` and then stopped sending bytes without closing, the model call could remain open for several minutes with no visible user progress or final error.

## Validation

- `npx vitest run tests/openai-codex-provider.test.ts`
- `npm run lint`
- `npm --prefix container run lint`
- `npm run format`