### PR TITLE
[codex] fix stalled Codex SSE timeout

### DIFF
--- a/container/src/providers/openai-codex.ts
+++ b/container/src/providers/openai-codex.ts
@@ -19,6 +19,7 @@ import {
   type NormalizedStreamCallArgs,
   ProviderRequestError,
 } from './shared.js';
+import { readWithIdleTimeout, STREAM_IDLE_TIMEOUT_MS } from './stream-utils.js';
 
 interface CodexAccumulatedContentPart {
   type: string;
@@ -836,7 +837,10 @@ export async function callOpenAICodexProviderStream(
 
   try {
     while (!streamDone) {
-      const { done, value } = await reader.read();
+      const { done, value } = await readWithIdleTimeout(
+        reader,
+        STREAM_IDLE_TIMEOUT_MS,
+      );
       if (done) break;
 
       buffer += decoder.decode(value, { stream: true });

--- a/tests/openai-codex-provider.test.ts
+++ b/tests/openai-codex-provider.test.ts
@@ -41,6 +41,7 @@ const baseArgs = {
 };
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -121,6 +122,46 @@ describe('OpenAI Codex provider', () => {
     });
 
     expect(result.choices[0]?.message.content).toBe('ls -la');
+  });
+
+  test('times out a stalled streaming response after the first event', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        const encoder = new TextEncoder();
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  'event: response.created\r\n' +
+                    'data: {"type":"response.created","response":{"id":"resp_4","model":"gpt-5.4"}}\r\n\r\n',
+                ),
+              );
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+          },
+        );
+      }),
+    );
+
+    const resultPromise = callOpenAICodexProviderStream({
+      ...baseArgs,
+      onTextDelta: () => undefined,
+    });
+    const assertion = expect(resultPromise).rejects.toThrow(
+      'Stream idle timeout after 90000ms',
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(90_000);
+
+    await assertion;
   });
 
   test('fails explicitly when Codex returns no output at all', async () => {


### PR DESCRIPTION
## Summary

Fixes a silent hang in the OpenAI Codex streaming provider. Codex SSE reads now use the same idle-timeout wrapper as the other streaming providers, so a stream that emits an initial event and then stalls surfaces a timeout instead of leaving the gateway turn open indefinitely.

## Root Cause

`container/src/providers/openai-codex.ts` called `reader.read()` directly. If the upstream SSE connection emitted `response.created` and then stopped sending bytes without closing, the model call could stay open for minutes with no visible user progress or final error.

## Validation

- `npx vitest run tests/openai-codex-provider.test.ts`
- `npm run lint`
- `npm --prefix container run lint`
- `npm run format`