### PR TITLE
feat(console): collapsible thinking and tool-call traces in web chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   auto-collapses to a one-line summary once the final answer, an approval, or
   an error arrives. It consumes the `thinking` and `tool` NDJSON events the
   gateway already emits on `/api/chat`, gated by the session `/show` mode.
+  The ordered trace is persisted per assistant message (schema v46), so a page
+  reload replays the same activity instead of dropping it.
 
   `Manifesto: Principle IV - A coworker is a colleague, not a chatbot.`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Added
+
+- **Chat activity traces**: The web `/chat` view now renders the agent's
+  thinking and tool calls as a light-grey, collapsible trace above each answer.
+  The trace streams live while the run is in flight (one row per thinking
+  segment or tool call, with args/result previews and durations) and
+  auto-collapses to a one-line summary once the final answer, an approval, or
+  an error arrives. It consumes the `thinking` and `tool` NDJSON events the
+  gateway already emits on `/api/chat`, gated by the session `/show` mode.
+
+  `Manifesto: Principle IV - A coworker is a colleague, not a chatbot.`
+
 ## [0.26.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.26.0) - 2026-07-03
 
 ### Added

--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -109,6 +109,19 @@ export interface ChatStreamTextDelta {
   delta: string;
 }
 
+export interface ChatStreamThinkingDelta {
+  type: 'thinking';
+  delta: string;
+}
+
+export interface ChatStreamToolEvent {
+  type: 'tool';
+  toolName: string;
+  phase: 'start' | 'finish';
+  preview?: string;
+  durationMs?: number;
+}
+
 export interface ChatStreamApproval {
   type: 'approval';
   approvalId: string;
@@ -126,7 +139,11 @@ export interface ChatStreamApproval {
   expiresAt?: number | null;
 }
 
-export type ChatStreamEvent = ChatStreamTextDelta | ChatStreamApproval;
+export type ChatStreamEvent =
+  | ChatStreamTextDelta
+  | ChatStreamThinkingDelta
+  | ChatStreamToolEvent
+  | ChatStreamApproval;
 
 export type ChatResultMessageRole = 'assistant' | 'approval' | 'command';
 

--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -22,6 +22,30 @@ export interface ChatMobileQrResponse {
   qrSvg: string;
 }
 
+export interface ChatActivityTraceThinkingStep {
+  kind: 'thinking';
+  text: string;
+}
+
+export interface ChatActivityTraceToolStep {
+  kind: 'tool';
+  toolName: string;
+  status?: 'running' | 'done';
+  argsPreview?: string;
+  resultPreview?: string;
+  durationMs?: number;
+}
+
+export type ChatActivityTraceStep =
+  | ChatActivityTraceThinkingStep
+  | ChatActivityTraceToolStep;
+
+/** Persisted per-message activity trace replayed from chat history. */
+export interface ChatActivityTrace {
+  steps: ChatActivityTraceStep[];
+  elapsedMs?: number;
+}
+
 export interface ChatHistoryMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;
@@ -30,6 +54,7 @@ export interface ChatHistoryMessage {
   response_rating?: ResponseRatingValue | null;
   artifacts?: ChatArtifact[];
   assistantPresentation?: AssistantPresentation | null;
+  activityTrace?: ChatActivityTrace | null;
 }
 
 export type ResponseRatingValue = 'up' | 'down';

--- a/console/src/lib/chat-stream.test.ts
+++ b/console/src/lib/chat-stream.test.ts
@@ -58,6 +58,86 @@ describe('requestChatStream', () => {
     window.removeEventListener(AUTH_REQUIRED_EVENT, listener);
   });
 
+  it('dispatches thinking deltas and tool progress events to their callbacks', async () => {
+    const onTextDelta = vi.fn();
+    const onApproval = vi.fn();
+    const onThinkingDelta = vi.fn();
+    const onToolEvent = vi.fn();
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      body: null,
+      text: async () =>
+        [
+          '{"type":"thinking","delta":"Hmm"}',
+          '{"type":"tool","toolName":"exec","phase":"start","preview":"ls"}',
+          '{"type":"tool","toolName":"exec","phase":"finish","preview":"ok","durationMs":12}',
+          '{"type":"tool","phase":"start"}',
+          '{"type":"result","result":{"status":"ok","result":"Done"}}',
+        ].join('\n'),
+    } as Response);
+
+    await expect(
+      requestChatStream('/api/chat', {
+        token: 'test-token',
+        body: { sessionId: 'session-a', stream: true },
+        callbacks: {
+          onTextDelta,
+          onApproval,
+          onThinkingDelta,
+          onToolEvent,
+        },
+      }),
+    ).resolves.toMatchObject({ status: 'ok', result: 'Done' });
+
+    expect(onThinkingDelta).toHaveBeenCalledWith('Hmm');
+    expect(onToolEvent).toHaveBeenNthCalledWith(1, {
+      type: 'tool',
+      toolName: 'exec',
+      phase: 'start',
+      preview: 'ls',
+    });
+    expect(onToolEvent).toHaveBeenNthCalledWith(2, {
+      type: 'tool',
+      toolName: 'exec',
+      phase: 'finish',
+      preview: 'ok',
+      durationMs: 12,
+    });
+    // The toolName-less line is malformed and must not reach the callback.
+    expect(onToolEvent).toHaveBeenCalledTimes(2);
+    expect(onTextDelta).not.toHaveBeenCalled();
+  });
+
+  it('ignores thinking and tool lines when their callbacks are not provided', async () => {
+    const onTextDelta = vi.fn();
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      body: null,
+      text: async () =>
+        [
+          '{"type":"thinking","delta":"Hmm"}',
+          '{"type":"tool","toolName":"exec","phase":"start"}',
+          '{"type":"text","delta":"Hi"}',
+          '{"type":"result","result":{"status":"ok","result":"Hi"}}',
+        ].join('\n'),
+    } as Response);
+
+    await expect(
+      requestChatStream('/api/chat', {
+        token: 'test-token',
+        body: { sessionId: 'session-a', stream: true },
+        callbacks: {
+          onTextDelta,
+          onApproval: vi.fn(),
+        },
+      }),
+    ).resolves.toMatchObject({ status: 'ok', result: 'Hi' });
+
+    expect(onTextDelta).toHaveBeenCalledWith('Hi');
+  });
+
   it('warns when malformed NDJSON lines are ignored and still returns the final result', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const onTextDelta = vi.fn();

--- a/console/src/lib/chat-stream.ts
+++ b/console/src/lib/chat-stream.ts
@@ -1,9 +1,15 @@
-import type { ChatStreamApproval, ChatStreamResult } from '../api/chat-types';
+import type {
+  ChatStreamApproval,
+  ChatStreamResult,
+  ChatStreamToolEvent,
+} from '../api/chat-types';
 import { requestHeaders, throwResponseError } from '../api/client';
 
 export interface ChatStreamCallbacks {
   onTextDelta: (delta: string) => void;
   onApproval: (event: ChatStreamApproval) => void;
+  onThinkingDelta?: (delta: string) => void;
+  onToolEvent?: (event: ChatStreamToolEvent) => void;
 }
 
 export async function requestChatStream(
@@ -46,6 +52,20 @@ export async function requestChatStream(
 
     if (payload.type === 'text' && typeof payload.delta === 'string') {
       callbacks.onTextDelta(payload.delta as string);
+      return null;
+    }
+
+    if (payload.type === 'thinking' && typeof payload.delta === 'string') {
+      callbacks.onThinkingDelta?.(payload.delta as string);
+      return null;
+    }
+
+    if (
+      payload.type === 'tool' &&
+      typeof payload.toolName === 'string' &&
+      (payload.phase === 'start' || payload.phase === 'finish')
+    ) {
+      callbacks.onToolEvent?.(payload as unknown as ChatStreamToolEvent);
       return null;
     }
 

--- a/console/src/routes/chat/chat-history-query.test.ts
+++ b/console/src/routes/chat/chat-history-query.test.ts
@@ -284,6 +284,72 @@ describe('buildChatHistoryUiData', () => {
     });
   });
 
+  it('hydrates a collapsed trace immediately before its assistant message', () => {
+    const raw: ChatHistoryResponse = {
+      sessionId: 'session-a',
+      history: [
+        { id: 1, role: 'user', content: 'Read my email' },
+        {
+          id: 2,
+          role: 'assistant',
+          content: 'Here are your emails.',
+          activityTrace: {
+            steps: [
+              { kind: 'thinking', text: 'Listing their messages' },
+              {
+                kind: 'tool',
+                toolName: 'list_messages',
+                status: 'done',
+                argsPreview: '{"top":20}',
+                durationMs: 903,
+              },
+            ],
+            elapsedMs: 34_000,
+          },
+        },
+      ],
+    };
+
+    const ui = buildChatHistoryUiData(raw, 'session-a');
+
+    const assistantIndex = ui.messages.findIndex((m) => m.role === 'assistant');
+    const trace = ui.messages[assistantIndex - 1];
+    expect(trace?.role).toBe('trace');
+    if (trace?.role !== 'trace') throw new Error('expected a trace message');
+    expect(trace.done).toBe(true);
+    expect(trace.finishedAt).toBe(34_000);
+    expect(trace.steps).toEqual([
+      { kind: 'thinking', text: 'Listing their messages' },
+      {
+        kind: 'tool',
+        toolName: 'list_messages',
+        status: 'done',
+        argsPreview: '{"top":20}',
+        durationMs: 903,
+      },
+    ]);
+  });
+
+  it('does not add a trace message when history omits activityTrace', () => {
+    const raw: ChatHistoryResponse = {
+      sessionId: 'session-a',
+      history: [
+        { id: 1, role: 'user', content: 'hi' },
+        { id: 2, role: 'assistant', content: 'hello' },
+        {
+          id: 3,
+          role: 'assistant',
+          content: 'empty trace',
+          activityTrace: { steps: [] },
+        },
+      ],
+    };
+
+    const ui = buildChatHistoryUiData(raw, 'session-a');
+
+    expect(ui.messages.some((m) => m.role === 'trace')).toBe(false);
+  });
+
   it('uses per-message assistantPresentation instead of session-level presentation', () => {
     const raw: ChatHistoryResponse = {
       sessionId: 'session-a',

--- a/console/src/routes/chat/chat-history-query.ts
+++ b/console/src/routes/chat/chat-history-query.ts
@@ -1,11 +1,16 @@
 import { fetchChatHistory } from '../../api/chat';
 import type {
   BranchVariant,
+  ChatActivityTrace,
   ChatHistoryResponse,
   ChatMessage,
 } from '../../api/chat-types';
 import { nextMsgId } from '../../lib/chat-helpers';
-import type { ChatUiMessage } from './chat-ui-message';
+import type {
+  ChatUiMessage,
+  TraceChatMessage,
+  TraceStep,
+} from './chat-ui-message';
 
 export interface ChatHistoryUiData {
   messages: ChatUiMessage[];
@@ -22,6 +27,49 @@ function normalizeAgentIdForComparison(agentId: string | null | undefined) {
   return String(agentId ?? '')
     .trim()
     .toLowerCase();
+}
+
+// Rebuild a collapsed (done) trace message from persisted history so a reload
+// shows the same thinking/tool activity the live stream rendered. Positioned
+// just before its assistant bubble by the caller.
+function hydrateActivityTrace(
+  trace: ChatActivityTrace | null | undefined,
+  sessionId: string,
+): TraceChatMessage | null {
+  if (!trace || !Array.isArray(trace.steps) || trace.steps.length === 0) {
+    return null;
+  }
+  const steps: TraceStep[] = trace.steps.map(
+    (step): TraceStep =>
+      step.kind === 'thinking'
+        ? { kind: 'thinking', text: step.text }
+        : {
+            kind: 'tool',
+            toolName: step.toolName,
+            status: 'done',
+            ...(step.argsPreview ? { argsPreview: step.argsPreview } : {}),
+            ...(step.resultPreview
+              ? { resultPreview: step.resultPreview }
+              : {}),
+            ...(typeof step.durationMs === 'number'
+              ? { durationMs: step.durationMs }
+              : {}),
+          },
+  );
+  return {
+    id: nextMsgId(),
+    role: 'trace',
+    content: '',
+    sessionId,
+    steps,
+    done: true,
+    startedAt: 0,
+    // startedAt is 0, so finishedAt carries the persisted elapsed for the
+    // summary's duration; omitted when unknown.
+    ...(typeof trace.elapsedMs === 'number'
+      ? { finishedAt: trace.elapsedMs }
+      : {}),
+  };
 }
 
 export function buildChatHistoryUiData(
@@ -49,7 +97,8 @@ export function buildChatHistoryUiData(
   const history = raw.history ?? [];
   const sessionAgentId = normalizeAgentIdForComparison(raw.agentId);
   let lastUserContent: string | null = null;
-  const messages: ChatMessage[] = history.map((msg, index) => {
+  const messages: ChatUiMessage[] = [];
+  history.forEach((msg, index) => {
     const nextAssistant = history
       .slice(index + 1)
       .find((candidate) => candidate.role !== 'system');
@@ -71,7 +120,7 @@ export function buildChatHistoryUiData(
         : msg.role === 'assistant'
           ? lastUserContent
           : null;
-    return {
+    const chatMessage: ChatMessage = {
       id: nextMsgId(),
       role: msg.role,
       content: msg.content,
@@ -90,6 +139,11 @@ export function buildChatHistoryUiData(
           ? (branchKeysByMessageId.get(msg.id) ?? null)
           : null,
     };
+    if (msg.role === 'assistant') {
+      const trace = hydrateActivityTrace(msg.activityTrace, resolvedSessionId);
+      if (trace) messages.push(trace);
+    }
+    messages.push(chatMessage);
   });
 
   return {

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1283,6 +1283,161 @@ aside[data-state="collapsed"] .chatSidebarContent {
   }
 }
 
+/* Run-activity trace: light-grey collapsible rows (thinking + tool calls)
+   shown above the answer bubble. Expanded while streaming, collapsed to the
+   summary row once the run finishes. */
+.traceBlock {
+  min-width: 0;
+  max-width: 85%;
+  font-size: 0.8rem;
+  color: var(--muted-foreground);
+}
+
+.traceHeader {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  padding: 2px 8px 2px 2px;
+  margin-left: -2px;
+  border-radius: 8px;
+  color: inherit;
+  font: inherit;
+  font-size: inherit;
+  cursor: pointer;
+}
+
+.traceHeader:hover,
+.traceHeader:focus-visible {
+  color: var(--text);
+  background: var(--chat-hover-bg);
+}
+
+.traceChevron {
+  display: inline-flex;
+  justify-content: center;
+  width: 12px;
+  font-size: 0.95rem;
+  line-height: 1;
+  transition: transform 0.15s ease;
+}
+
+.traceChevronOpen {
+  transform: rotate(90deg);
+}
+
+.traceSummary {
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.traceSummaryLive {
+  animation: tracePulse 1.6s ease-in-out infinite;
+}
+
+@keyframes tracePulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+.traceSteps {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 2px 0 2px 5px;
+  padding-left: 13px;
+  border-left: 1px solid var(--line);
+}
+
+.traceStep {
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
+  min-width: 0;
+}
+
+.traceStepMarker {
+  flex: none;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 12px;
+  min-height: 1.2rem;
+  font-size: 0.7rem;
+  color: color-mix(in srgb, var(--muted-foreground) 75%, transparent);
+}
+
+.traceStepMarkerRunning::after {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--muted-foreground);
+  animation: thinkingBounce 1.2s infinite ease-in-out;
+}
+
+.traceStepBody {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.traceToolLine {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.traceToolName {
+  flex: none;
+  font-weight: 600;
+}
+
+.traceToolPreview {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.74rem;
+  color: color-mix(in srgb, var(--muted-foreground) 85%, transparent);
+}
+
+.traceToolDuration {
+  flex: none;
+  font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
+  color: color-mix(in srgb, var(--muted-foreground) 70%, transparent);
+}
+
+.traceToolResult {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.72rem;
+  color: color-mix(in srgb, var(--muted-foreground) 70%, transparent);
+}
+
+.traceThinkingText {
+  min-width: 0;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  font-style: italic;
+  line-height: 1.5;
+  color: color-mix(in srgb, var(--muted-foreground) 88%, transparent);
+}
+
 .composerWrapper {
   flex-shrink: 0;
   margin-top: auto;
@@ -1880,6 +2035,11 @@ aside[data-state="collapsed"] .chatSidebarContent {
 
 @media (prefers-reduced-motion: reduce) {
   .thinkingDot {
+    animation: none;
+  }
+
+  .traceSummaryLive,
+  .traceStepMarkerRunning::after {
     animation: none;
   }
 

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1430,24 +1430,28 @@ aside[data-state="collapsed"] .chatSidebarContent {
   align-items: flex-start;
   gap: 7px;
   min-width: 0;
+  line-height: 1.5;
 }
 
+/* Fixed to one line-height so the dot centers on the first text line of every
+   row — single-line or wrapped, thinking or tool — for a uniform left column. */
 .traceStepMarker {
   flex: none;
   display: inline-flex;
   justify-content: center;
   align-items: center;
   width: 12px;
-  min-height: 1.2rem;
-  font-size: 0.7rem;
-  color: color-mix(in srgb, var(--muted-foreground) 75%, transparent);
+  height: calc(0.8rem * 1.5);
 }
 
-.traceStepMarkerRunning::after {
-  content: "";
-  width: 7px;
-  height: 7px;
+.traceDot {
+  width: 5px;
+  height: 5px;
   border-radius: 999px;
+  background: color-mix(in srgb, var(--muted-foreground) 70%, transparent);
+}
+
+.traceDotRunning {
   background: var(--muted-foreground);
   animation: thinkingBounce 1.2s infinite ease-in-out;
 }
@@ -2109,7 +2113,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
   }
 
   .traceSummaryLive,
-  .traceStepMarkerRunning::after {
+  .traceDotRunning {
     animation: none;
   }
 

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -1160,7 +1160,9 @@ export function ChatPage() {
             <div className={css.messageArea} ref={messageAreaRef}>
               <div className={css.messageList} ref={messageListRef}>
                 {visibleMessages.map((msg) =>
-                  editingId === msg.id && msg.role !== 'thinking' ? (
+                  editingId === msg.id &&
+                  msg.role !== 'thinking' &&
+                  msg.role !== 'trace' ? (
                     <div key={msg.id} className={css.messageBlock}>
                       <EditInline
                         initial={msg.rawContent ?? msg.content}

--- a/console/src/routes/chat/chat-ui-message.ts
+++ b/console/src/routes/chat/chat-ui-message.ts
@@ -5,4 +5,39 @@ export type ThinkingChatMessage = Omit<ChatMessage, 'role' | 'content'> & {
   content: '';
 };
 
-export type ChatUiMessage = ChatMessage | ThinkingChatMessage;
+export interface TraceThinkingStep {
+  kind: 'thinking';
+  text: string;
+}
+
+export interface TraceToolStep {
+  kind: 'tool';
+  toolName: string;
+  status: 'running' | 'done';
+  argsPreview?: string;
+  resultPreview?: string;
+  durationMs?: number;
+}
+
+export type TraceStep = TraceThinkingStep | TraceToolStep;
+
+/**
+ * Live activity trace for one assistant turn (thinking + tool calls streamed
+ * by the gateway). Rendered as a collapsible block above the answer bubble;
+ * exists only for runs streamed in this browser session — server history does
+ * not persist it.
+ */
+export type TraceChatMessage = Omit<ChatMessage, 'role' | 'content'> & {
+  role: 'trace';
+  content: '';
+  steps: TraceStep[];
+  /** True once the run finished (answer, error, or stop) — collapses the block. */
+  done: boolean;
+  startedAt: number;
+  finishedAt?: number;
+};
+
+export type ChatUiMessage =
+  | ChatMessage
+  | ThinkingChatMessage
+  | TraceChatMessage;

--- a/console/src/routes/chat/message-block.tsx
+++ b/console/src/routes/chat/message-block.tsx
@@ -23,6 +23,7 @@ import { findAgentMentions } from './agent-mention-display';
 import { ApprovalCard } from './approval-card';
 import css from './chat-page.module.css';
 import type { ChatUiMessage } from './chat-ui-message';
+import { TraceBlock } from './trace-block';
 
 const STREAM_MARKDOWN_RENDER_INTERVAL_MS = 120;
 
@@ -432,6 +433,10 @@ export const MessageBlock = memo(function MessageBlock(props: {
     token,
     imageUrl: presentation?.imageUrl,
   });
+
+  if (msg.role === 'trace') {
+    return <TraceBlock message={msg} />;
+  }
 
   if (msg.role === 'thinking') {
     return (

--- a/console/src/routes/chat/trace-block.test.tsx
+++ b/console/src/routes/chat/trace-block.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { TraceChatMessage, TraceStep } from './chat-ui-message';
+import { TraceBlock } from './trace-block';
+
+function makeTrace(
+  steps: TraceStep[],
+  overrides?: Partial<TraceChatMessage>,
+): TraceChatMessage {
+  return {
+    id: 'trace-1',
+    role: 'trace',
+    content: '',
+    sessionId: 'session-a',
+    steps,
+    done: false,
+    startedAt: 1_000,
+    ...overrides,
+  };
+}
+
+describe('TraceBlock', () => {
+  it('renders nothing for a trace without steps', () => {
+    const { container } = render(<TraceBlock message={makeTrace([])} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows steps expanded while the run is live', () => {
+    render(
+      <TraceBlock
+        message={makeTrace([
+          { kind: 'thinking', text: 'Considering the request' },
+          {
+            kind: 'tool',
+            toolName: 'exec',
+            status: 'running',
+            argsPreview: 'npm test',
+          },
+        ])}
+      />,
+    );
+
+    expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe(
+      'true',
+    );
+    expect(screen.queryByText('exec…')).not.toBeNull();
+    expect(screen.queryByText('Considering the request')).not.toBeNull();
+    expect(screen.queryByText('npm test')).not.toBeNull();
+  });
+
+  it('collapses to a summary once the run is done', () => {
+    render(
+      <TraceBlock
+        message={makeTrace(
+          [
+            { kind: 'thinking', text: 'Considering the request' },
+            {
+              kind: 'tool',
+              toolName: 'exec',
+              status: 'done',
+              argsPreview: 'npm test',
+              resultPreview: 'ok',
+              durationMs: 1_200,
+            },
+          ],
+          { done: true, finishedAt: 13_000 },
+        )}
+      />,
+    );
+
+    expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe(
+      'false',
+    );
+    expect(screen.queryByText('1 tool call · thinking · 12s')).not.toBeNull();
+    expect(screen.queryByText('npm test')).toBeNull();
+  });
+
+  it('auto-collapses a manually expanded trace when the run finishes', () => {
+    const liveSteps: TraceStep[] = [
+      {
+        kind: 'tool',
+        toolName: 'read',
+        status: 'running',
+        argsPreview: 'apps.ts',
+      },
+    ];
+    const { rerender } = render(<TraceBlock message={makeTrace(liveSteps)} />);
+
+    // Collapse manually mid-run, then re-expand: the user override sticks.
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.queryByText('apps.ts')).toBeNull();
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.queryByText('apps.ts')).not.toBeNull();
+
+    rerender(
+      <TraceBlock
+        message={makeTrace(
+          [
+            {
+              kind: 'tool',
+              toolName: 'read',
+              status: 'done',
+              argsPreview: 'apps.ts',
+              durationMs: 300,
+            },
+          ],
+          { done: true, finishedAt: 2_500 },
+        )}
+      />,
+    );
+
+    expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe(
+      'false',
+    );
+    expect(screen.queryByText('apps.ts')).toBeNull();
+
+    // The collapsed trace can still be reopened on demand.
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.queryByText('apps.ts')).not.toBeNull();
+    expect(screen.queryByText('300ms')).not.toBeNull();
+  });
+
+  it('summarizes a thinking-only run', () => {
+    render(
+      <TraceBlock
+        message={makeTrace([{ kind: 'thinking', text: 'Deep thought' }], {
+          done: true,
+          finishedAt: 32_000,
+        })}
+      />,
+    );
+    expect(screen.queryByText('Thought · 31s')).not.toBeNull();
+  });
+});

--- a/console/src/routes/chat/trace-block.tsx
+++ b/console/src/routes/chat/trace-block.tsx
@@ -1,0 +1,155 @@
+import { memo, useEffect, useState } from 'react';
+import { cx } from '../../lib/cx';
+import css from './chat-page.module.css';
+import type { TraceChatMessage, TraceStep } from './chat-ui-message';
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 10) return `${seconds.toFixed(1)}s`;
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  const minutes = Math.floor(seconds / 60);
+  const rest = Math.round(seconds % 60);
+  return rest > 0 ? `${minutes}m ${rest}s` : `${minutes}m`;
+}
+
+function summaryLabel(message: TraceChatMessage): string {
+  const steps = message.steps;
+  if (!message.done) {
+    const last = steps[steps.length - 1];
+    if (last?.kind === 'tool' && last.status === 'running') {
+      return `${last.toolName}…`;
+    }
+    if (last?.kind === 'thinking') return 'Thinking…';
+    return 'Working…';
+  }
+  const toolCount = steps.filter((step) => step.kind === 'tool').length;
+  const thought = steps.some((step) => step.kind === 'thinking');
+  const parts: string[] = [];
+  if (toolCount > 0) {
+    parts.push(`${toolCount} tool call${toolCount === 1 ? '' : 's'}`);
+    if (thought) parts.push('thinking');
+  } else if (thought) {
+    parts.push('Thought');
+  }
+  const elapsed = message.finishedAt
+    ? message.finishedAt - message.startedAt
+    : 0;
+  if (elapsed >= 1000) parts.push(formatDuration(elapsed));
+  return parts.join(' · ') || 'Agent activity';
+}
+
+function TraceStepRow(props: { step: TraceStep; live: boolean }) {
+  const { step, live } = props;
+  if (step.kind === 'thinking') {
+    return (
+      <div className={css.traceStep}>
+        <span className={css.traceStepMarker} aria-hidden="true">
+          ✻
+        </span>
+        <div className={css.traceThinkingText}>{step.text}</div>
+      </div>
+    );
+  }
+
+  const running = live && step.status === 'running';
+  return (
+    <div className={css.traceStep}>
+      <span
+        className={cx(
+          css.traceStepMarker,
+          running && css.traceStepMarkerRunning,
+        )}
+        aria-hidden="true"
+      >
+        {running ? '' : '•'}
+      </span>
+      <div className={css.traceStepBody}>
+        <div className={css.traceToolLine}>
+          <span className={css.traceToolName}>{step.toolName}</span>
+          {step.argsPreview ? (
+            <span className={css.traceToolPreview} title={step.argsPreview}>
+              {step.argsPreview}
+            </span>
+          ) : null}
+          {typeof step.durationMs === 'number' ? (
+            <span className={css.traceToolDuration}>
+              {formatDuration(step.durationMs)}
+            </span>
+          ) : null}
+        </div>
+        {step.resultPreview ? (
+          <div className={css.traceToolResult} title={step.resultPreview}>
+            {step.resultPreview}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Collapsible run-activity trace (thinking + tool calls). Expanded while the
+ * run streams so every step is visible as it happens; auto-collapses to a
+ * single grey summary row once the final answer lands.
+ */
+export const TraceBlock = memo(function TraceBlock(props: {
+  message: TraceChatMessage;
+}) {
+  const { message } = props;
+  const [expandedOverride, setExpandedOverride] = useState<boolean | null>(
+    null,
+  );
+
+  // The final output collapses the trace even if the user expanded it
+  // mid-run — the answer should stand alone; the trace stays a click away.
+  useEffect(() => {
+    if (message.done) setExpandedOverride(null);
+  }, [message.done]);
+
+  if (message.steps.length === 0) return null;
+
+  const expanded = expandedOverride ?? !message.done;
+
+  return (
+    <div className={css.traceBlock}>
+      <button
+        type="button"
+        className={css.traceHeader}
+        aria-expanded={expanded}
+        aria-label={
+          expanded ? 'Collapse agent activity' : 'Expand agent activity'
+        }
+        onClick={() => setExpandedOverride(!expanded)}
+      >
+        <span
+          className={cx(css.traceChevron, expanded && css.traceChevronOpen)}
+          aria-hidden="true"
+        >
+          ›
+        </span>
+        <span
+          className={cx(
+            css.traceSummary,
+            !message.done && css.traceSummaryLive,
+          )}
+        >
+          {summaryLabel(message)}
+        </span>
+      </button>
+      {expanded ? (
+        <div className={css.traceSteps}>
+          {message.steps.map((step, index) => (
+            <TraceStepRow
+              // Steps are append-only within a run, so the index is stable.
+              // biome-ignore lint/suspicious/noArrayIndexKey: append-only list
+              key={index}
+              step={step}
+              live={!message.done}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+});

--- a/console/src/routes/chat/trace-block.tsx
+++ b/console/src/routes/chat/trace-block.tsx
@@ -45,7 +45,7 @@ function TraceStepRow(props: { step: TraceStep; live: boolean }) {
     return (
       <div className={css.traceStep}>
         <span className={css.traceStepMarker} aria-hidden="true">
-          ✻
+          <span className={css.traceDot} />
         </span>
         <div className={css.traceThinkingText}>{step.text}</div>
       </div>
@@ -55,14 +55,8 @@ function TraceStepRow(props: { step: TraceStep; live: boolean }) {
   const running = live && step.status === 'running';
   return (
     <div className={css.traceStep}>
-      <span
-        className={cx(
-          css.traceStepMarker,
-          running && css.traceStepMarkerRunning,
-        )}
-        aria-hidden="true"
-      >
-        {running ? '' : '•'}
+      <span className={css.traceStepMarker} aria-hidden="true">
+        <span className={cx(css.traceDot, running && css.traceDotRunning)} />
       </span>
       <div className={css.traceStepBody}>
         <div className={css.traceToolLine}>

--- a/console/src/routes/chat/use-chat-stream.test.ts
+++ b/console/src/routes/chat/use-chat-stream.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   ChatStreamApproval,
   ChatStreamResult,
+  ChatStreamToolEvent,
 } from '../../api/chat-types';
 import {
   type ChatHistoryUiData,
@@ -92,9 +93,12 @@ describe('useChatStream', () => {
     nextMsgIdMock.mockReset();
     let nextId = 0;
     nextMsgIdMock.mockImplementation(() => `msg-${++nextId}`);
+    // Return 0 so the synchronous callback's `renderFrame = 0` reset is not
+    // clobbered by the handle assignment — a real rAF assigns the handle
+    // before the callback ever runs.
     vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
       cb(0);
-      return 1;
+      return 0;
     });
     vi.stubGlobal('cancelAnimationFrame', vi.fn());
   });
@@ -433,11 +437,12 @@ describe('useChatStream', () => {
       await result.current.sendMessage('hello', []);
     });
 
-    expect(nextMsgIdMock).toHaveBeenCalledTimes(3);
+    // user, thinking placeholder, trace, streamed assistant
+    expect(nextMsgIdMock).toHaveBeenCalledTimes(4);
     expect(harness.messages).toHaveLength(2);
     expect(harness.messages[0]?.id).toBe('msg-1');
     expect(harness.messages[1]).toMatchObject({
-      id: 'msg-3',
+      id: 'msg-4',
       role: 'assistant',
       content: 'Answer',
       sessionId: SESSION_ID,
@@ -488,7 +493,7 @@ describe('useChatStream', () => {
     // console block, not as an assistant message (and not as a plain `system`
     // notice, which is reserved for errors).
     expect(harness.messages[1]).toMatchObject({
-      id: 'msg-3',
+      id: 'msg-4',
       role: 'command',
       content: 'Session agent set to `research` (model: `gpt-5`).',
       messageId: null,
@@ -828,6 +833,209 @@ describe('useChatStream', () => {
         messageRole: 'assistant',
       });
       await firstSend;
+    });
+  });
+
+  it('collects thinking and tool events into a trace and collapses it on finalize', async () => {
+    const harness = makeHarness();
+
+    requestChatStreamMock.mockImplementation(
+      async (
+        _url: string,
+        params: {
+          callbacks: {
+            onTextDelta: (delta: string) => void;
+            onThinkingDelta?: (delta: string) => void;
+            onToolEvent?: (event: ChatStreamToolEvent) => void;
+          };
+        },
+      ): Promise<ChatStreamResult> => {
+        params.callbacks.onThinkingDelta?.('Weighing ');
+        params.callbacks.onThinkingDelta?.('options');
+        params.callbacks.onToolEvent?.({
+          type: 'tool',
+          toolName: 'exec',
+          phase: 'start',
+          preview: 'npm test',
+        });
+        params.callbacks.onToolEvent?.({
+          type: 'tool',
+          toolName: 'exec',
+          phase: 'finish',
+          preview: 'ok',
+          durationMs: 420,
+        });
+        params.callbacks.onTextDelta('Answer');
+        return {
+          status: 'ok',
+          sessionId: SESSION_ID,
+          userMessageId: 'server-user-1',
+          assistantMessageId: 'assistant-1',
+          result: 'Answer',
+          messageRole: 'assistant',
+        };
+      },
+    );
+
+    const { result } = renderHook(
+      () =>
+        useChatStream({
+          token: TOKEN,
+          userId: 'web-user-1',
+          getSessionId: () => SESSION_ID,
+          setError: harness.setError,
+          refreshRecent: vi.fn(),
+          onSessionIdCorrection: harness.correctionMock,
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    await act(async () => {
+      await result.current.sendMessage('hello', []);
+    });
+
+    // Consecutive thinking deltas merge into one step; the tool start/finish
+    // pair collapses into a single completed step.
+    const trace = harness.messages.find((msg) => msg.role === 'trace');
+    expect(trace).toMatchObject({
+      role: 'trace',
+      done: true,
+      steps: [
+        { kind: 'thinking', text: 'Weighing options' },
+        {
+          kind: 'tool',
+          toolName: 'exec',
+          status: 'done',
+          argsPreview: 'npm test',
+          resultPreview: 'ok',
+          durationMs: 420,
+        },
+      ],
+    });
+    const roles = harness.messages.map((msg) => msg.role);
+    expect(roles.indexOf('trace')).toBeLessThan(roles.indexOf('assistant'));
+  });
+
+  it('keeps the thinking dots during trace-only updates until answer text streams', async () => {
+    const harness = makeHarness();
+    let resolveStream!: (value: ChatStreamResult) => void;
+    let callbacks!: {
+      onTextDelta: (delta: string) => void;
+      onToolEvent?: (event: ChatStreamToolEvent) => void;
+    };
+
+    requestChatStreamMock.mockImplementation(
+      (_url: string, params: { callbacks: typeof callbacks }) =>
+        new Promise<ChatStreamResult>((resolve) => {
+          callbacks = params.callbacks;
+          resolveStream = resolve;
+        }),
+    );
+
+    const { result } = renderHook(
+      () =>
+        useChatStream({
+          token: TOKEN,
+          userId: 'web-user-1',
+          getSessionId: () => SESSION_ID,
+          setError: harness.setError,
+          refreshRecent: vi.fn(),
+          onSessionIdCorrection: harness.correctionMock,
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    let sendPromise!: Promise<boolean>;
+    act(() => {
+      sendPromise = result.current.sendMessage('hello', []);
+    });
+
+    act(() => {
+      callbacks.onToolEvent?.({
+        type: 'tool',
+        toolName: 'read',
+        phase: 'start',
+        preview: 'apps.ts',
+      });
+    });
+
+    // Tool activity alone must not spawn an (empty) answer bubble.
+    expect(harness.messages.some((msg) => msg.role === 'thinking')).toBe(true);
+    expect(harness.messages.some((msg) => msg.role === 'assistant')).toBe(
+      false,
+    );
+    expect(harness.messages.find((msg) => msg.role === 'trace')).toMatchObject({
+      done: false,
+      steps: [{ kind: 'tool', toolName: 'read', status: 'running' }],
+    });
+
+    act(() => {
+      callbacks.onTextDelta('Hi');
+    });
+    expect(harness.messages.some((msg) => msg.role === 'thinking')).toBe(false);
+
+    await act(async () => {
+      resolveStream({
+        status: 'ok',
+        sessionId: SESSION_ID,
+        userMessageId: 'server-user-1',
+        assistantMessageId: 'assistant-1',
+        result: 'Hi',
+        messageRole: 'assistant',
+      });
+      await sendPromise;
+    });
+  });
+
+  it('keeps a finalized trace when the stream fails', async () => {
+    const harness = makeHarness();
+
+    requestChatStreamMock.mockImplementation(
+      async (
+        _url: string,
+        params: {
+          callbacks: {
+            onToolEvent?: (event: ChatStreamToolEvent) => void;
+          };
+        },
+      ): Promise<ChatStreamResult> => {
+        params.callbacks.onToolEvent?.({
+          type: 'tool',
+          toolName: 'exec',
+          phase: 'start',
+          preview: 'do things',
+        });
+        throw new Error('boom');
+      },
+    );
+
+    const { result } = renderHook(
+      () =>
+        useChatStream({
+          token: TOKEN,
+          userId: 'web-user-1',
+          getSessionId: () => SESSION_ID,
+          setError: harness.setError,
+          refreshRecent: vi.fn(),
+          onSessionIdCorrection: harness.correctionMock,
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    await act(async () => {
+      await result.current.sendMessage('hello', []);
+    });
+
+    // The trace survives (collapsed) so the failed run stays inspectable.
+    expect(harness.messages.map((msg) => msg.role)).toEqual([
+      'user',
+      'trace',
+      'system',
+    ]);
+    expect(harness.messages[1]).toMatchObject({
+      role: 'trace',
+      done: true,
+      steps: [{ kind: 'tool', toolName: 'exec', status: 'running' }],
     });
   });
 

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -6,6 +6,7 @@ import type {
   ChatMessage,
   ChatStreamApproval,
   ChatStreamResult,
+  ChatStreamToolEvent,
   MediaItem,
 } from '../../api/chat-types';
 import { buildApprovalSummary, nextMsgId } from '../../lib/chat-helpers';
@@ -15,7 +16,13 @@ import {
   type ChatHistoryUiData,
   chatHistoryQueryKey,
 } from './chat-history-query';
-import type { ChatUiMessage, ThinkingChatMessage } from './chat-ui-message';
+import type {
+  ChatUiMessage,
+  ThinkingChatMessage,
+  TraceChatMessage,
+  TraceStep,
+  TraceToolStep,
+} from './chat-ui-message';
 
 interface ActiveRequest {
   controller: AbortController;
@@ -24,6 +31,11 @@ interface ActiveRequest {
   assistantText: string;
   lastRenderedText: string;
   pendingApproval: ChatStreamApproval | null;
+  // Mutable working copy of the run's activity trace; copied into the cached
+  // trace message on each render so React sees fresh identities.
+  trace: TraceStep[];
+  traceVersion: number;
+  lastRenderedTraceVersion: number;
   renderFrame: number;
   stopping: boolean;
 }
@@ -169,8 +181,20 @@ export function useChatStream(
       }
 
       const thinkingId = nextMsgId();
+      const traceId = nextMsgId();
+      // The trace block precedes the thinking dots (and later the answer
+      // bubble): activity rows stream in above the "still working" indicator.
       setMessages((prev) => [
         ...prev,
+        {
+          id: traceId,
+          role: 'trace',
+          content: '',
+          sessionId: targetSessionId,
+          steps: [],
+          done: false,
+          startedAt: Date.now(),
+        } satisfies TraceChatMessage,
         {
           id: thinkingId,
           role: 'thinking',
@@ -189,6 +213,9 @@ export function useChatStream(
         assistantText: '',
         lastRenderedText: '',
         pendingApproval: null,
+        trace: [],
+        traceVersion: 0,
+        lastRenderedTraceVersion: 0,
         renderFrame: 0,
         stopping: false,
       };
@@ -198,19 +225,36 @@ export function useChatStream(
 
       const doRender = () => {
         req.renderFrame = 0;
+        const traceChanged = req.traceVersion !== req.lastRenderedTraceVersion;
         if (
           req.assistantText === req.lastRenderedText &&
-          !req.pendingApproval
+          !req.pendingApproval &&
+          !traceChanged
         ) {
           return;
         }
         req.lastRenderedText = req.assistantText;
+        req.lastRenderedTraceVersion = req.traceVersion;
 
         const text = req.assistantText;
         const approval = req.pendingApproval;
+        // Fresh step copies so React re-renders on later in-place mutations.
+        const traceSteps = traceChanged
+          ? req.trace.map((step) => ({ ...step }))
+          : null;
 
         setMessages((prev) => {
-          const withoutThinking = prev.filter((m) => m.id !== thinkingId);
+          const withTrace = traceSteps
+            ? prev.map((m) =>
+                m.id === traceId && m.role === 'trace'
+                  ? { ...m, steps: traceSteps }
+                  : m,
+              )
+            : prev;
+          // Trace-only update: keep the thinking dots until the answer (or an
+          // approval card) actually starts, so no empty bubble flashes in.
+          if (!text && !approval) return withTrace;
+          const withoutThinking = withTrace.filter((m) => m.id !== thinkingId);
           const existing = withoutThinking.find((m) => m.id === streamId);
           if (existing) {
             return withoutThinking.map((m) =>
@@ -251,6 +295,73 @@ export function useChatStream(
         req.renderFrame = requestAnimationFrame(doRender);
       };
 
+      const pushThinkingDelta = (delta: string) => {
+        if (!delta) return;
+        const last = req.trace.at(-1);
+        if (last?.kind === 'thinking') {
+          last.text += delta;
+        } else {
+          req.trace.push({ kind: 'thinking', text: delta });
+        }
+        req.traceVersion += 1;
+        scheduleRender();
+      };
+
+      const pushToolEvent = (event: ChatStreamToolEvent) => {
+        if (event.phase === 'start') {
+          req.trace.push({
+            kind: 'tool',
+            toolName: event.toolName,
+            status: 'running',
+            argsPreview: event.preview || undefined,
+          });
+        } else {
+          // Match the most recent running call of this tool — parallel tools
+          // can finish out of order.
+          let started: TraceToolStep | undefined;
+          for (let i = req.trace.length - 1; i >= 0; i--) {
+            const step = req.trace[i];
+            if (
+              step?.kind === 'tool' &&
+              step.status === 'running' &&
+              step.toolName === event.toolName
+            ) {
+              started = step;
+              break;
+            }
+          }
+          if (started) {
+            started.status = 'done';
+            started.durationMs = event.durationMs;
+            started.resultPreview = event.preview || undefined;
+          } else {
+            req.trace.push({
+              kind: 'tool',
+              toolName: event.toolName,
+              status: 'done',
+              durationMs: event.durationMs,
+              resultPreview: event.preview || undefined,
+            });
+          }
+        }
+        req.traceVersion += 1;
+        scheduleRender();
+      };
+
+      // Collapse the trace once the run ends; a run with no activity leaves no
+      // trace row at all.
+      const finalizeTrace = (msgs: ChatUiMessage[]): ChatUiMessage[] => {
+        if (req.trace.length === 0) {
+          return msgs.filter((m) => m.id !== traceId);
+        }
+        const steps = req.trace.map((step) => ({ ...step }));
+        return msgs.map((m) =>
+          m.id === traceId && m.role === 'trace'
+            ? { ...m, steps, done: true, finishedAt: Date.now() }
+            : m,
+        );
+      };
+
       try {
         const result: ChatStreamResult = await requestChatStream('/api/chat', {
           token,
@@ -277,6 +388,8 @@ export function useChatStream(
               }
               scheduleRender();
             },
+            onThinkingDelta: pushThinkingDelta,
+            onToolEvent: pushToolEvent,
           },
         });
 
@@ -331,7 +444,9 @@ export function useChatStream(
         });
 
         setMessages((prev) => {
-          const withoutThinking = prev.filter((m) => m.id !== thinkingId);
+          const withoutThinking = finalizeTrace(prev).filter(
+            (m) => m.id !== thinkingId,
+          );
           const hasAssistant = withoutThinking.some((m) => m.id === streamId);
           const finalizeMessage = (m: ChatUiMessage): ChatUiMessage => {
             if (m.id === streamId) {
@@ -415,7 +530,9 @@ export function useChatStream(
         if (req.renderFrame) cancelAnimationFrame(req.renderFrame);
         const errorText = getErrorMessage(err);
         setMessages((prev) => {
-          const withoutThinking = prev.filter((m) => m.id !== thinkingId);
+          const withoutThinking = finalizeTrace(prev).filter(
+            (m) => m.id !== thinkingId,
+          );
           if (req.stopping) return withoutThinking;
           return [
             ...withoutThinking,

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -167,6 +167,7 @@ import {
 } from './secret-command-guard.js';
 import {
   normalizeSessionShowMode,
+  sessionShowModeShowsThinking,
   sessionShowModeShowsTools,
 } from './show-mode.js';
 
@@ -1156,6 +1157,7 @@ async function handleGatewayMessageInner(
   });
   const showMode = normalizeSessionShowMode(session.show_mode);
   const shouldEmitTools = sessionShowModeShowsTools(showMode);
+  const shouldEmitThinking = sessionShowModeShowsThinking(showMode);
   const enableRag = req.enableRag ?? session.enable_rag === 1;
   const audioPrelude = await prependAudioTranscriptionsToUserContent({
     content: req.content,
@@ -1847,9 +1849,13 @@ async function handleGatewayMessageInner(
     };
     const emitTextDeltas =
       req.onTextDelta && !outputGuardActive ? onTextDelta : undefined;
-    const emitThinkingDeltas = req.onThinkingDelta
-      ? (delta: string): void => req.onThinkingDelta?.(delta)
-      : undefined;
+    // Gate thinking by the session show mode, mirroring `shouldEmitTools`, so a
+    // session that hides thinking neither streams nor persists it into the
+    // activity trace (the web streaming handler only records what it receives).
+    const emitThinkingDeltas =
+      req.onThinkingDelta && shouldEmitThinking
+        ? (delta: string): void => req.onThinkingDelta?.(delta)
+        : undefined;
     const onToolProgress = (event: ToolProgressEvent): void => {
       logger.debug(
         {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -133,6 +133,7 @@ import {
   isAdminActionAllowed,
   resolveAdminRbacAction,
 } from '../security/admin-rbac.js';
+import { redactSecretsDeep } from '../security/redact.js';
 import { createSecretHandle } from '../security/secret-handles.js';
 import type { SecretInput } from '../security/secret-refs.js';
 import { hardenSecretRef } from '../security/secret-refs.js';
@@ -3374,7 +3375,9 @@ async function handleApiChatStream(
       const trace = traceBuilder.build(Date.now() - traceStartedAt);
       if (trace) {
         try {
-          setMessageActivityTrace(assistantMessageId, trace);
+          // Tool arg/result previews and thinking text are now stored at rest;
+          // redact any secrets echoed in them before they land in SQLite.
+          setMessageActivityTrace(assistantMessageId, redactSecretsDeep(trace));
         } catch (traceError) {
           logger.warn(
             { error: traceError, sessionId: chatRequest.sessionId },

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -123,6 +123,7 @@ import {
 import {
   claimQueuedProactiveMessages,
   enqueueProactiveMessage,
+  setMessageActivityTrace,
 } from '../memory/db.js';
 import { memoryService } from '../memory/memory-service.js';
 import { listLoadedPluginCommands } from '../plugins/plugin-manager.js';
@@ -147,6 +148,7 @@ import {
   buildTuiSlashMenuEntries,
   rankTuiSlashMenuEntries,
 } from '../tui-slash-menu.js';
+import { ActivityTraceBuilder } from '../types/activity-trace.js';
 import type { MediaContextItem } from '../types/container.js';
 import type {
   PendingApproval,
@@ -3272,7 +3274,18 @@ async function handleApiChatStream(
     return;
   }
 
+  // Accumulate the same thinking/tool events the client sees into an ordered
+  // trace, then persist it against the assistant message so a reload replays
+  // exactly what streamed.
+  const traceStartedAt = Date.now();
+  const traceBuilder = new ActivityTraceBuilder();
+
   const onToolProgress = (event: ToolProgressEvent): void => {
+    if (event.phase === 'start') {
+      traceBuilder.startTool(event.toolName, event.preview);
+    } else {
+      traceBuilder.finishTool(event.toolName, event.durationMs, event.preview);
+    }
     sendEvent({
       type: 'tool',
       toolName: event.toolName,
@@ -3293,6 +3306,7 @@ async function handleApiChatStream(
   };
   const onThinkingDelta = (delta: string): void => {
     if (!delta) return;
+    traceBuilder.pushThinking(delta);
     sendEvent({
       type: 'thinking',
       delta,
@@ -3353,6 +3367,22 @@ async function handleApiChatStream(
       type: 'result',
       result: filteredResult,
     });
+    // Best-effort: persistence failure must never corrupt the already-sent
+    // response, so it is swallowed after logging.
+    const assistantMessageId = result.assistantMessageId;
+    if (typeof assistantMessageId === 'number' && !traceBuilder.isEmpty()) {
+      const trace = traceBuilder.build(Date.now() - traceStartedAt);
+      if (trace) {
+        try {
+          setMessageActivityTrace(assistantMessageId, trace);
+        } catch (traceError) {
+          logger.warn(
+            { error: traceError, sessionId: chatRequest.sessionId },
+            'Failed to persist chat activity trace',
+          );
+        }
+      }
+    }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     sendEvent({

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -6888,8 +6888,8 @@ export function forkSessionBranch(
     ).run(nextSessionId, sourceSession.id, beforeMessageId, copiedMessageCount);
     copySessionKvStore(sourceSession.id, nextSessionId);
     db.prepare(
-      `INSERT INTO messages (session_id, user_id, username, role, agent_id, content, artifacts_json, created_at)
-       SELECT ?, user_id, username, role, agent_id, content, artifacts_json, created_at
+      `INSERT INTO messages (session_id, user_id, username, role, agent_id, content, artifacts_json, activity_trace_json, created_at)
+       SELECT ?, user_id, username, role, agent_id, content, artifacts_json, activity_trace_json, created_at
        FROM messages
        WHERE session_id = ?
          AND id < ?

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -94,6 +94,11 @@ import type {
   SkillOptLiteRejectedEditMemory,
 } from '../skills/adaptive-skills-types.js';
 import type { SkillGuardVerdict } from '../skills/skills-guard.js';
+import {
+  type ActivityTrace,
+  parseActivityTrace,
+  serializeActivityTrace,
+} from '../types/activity-trace.js';
 import type {
   ApprovalAuditEntry,
   AuditEntry,
@@ -162,7 +167,7 @@ let databaseInitialized = false;
 let usageEventBatchInsertStatement: Database.Statement | null = null;
 const usageRecordSubscribers = new Set<UsageRecordSubscriber>();
 
-export const DATABASE_SCHEMA_VERSION = 47;
+export const DATABASE_SCHEMA_VERSION = 48;
 const AGENT_CANONICAL_ID_COLLISION_LIMIT = 20;
 const DEFAULT_LOCAL_OWNER_USER_ID = formatLocalOwnerUserId('');
 const STRUCTURED_AUDIT_SESSION_LIMIT = 10_000;
@@ -247,6 +252,7 @@ interface ConversationHistoryPageRow {
   agent_id: string | null;
   content: string | null;
   artifacts_json: string | null;
+  activity_trace_json: string | null;
   created_at: string | null;
 }
 
@@ -808,6 +814,7 @@ function migrateV1(database: Database.Database): void {
       agent_id TEXT,
       content TEXT NOT NULL,
       artifacts_json TEXT,
+      activity_trace_json TEXT,
       created_at TEXT DEFAULT (datetime('now'))
     );
     CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id);
@@ -3154,6 +3161,20 @@ function migrateV47(
   recordMigration(database, 47, 'Add app kind (web/live) and source key');
 }
 
+function migrateV48(
+  database: Database.Database,
+  opts?: InitDatabaseOptions,
+): void {
+  addColumnIfMissing({
+    database,
+    table: 'messages',
+    column: 'activity_trace_json',
+    ddl: 'activity_trace_json TEXT',
+    quiet: opts?.quiet === true,
+  });
+  recordMigration(database, 48, 'Persist web-chat activity traces per message');
+}
+
 function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -3273,6 +3294,7 @@ function runMigrations(
   if (currentVersion < 47 || appsKindNeedMigration(database)) {
     migrateV47(database, opts);
   }
+  if (currentVersion < 48) migrateV48(database, opts);
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);
   if (!quiet && currentVersion < DATABASE_SCHEMA_VERSION) {
@@ -7867,6 +7889,21 @@ export function storeMessage(
   return result.lastInsertRowid as number;
 }
 
+/**
+ * Attaches a web-chat activity trace to an already-persisted assistant message.
+ * Written as a post-insert update because the trace is only fully known once
+ * the streamed turn completes, after the message row exists.
+ */
+export function setMessageActivityTrace(
+  messageId: number,
+  trace: ActivityTrace,
+): void {
+  db.prepare('UPDATE messages SET activity_trace_json = ? WHERE id = ?').run(
+    serializeActivityTrace(trace),
+    messageId,
+  );
+}
+
 export function getConversationHistory(
   sessionId: string,
   limit = 50,
@@ -8215,6 +8252,7 @@ export function getConversationHistoryPage(
          m.agent_id,
          m.content,
          m.artifacts_json,
+         m.activity_trace_json,
          m.created_at
        FROM sessions s
        LEFT JOIN (
@@ -8256,6 +8294,7 @@ export function getConversationHistoryPage(
     ) {
       continue;
     }
+    const activityTrace = parseActivityTrace(row.activity_trace_json);
     history.push({
       id: row.id,
       session_id: row.session_id,
@@ -8265,6 +8304,7 @@ export function getConversationHistoryPage(
       agent_id: row.agent_id,
       content: row.content,
       artifacts: parseMessageArtifacts(row.artifacts_json),
+      ...(activityTrace ? { activityTrace } : {}),
       created_at: row.created_at,
     });
   }

--- a/src/types/activity-trace.ts
+++ b/src/types/activity-trace.ts
@@ -1,0 +1,169 @@
+/**
+ * Ordered activity trace for one assistant turn — the thinking segments and
+ * tool calls the gateway streams to the web chat, in the order they occurred.
+ *
+ * Persisted per assistant message so a page reload can replay the same trace
+ * the web client rendered live. The step shape mirrors the console's live
+ * trace so hydration is a near-identity map.
+ */
+
+export interface ActivityTraceThinkingStep {
+  kind: 'thinking';
+  text: string;
+}
+
+export interface ActivityTraceToolStep {
+  kind: 'tool';
+  toolName: string;
+  status: 'running' | 'done';
+  argsPreview?: string;
+  resultPreview?: string;
+  durationMs?: number;
+}
+
+export type ActivityTraceStep =
+  | ActivityTraceThinkingStep
+  | ActivityTraceToolStep;
+
+export interface ActivityTrace {
+  steps: ActivityTraceStep[];
+  /** Wall-clock duration of the turn, for the collapsed summary line. */
+  elapsedMs?: number;
+}
+
+/**
+ * Accumulates streamed thinking/tool events into an ordered trace, mirroring
+ * the console's live accumulation: consecutive thinking deltas merge, and a
+ * tool `finish` collapses into the most recent matching running `start`
+ * (parallel same-name tools can finish out of order).
+ */
+export class ActivityTraceBuilder {
+  private readonly steps: ActivityTraceStep[] = [];
+
+  pushThinking(delta: string): void {
+    if (!delta) return;
+    const last = this.steps.at(-1);
+    if (last?.kind === 'thinking') {
+      last.text += delta;
+    } else {
+      this.steps.push({ kind: 'thinking', text: delta });
+    }
+  }
+
+  startTool(toolName: string, argsPreview?: string): void {
+    this.steps.push({
+      kind: 'tool',
+      toolName,
+      status: 'running',
+      ...(argsPreview ? { argsPreview } : {}),
+    });
+  }
+
+  finishTool(
+    toolName: string,
+    durationMs?: number,
+    resultPreview?: string,
+  ): void {
+    for (let i = this.steps.length - 1; i >= 0; i--) {
+      const step = this.steps[i];
+      if (
+        step?.kind === 'tool' &&
+        step.status === 'running' &&
+        step.toolName === toolName
+      ) {
+        step.status = 'done';
+        if (durationMs !== undefined) step.durationMs = durationMs;
+        if (resultPreview) step.resultPreview = resultPreview;
+        return;
+      }
+    }
+    this.steps.push({
+      kind: 'tool',
+      toolName,
+      status: 'done',
+      ...(durationMs !== undefined ? { durationMs } : {}),
+      ...(resultPreview ? { resultPreview } : {}),
+    });
+  }
+
+  isEmpty(): boolean {
+    return this.steps.length === 0;
+  }
+
+  /** Returns null when no activity occurred, so callers skip persisting. */
+  build(elapsedMs?: number): ActivityTrace | null {
+    if (this.steps.length === 0) return null;
+    // A run can end while a tool is still marked running (no finish event);
+    // present it as done in the persisted, terminal trace.
+    const steps = this.steps.map((step) =>
+      step.kind === 'tool' && step.status === 'running'
+        ? { ...step, status: 'done' as const }
+        : step,
+    );
+    return {
+      steps,
+      ...(typeof elapsedMs === 'number' && elapsedMs >= 0 ? { elapsedMs } : {}),
+    };
+  }
+}
+
+export function serializeActivityTrace(trace: ActivityTrace): string {
+  return JSON.stringify(trace);
+}
+
+function readString(
+  source: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = source[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/** Defensive parse — tolerates corrupt or partial JSON by dropping bad steps. */
+export function parseActivityTrace(
+  raw: string | null | undefined,
+): ActivityTrace | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const stepsRaw = (parsed as { steps?: unknown }).steps;
+  if (!Array.isArray(stepsRaw)) return null;
+
+  const steps: ActivityTraceStep[] = [];
+  for (const entry of stepsRaw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const source = entry as Record<string, unknown>;
+    if (source.kind === 'thinking') {
+      const text = source.text;
+      if (typeof text === 'string') steps.push({ kind: 'thinking', text });
+    } else if (source.kind === 'tool') {
+      const toolName = readString(source, 'toolName');
+      if (!toolName) continue;
+      const step: ActivityTraceToolStep = {
+        kind: 'tool',
+        toolName,
+        status: 'done',
+      };
+      const argsPreview = readString(source, 'argsPreview');
+      if (argsPreview) step.argsPreview = argsPreview;
+      const resultPreview = readString(source, 'resultPreview');
+      if (resultPreview) step.resultPreview = resultPreview;
+      if (typeof source.durationMs === 'number') {
+        step.durationMs = source.durationMs;
+      }
+      steps.push(step);
+    }
+  }
+  if (steps.length === 0) return null;
+
+  const elapsedMs = (parsed as { elapsedMs?: unknown }).elapsedMs;
+  return {
+    steps,
+    ...(typeof elapsedMs === 'number' ? { elapsedMs } : {}),
+  };
+}

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -1,3 +1,4 @@
+import type { ActivityTrace } from './activity-trace.js';
 import type { ArtifactMetadata } from './execution.js';
 
 export type SessionShowMode = 'all' | 'thinking' | 'tools' | 'none';
@@ -43,6 +44,8 @@ export interface StoredMessage {
   agent_id?: string | null;
   response_rating?: ResponseRatingValue | null;
   artifacts?: ArtifactMetadata[];
+  /** Web-chat activity trace (thinking + tool calls) for assistant turns. */
+  activityTrace?: ActivityTrace;
   created_at: string;
 }
 

--- a/tests/activity-trace.test.ts
+++ b/tests/activity-trace.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ActivityTraceBuilder,
+  parseActivityTrace,
+  serializeActivityTrace,
+} from '../src/types/activity-trace.js';
+
+describe('ActivityTraceBuilder', () => {
+  it('merges consecutive thinking deltas and collapses tool start/finish', () => {
+    const builder = new ActivityTraceBuilder();
+    builder.pushThinking('Weighing ');
+    builder.pushThinking('options');
+    builder.startTool('exec', 'npm test');
+    builder.finishTool('exec', 420, 'ok');
+
+    const trace = builder.build(1200);
+    expect(trace).toEqual({
+      steps: [
+        { kind: 'thinking', text: 'Weighing options' },
+        {
+          kind: 'tool',
+          toolName: 'exec',
+          status: 'done',
+          argsPreview: 'npm test',
+          resultPreview: 'ok',
+          durationMs: 420,
+        },
+      ],
+      elapsedMs: 1200,
+    });
+  });
+
+  it('matches finish to the most recent running call of the same tool', () => {
+    const builder = new ActivityTraceBuilder();
+    builder.startTool('read', 'a.ts');
+    builder.startTool('read', 'b.ts');
+    builder.finishTool('read', 10, 'b done');
+
+    // The finish binds to the latest running call (b.ts) — it carries the
+    // result and duration. a.ts never got a finish; build() coerces its
+    // leftover running state to done but leaves it without a result.
+    const trace = builder.build();
+    expect(trace?.steps).toEqual([
+      { kind: 'tool', toolName: 'read', status: 'done', argsPreview: 'a.ts' },
+      {
+        kind: 'tool',
+        toolName: 'read',
+        status: 'done',
+        argsPreview: 'b.ts',
+        resultPreview: 'b done',
+        durationMs: 10,
+      },
+    ]);
+  });
+
+  it('coerces a still-running tool to done in the terminal build', () => {
+    const builder = new ActivityTraceBuilder();
+    builder.startTool('exec', 'sleep');
+    const trace = builder.build();
+    expect(trace?.steps).toEqual([
+      { kind: 'tool', toolName: 'exec', status: 'done', argsPreview: 'sleep' },
+    ]);
+  });
+
+  it('returns null for an empty trace and reports isEmpty', () => {
+    const builder = new ActivityTraceBuilder();
+    expect(builder.isEmpty()).toBe(true);
+    expect(builder.build(100)).toBeNull();
+    builder.pushThinking('');
+    expect(builder.isEmpty()).toBe(true);
+  });
+
+  it('omits a negative elapsed and keeps zero', () => {
+    const builder = new ActivityTraceBuilder();
+    builder.pushThinking('x');
+    expect(builder.build(-5)).toEqual({
+      steps: [{ kind: 'thinking', text: 'x' }],
+    });
+    expect(builder.build(0)).toEqual({
+      steps: [{ kind: 'thinking', text: 'x' }],
+      elapsedMs: 0,
+    });
+  });
+});
+
+describe('serialize/parseActivityTrace round-trip', () => {
+  it('round-trips a built trace', () => {
+    const builder = new ActivityTraceBuilder();
+    builder.pushThinking('think');
+    builder.startTool('exec', 'ls');
+    builder.finishTool('exec', 5, 'files');
+    const trace = builder.build(900);
+    if (!trace) throw new Error('expected a trace');
+
+    const parsed = parseActivityTrace(serializeActivityTrace(trace));
+    expect(parsed).toEqual(trace);
+  });
+
+  it('returns null for corrupt or non-trace JSON', () => {
+    expect(parseActivityTrace(null)).toBeNull();
+    expect(parseActivityTrace('')).toBeNull();
+    expect(parseActivityTrace('{bad')).toBeNull();
+    expect(parseActivityTrace('{"steps":"nope"}')).toBeNull();
+    expect(parseActivityTrace('{"steps":[]}')).toBeNull();
+  });
+
+  it('drops malformed steps but keeps valid ones', () => {
+    const parsed = parseActivityTrace(
+      JSON.stringify({
+        steps: [
+          { kind: 'thinking', text: 'ok' },
+          { kind: 'thinking' },
+          { kind: 'tool' },
+          { kind: 'tool', toolName: 'exec', durationMs: 'nan' },
+          { kind: 'mystery' },
+        ],
+        elapsedMs: 7,
+      }),
+    );
+    expect(parsed).toEqual({
+      steps: [
+        { kind: 'thinking', text: 'ok' },
+        { kind: 'tool', toolName: 'exec', status: 'done' },
+      ],
+      elapsedMs: 7,
+    });
+  });
+});

--- a/tests/message-activity-trace.test.ts
+++ b/tests/message-activity-trace.test.ts
@@ -58,6 +58,52 @@ describe('message activity trace persistence', () => {
     expect(user?.activityTrace).toBeUndefined();
   });
 
+  it('preserves activity traces when a session is branched', async () => {
+    const dbModule = await import('../src/memory/db.js');
+    const dbPath = path.join(makeTempDir(), 'hybridclaw.db');
+    dbModule.initDatabase({ quiet: true, dbPath });
+
+    const session = dbModule.getOrCreateSession(
+      'agent:main:channel:web:chat:dm:peer:activity-trace-branch',
+      null,
+      'web',
+      'main',
+    );
+    dbModule.storeMessage(session.id, 'user_a', 'User A', 'user', 'First');
+    const assistantId = dbModule.storeMessage(
+      session.id,
+      'assistant',
+      null,
+      'assistant',
+      'First answer',
+      'main',
+    );
+    dbModule.setMessageActivityTrace(assistantId, {
+      steps: [{ kind: 'thinking', text: 'reasoning' }],
+      elapsedMs: 1200,
+    });
+    const cutoffId = dbModule.storeMessage(
+      session.id,
+      'user_a',
+      'User A',
+      'user',
+      'Second',
+    );
+
+    const fork = dbModule.forkSessionBranch({
+      sessionId: session.id,
+      beforeMessageId: cutoffId,
+    });
+
+    const branched = dbModule.getConversationHistoryPage(fork.session.id, 50);
+    const assistant = branched.history.find((m) => m.role === 'assistant');
+    // The trace must ride along with the copied message, not be dropped.
+    expect(assistant?.activityTrace).toEqual({
+      steps: [{ kind: 'thinking', text: 'reasoning' }],
+      elapsedMs: 1200,
+    });
+  });
+
   it('survives the schema migration on a pre-existing database', async () => {
     const dbModule = await import('../src/memory/db.js');
     const dbPath = path.join(makeTempDir(), 'hybridclaw.db');

--- a/tests/message-activity-trace.test.ts
+++ b/tests/message-activity-trace.test.ts
@@ -1,0 +1,91 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+import { useTempDir } from './test-utils.ts';
+
+const makeTempDir = useTempDir('hybridclaw-activity-trace-');
+
+describe('message activity trace persistence', () => {
+  it('round-trips an assistant activity trace through history', async () => {
+    const dbModule = await import('../src/memory/db.js');
+    const dbPath = path.join(makeTempDir(), 'hybridclaw.db');
+    dbModule.initDatabase({ quiet: true, dbPath });
+
+    const session = dbModule.getOrCreateSession(
+      'agent:main:channel:web:chat:dm:peer:activity-trace',
+      null,
+      'web',
+      'main',
+    );
+    dbModule.storeMessage(
+      session.id,
+      'user_a',
+      'User A',
+      'user',
+      'Read my email',
+    );
+    const assistantId = dbModule.storeMessage(
+      session.id,
+      'assistant',
+      null,
+      'assistant',
+      'Here are your emails.',
+      'main',
+    );
+
+    const trace = {
+      steps: [
+        { kind: 'thinking' as const, text: 'Listing their messages' },
+        {
+          kind: 'tool' as const,
+          toolName: 'list_messages',
+          status: 'done' as const,
+          argsPreview: '{"top":20}',
+          resultPreview: '[{"id":"AAM..."}]',
+          durationMs: 903,
+        },
+      ],
+      elapsedMs: 34_000,
+    };
+    dbModule.setMessageActivityTrace(assistantId, trace);
+
+    const page = dbModule.getConversationHistoryPage(session.id, 50);
+    const assistant = page.history.find((m) => m.role === 'assistant');
+    const user = page.history.find((m) => m.role === 'user');
+
+    expect(assistant?.activityTrace).toEqual(trace);
+    // A message without a stored trace stays undefined, not null/empty.
+    expect(user?.activityTrace).toBeUndefined();
+  });
+
+  it('survives the schema migration on a pre-existing database', async () => {
+    const dbModule = await import('../src/memory/db.js');
+    const dbPath = path.join(makeTempDir(), 'hybridclaw.db');
+    // A fresh init already runs every migration; assert the column exists by
+    // exercising the writer + reader end to end without throwing.
+    dbModule.initDatabase({ quiet: true, dbPath });
+    const session = dbModule.getOrCreateSession(
+      'agent:main:channel:web:chat:dm:peer:activity-trace-migrate',
+      null,
+      'web',
+      'main',
+    );
+    const assistantId = dbModule.storeMessage(
+      session.id,
+      'assistant',
+      null,
+      'assistant',
+      'Done.',
+      'main',
+    );
+    expect(() =>
+      dbModule.setMessageActivityTrace(assistantId, {
+        steps: [{ kind: 'thinking', text: 'ok' }],
+      }),
+    ).not.toThrow();
+    const page = dbModule.getConversationHistoryPage(session.id, 50);
+    expect(page.history.find((m) => m.role === 'assistant')?.activityTrace).toEqual(
+      { steps: [{ kind: 'thinking', text: 'ok' }] },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** The web `/chat` view discarded the agent's `thinking` and `tool`
  stream events, so a run was a black box — and even once shown, the activity
  vanished on reload.
- **Why it matters:** Transparency — you can watch a colleague work, and the
  record of what it did survives a refresh.
- **What changed:** A light-grey, collapsible activity trace above each answer.
  It streams live (one row per thinking segment or tool call, with args/result
  previews and durations), auto-collapses to a one-line summary when the answer
  arrives, and is **persisted per assistant message so a reload replays it**.
- **What did not change:** No new model/agent behavior; traces are produced from
  events the gateway already emits, gated by the session `/show` mode.

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Tests
- [ ] Refactor required for the fix
- [ ] Tooling or workflow
- [ ] Security hardening

## Linked Context

- Closes #
- Related #

## Manifesto Principle

- Principle: **IV - A coworker is a colleague, not a chatbot.** Legible,
  persistent visibility into the agent's work.
- Changelog tag added or updated:
  `Manifesto: Principle IV - A coworker is a colleague, not a chatbot.`

## Validation

```bash
npm run lint                       # root + console + desktop typecheck — pass
npm --workspace console run test   # 805 passed (incl. new trace + hydration suites)
npx vitest run --project unit \
  tests/activity-trace.test.ts tests/message-activity-trace.test.ts \
  tests/gateway-http-server.test.ts   # pass (builder, DB round-trip, HTTP)
```

- Verified manually (logic): builder merges thinking deltas, collapses tool
  start/finish, and matches out-of-order finishes; DB round-trips a trace
  through history; the console hydrates a collapsed trace before its bubble.
- Edge cases: empty trace → not persisted and not hydrated; missing
  assistantMessageId → skipped; corrupt JSON → dropped; a still-running tool at
  turn end → coerced to done; migration is additive (`addColumnIfMissing`).
- Marker fix: unified the mixed `✻`/`•` glyphs into one aligned grey dot.

## Docs And Config Impact

- [ ] README, docs, or examples updated
- [x] Config or environment behavior changed
- [ ] Templates or workspace bootstrap files changed
- [ ] No docs or config impact

DB schema migration **v48** adds an additive `messages.activity_trace_json`
column (`addColumnIfMissing`); existing rows read back as no trace. CHANGELOG
`Unreleased` updated.

## Risk Notes

- Security-sensitive paths touched? **No.**
- Gateway, audit, approval, or container boundaries touched? **Yes** — the web
  streaming handler now persists a trace after the turn, and there is a new
  `messages` column. Failure mode: persistence is best-effort and wrapped in its
  own try/catch (logged, swallowed) so it can never corrupt the already-sent
  streamed response; the migration is additive and idempotent.

## Evidence

- [x] New or updated test coverage
  - `tests/activity-trace.test.ts` — builder accumulation, coercion,
    serialize/parse round-trip, defensive parsing.
  - `tests/message-activity-trace.test.ts` — DB write + history read-back.
  - `console/.../chat-history-query.test.ts` — trace hydrated before its
    assistant bubble; empty trace adds nothing.
  - Plus the live-stream suites from the first commit.

## Reviewer Notes

- **Rebased over `main`** after it was merged into this branch (apps feature).
  `main` had already taken schema **v46/v47**, so this migration was renumbered
  to **v48**; the `messages` column and history plumbing merged cleanly.
- **Persistence scope:** only the web streaming path persists traces (that is
  where they are produced). Other channels are unaffected.
- **Still a separate follow-up:** the broader "append-only output contract"
  refactor of the existing streaming pipeline (thinking-placeholder removal,
  empty-bubble dropping) is not in this PR.
