### PR TITLE
[codex] Fix email polling with stale mailbox UID state

### DIFF
--- a/src/channels/email/connection.ts
+++ b/src/channels/email/connection.ts
@@ -65,19 +65,36 @@ function resolveCursorStatePath(address: string): string {
   );
 }
 
-function resolveMailboxUidNext(client: ImapFlow): number {
-  return Math.max(1, client.mailbox ? client.mailbox.uidNext : 1);
+function normalizeUidNext(value: unknown): number {
+  const normalized = Math.max(1, Math.trunc(Number(value) || 1));
+  return Number.isFinite(normalized) ? normalized : 1;
 }
 
-function resolveMailboxUidValidity(client: ImapFlow): string | null {
-  return client.mailbox
-    ? normalizeUidValidity(client.mailbox.uidValidity)
-    : null;
+async function resolveMailboxStatus(
+  client: ImapFlow,
+  folder: string,
+): Promise<{ uidNext: number; uidValidity: string | null }> {
+  const status = await client.status(folder, {
+    uidNext: true,
+    uidValidity: true,
+  });
+  const statusRecord =
+    status && typeof status === 'object'
+      ? (status as { uidNext?: unknown; uidValidity?: unknown })
+      : null;
+  const mailbox =
+    client.mailbox && typeof client.mailbox === 'object'
+      ? client.mailbox
+      : null;
+  return {
+    uidNext: normalizeUidNext(statusRecord?.uidNext ?? mailbox?.uidNext),
+    uidValidity: normalizeUidValidity(
+      statusRecord?.uidValidity ?? mailbox?.uidValidity,
+    ),
+  };
 }
 
-function normalizeUidValidity(
-  value: bigint | string | null | undefined,
-): string | null {
+function normalizeUidValidity(value: unknown): string | null {
   if (typeof value === 'bigint') {
     return value.toString();
   }
@@ -329,7 +346,8 @@ export function createEmailConnectionManager(
 
     const lock = await activeClient.getMailboxLock(folder);
     try {
-      const uidValidity = resolveMailboxUidValidity(activeClient);
+      const mailboxStatus = await resolveMailboxStatus(activeClient, folder);
+      const uidValidity = mailboxStatus.uidValidity;
       const storedCursor = persistedCursorState.get(folder);
       const compatibleStoredCursor =
         storedCursor && storedCursor.uidValidity === uidValidity
@@ -339,7 +357,7 @@ export function createEmailConnectionManager(
         ? compatibleStoredCursor.lastProcessedUid
         : 0;
 
-      const maxKnownUid = resolveMailboxUidNext(activeClient) - 1;
+      const maxKnownUid = mailboxStatus.uidNext - 1;
       if (!compatibleStoredCursor) {
         persistedCursorState.set(folder, {
           uidValidity,
@@ -351,34 +369,24 @@ export function createEmailConnectionManager(
         );
         return;
       }
-      if (maxKnownUid <= lastProcessedUid) {
-        if (
-          !storedCursor ||
-          storedCursor.uidValidity !== uidValidity ||
-          storedCursor.lastProcessedUid !== lastProcessedUid
-        ) {
-          persistedCursorState.set(folder, {
-            uidValidity,
-            lastProcessedUid,
-          });
-          await savePersistedFolderCursorState(
-            config.address,
-            persistedCursorState,
-          );
-        }
-        return;
-      }
-
       const allUids =
-        (await activeClient.search({ all: true }, { uid: true })) || [];
+        (await activeClient.search(
+          { uid: `${lastProcessedUid + 1}:*` },
+          { uid: true },
+        )) || [];
       const pending = [...new Set(allUids)]
         .filter((uid) => uid > lastProcessedUid)
         .sort((left, right) => left - right);
       if (pending.length === 0) {
-        if (!storedCursor || storedCursor.uidValidity !== uidValidity) {
+        const nextLastProcessedUid = Math.max(lastProcessedUid, maxKnownUid);
+        if (
+          !storedCursor ||
+          storedCursor.uidValidity !== uidValidity ||
+          storedCursor.lastProcessedUid !== nextLastProcessedUid
+        ) {
           persistedCursorState.set(folder, {
             uidValidity,
-            lastProcessedUid: maxKnownUid,
+            lastProcessedUid: nextLastProcessedUid,
           });
           await savePersistedFolderCursorState(
             config.address,

--- a/src/channels/email/connection.ts
+++ b/src/channels/email/connection.ts
@@ -78,19 +78,9 @@ async function resolveMailboxStatus(
     uidNext: true,
     uidValidity: true,
   });
-  const statusRecord =
-    status && typeof status === 'object'
-      ? (status as { uidNext?: unknown; uidValidity?: unknown })
-      : null;
-  const mailbox =
-    client.mailbox && typeof client.mailbox === 'object'
-      ? client.mailbox
-      : null;
   return {
-    uidNext: normalizeUidNext(statusRecord?.uidNext ?? mailbox?.uidNext),
-    uidValidity: normalizeUidValidity(
-      statusRecord?.uidValidity ?? mailbox?.uidValidity,
-    ),
+    uidNext: normalizeUidNext(status.uidNext),
+    uidValidity: normalizeUidValidity(status.uidValidity),
   };
 }
 
@@ -369,6 +359,24 @@ export function createEmailConnectionManager(
         );
         return;
       }
+      if (maxKnownUid <= lastProcessedUid) {
+        if (
+          !storedCursor ||
+          storedCursor.uidValidity !== uidValidity ||
+          storedCursor.lastProcessedUid !== lastProcessedUid
+        ) {
+          persistedCursorState.set(folder, {
+            uidValidity,
+            lastProcessedUid,
+          });
+          await savePersistedFolderCursorState(
+            config.address,
+            persistedCursorState,
+          );
+        }
+        return;
+      }
+
       const allUids =
         (await activeClient.search(
           { uid: `${lastProcessedUid + 1}:*` },

--- a/tests/email.connection.test.ts
+++ b/tests/email.connection.test.ts
@@ -36,6 +36,11 @@ describe('email connection manager', () => {
     let uidNext = 3;
     const processedUids: number[] = [];
     const search = vi.fn(async () => [...mailboxUids]);
+    const status = vi.fn(async (folder: string) => ({
+      path: folder,
+      uidNext,
+      uidValidity: 1n,
+    }));
     const messageFlagsAdd = vi.fn(async () => true);
     const fetch = vi.fn(async function* (uids: number[]) {
       for (const uid of uids) {
@@ -71,6 +76,7 @@ describe('email connection manager', () => {
             release: vi.fn(),
           };
         });
+        status = status;
         search = search;
         fetch = fetch;
         messageFlagsAdd = messageFlagsAdd;
@@ -109,7 +115,7 @@ describe('email connection manager', () => {
     uidNext = 4;
     await runManager();
     expect(processedUids).toEqual([3]);
-    expect(search).toHaveBeenCalledWith({ all: true }, { uid: true });
+    expect(search).toHaveBeenCalledWith({ uid: '3:*' }, { uid: true });
     expect(messageFlagsAdd).toHaveBeenCalledTimes(1);
     expect(messageFlagsAdd).toHaveBeenCalledWith([3], ['\\Seen'], {
       uid: true,
@@ -144,6 +150,11 @@ describe('email connection manager', () => {
 
     const processedUids: number[] = [];
     const search = vi.fn(async () => [1, 2, 3]);
+    const status = vi.fn(async (folder: string) => ({
+      path: folder,
+      uidNext: 4,
+      uidValidity: 1n,
+    }));
     const messageFlagsAdd = vi.fn(async () => true);
     const fetch = vi.fn(async function* (uids: number[]) {
       for (const uid of uids) {
@@ -179,6 +190,7 @@ describe('email connection manager', () => {
             release: vi.fn(),
           };
         });
+        status = status;
         search = search;
         fetch = fetch;
         messageFlagsAdd = messageFlagsAdd;
@@ -201,12 +213,114 @@ describe('email connection manager', () => {
     await manager.start();
     await manager.stop();
 
-    expect(search).toHaveBeenCalledWith({ all: true }, { uid: true });
+    expect(search).toHaveBeenCalledWith({ uid: '2:*' }, { uid: true });
     expect(processedUids).toEqual([2, 3]);
     expect(messageFlagsAdd).toHaveBeenNthCalledWith(1, [2], ['\\Seen'], {
       uid: true,
     });
     expect(messageFlagsAdd).toHaveBeenNthCalledWith(2, [3], ['\\Seen'], {
+      uid: true,
+    });
+  });
+
+  test('does not trust stale mailbox uidNext when polling for later UIDs', async () => {
+    const dataDir = makeTempDir('hybridclaw-email-connection-');
+
+    const cursorStatePath = path.join(
+      dataDir,
+      'email',
+      `${Buffer.from(BASE_EMAIL_CONFIG.address).toString('base64url').replace(/=+$/g, '')}-cursor-state.json`,
+    );
+    fs.mkdirSync(path.dirname(cursorStatePath), { recursive: true });
+    fs.writeFileSync(
+      cursorStatePath,
+      JSON.stringify(
+        {
+          version: 1,
+          folders: {
+            INBOX: {
+              uidValidity: '1',
+              lastProcessedUid: 3,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const processedUids: number[] = [];
+    const search = vi.fn(async () => [4]);
+    const status = vi.fn(async (folder: string) => ({
+      path: folder,
+      uidNext: 4,
+      uidValidity: 1n,
+    }));
+    const messageFlagsAdd = vi.fn(async () => true);
+    const fetch = vi.fn(async function* (uids: number[]) {
+      for (const uid of uids) {
+        yield {
+          uid,
+          source: Buffer.from(`raw-${uid}`, 'utf8'),
+        };
+      }
+    });
+
+    vi.doMock('../src/config/config.js', () => ({
+      DATA_DIR: dataDir,
+    }));
+    vi.doMock('imapflow', () => ({
+      ImapFlow: class {
+        mailbox = {
+          path: 'INBOX',
+          uidNext: 4,
+          uidValidity: 1n,
+        };
+        connect = vi.fn(async () => {});
+        logout = vi.fn(async () => {});
+        close = vi.fn(() => {});
+        removeAllListeners = vi.fn(() => {});
+        on = vi.fn(() => this);
+        getMailboxLock = vi.fn(async (folder: string) => {
+          this.mailbox = {
+            path: folder,
+            uidNext: 4,
+            uidValidity: 1n,
+          };
+          return {
+            release: vi.fn(),
+          };
+        });
+        status = status;
+        search = search;
+        fetch = fetch;
+        messageFlagsAdd = messageFlagsAdd;
+      },
+    }));
+
+    const { createEmailConnectionManager } = await import(
+      '../src/channels/email/connection.js'
+    );
+    const manager = createEmailConnectionManager(
+      BASE_EMAIL_CONFIG,
+      'secret',
+      async (messages) => {
+        for (const message of messages) {
+          processedUids.push(message.uid);
+        }
+      },
+    );
+
+    await manager.start();
+    await manager.stop();
+
+    expect(status).toHaveBeenCalledWith('INBOX', {
+      uidNext: true,
+      uidValidity: true,
+    });
+    expect(search).toHaveBeenCalledWith({ uid: '4:*' }, { uid: true });
+    expect(processedUids).toEqual([4]);
+    expect(messageFlagsAdd).toHaveBeenCalledWith([4], ['\\Seen'], {
       uid: true,
     });
   });
@@ -331,6 +445,11 @@ describe('email connection manager', () => {
             release: vi.fn(),
           };
         });
+        status = vi.fn(async (folder: string) => ({
+          path: folder,
+          uidNext: 1,
+          uidValidity: 1n,
+        }));
         search = vi.fn(async () => []);
         fetch = vi.fn(async function* () {});
         messageFlagsAdd = vi.fn(async () => true);

--- a/tests/email.connection.test.ts
+++ b/tests/email.connection.test.ts
@@ -253,7 +253,7 @@ describe('email connection manager', () => {
     const search = vi.fn(async () => [4]);
     const status = vi.fn(async (folder: string) => ({
       path: folder,
-      uidNext: 4,
+      uidNext: 5,
       uidValidity: 1n,
     }));
     const messageFlagsAdd = vi.fn(async () => true);
@@ -323,6 +323,98 @@ describe('email connection manager', () => {
     expect(messageFlagsAdd).toHaveBeenCalledWith([4], ['\\Seen'], {
       uid: true,
     });
+  });
+
+  test('skips UID search when fresh mailbox status shows no new mail', async () => {
+    const dataDir = makeTempDir('hybridclaw-email-connection-');
+
+    const cursorStatePath = path.join(
+      dataDir,
+      'email',
+      `${Buffer.from(BASE_EMAIL_CONFIG.address).toString('base64url').replace(/=+$/g, '')}-cursor-state.json`,
+    );
+    fs.mkdirSync(path.dirname(cursorStatePath), { recursive: true });
+    fs.writeFileSync(
+      cursorStatePath,
+      JSON.stringify(
+        {
+          version: 1,
+          folders: {
+            INBOX: {
+              uidValidity: '1',
+              lastProcessedUid: 3,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const processedUids: number[] = [];
+    const search = vi.fn(async () => [4]);
+    const status = vi.fn(async (folder: string) => ({
+      path: folder,
+      uidNext: 4,
+      uidValidity: 1n,
+    }));
+    const messageFlagsAdd = vi.fn(async () => true);
+
+    vi.doMock('../src/config/config.js', () => ({
+      DATA_DIR: dataDir,
+    }));
+    vi.doMock('imapflow', () => ({
+      ImapFlow: class {
+        mailbox = {
+          path: 'INBOX',
+          uidNext: 4,
+          uidValidity: 1n,
+        };
+        connect = vi.fn(async () => {});
+        logout = vi.fn(async () => {});
+        close = vi.fn(() => {});
+        removeAllListeners = vi.fn(() => {});
+        on = vi.fn(() => this);
+        getMailboxLock = vi.fn(async (folder: string) => {
+          this.mailbox = {
+            path: folder,
+            uidNext: 4,
+            uidValidity: 1n,
+          };
+          return {
+            release: vi.fn(),
+          };
+        });
+        status = status;
+        search = search;
+        fetch = vi.fn(async function* () {});
+        messageFlagsAdd = messageFlagsAdd;
+      },
+    }));
+
+    const { createEmailConnectionManager } = await import(
+      '../src/channels/email/connection.js'
+    );
+    const manager = createEmailConnectionManager(
+      BASE_EMAIL_CONFIG,
+      'secret',
+      async (messages) => {
+        for (const message of messages) {
+          processedUids.push(message.uid);
+        }
+      },
+    );
+
+    await manager.start();
+    await manager.stop();
+
+    expect(status).toHaveBeenCalledWith('INBOX', {
+      uidNext: true,
+      uidValidity: true,
+    });
+    expect(search).not.toHaveBeenCalled();
+    expect(processedUids).toEqual([]);
+    expect(messageFlagsAdd).not.toHaveBeenCalled();
   });
 
   test('keeps expected DNS failures local and logs a readable reconnect warning', async () => {


### PR DESCRIPTION
## Summary

- Refresh IMAP mailbox UID metadata with `STATUS` before each email poll.
- Search only the UID range after the persisted cursor instead of trusting cached `mailbox.uidNext`.
- Add a regression test for a new message being missed when the selected mailbox UID state is stale.

## Root Cause

The email poller could skip `SEARCH` when `client.mailbox.uidNext` had not been refreshed on a long-lived IMAP connection. Pressing "Save channel settings" restarted the email integration, which refreshed the mailbox state and caused the pending reply to be processed.

## Validation

- `npm run format`
- `npm run lint`
- `/Users/bkoehler/src/hybridclaw/node_modules/.bin/vitest --root /Users/bkoehler/.codex/worktrees/d2f4/hybridclaw --config /Users/bkoehler/src/hybridclaw/vitest.config.ts run tests/email.connection.test.ts`