### PR TITLE
[codex] Preserve full tool progress output

### DIFF
--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -574,26 +574,21 @@ interface CompletedToolCallExecution {
   artifacts: ArtifactMetadata[];
 }
 
-function logToolCallStart(
-  toolName: string,
-  argsJson: string,
-  approval: ToolApprovalEvaluation,
-): void {
-  const yellowNarration = approvalRuntime.formatYellowNarration(approval);
-  const toolPreview =
-    approval.tier === 'yellow'
-      ? toolName === 'web_search'
-        ? approval.commandPreview
-        : yellowNarration
-      : argsJson.length > 100
-        ? `${argsJson.slice(0, 99)}…`
-        : argsJson;
-  console.error(`[tool] ${formatToolNameForLog(toolName)}: ${toolPreview}`);
+function logToolCallStart(toolName: string, argsJson: string): void {
+  console.error(
+    `[tool] ${formatToolNameForLog(toolName)}: ${formatToolProgressText(
+      argsJson,
+    )}`,
+  );
 }
 
 function formatToolNameForLog(toolName: string): string {
   if (!toolName.startsWith('browser_')) return toolName;
   return `${toolName} [browser=${getBrowserProviderLogLabel()}]`;
+}
+
+function formatToolProgressText(text: string): string {
+  return `json:${JSON.stringify(text)}`;
 }
 
 function appendCompletedToolCall(params: {
@@ -712,7 +707,7 @@ async function executePreparedToolCall(
   console.error(
     `[tool] ${formatToolNameForLog(
       toolName,
-    )} result (${toolDuration}ms): ${result.slice(0, 100)}`,
+    )} result (${toolDuration}ms): ${formatToolProgressText(result)}`,
   );
 
   return {
@@ -1194,11 +1189,7 @@ async function processRequest(
         arguments: approvedToolCall.argsJson,
       },
     };
-    logToolCallStart(
-      approvedToolCall.toolName,
-      approvedToolCall.argsJson,
-      approval,
-    );
+    logToolCallStart(approvedToolCall.toolName, approvedToolCall.argsJson);
     history.push({
       role: 'assistant',
       content: null,
@@ -1644,7 +1635,6 @@ async function processRequest(
           logToolCallStart(
             candidate.function.name,
             candidate.function.arguments,
-            candidateApproval,
           );
           preparedBatch.push({
             call: candidate,
@@ -1720,7 +1710,7 @@ async function processRequest(
           toolName,
           argsJson: call.function.arguments,
         }));
-      logToolCallStart(toolName, call.function.arguments, approval);
+      logToolCallStart(toolName, call.function.arguments);
 
       if (approval.decision === 'required') {
         toolsUsed.push(toolName);

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -96,6 +96,10 @@ import {
   takeCachedValue,
 } from './tool-parallelism.js';
 import {
+  formatLineSafeToolProgressText,
+  formatToolCallStartProgressText,
+} from './tool-progress-log.js';
+import {
   executeToolWithMetadata,
   getMessageToolDescription,
   getPendingSideEffects,
@@ -574,10 +578,16 @@ interface CompletedToolCallExecution {
   artifacts: ArtifactMetadata[];
 }
 
-function logToolCallStart(toolName: string, argsJson: string): void {
+function logToolCallStart(
+  toolName: string,
+  argsJson: string,
+  approval: ToolApprovalEvaluation,
+): void {
   console.error(
-    `[tool] ${formatToolNameForLog(toolName)}: ${formatToolProgressText(
+    `[tool] ${formatToolNameForLog(toolName)}: ${formatToolCallStartProgressText(
+      toolName,
       argsJson,
+      approval,
     )}`,
   );
 }
@@ -585,10 +595,6 @@ function logToolCallStart(toolName: string, argsJson: string): void {
 function formatToolNameForLog(toolName: string): string {
   if (!toolName.startsWith('browser_')) return toolName;
   return `${toolName} [browser=${getBrowserProviderLogLabel()}]`;
-}
-
-function formatToolProgressText(text: string): string {
-  return `json:${JSON.stringify(text)}`;
 }
 
 function appendCompletedToolCall(params: {
@@ -707,7 +713,7 @@ async function executePreparedToolCall(
   console.error(
     `[tool] ${formatToolNameForLog(
       toolName,
-    )} result (${toolDuration}ms): ${formatToolProgressText(result)}`,
+    )} result (${toolDuration}ms): ${formatLineSafeToolProgressText(result)}`,
   );
 
   return {
@@ -1189,7 +1195,11 @@ async function processRequest(
         arguments: approvedToolCall.argsJson,
       },
     };
-    logToolCallStart(approvedToolCall.toolName, approvedToolCall.argsJson);
+    logToolCallStart(
+      approvedToolCall.toolName,
+      approvedToolCall.argsJson,
+      approval,
+    );
     history.push({
       role: 'assistant',
       content: null,
@@ -1635,6 +1645,7 @@ async function processRequest(
           logToolCallStart(
             candidate.function.name,
             candidate.function.arguments,
+            candidateApproval,
           );
           preparedBatch.push({
             call: candidate,
@@ -1710,7 +1721,7 @@ async function processRequest(
           toolName,
           argsJson: call.function.arguments,
         }));
-      logToolCallStart(toolName, call.function.arguments);
+      logToolCallStart(toolName, call.function.arguments, approval);
 
       if (approval.decision === 'required') {
         toolsUsed.push(toolName);

--- a/container/src/tool-progress-log.ts
+++ b/container/src/tool-progress-log.ts
@@ -1,0 +1,38 @@
+import {
+  approvalRuntime,
+  type ToolApprovalEvaluation,
+} from './tool-approval.js';
+
+// The prefix marks arbitrary preview text encoded as a JSON string.
+export const LINE_SAFE_TOOL_PROGRESS_PREFIX = 'json:';
+export const TOOL_PROGRESS_PREVIEW_MAX_CHARS = 8_192;
+const TOOL_PROGRESS_TRUNCATION_MARKER = '[tool progress truncated]';
+
+function truncateToolProgressText(text: string): string {
+  if (text.length <= TOOL_PROGRESS_PREVIEW_MAX_CHARS) return text;
+  return `${text.slice(
+    0,
+    TOOL_PROGRESS_PREVIEW_MAX_CHARS,
+  )}\n${TOOL_PROGRESS_TRUNCATION_MARKER}`;
+}
+
+export function formatLineSafeToolProgressText(text: string): string {
+  return `${LINE_SAFE_TOOL_PROGRESS_PREFIX}${JSON.stringify(
+    truncateToolProgressText(text),
+  )}`;
+}
+
+export function formatToolCallStartProgressText(
+  toolName: string,
+  argsJson: string,
+  approval: ToolApprovalEvaluation,
+): string {
+  if (approval.tier === 'yellow') {
+    const preview =
+      toolName === 'web_search'
+        ? approval.commandPreview
+        : approvalRuntime.formatYellowNarration(approval);
+    return formatLineSafeToolProgressText(preview);
+  }
+  return formatLineSafeToolProgressText(argsJson);
+}

--- a/src/infra/tool-progress-parser.ts
+++ b/src/infra/tool-progress-parser.ts
@@ -8,6 +8,7 @@ const TOOL_RESULT_RE = new RegExp(
 const TOOL_START_RE = new RegExp(
   `^\\[tool\\]\\s+${TOOL_NAME_PATTERN}${TOOL_LABEL_PATTERN}:\\s*(.*)$`,
 );
+const LINE_SAFE_TOOL_PROGRESS_PREFIX = 'json:';
 
 export type ParsedToolProgressLine = Pick<
   ToolProgressEvent,
@@ -23,7 +24,7 @@ export function parseToolProgressLine(
       toolName: resultMatch[1] || 'tool',
       phase: 'finish',
       durationMs: parseInt(resultMatch[2] || '0', 10),
-      preview: resultMatch[3] || '',
+      preview: parseToolProgressPreview(resultMatch[3] || ''),
     };
   }
 
@@ -32,6 +33,16 @@ export function parseToolProgressLine(
   return {
     toolName: startMatch[1] || 'tool',
     phase: 'start',
-    preview: startMatch[2] || '',
+    preview: parseToolProgressPreview(startMatch[2] || ''),
   };
+}
+
+function parseToolProgressPreview(raw: string): string {
+  if (!raw.startsWith(LINE_SAFE_TOOL_PROGRESS_PREFIX)) return raw;
+  try {
+    const parsed = JSON.parse(raw.slice(LINE_SAFE_TOOL_PROGRESS_PREFIX.length));
+    return typeof parsed === 'string' ? parsed : raw;
+  } catch {
+    return raw;
+  }
 }

--- a/tests/board-card-store.test.ts
+++ b/tests/board-card-store.test.ts
@@ -29,6 +29,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.doUnmock('node:crypto');
   if (originalDataDir === undefined) delete process.env.HYBRIDCLAW_DATA_DIR;
   else process.env.HYBRIDCLAW_DATA_DIR = originalDataDir;
   if (originalHome === undefined) delete process.env.HOME;
@@ -548,6 +549,16 @@ describe.sequential('board card store', () => {
   });
 
   test('emits board edge mutations through F2 runtime events and structured audit', async () => {
+    vi.doMock('node:crypto', async () => {
+      const actual =
+        await vi.importActual<typeof import('node:crypto')>('node:crypto');
+      const uuids = ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'];
+      return {
+        ...actual,
+        randomUUID: vi.fn(() => uuids.shift() || actual.randomUUID()),
+      };
+    });
+
     const { boardModule, dbModule } = await loadBoardStore();
     const { subscribeRuntimeEvents, subscribeSkillRunEvents } = await import(
       '../src/skills/skill-run-events.js'

--- a/tests/container.tool-progress-log.test.ts
+++ b/tests/container.tool-progress-log.test.ts
@@ -1,0 +1,122 @@
+import { expect, test } from 'vitest';
+
+import type { ToolApprovalEvaluation } from '../container/src/tool-approval.js';
+import {
+  formatLineSafeToolProgressText,
+  formatToolCallStartProgressText,
+  LINE_SAFE_TOOL_PROGRESS_PREFIX,
+  TOOL_PROGRESS_PREVIEW_MAX_CHARS,
+} from '../container/src/tool-progress-log.js';
+
+function decodeLineSafeProgress(value: string): string {
+  expect(value.startsWith(LINE_SAFE_TOOL_PROGRESS_PREFIX)).toBe(true);
+  return JSON.parse(
+    value.slice(LINE_SAFE_TOOL_PROGRESS_PREFIX.length),
+  ) as string;
+}
+
+function makeApproval(
+  overrides: Partial<ToolApprovalEvaluation> = {},
+): ToolApprovalEvaluation {
+  return {
+    baseTier: 'green',
+    tier: 'green',
+    autonomyLevel: 'full-autonomous',
+    stakes: 'low',
+    stakesScore: {
+      level: 'low',
+      score: 0,
+      confidence: 1,
+      reasons: ['test'],
+      classifier: 'test',
+    },
+    stakesMiddlewareDecision: { action: 'allow' },
+    escalationRoute: 'operator',
+    decision: 'auto',
+    actionKey: 'read',
+    fingerprint: 'fingerprint:test',
+    intent: 'run read',
+    consequenceIfDenied: 'The tool call will be skipped.',
+    reason: 'read-only test action',
+    commandPreview: '{"path":"README.md"}',
+    pinned: false,
+    hostHints: [],
+    ...overrides,
+  };
+}
+
+test('formats multiline tool progress as one line-safe payload', () => {
+  const preview = 'line 1\nline 2';
+
+  expect(decodeLineSafeProgress(formatLineSafeToolProgressText(preview))).toBe(
+    preview,
+  );
+});
+
+test('caps large line-safe tool progress payloads', () => {
+  const formatted = formatLineSafeToolProgressText(
+    'x'.repeat(TOOL_PROGRESS_PREVIEW_MAX_CHARS + 32),
+  );
+  const preview = decodeLineSafeProgress(formatted);
+
+  expect(preview).toHaveLength(
+    TOOL_PROGRESS_PREVIEW_MAX_CHARS + '\n[tool progress truncated]'.length,
+  );
+  expect(preview.endsWith('\n[tool progress truncated]')).toBe(true);
+});
+
+test('logs full green-tier tool-call arguments under the preview cap', () => {
+  const argsJson = JSON.stringify({
+    action: 'send',
+    subject: 'HERE',
+    content: 'line 1\nline 2',
+  });
+
+  expect(
+    decodeLineSafeProgress(
+      formatToolCallStartProgressText('message', argsJson, makeApproval()),
+    ),
+  ).toBe(argsJson);
+});
+
+test('masks yellow-tier browser input arguments before logging progress', () => {
+  const argsJson = JSON.stringify({ ref: '@e9', text: 'secret password' });
+  const approval = makeApproval({
+    baseTier: 'yellow',
+    tier: 'yellow',
+    decision: 'implicit',
+    actionKey: 'browser_type',
+    intent: 'run browser_type',
+    commandPreview: argsJson,
+    implicitDelayMs: 5_000,
+  });
+
+  const preview = decodeLineSafeProgress(
+    formatToolCallStartProgressText('browser_type', argsJson, approval),
+  );
+
+  expect(preview).toBe(
+    'run browser_type. Waiting 5s for interruption before running.',
+  );
+  expect(preview).not.toContain('secret password');
+});
+
+test('uses yellow-tier web search command previews instead of raw arguments', () => {
+  const argsJson = JSON.stringify({
+    query: 'private customer account issue',
+  });
+  const approval = makeApproval({
+    baseTier: 'yellow',
+    tier: 'yellow',
+    decision: 'implicit',
+    actionKey: 'web_search',
+    intent: 'run web_search',
+    commandPreview: 'search the web for project documentation',
+  });
+
+  expect(
+    decodeLineSafeProgress(
+      formatToolCallStartProgressText('web_search', argsJson, approval),
+    ),
+  ).toBe('search the web for project documentation');
+});

--- a/tests/tool-progress-parser.test.ts
+++ b/tests/tool-progress-parser.test.ts
@@ -16,6 +16,41 @@ test('parses plain tool start and result progress lines', () => {
   });
 });
 
+test('parses complete line-safe tool progress payloads', () => {
+  const args = JSON.stringify({
+    action: 'send',
+    subject: 'HERE',
+    content: 'line 1\nline 2',
+  });
+  expect(
+    parseToolProgressLine(`[tool] message: json:${JSON.stringify(args)}`),
+  ).toEqual({
+    toolName: 'message',
+    phase: 'start',
+    preview: args,
+  });
+
+  const result = JSON.stringify(
+    {
+      ok: true,
+      action: 'send',
+      nested: { status: 'queued' },
+    },
+    null,
+    2,
+  );
+  expect(
+    parseToolProgressLine(
+      `[tool] message result (1332ms): json:${JSON.stringify(result)}`,
+    ),
+  ).toEqual({
+    toolName: 'message',
+    phase: 'finish',
+    durationMs: 1332,
+    preview: result,
+  });
+});
+
 test('parses labelled browser tool progress lines using the canonical tool name', () => {
   expect(
     parseToolProgressLine(


### PR DESCRIPTION
## What changed

- Emit complete tool-call arguments and tool results in container progress logs using a line-safe `json:<JSON string>` payload.
- Decode line-safe progress payloads in the gateway parser before streaming and persisting activity traces.
- Add regression coverage for multiline JSON tool-result previews so pretty-printed results no longer collapse to a dangling `{`.

## Why

The activity trace UI was receiving only the first physical stderr line for pretty-printed tool results. For JSON results, that meant the persisted preview could be just `{` even though the full result was available in audit logs.

## Impact

Web/chat activity traces now preserve full tool calls and results instead of truncated previews. Existing legacy progress lines still parse unchanged.

## Validation

- `npx vitest run tests/tool-progress-parser.test.ts`
- `npm --prefix container run lint`
- `npm run build`
- `npm run format`
- `npm run lint`
- `git diff --check`

Note: `npm run format` completed with existing optional-chain warnings and no fixes applied.