### PR TITLE
[codex] Preserve interim assistant drafts

### DIFF
--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -27,6 +27,11 @@ export interface ChatActivityTraceThinkingStep {
   text: string;
 }
 
+export interface ChatActivityTraceDraftStep {
+  kind: 'draft';
+  text: string;
+}
+
 export interface ChatActivityTraceToolStep {
   kind: 'tool';
   toolName: string;
@@ -38,6 +43,7 @@ export interface ChatActivityTraceToolStep {
 
 export type ChatActivityTraceStep =
   | ChatActivityTraceThinkingStep
+  | ChatActivityTraceDraftStep
   | ChatActivityTraceToolStep;
 
 /** Persisted per-message activity trace replayed from chat history. */

--- a/console/src/routes/chat/chat-history-query.test.ts
+++ b/console/src/routes/chat/chat-history-query.test.ts
@@ -296,6 +296,7 @@ describe('buildChatHistoryUiData', () => {
           activityTrace: {
             steps: [
               { kind: 'thinking', text: 'Listing their messages' },
+              { kind: 'draft', text: 'I will check the inbox first.' },
               {
                 kind: 'tool',
                 toolName: 'list_messages',
@@ -320,6 +321,7 @@ describe('buildChatHistoryUiData', () => {
     expect(trace.finishedAt).toBe(34_000);
     expect(trace.steps).toEqual([
       { kind: 'thinking', text: 'Listing their messages' },
+      { kind: 'draft', text: 'I will check the inbox first.' },
       {
         kind: 'tool',
         toolName: 'list_messages',

--- a/console/src/routes/chat/chat-history-query.ts
+++ b/console/src/routes/chat/chat-history-query.ts
@@ -39,23 +39,24 @@ function hydrateActivityTrace(
   if (!trace || !Array.isArray(trace.steps) || trace.steps.length === 0) {
     return null;
   }
-  const steps: TraceStep[] = trace.steps.map(
-    (step): TraceStep =>
-      step.kind === 'thinking'
-        ? { kind: 'thinking', text: step.text }
-        : {
-            kind: 'tool',
-            toolName: step.toolName,
-            status: 'done',
-            ...(step.argsPreview ? { argsPreview: step.argsPreview } : {}),
-            ...(step.resultPreview
-              ? { resultPreview: step.resultPreview }
-              : {}),
-            ...(typeof step.durationMs === 'number'
-              ? { durationMs: step.durationMs }
-              : {}),
-          },
-  );
+  const steps: TraceStep[] = trace.steps.map((step): TraceStep => {
+    if (step.kind === 'thinking') {
+      return { kind: 'thinking', text: step.text };
+    }
+    if (step.kind === 'draft') {
+      return { kind: 'draft', text: step.text };
+    }
+    return {
+      kind: 'tool',
+      toolName: step.toolName,
+      status: 'done',
+      ...(step.argsPreview ? { argsPreview: step.argsPreview } : {}),
+      ...(step.resultPreview ? { resultPreview: step.resultPreview } : {}),
+      ...(typeof step.durationMs === 'number'
+        ? { durationMs: step.durationMs }
+        : {}),
+    };
+  });
   return {
     id: nextMsgId(),
     role: 'trace',

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1522,6 +1522,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 .traceDraftInterim {
+  align-self: flex-start;
   min-width: 0;
   max-width: 85%;
   padding: 1px 4px;

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1353,9 +1353,18 @@ aside[data-state="collapsed"] .chatSidebarContent {
   }
 }
 
-/* Run-activity trace: light-grey collapsible rows (thinking + tool calls)
-   shown above the answer bubble. Expanded while streaming, collapsed to the
-   summary row once the run finishes. */
+/* Run-activity trace: light-grey collapsible rows (thinking and tool calls)
+   with visible interim drafts kept outside the collapsible rows. Expanded
+   while streaming, collapsed to summary rows once the run finishes. */
+.traceSequence {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+  max-width: 100%;
+}
+
 .traceBlock {
   min-width: 0;
   max-width: 85%;
@@ -1510,6 +1519,22 @@ aside[data-state="collapsed"] .chatSidebarContent {
   font-style: italic;
   line-height: 1.5;
   color: color-mix(in srgb, var(--muted-foreground) 88%, transparent);
+}
+
+.traceDraftInterim {
+  min-width: 0;
+  max-width: 85%;
+  padding: 1px 4px;
+  font-size: 0.92rem;
+  color: var(--text);
+}
+
+.traceDraftInterim .markdownContent > :first-child {
+  margin-top: 0;
+}
+
+.traceDraftInterim .markdownContent > :last-child {
+  margin-bottom: 0;
 }
 
 .composerWrapper {

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -1302,7 +1302,8 @@ export function ChatPage() {
                 {visibleMessages.map((msg) =>
                   editingId === msg.id &&
                   msg.role !== 'thinking' &&
-                  msg.role !== 'trace' ? (
+                  msg.role !== 'trace' &&
+                  msg.role !== 'draft' ? (
                     <div key={msg.id} className={css.messageBlock}>
                       <EditInline
                         initial={msg.rawContent ?? msg.content}

--- a/console/src/routes/chat/chat-ui-message.ts
+++ b/console/src/routes/chat/chat-ui-message.ts
@@ -5,6 +5,10 @@ export type ThinkingChatMessage = Omit<ChatMessage, 'role' | 'content'> & {
   content: '';
 };
 
+export type DraftChatMessage = Omit<ChatMessage, 'role'> & {
+  role: 'draft';
+};
+
 export interface TraceThinkingStep {
   kind: 'thinking';
   text: string;
@@ -43,5 +47,6 @@ export type TraceChatMessage = Omit<ChatMessage, 'role' | 'content'> & {
 
 export type ChatUiMessage =
   | ChatMessage
+  | DraftChatMessage
   | ThinkingChatMessage
   | TraceChatMessage;

--- a/console/src/routes/chat/chat-ui-message.ts
+++ b/console/src/routes/chat/chat-ui-message.ts
@@ -10,6 +10,11 @@ export interface TraceThinkingStep {
   text: string;
 }
 
+export interface TraceDraftStep {
+  kind: 'draft';
+  text: string;
+}
+
 export interface TraceToolStep {
   kind: 'tool';
   toolName: string;
@@ -19,13 +24,12 @@ export interface TraceToolStep {
   durationMs?: number;
 }
 
-export type TraceStep = TraceThinkingStep | TraceToolStep;
+export type TraceStep = TraceThinkingStep | TraceDraftStep | TraceToolStep;
 
 /**
- * Live activity trace for one assistant turn (thinking + tool calls streamed
- * by the gateway). Rendered as a collapsible block above the answer bubble;
- * exists only for runs streamed in this browser session — server history does
- * not persist it.
+ * Live activity trace for one assistant turn. Thinking/tool steps render as
+ * collapsible grey activity rows; draft steps render as visible interim
+ * assistant text between those rows.
  */
 export type TraceChatMessage = Omit<ChatMessage, 'role' | 'content'> & {
   role: 'trace';

--- a/console/src/routes/chat/message-block.test.tsx
+++ b/console/src/routes/chat/message-block.test.tsx
@@ -93,6 +93,37 @@ describe('MessageBlock artifacts', () => {
     expect(bubble.classList.contains(css.bubbleUser)).toBe(true);
   });
 
+  it('renders streaming draft assistant text without bubble chrome', () => {
+    const draft: ChatUiMessage = {
+      id: 'draft-1',
+      role: 'draft',
+      content: 'Got the weather. Sending the email now.',
+      sessionId: 'session-a',
+      artifacts: [],
+      replayRequest: null,
+    };
+
+    render(
+      <MessageBlock
+        message={draft}
+        token="test-token"
+        isStreaming={true}
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={vi.fn()}
+        approvalBusy={false}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
+
+    const text = screen.getByText('Got the weather. Sending the email now.');
+    expect(text.closest(`.${css.traceDraftInterim}`)).not.toBeNull();
+    expect(text.closest(`.${css.bubbleAssistant}`)).toBeNull();
+    expect(screen.queryByText('Assistant')).toBeNull();
+  });
+
   it('links a leading user skill slash command to the skill detail page', () => {
     const content = '/blink List my Blink cameras and summarize events';
     render(

--- a/console/src/routes/chat/message-block.tsx
+++ b/console/src/routes/chat/message-block.tsx
@@ -417,9 +417,11 @@ export const MessageBlock = memo(function MessageBlock(props: {
   }, [msg.artifacts]);
 
   const isApproval = msg.role === 'approval';
+  const isDraft = msg.role === 'draft';
   const shouldRenderApprovalCard = isApproval && Boolean(msg.pendingApproval);
   const isMarkdownMessage =
     msg.role === 'assistant' ||
+    isDraft ||
     msg.role === 'command' ||
     (isApproval && !shouldRenderApprovalCard);
   const renderedHtml = useRenderedMarkdown(
@@ -449,6 +451,19 @@ export const MessageBlock = memo(function MessageBlock(props: {
         <span className={css.thinkingDot} />
         <span className={css.thinkingDot} />
         <span className={css.thinkingDot} />
+      </div>
+    );
+  }
+
+  if (isDraft) {
+    return (
+      <div className={css.traceDraftInterim}>
+        <div
+          ref={markdownRef}
+          className={css.markdownContent}
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: markdown output is rendered by marked and sanitized through sanitize-html
+          dangerouslySetInnerHTML={{ __html: renderedHtml }}
+        />
       </div>
     );
   }

--- a/console/src/routes/chat/trace-block.test.tsx
+++ b/console/src/routes/chat/trace-block.test.tsx
@@ -114,7 +114,9 @@ describe('TraceBlock', () => {
     const secondControl = controls[1];
     if (!firstControl || !secondControl) throw new Error('expected controls');
     expect(firstControl.textContent).toContain('Thought');
-    expect(secondControl.textContent).toContain('1 tool call · thinking');
+    expect(secondControl.textContent).toContain(
+      '1 tool call · thinking · 4.0s',
+    );
     expect(screen.queryByText('I need a location first.')).not.toBeNull();
     expect(screen.queryByText('Considering the request')).toBeNull();
     expect(screen.queryByText('send email')).toBeNull();

--- a/console/src/routes/chat/trace-block.test.tsx
+++ b/console/src/routes/chat/trace-block.test.tsx
@@ -30,6 +30,7 @@ describe('TraceBlock', () => {
       <TraceBlock
         message={makeTrace([
           { kind: 'thinking', text: 'Considering the request' },
+          { kind: 'draft', text: 'I need to check one thing first.' },
           {
             kind: 'tool',
             toolName: 'exec',
@@ -40,11 +41,18 @@ describe('TraceBlock', () => {
       />,
     );
 
-    expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe(
-      'true',
-    );
+    const controls = screen.getAllByRole('button');
+    expect(controls).toHaveLength(2);
+    const firstControl = controls[0];
+    const secondControl = controls[1];
+    if (!firstControl || !secondControl) throw new Error('expected controls');
+    expect(firstControl.getAttribute('aria-expanded')).toBe('true');
+    expect(secondControl.getAttribute('aria-expanded')).toBe('true');
     expect(screen.queryByText('exec…')).not.toBeNull();
     expect(screen.queryByText('Considering the request')).not.toBeNull();
+    expect(
+      screen.queryByText('I need to check one thing first.'),
+    ).not.toBeNull();
     expect(screen.queryByText('npm test')).not.toBeNull();
   });
 
@@ -62,6 +70,7 @@ describe('TraceBlock', () => {
               resultPreview: 'ok',
               durationMs: 1_200,
             },
+            { kind: 'draft', text: 'I need to check one thing first.' },
           ],
           { done: true, finishedAt: 13_000 },
         )}
@@ -72,7 +81,47 @@ describe('TraceBlock', () => {
       'false',
     );
     expect(screen.queryByText('1 tool call · thinking · 12s')).not.toBeNull();
+    expect(
+      screen.queryByText('I need to check one thing first.'),
+    ).not.toBeNull();
     expect(screen.queryByText('npm test')).toBeNull();
+  });
+
+  it('keeps interim drafts outside collapsed trace segments', () => {
+    render(
+      <TraceBlock
+        message={makeTrace(
+          [
+            { kind: 'thinking', text: 'Considering the request' },
+            { kind: 'draft', text: 'I need a location first.' },
+            {
+              kind: 'tool',
+              toolName: 'message',
+              status: 'done',
+              argsPreview: 'send email',
+              durationMs: 250,
+            },
+            { kind: 'thinking', text: 'Waiting for the tool result' },
+          ],
+          { done: true, finishedAt: 5_000 },
+        )}
+      />,
+    );
+
+    const controls = screen.getAllByRole('button');
+    expect(controls).toHaveLength(2);
+    const firstControl = controls[0];
+    const secondControl = controls[1];
+    if (!firstControl || !secondControl) throw new Error('expected controls');
+    expect(firstControl.textContent).toContain('Thought');
+    expect(secondControl.textContent).toContain('1 tool call · thinking');
+    expect(screen.queryByText('I need a location first.')).not.toBeNull();
+    expect(screen.queryByText('Considering the request')).toBeNull();
+    expect(screen.queryByText('send email')).toBeNull();
+
+    fireEvent.click(firstControl);
+    expect(screen.queryByText('Considering the request')).not.toBeNull();
+    expect(screen.queryByText('I need a location first.')).not.toBeNull();
   });
 
   it('auto-collapses a manually expanded trace when the run finishes', () => {

--- a/console/src/routes/chat/trace-block.tsx
+++ b/console/src/routes/chat/trace-block.tsx
@@ -214,23 +214,29 @@ export const TraceBlock = memo(function TraceBlock(props: {
   const activityPartCount = parts.filter(
     (part) => part.kind === 'activity',
   ).length;
+  let activityPartIndex = -1;
 
   return (
     <div className={css.traceSequence}>
-      {parts.map((part, index) =>
-        part.kind === 'draft' ? (
-          // biome-ignore lint/suspicious/noArrayIndexKey: trace parts are append-only
-          <TraceDraftInterim key={index} text={part.text} />
-        ) : (
+      {parts.map((part, index) => {
+        if (part.kind === 'draft') {
+          return (
+            // biome-ignore lint/suspicious/noArrayIndexKey: trace parts are append-only
+            <TraceDraftInterim key={index} text={part.text} />
+          );
+        }
+
+        activityPartIndex += 1;
+        return (
           <TraceActivityBlock
             // biome-ignore lint/suspicious/noArrayIndexKey: trace parts are append-only
             key={index}
             message={message}
             steps={part.steps}
-            includeDuration={activityPartCount === 1}
+            includeDuration={activityPartIndex === activityPartCount - 1}
           />
-        ),
-      )}
+        );
+      })}
     </div>
   );
 });

--- a/console/src/routes/chat/trace-block.tsx
+++ b/console/src/routes/chat/trace-block.tsx
@@ -1,7 +1,14 @@
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { cx } from '../../lib/cx';
+import { renderMarkdown } from '../../lib/markdown';
 import css from './chat-page.module.css';
 import type { TraceChatMessage, TraceStep } from './chat-ui-message';
+
+type TraceActivityStep = Exclude<TraceStep, { kind: 'draft' }>;
+
+type TracePart =
+  | { kind: 'activity'; steps: TraceActivityStep[] }
+  | { kind: 'draft'; text: string };
 
 function formatDuration(ms: number): string {
   if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`;
@@ -13,8 +20,11 @@ function formatDuration(ms: number): string {
   return rest > 0 ? `${minutes}m ${rest}s` : `${minutes}m`;
 }
 
-function summaryLabel(message: TraceChatMessage): string {
-  const steps = message.steps;
+function summaryLabel(
+  message: TraceChatMessage,
+  steps: TraceActivityStep[],
+  includeDuration: boolean,
+): string {
   if (!message.done) {
     const last = steps[steps.length - 1];
     if (last?.kind === 'tool' && last.status === 'running') {
@@ -35,11 +45,36 @@ function summaryLabel(message: TraceChatMessage): string {
   const elapsed = message.finishedAt
     ? message.finishedAt - message.startedAt
     : 0;
-  if (elapsed >= 1000) parts.push(formatDuration(elapsed));
+  if (includeDuration && elapsed >= 1000) parts.push(formatDuration(elapsed));
   return parts.join(' · ') || 'Agent activity';
 }
 
-function TraceStepRow(props: { step: TraceStep; live: boolean }) {
+function splitTraceParts(steps: TraceStep[]): TracePart[] {
+  const parts: TracePart[] = [];
+  let activitySteps: TraceActivityStep[] = [];
+
+  const flushActivity = () => {
+    if (activitySteps.length === 0) return;
+    parts.push({ kind: 'activity', steps: activitySteps });
+    activitySteps = [];
+  };
+
+  for (const step of steps) {
+    if (step.kind === 'draft') {
+      flushActivity();
+      if (step.text.trim()) {
+        parts.push({ kind: 'draft', text: step.text });
+      }
+      continue;
+    }
+    activitySteps.push(step);
+  }
+
+  flushActivity();
+  return parts;
+}
+
+function TraceStepRow(props: { step: TraceActivityStep; live: boolean }) {
   const { step, live } = props;
   if (step.kind === 'thinking') {
     return (
@@ -82,15 +117,29 @@ function TraceStepRow(props: { step: TraceStep; live: boolean }) {
   );
 }
 
-/**
- * Collapsible run-activity trace (thinking + tool calls). Expanded while the
- * run streams so every step is visible as it happens; auto-collapses to a
- * single grey summary row once the final answer lands.
- */
-export const TraceBlock = memo(function TraceBlock(props: {
+function TraceDraftInterim(props: { text: string }) {
+  const renderedHtml = useMemo(
+    () => renderMarkdown(props.text, { highlight: false }),
+    [props.text],
+  );
+
+  return (
+    <div className={css.traceDraftInterim}>
+      <div
+        className={css.markdownContent}
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: markdown output is rendered by marked and sanitized through sanitize-html
+        dangerouslySetInnerHTML={{ __html: renderedHtml }}
+      />
+    </div>
+  );
+}
+
+function TraceActivityBlock(props: {
   message: TraceChatMessage;
+  steps: TraceActivityStep[];
+  includeDuration: boolean;
 }) {
-  const { message } = props;
+  const { message, steps, includeDuration } = props;
   const [expandedOverride, setExpandedOverride] = useState<boolean | null>(
     null,
   );
@@ -101,7 +150,7 @@ export const TraceBlock = memo(function TraceBlock(props: {
     if (message.done) setExpandedOverride(null);
   }, [message.done]);
 
-  if (message.steps.length === 0) return null;
+  if (steps.length === 0) return null;
 
   const expanded = expandedOverride ?? !message.done;
 
@@ -128,14 +177,14 @@ export const TraceBlock = memo(function TraceBlock(props: {
             !message.done && css.traceSummaryLive,
           )}
         >
-          {summaryLabel(message)}
+          {summaryLabel(message, steps, includeDuration)}
         </span>
       </button>
       {expanded ? (
         <div className={css.traceSteps}>
-          {message.steps.map((step, index) => (
+          {steps.map((step, index) => (
             <TraceStepRow
-              // Steps are append-only within a run, so the index is stable.
+              // Steps are append-only within a segment, so the index is stable.
               // biome-ignore lint/suspicious/noArrayIndexKey: append-only list
               key={index}
               step={step}
@@ -144,6 +193,44 @@ export const TraceBlock = memo(function TraceBlock(props: {
           ))}
         </div>
       ) : null}
+    </div>
+  );
+}
+
+/**
+ * Collapsible run-activity trace (thinking + tool calls) plus visible interim
+ * assistant drafts. Drafts stay outside the collapsible grey trace so they
+ * remain readable after the run finishes.
+ */
+export const TraceBlock = memo(function TraceBlock(props: {
+  message: TraceChatMessage;
+}) {
+  const { message } = props;
+
+  if (message.steps.length === 0) return null;
+
+  const parts = splitTraceParts(message.steps);
+  if (parts.length === 0) return null;
+  const activityPartCount = parts.filter(
+    (part) => part.kind === 'activity',
+  ).length;
+
+  return (
+    <div className={css.traceSequence}>
+      {parts.map((part, index) =>
+        part.kind === 'draft' ? (
+          // biome-ignore lint/suspicious/noArrayIndexKey: trace parts are append-only
+          <TraceDraftInterim key={index} text={part.text} />
+        ) : (
+          <TraceActivityBlock
+            // biome-ignore lint/suspicious/noArrayIndexKey: trace parts are append-only
+            key={index}
+            message={message}
+            steps={part.steps}
+            includeDuration={activityPartCount === 1}
+          />
+        ),
+      )}
     </div>
   );
 });

--- a/console/src/routes/chat/use-chat-stream.test.ts
+++ b/console/src/routes/chat/use-chat-stream.test.ts
@@ -991,9 +991,73 @@ describe('useChatStream', () => {
       });
       await sendPromise;
     });
+
+    expect(
+      harness.messages.find((msg) => msg.role === 'assistant'),
+    ).toMatchObject({
+      content: 'Hi',
+    });
+    expect(harness.messages.some((msg) => msg.role === 'draft')).toBe(false);
   });
 
-  it('moves streamed assistant drafts into the trace when a tool starts', async () => {
+  it('streams no-trace assistant text as an assistant preview', async () => {
+    const harness = makeHarness();
+    let resolveStream!: (value: ChatStreamResult) => void;
+    let callbacks!: {
+      onTextDelta: (delta: string) => void;
+    };
+
+    requestChatStreamMock.mockImplementation(
+      (_url: string, params: { callbacks: typeof callbacks }) =>
+        new Promise<ChatStreamResult>((resolve) => {
+          callbacks = params.callbacks;
+          resolveStream = resolve;
+        }),
+    );
+
+    const { result } = renderHook(
+      () =>
+        useChatStream({
+          token: TOKEN,
+          userId: 'web-user-1',
+          getSessionId: () => SESSION_ID,
+          setError: harness.setError,
+          refreshRecent: vi.fn(),
+          onSessionIdCorrection: harness.correctionMock,
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    let sendPromise!: Promise<boolean>;
+    act(() => {
+      sendPromise = result.current.sendMessage('hello', []);
+    });
+
+    act(() => {
+      callbacks.onTextDelta('Plain answer.');
+    });
+
+    expect(
+      harness.messages.find((msg) => msg.role === 'assistant'),
+    ).toMatchObject({
+      content: 'Plain answer.',
+    });
+    expect(harness.messages.some((msg) => msg.role === 'draft')).toBe(false);
+
+    await act(async () => {
+      resolveStream({
+        status: 'ok',
+        sessionId: SESSION_ID,
+        userMessageId: 'server-user-1',
+        assistantMessageId: 'assistant-1',
+        result: 'Plain answer.',
+        messageRole: 'assistant',
+      });
+      await sendPromise;
+    });
+  });
+
+  it('demotes streamed assistant text into the trace when a tool starts', async () => {
     const harness = makeHarness();
     let resolveStream!: (value: ChatStreamResult) => void;
     let callbacks!: {
@@ -1030,12 +1094,12 @@ describe('useChatStream', () => {
     act(() => {
       callbacks.onTextDelta('I need a location first.');
     });
-    expect(harness.messages.find((msg) => msg.role === 'draft')).toMatchObject({
+    expect(
+      harness.messages.find((msg) => msg.role === 'assistant'),
+    ).toMatchObject({
       content: 'I need a location first.',
     });
-    expect(harness.messages.some((msg) => msg.role === 'assistant')).toBe(
-      false,
-    );
+    expect(harness.messages.some((msg) => msg.role === 'draft')).toBe(false);
 
     act(() => {
       callbacks.onToolEvent?.({

--- a/console/src/routes/chat/use-chat-stream.test.ts
+++ b/console/src/routes/chat/use-chat-stream.test.ts
@@ -973,6 +973,12 @@ describe('useChatStream', () => {
       callbacks.onTextDelta('Hi');
     });
     expect(harness.messages.some((msg) => msg.role === 'thinking')).toBe(false);
+    expect(harness.messages.find((msg) => msg.role === 'draft')).toMatchObject({
+      content: 'Hi',
+    });
+    expect(harness.messages.some((msg) => msg.role === 'assistant')).toBe(
+      false,
+    );
 
     await act(async () => {
       resolveStream({
@@ -1024,11 +1030,12 @@ describe('useChatStream', () => {
     act(() => {
       callbacks.onTextDelta('I need a location first.');
     });
-    expect(
-      harness.messages.find((msg) => msg.role === 'assistant'),
-    ).toMatchObject({
+    expect(harness.messages.find((msg) => msg.role === 'draft')).toMatchObject({
       content: 'I need a location first.',
     });
+    expect(harness.messages.some((msg) => msg.role === 'assistant')).toBe(
+      false,
+    );
 
     act(() => {
       callbacks.onToolEvent?.({

--- a/console/src/routes/chat/use-chat-stream.test.ts
+++ b/console/src/routes/chat/use-chat-stream.test.ts
@@ -987,6 +987,118 @@ describe('useChatStream', () => {
     });
   });
 
+  it('moves streamed assistant drafts into the trace when a tool starts', async () => {
+    const harness = makeHarness();
+    let resolveStream!: (value: ChatStreamResult) => void;
+    let callbacks!: {
+      onTextDelta: (delta: string) => void;
+      onToolEvent?: (event: ChatStreamToolEvent) => void;
+    };
+
+    requestChatStreamMock.mockImplementation(
+      (_url: string, params: { callbacks: typeof callbacks }) =>
+        new Promise<ChatStreamResult>((resolve) => {
+          callbacks = params.callbacks;
+          resolveStream = resolve;
+        }),
+    );
+
+    const { result } = renderHook(
+      () =>
+        useChatStream({
+          token: TOKEN,
+          userId: 'web-user-1',
+          getSessionId: () => SESSION_ID,
+          setError: harness.setError,
+          refreshRecent: vi.fn(),
+          onSessionIdCorrection: harness.correctionMock,
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    let sendPromise!: Promise<boolean>;
+    act(() => {
+      sendPromise = result.current.sendMessage('hello', []);
+    });
+
+    act(() => {
+      callbacks.onTextDelta('I need a location first.');
+    });
+    expect(
+      harness.messages.find((msg) => msg.role === 'assistant'),
+    ).toMatchObject({
+      content: 'I need a location first.',
+    });
+
+    act(() => {
+      callbacks.onToolEvent?.({
+        type: 'tool',
+        toolName: 'message',
+        phase: 'start',
+        preview: 'run message send',
+      });
+    });
+
+    expect(harness.messages.some((msg) => msg.role === 'assistant')).toBe(
+      false,
+    );
+    expect(harness.messages.find((msg) => msg.role === 'trace')).toMatchObject({
+      done: false,
+      steps: [
+        { kind: 'draft', text: 'I need a location first.' },
+        {
+          kind: 'tool',
+          toolName: 'message',
+          status: 'running',
+          argsPreview: 'run message send',
+        },
+      ],
+    });
+
+    act(() => {
+      callbacks.onToolEvent?.({
+        type: 'tool',
+        toolName: 'message',
+        phase: 'finish',
+        preview: 'ok',
+        durationMs: 200,
+      });
+      callbacks.onTextDelta('Final answer.');
+    });
+
+    await act(async () => {
+      resolveStream({
+        status: 'ok',
+        sessionId: SESSION_ID,
+        userMessageId: 'server-user-1',
+        assistantMessageId: 'assistant-1',
+        result: 'Final answer.',
+        messageRole: 'assistant',
+      });
+      await sendPromise;
+    });
+
+    expect(
+      harness.messages.find((msg) => msg.role === 'assistant'),
+    ).toMatchObject({
+      content: 'Final answer.',
+    });
+    expect(harness.messages.find((msg) => msg.role === 'trace')).toMatchObject({
+      done: true,
+      steps: [
+        { kind: 'draft', text: 'I need a location first.' },
+        {
+          kind: 'tool',
+          toolName: 'message',
+          status: 'done',
+          argsPreview: 'run message send',
+          resultPreview: 'ok',
+          durationMs: 200,
+        },
+      ],
+    });
+  });
+
   it('keeps a finalized trace when the stream fails', async () => {
     const harness = makeHarness();
 

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -252,6 +252,10 @@ export function useChatStream(
 
         const text = req.assistantText;
         const approval = req.pendingApproval;
+        const liveRole =
+          req.messageRole === 'assistant' && !approval
+            ? 'draft'
+            : req.messageRole;
         // Fresh step copies so React re-renders on later in-place mutations.
         const traceSteps = traceChanged
           ? req.trace.map((step) => ({ ...step }))
@@ -279,7 +283,7 @@ export function useChatStream(
               m === existing
                 ? {
                     ...m,
-                    role: req.messageRole,
+                    role: liveRole,
                     content: text,
                     pendingApproval: approval,
                   }
@@ -290,7 +294,7 @@ export function useChatStream(
             ...withoutThinking,
             {
               id: streamId,
-              role: req.messageRole,
+              role: liveRole,
               content: text,
               sessionId: req.sessionId,
               artifacts: [],

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -253,7 +253,7 @@ export function useChatStream(
         const text = req.assistantText;
         const approval = req.pendingApproval;
         const liveRole =
-          req.messageRole === 'assistant' && !approval
+          req.messageRole === 'assistant' && !approval && req.trace.length > 0
             ? 'draft'
             : req.messageRole;
         // Fresh step copies so React re-renders on later in-place mutations.

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -266,8 +266,12 @@ export function useChatStream(
               )
             : prev;
           // Trace-only update: keep the thinking dots until the answer (or an
-          // approval card) actually starts, so no empty bubble flashes in.
-          if (!text && !approval) return withTrace;
+          // approval card) actually starts, so no empty bubble flashes in. If
+          // a previously streamed assistant draft was demoted into the trace,
+          // remove its live answer bubble too.
+          if (!text && !approval) {
+            return withTrace.filter((m) => m.id !== streamId);
+          }
           const withoutThinking = withTrace.filter((m) => m.id !== thinkingId);
           const existing = withoutThinking.find((m) => m.id === streamId);
           if (existing) {
@@ -321,8 +325,27 @@ export function useChatStream(
         scheduleRender();
       };
 
+      const pushDraftText = (text: string) => {
+        const draft = text.trim();
+        if (!draft) return;
+        const last = req.trace.at(-1);
+        if (last?.kind === 'draft') {
+          last.text = `${last.text}\n\n${draft}`;
+        } else {
+          req.trace.push({ kind: 'draft', text: draft });
+        }
+        req.traceVersion += 1;
+      };
+
+      const demoteAssistantTextToDraft = () => {
+        if (!req.assistantText.trim()) return;
+        pushDraftText(req.assistantText);
+        req.assistantText = '';
+      };
+
       const pushToolEvent = (event: ChatStreamToolEvent) => {
         if (event.phase === 'start') {
+          demoteAssistantTextToDraft();
           req.trace.push({
             kind: 'tool',
             toolName: event.toolName,

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -3280,9 +3280,16 @@ async function handleApiChatStream(
   // exactly what streamed.
   const traceStartedAt = Date.now();
   const traceBuilder = new ActivityTraceBuilder();
+  let streamedTextBeforeNextTool = '';
+
+  const pushStreamedTextDraft = (): void => {
+    traceBuilder.pushDraft(streamedTextBeforeNextTool);
+    streamedTextBeforeNextTool = '';
+  };
 
   const onToolProgress = (event: ToolProgressEvent): void => {
     if (event.phase === 'start') {
+      pushStreamedTextDraft();
       traceBuilder.startTool(event.toolName, event.preview);
     } else {
       traceBuilder.finishTool(event.toolName, event.durationMs, event.preview);
@@ -3300,6 +3307,7 @@ async function handleApiChatStream(
   const onTextDelta = (delta: string): void => {
     const filteredDelta = streamFilter.push(delta);
     if (!filteredDelta) return;
+    streamedTextBeforeNextTool += filteredDelta;
     sendEvent({
       type: 'text',
       delta: filteredDelta,

--- a/src/types/activity-trace.ts
+++ b/src/types/activity-trace.ts
@@ -1,6 +1,7 @@
 /**
- * Ordered activity trace for one assistant turn — the thinking segments and
- * tool calls the gateway streams to the web chat, in the order they occurred.
+ * Ordered activity trace for one assistant turn — thinking segments,
+ * intermediate assistant drafts, and tool calls the gateway streams to the web
+ * chat, in the order they occurred.
  *
  * Persisted per assistant message so a page reload can replay the same trace
  * the web client rendered live. The step shape mirrors the console's live
@@ -9,6 +10,11 @@
 
 export interface ActivityTraceThinkingStep {
   kind: 'thinking';
+  text: string;
+}
+
+export interface ActivityTraceDraftStep {
+  kind: 'draft';
   text: string;
 }
 
@@ -23,6 +29,7 @@ export interface ActivityTraceToolStep {
 
 export type ActivityTraceStep =
   | ActivityTraceThinkingStep
+  | ActivityTraceDraftStep
   | ActivityTraceToolStep;
 
 export interface ActivityTrace {
@@ -32,9 +39,9 @@ export interface ActivityTrace {
 }
 
 /**
- * Accumulates streamed thinking/tool events into an ordered trace, mirroring
- * the console's live accumulation: consecutive thinking deltas merge, and a
- * tool `finish` collapses into the most recent matching running `start`
+ * Accumulates streamed thinking/draft/tool events into an ordered trace,
+ * mirroring the console's live accumulation: consecutive thinking deltas merge,
+ * and a tool `finish` collapses into the most recent matching running `start`
  * (parallel same-name tools can finish out of order).
  */
 export class ActivityTraceBuilder {
@@ -47,6 +54,17 @@ export class ActivityTraceBuilder {
       last.text += delta;
     } else {
       this.steps.push({ kind: 'thinking', text: delta });
+    }
+  }
+
+  pushDraft(text: string): void {
+    const draft = text.trim();
+    if (!draft) return;
+    const last = this.steps.at(-1);
+    if (last?.kind === 'draft') {
+      last.text = `${last.text}\n\n${draft}`;
+    } else {
+      this.steps.push({ kind: 'draft', text: draft });
     }
   }
 
@@ -141,6 +159,9 @@ export function parseActivityTrace(
     if (source.kind === 'thinking') {
       const text = source.text;
       if (typeof text === 'string') steps.push({ kind: 'thinking', text });
+    } else if (source.kind === 'draft') {
+      const text = source.text;
+      if (typeof text === 'string') steps.push({ kind: 'draft', text });
     } else if (source.kind === 'tool') {
       const toolName = readString(source, 'toolName');
       if (!toolName) continue;

--- a/tests/activity-trace.test.ts
+++ b/tests/activity-trace.test.ts
@@ -30,6 +30,28 @@ describe('ActivityTraceBuilder', () => {
     });
   });
 
+  it('records assistant drafts separately from thinking before tools', () => {
+    const builder = new ActivityTraceBuilder();
+    builder.pushThinking('Checking context.');
+    builder.pushDraft('\n\nI need a location before I can continue.');
+    builder.startTool('message', 'run message send');
+
+    const trace = builder.build();
+    expect(trace?.steps).toEqual([
+      { kind: 'thinking', text: 'Checking context.' },
+      {
+        kind: 'draft',
+        text: 'I need a location before I can continue.',
+      },
+      {
+        kind: 'tool',
+        toolName: 'message',
+        status: 'done',
+        argsPreview: 'run message send',
+      },
+    ]);
+  });
+
   it('matches finish to the most recent running call of the same tool', () => {
     const builder = new ActivityTraceBuilder();
     builder.startTool('read', 'a.ts');
@@ -109,7 +131,9 @@ describe('serialize/parseActivityTrace round-trip', () => {
       JSON.stringify({
         steps: [
           { kind: 'thinking', text: 'ok' },
+          { kind: 'draft', text: 'draft text' },
           { kind: 'thinking' },
+          { kind: 'draft' },
           { kind: 'tool' },
           { kind: 'tool', toolName: 'exec', durationMs: 'nan' },
           { kind: 'mystery' },
@@ -120,6 +144,7 @@ describe('serialize/parseActivityTrace round-trip', () => {
     expect(parsed).toEqual({
       steps: [
         { kind: 'thinking', text: 'ok' },
+        { kind: 'draft', text: 'draft text' },
         { kind: 'tool', toolName: 'exec', status: 'done' },
       ],
       elapsedMs: 7,

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -710,6 +710,7 @@ async function importFreshHealth(options?: {
     enable_rag: 1,
   }));
   const storeMessage = vi.fn(() => 1);
+  const setMessageActivityTrace = vi.fn();
   const buildConversationContext = vi.fn(() => ({
     messages: [{ role: 'system', content: 'Mock HybridClaw system prompt' }],
     skills: [],
@@ -2214,6 +2215,7 @@ async function importFreshHealth(options?: {
     claimQueuedProactiveMessages,
     getSessionById,
     resetSessionIfExpired: vi.fn(() => null),
+    setMessageActivityTrace,
   }));
   vi.doMock('../src/memory/memory-service.js', () => ({
     memoryService: {
@@ -2531,6 +2533,7 @@ async function importFreshHealth(options?: {
     getSessionById,
     getOrCreateSession,
     storeMessage,
+    setMessageActivityTrace,
     getAgentById,
     buildConversationContext,
     callOpenAICompatibleModel,
@@ -9831,6 +9834,89 @@ describe('gateway HTTP server', () => {
         }),
       },
     ]);
+  });
+
+  test('persists streamed assistant drafts before tool calls in activity traces', async () => {
+    const state = await importFreshHealth();
+    state.handleGatewayMessage.mockImplementationOnce(
+      async (request: {
+        sessionId: string;
+        onTextDelta?: (delta: string) => void;
+        onToolProgress?: (event: {
+          toolName: string;
+          phase: 'start' | 'finish';
+          preview?: string;
+          durationMs?: number;
+        }) => void;
+      }) => {
+        request.onTextDelta?.('I need a location first.');
+        request.onToolProgress?.({
+          toolName: 'message',
+          phase: 'start',
+          preview: 'run message send',
+        });
+        request.onToolProgress?.({
+          toolName: 'message',
+          phase: 'finish',
+          preview: 'ok',
+          durationMs: 200,
+        });
+        request.onTextDelta?.('Final answer.');
+        return {
+          status: 'success' as const,
+          result: 'Final answer.',
+          sessionId: request.sessionId,
+          toolsUsed: ['message'],
+          toolExecutions: [],
+          assistantMessageId: 42,
+          artifacts: [],
+        };
+      },
+    );
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/chat',
+      body: {
+        sessionId: 'session-draft-trace',
+        channelId: 'web',
+        userId: 'user-web',
+        username: 'web',
+        content: 'send a forecast',
+        stream: true,
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    const events = res.body
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(events.map((event) => event.type)).toEqual([
+      'text',
+      'tool',
+      'tool',
+      'text',
+      'result',
+    ]);
+    expect(state.setMessageActivityTrace).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({
+        steps: [
+          { kind: 'draft', text: 'I need a location first.' },
+          {
+            kind: 'tool',
+            toolName: 'message',
+            status: 'done',
+            argsPreview: 'run message send',
+            resultPreview: 'ok',
+            durationMs: 200,
+          },
+        ],
+      }),
+    );
   });
 
   test('blocks shell secret set commands from streaming /api/chat before the model sees them', async () => {

--- a/tests/message-activity-trace.test.ts
+++ b/tests/message-activity-trace.test.ts
@@ -36,6 +36,7 @@ describe('message activity trace persistence', () => {
     const trace = {
       steps: [
         { kind: 'thinking' as const, text: 'Listing their messages' },
+        { kind: 'draft' as const, text: 'I will check the inbox first.' },
         {
           kind: 'tool' as const,
           toolName: 'list_messages',


### PR DESCRIPTION
## Summary
- Persist assistant text streamed before tool calls as draft activity trace steps.
- Render live assistant text as unbubbled draft text once trace activity has begun, while preserving normal bubble streaming for simple no-trace answers.
- Hydrate draft trace steps from history so reloads preserve the same timeline.
- Keep elapsed-time summaries visible on the last activity segment when interim drafts split a trace.

## Root Cause
Assistant text emitted on tool-call turns was shown live as a normal assistant bubble, then removed during final stream reconciliation because only the final assistant message was persisted. The fix records those interim texts as draft trace steps and uses a dedicated live draft role for already-active trace runs, so provisional text after tools/thinking does not appear with final-answer bubble chrome.

## Claude Review Follow-up
- Narrowed live draft styling so common no-tool answers continue streaming as assistant bubbles.
- Restored elapsed-time display for split traces by showing duration on the final activity segment.

## Validation
- `npm --prefix console test -- --run src/routes/chat/use-chat-stream.test.ts src/routes/chat/trace-block.test.tsx src/routes/chat/message-block.test.tsx`
- `npx vitest run tests/activity-trace.test.ts tests/message-activity-trace.test.ts tests/gateway-http-server.test.ts --testNamePattern "activity trace|assistant drafts|drafts before tool|web slash commands through the streaming"`
- `npm run typecheck`
- `npm run lint`
- `npm run format`
- `npx biome check console/src/routes/chat/trace-block.tsx console/src/routes/chat/trace-block.test.tsx console/src/routes/chat/chat-page.module.css console/src/routes/chat/chat-ui-message.ts`
- `git diff --check`