### PR TITLE
[codex] audit onboarding lifecycle events

### DIFF
--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -158,7 +158,13 @@ import {
   firstNumber,
   resolveWorkspaceRelativePath,
 } from './gateway-utils.js';
-import { recordBootstrapHatchingTurnResult } from './hatching-completion.js';
+import {
+  recordBootstrapHatchingTurnResult,
+  recordBootstrapOnboardingAbort,
+  recordBootstrapOnboardingAssistantMessage,
+  recordBootstrapOnboardingStart,
+  recordBootstrapOnboardingUserReply,
+} from './hatching-completion.js';
 import { isSupportedProactiveChannelId } from './proactive-delivery.js';
 import { forwardGatewayMessageToProxyAgent } from './proxy-agent.js';
 import {
@@ -1086,6 +1092,7 @@ async function handleGatewayMessageInner(
     ? {
         workspacePath,
         workspaceInitialized: false,
+        onboardingTransition: undefined,
       }
     : ensureBootstrapFiles(agentId);
   const startupBootstrapFile = req.workspacePathOverride
@@ -1408,6 +1415,40 @@ async function handleGatewayMessageInner(
       source,
     },
   });
+  const onboardingAuditContext =
+    startupBootstrapFile === 'BOOTSTRAP.md'
+      ? {
+          sessionId: req.sessionId,
+          runId,
+          agentId,
+          source,
+          bootstrapFile: startupBootstrapFile,
+          channelId: req.channelId,
+          workspacePath,
+        }
+      : null;
+  if (workspaceBootstrap.onboardingTransition) {
+    recordBootstrapOnboardingAbort(
+      {
+        sessionId: req.sessionId,
+        runId,
+        agentId,
+        source,
+        bootstrapFile: workspaceBootstrap.onboardingTransition.bootstrapFile,
+        channelId: req.channelId,
+        workspacePath,
+      },
+      workspaceBootstrap.onboardingTransition,
+    );
+  }
+  if (onboardingAuditContext) {
+    recordBootstrapOnboardingStart(onboardingAuditContext);
+    recordBootstrapOnboardingUserReply(onboardingAuditContext, {
+      turnIndex,
+      messageChars: userTurnContent.length,
+      mediaCount: media.length,
+    });
+  }
 
   if (modelRequiresChatbotId(model) && !chatbotId) {
     const error =
@@ -1962,6 +2003,7 @@ async function handleGatewayMessageInner(
       agentId,
       bootstrapFile: startupBootstrapFile,
       toolExecutions,
+      audit: onboardingAuditContext || undefined,
     });
     if (hatchingCompletion) {
       logger.info(
@@ -2347,6 +2389,15 @@ async function handleGatewayMessageInner(
       startedAt,
       replaceBuiltInMemory: pluginMemoryBehavior.replacesBuiltInMemory,
     });
+    if (onboardingAuditContext) {
+      recordBootstrapOnboardingAssistantMessage(onboardingAuditContext, {
+        turnIndex,
+        assistantMessageId: storedTurn.assistantMessageId,
+        messageChars: resultText.length,
+        toolCallCount: toolExecutions.length,
+        messageRole: output.pendingApproval ? 'approval' : 'assistant',
+      });
+    }
     const storedTurnMessages = buildStoredTurnMessages({
       sessionId: req.sessionId,
       userId: req.userId,

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -618,7 +618,13 @@ import {
   resolveWorkspaceRelativePath,
 } from './gateway-utils.js';
 import { initializeGoalContinuationRunner } from './goal-continuation-runner.js';
-import { recordBootstrapHatchingTurnResult } from './hatching-completion.js';
+import {
+  recordBootstrapHatchingTurnResult,
+  recordBootstrapOnboardingAbort,
+  recordBootstrapOnboardingAssistantMessage,
+  recordBootstrapOnboardingQuickMessage,
+  recordBootstrapOnboardingStart,
+} from './hatching-completion.js';
 import { listSuspendedSessions } from './interactive-escalation.js';
 import { listPendingApprovals } from './pending-approvals.js';
 import { isDiscordChannelId } from './proactive-delivery.js';
@@ -8557,9 +8563,25 @@ function resolveBootstrapAutostartContext(params: {
     agentId: autostartAgentId,
     session,
   });
-  ensureBootstrapFiles(resolved.agentId);
+  const workspaceBootstrap = ensureBootstrapFiles(resolved.agentId);
   const bootstrapFile = resolveStartupBootstrapFile(resolved.agentId);
-  if (!bootstrapFile) return null;
+  if (!bootstrapFile) {
+    if (workspaceBootstrap.onboardingTransition) {
+      recordBootstrapOnboardingAbort(
+        {
+          sessionId: session.id,
+          runId: makeAuditRunId('onboarding'),
+          agentId: resolved.agentId,
+          source: BOOTSTRAP_AUTOSTART_SOURCE,
+          bootstrapFile: workspaceBootstrap.onboardingTransition.bootstrapFile,
+          channelId,
+          workspacePath: path.resolve(agentWorkspaceDir(resolved.agentId)),
+        },
+        workspaceBootstrap.onboardingTransition,
+      );
+    }
+    return null;
+  }
 
   return {
     channelId,
@@ -8630,6 +8652,18 @@ export async function ensureGatewayBootstrapAutostart(params: {
     });
     const provider = resolveModelProvider(model);
     const turnIndex = Math.max(1, session.message_count + 1);
+    const onboardingAuditContext =
+      bootstrapFile === 'BOOTSTRAP.md'
+        ? {
+            sessionId: session.id,
+            runId,
+            agentId: resolved.agentId,
+            source: BOOTSTRAP_AUTOSTART_SOURCE,
+            bootstrapFile,
+            channelId,
+            workspacePath,
+          }
+        : null;
 
     recordAuditEvent({
       sessionId: session.id,
@@ -8643,6 +8677,9 @@ export async function ensureGatewayBootstrapAutostart(params: {
         source: BOOTSTRAP_AUTOSTART_SOURCE,
       },
     });
+    if (onboardingAuditContext) {
+      recordBootstrapOnboardingStart(onboardingAuditContext);
+    }
     const chatbotResolution = await resolveGatewayChatbotId({
       model,
       chatbotId: resolved.chatbotId,
@@ -8748,7 +8785,13 @@ export async function ensureGatewayBootstrapAutostart(params: {
       },
     });
     if (preludeText) {
-      storeBootstrapAssistantMessage(preludeText);
+      const preludeMessageId = storeBootstrapAssistantMessage(preludeText);
+      if (onboardingAuditContext) {
+        recordBootstrapOnboardingQuickMessage(onboardingAuditContext, {
+          assistantMessageId: preludeMessageId,
+          messageChars: preludeText.length,
+        });
+      }
     }
     const baseAssistantMessages = hasPrelude ? 1 : 0;
 
@@ -8979,6 +9022,7 @@ export async function ensureGatewayBootstrapAutostart(params: {
       agentId: resolved.agentId,
       bootstrapFile,
       toolExecutions: output.toolExecutions || [],
+      audit: onboardingAuditContext || undefined,
     });
     if (hatchingCompletion) {
       logger.info(
@@ -9078,6 +9122,14 @@ export async function ensureGatewayBootstrapAutostart(params: {
     }
 
     const assistantMessageId = storeBootstrapAssistantMessage(resultText);
+    if (onboardingAuditContext) {
+      recordBootstrapOnboardingAssistantMessage(onboardingAuditContext, {
+        turnIndex,
+        assistantMessageId,
+        messageChars: resultText.length,
+        toolCallCount: (output.toolExecutions || []).length,
+      });
+    }
     setMemoryValue(session.id, markerKey, {
       status: 'completed',
       fileName: bootstrapFile,

--- a/src/gateway/hatching-completion.ts
+++ b/src/gateway/hatching-completion.ts
@@ -1,7 +1,9 @@
+import { recordAuditEvent } from '../audit/audit-events.js';
 import type { ToolExecution } from '../types/execution.js';
 import {
   completeHatchingAfterMessageSend,
   recordHatchingTurnWithoutMessage,
+  type WorkspaceOnboardingTransition,
 } from '../workspace.js';
 
 type MessageSend = {
@@ -15,6 +17,166 @@ export type BootstrapHatchingTurnResult = {
   reason: string;
   turnsWithoutMessage?: number;
 };
+
+type BootstrapFileName = 'BOOTSTRAP.md' | 'OPENING.md';
+type OnboardingAbortRule =
+  | WorkspaceOnboardingTransition['rule']
+  | 'hatching_no_message_limit';
+
+export interface BootstrapOnboardingAuditContext {
+  sessionId: string;
+  runId: string;
+  agentId: string;
+  source: string;
+  bootstrapFile: BootstrapFileName;
+  channelId?: string | null;
+  workspacePath?: string;
+}
+
+function buildBaseOnboardingPayload(
+  context: BootstrapOnboardingAuditContext,
+): Record<string, unknown> {
+  return {
+    workspaceAgentId: context.agentId,
+    source: context.source,
+    bootstrapFile: context.bootstrapFile,
+    channelId: context.channelId || null,
+    workspacePath: context.workspacePath || null,
+  };
+}
+
+export function recordBootstrapOnboardingStart(
+  context: BootstrapOnboardingAuditContext,
+): void {
+  if (context.bootstrapFile !== 'BOOTSTRAP.md') return;
+  recordAuditEvent({
+    sessionId: context.sessionId,
+    runId: context.runId,
+    event: {
+      type: 'onboarding.start',
+      ...buildBaseOnboardingPayload(context),
+      reason: 'bootstrap hatching turn started',
+    },
+  });
+}
+
+export function recordBootstrapOnboardingQuickMessage(
+  context: BootstrapOnboardingAuditContext,
+  params: {
+    assistantMessageId: number;
+    messageChars: number;
+  },
+): void {
+  if (context.bootstrapFile !== 'BOOTSTRAP.md') return;
+  recordAuditEvent({
+    sessionId: context.sessionId,
+    runId: context.runId,
+    event: {
+      type: 'onboarding.quick_message',
+      ...buildBaseOnboardingPayload(context),
+      assistantMessageId: params.assistantMessageId,
+      messageChars: params.messageChars,
+      messageRole: 'assistant',
+      reason: 'bootstrap prelude sent',
+    },
+  });
+}
+
+export function recordBootstrapOnboardingUserReply(
+  context: BootstrapOnboardingAuditContext,
+  params: {
+    turnIndex: number;
+    messageChars: number;
+    mediaCount: number;
+  },
+): void {
+  if (context.bootstrapFile !== 'BOOTSTRAP.md') return;
+  recordAuditEvent({
+    sessionId: context.sessionId,
+    runId: context.runId,
+    event: {
+      type: 'onboarding.user_reply',
+      ...buildBaseOnboardingPayload(context),
+      turnIndex: params.turnIndex,
+      messageChars: params.messageChars,
+      mediaCount: params.mediaCount,
+      messageRole: 'user',
+      reason: 'onboarding user reply received',
+    },
+  });
+}
+
+export function recordBootstrapOnboardingAssistantMessage(
+  context: BootstrapOnboardingAuditContext,
+  params: {
+    turnIndex: number;
+    assistantMessageId: number;
+    messageChars: number;
+    toolCallCount: number;
+    messageRole?: 'assistant' | 'approval';
+  },
+): void {
+  if (context.bootstrapFile !== 'BOOTSTRAP.md') return;
+  recordAuditEvent({
+    sessionId: context.sessionId,
+    runId: context.runId,
+    event: {
+      type: 'onboarding.assistant_message',
+      ...buildBaseOnboardingPayload(context),
+      turnIndex: params.turnIndex,
+      assistantMessageId: params.assistantMessageId,
+      messageChars: params.messageChars,
+      toolCallCount: params.toolCallCount,
+      messageRole: params.messageRole || 'assistant',
+      reason: 'onboarding assistant message stored',
+    },
+  });
+}
+
+export function recordBootstrapOnboardingAbort(
+  context: BootstrapOnboardingAuditContext,
+  transition: {
+    reason: string;
+    rule: OnboardingAbortRule;
+    completedAt?: string;
+    turnsWithoutMessage?: number;
+  },
+): void {
+  if (context.bootstrapFile !== 'BOOTSTRAP.md') return;
+  recordAuditEvent({
+    sessionId: context.sessionId,
+    runId: context.runId,
+    event: {
+      type: 'onboarding.abort',
+      ...buildBaseOnboardingPayload(context),
+      reason: transition.reason,
+      gatewayRule: transition.rule,
+      ...(transition.completedAt
+        ? { completedAt: transition.completedAt }
+        : {}),
+      ...(transition.turnsWithoutMessage
+        ? { turnsWithoutMessage: transition.turnsWithoutMessage }
+        : {}),
+    },
+  });
+}
+
+function recordBootstrapOnboardingComplete(
+  context: BootstrapOnboardingAuditContext,
+  result: BootstrapHatchingTurnResult,
+): void {
+  if (context.bootstrapFile !== 'BOOTSTRAP.md') return;
+  recordAuditEvent({
+    sessionId: context.sessionId,
+    runId: context.runId,
+    event: {
+      type: 'onboarding.complete',
+      ...buildBaseOnboardingPayload(context),
+      reason: result.reason,
+      gatewayRule: 'message_send',
+    },
+  });
+}
 
 function parseJsonObject(value: string): Record<string, unknown> | null {
   try {
@@ -71,6 +233,7 @@ export function recordBootstrapHatchingTurnResult(params: {
   bootstrapFile: 'BOOTSTRAP.md' | 'OPENING.md' | null;
   toolExecutions: ToolExecution[];
   handledAt?: string;
+  audit?: BootstrapOnboardingAuditContext;
 }): BootstrapHatchingTurnResult | null {
   if (params.bootstrapFile !== 'BOOTSTRAP.md') return null;
 
@@ -78,13 +241,27 @@ export function recordBootstrapHatchingTurnResult(params: {
     .map(readSuccessfulMessageSend)
     .find((candidate): candidate is MessageSend => Boolean(candidate));
   if (!send) {
-    return recordHatchingTurnWithoutMessage({ agentId: params.agentId });
+    const result = recordHatchingTurnWithoutMessage({
+      agentId: params.agentId,
+    });
+    if (params.audit && result.completed) {
+      recordBootstrapOnboardingAbort(params.audit, {
+        reason: result.reason,
+        rule: 'hatching_no_message_limit',
+        turnsWithoutMessage: result.turnsWithoutMessage,
+      });
+    }
+    return result;
   }
 
-  return completeHatchingAfterMessageSend({
+  const result = completeHatchingAfterMessageSend({
     agentId: params.agentId,
     recipient: send.recipient,
     subject: send.subject,
     handledAt: params.handledAt,
   });
+  if (params.audit && result.completed) {
+    recordBootstrapOnboardingComplete(params.audit, result);
+  }
+  return result;
 }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -101,6 +101,7 @@ export interface ContextFile {
 export interface EnsureBootstrapFilesResult {
   workspacePath: string;
   workspaceInitialized: boolean;
+  onboardingTransition?: WorkspaceOnboardingTransition;
 }
 
 export interface ResetWorkspaceResult {
@@ -122,6 +123,14 @@ interface WorkspaceOnboardingState {
   bootstrapSeededAt?: string;
   onboardingCompletedAt?: string;
   hatchingTurnsWithoutMessage?: number;
+}
+
+export interface WorkspaceOnboardingTransition {
+  type: 'abort';
+  bootstrapFile: 'BOOTSTRAP.md';
+  completedAt: string;
+  reason: string;
+  rule: 'missing_bootstrap_after_seed' | 'existing_workspace_without_bootstrap';
 }
 
 function resolveWorkspaceStatePath(wsDir: string): string {
@@ -656,6 +665,7 @@ export function ensureBootstrapFiles(
   const statePath = resolveWorkspaceStatePath(wsDir);
   let state = readWorkspaceOnboardingState(statePath);
   let stateDirty = false;
+  let onboardingTransition: WorkspaceOnboardingTransition | undefined;
   const markState = (next: Partial<WorkspaceOnboardingState>) => {
     state = { ...state, ...next };
     stateDirty = true;
@@ -697,10 +707,23 @@ export function ensureBootstrapFiles(
     state.bootstrapSeededAt ||
     (!workspaceInitialized && !options.seedOneTimeBootstrap)
   ) {
+    const completedAt = nowIso();
+    const seededBefore = Boolean(state.bootstrapSeededAt);
     markState({
-      onboardingCompletedAt: nowIso(),
+      onboardingCompletedAt: completedAt,
       hatchingTurnsWithoutMessage: 0,
     });
+    onboardingTransition = {
+      type: 'abort',
+      bootstrapFile: 'BOOTSTRAP.md',
+      completedAt,
+      reason: seededBefore
+        ? 'BOOTSTRAP.md was absent after onboarding had been seeded'
+        : 'Existing workspace did not have BOOTSTRAP.md',
+      rule: seededBefore
+        ? 'missing_bootstrap_after_seed'
+        : 'existing_workspace_without_bootstrap',
+    };
   } else {
     const templatePath = path.join(TEMPLATES_DIR, 'BOOTSTRAP.md');
     if (fs.existsSync(templatePath)) {
@@ -744,6 +767,7 @@ export function ensureBootstrapFiles(
   return {
     workspacePath: wsDir,
     workspaceInitialized,
+    onboardingTransition,
   };
 }
 

--- a/tests/gateway-service.bootstrap-autostart.test.ts
+++ b/tests/gateway-service.bootstrap-autostart.test.ts
@@ -79,7 +79,9 @@ test('ensureGatewayBootstrapAutostart stores prelude and bootstrap opener once p
     toolExecutions: [],
   });
 
-  const { initDatabase } = await import('../src/memory/db.ts');
+  const { getRecentStructuredAuditForSession, initDatabase } = await import(
+    '../src/memory/db.ts'
+  );
   const { ensureGatewayBootstrapAutostart, getGatewayHistory } = await import(
     '../src/gateway/gateway-service.ts'
   );
@@ -183,6 +185,37 @@ test('ensureGatewayBootstrapAutostart stores prelude and bootstrap opener once p
 
   const storedSession = memoryService.getSessionById(sessionId);
   expect(storedSession?.message_count).toBe(2);
+  const auditRows = getRecentStructuredAuditForSession(
+    storedSession?.id || sessionId,
+    100,
+  );
+  const quickMessageEvent = auditRows.find(
+    (row) => row.event_type === 'onboarding.quick_message',
+  );
+  const assistantMessageEvent = auditRows.find(
+    (row) => row.event_type === 'onboarding.assistant_message',
+  );
+  expect(quickMessageEvent).toBeTruthy();
+  expect(assistantMessageEvent).toBeTruthy();
+  expect(JSON.parse(String(quickMessageEvent?.payload || '{}'))).toMatchObject({
+    type: 'onboarding.quick_message',
+    workspaceAgentId: 'main',
+    source: 'gateway.bootstrap',
+    bootstrapFile: 'BOOTSTRAP.md',
+    messageRole: 'assistant',
+    messageChars: DEFAULT_GATEWAY_AUXILIARY_PRELUDE.length,
+  });
+  expect(
+    JSON.parse(String(assistantMessageEvent?.payload || '{}')),
+  ).toMatchObject({
+    type: 'onboarding.assistant_message',
+    workspaceAgentId: 'main',
+    source: 'gateway.bootstrap',
+    bootstrapFile: 'BOOTSTRAP.md',
+    messageRole: 'assistant',
+    messageChars: 'Hello. I am ready to get you oriented.'.length,
+    toolCallCount: 0,
+  });
   expect(pluginManagerMock.notifySessionStart).toHaveBeenCalledTimes(1);
   expect(pluginManagerMock.notifyBeforeAgentStart).toHaveBeenCalledTimes(1);
   expect(pluginManagerMock.notifyMemoryWrites).toHaveBeenCalledWith(
@@ -197,6 +230,56 @@ test('ensureGatewayBootstrapAutostart stores prelude and bootstrap opener once p
   await ensureGatewayBootstrapAutostart({ sessionId });
   expect(runAgentMock).toHaveBeenCalledTimes(1);
   expect(getGatewayHistory(sessionId, 10).history).toHaveLength(2);
+});
+
+test('ensureGatewayBootstrapAutostart audits onboarding abort when bootstrap is already absent', async () => {
+  setupHome();
+
+  const { upsertRegisteredAgent } = await import(
+    '../src/agents/agent-registry.ts'
+  );
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.ts');
+  const {
+    getRecentStructuredAuditForSession,
+    getSessionById,
+    initDatabase,
+  } = await import('../src/memory/db.ts');
+  const { ensureGatewayBootstrapAutostart } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  const { ensureBootstrapFiles } = await import('../src/workspace.ts');
+
+  initDatabase({ quiet: true });
+  upsertRegisteredAgent({ id: 'research' });
+  ensureBootstrapFiles('research');
+
+  const workspaceDir = agentWorkspaceDir('research');
+  fs.unlinkSync(path.join(workspaceDir, 'BOOTSTRAP.md'));
+
+  const sessionId =
+    'agent:main:channel:web:chat:dm:peer:bootstrap-missing-abort';
+  await ensureGatewayBootstrapAutostart({
+    sessionId,
+    channelId: 'web',
+    userId: 'user-1',
+    username: 'user',
+    agentId: 'research',
+  });
+
+  expect(runAgentMock).not.toHaveBeenCalled();
+  const storedSessionId = getSessionById(sessionId)?.id || sessionId;
+  const auditRows = getRecentStructuredAuditForSession(storedSessionId, 20);
+  const abortEvent = auditRows.find(
+    (row) => row.event_type === 'onboarding.abort',
+  );
+  expect(abortEvent).toBeTruthy();
+  expect(JSON.parse(String(abortEvent?.payload || '{}'))).toMatchObject({
+    type: 'onboarding.abort',
+    workspaceAgentId: 'research',
+    source: 'gateway.bootstrap',
+    bootstrapFile: 'BOOTSTRAP.md',
+    gatewayRule: 'missing_bootstrap_after_seed',
+  });
 });
 
 test('ensureGatewayBootstrapAutostart does not refresh started sessions on history probes', async () => {

--- a/tests/gateway-service.context-references.test.ts
+++ b/tests/gateway-service.context-references.test.ts
@@ -340,7 +340,9 @@ test('handleGatewayMessage completes hatching after the welcome message send', a
     draft.hybridai.defaultModel = 'gpt-5-mini';
     draft.hybridai.onboardingModel = 'gpt-5.5';
   });
-  const { initDatabase } = await import('../src/memory/db.ts');
+  const { getRecentStructuredAuditForSession, initDatabase } = await import(
+    '../src/memory/db.ts'
+  );
   const { handleGatewayMessage } = await import(
     '../src/gateway/gateway-chat-service.ts'
   );
@@ -399,6 +401,62 @@ test('handleGatewayMessage completes hatching after the welcome message send', a
   expect(
     (runAgentMock.mock.calls[1]?.[0] as { model?: string } | undefined)?.model,
   ).toBe('gpt-5-mini');
+
+  const auditRows = getRecentStructuredAuditForSession(
+    'session-onboarding-email-complete',
+    100,
+  );
+  const startEvent = auditRows.find(
+    (row) => row.event_type === 'onboarding.start',
+  );
+  const completeEvent = auditRows.find(
+    (row) => row.event_type === 'onboarding.complete',
+  );
+  const userReplyEvent = auditRows.find(
+    (row) => row.event_type === 'onboarding.user_reply',
+  );
+  const assistantMessageEvent = auditRows.find(
+    (row) => row.event_type === 'onboarding.assistant_message',
+  );
+  expect(startEvent).toBeTruthy();
+  expect(userReplyEvent).toBeTruthy();
+  expect(assistantMessageEvent).toBeTruthy();
+  expect(completeEvent).toBeTruthy();
+  expect(JSON.parse(String(startEvent?.payload || '{}'))).toMatchObject({
+    type: 'onboarding.start',
+    workspaceAgentId: 'research',
+    source: 'gateway.chat',
+    bootstrapFile: 'BOOTSTRAP.md',
+    channelId: 'web',
+  });
+  expect(JSON.parse(String(userReplyEvent?.payload || '{}'))).toMatchObject({
+    type: 'onboarding.user_reply',
+    workspaceAgentId: 'research',
+    source: 'gateway.chat',
+    bootstrapFile: 'BOOTSTRAP.md',
+    turnIndex: 1,
+    mediaCount: 0,
+    messageRole: 'user',
+  });
+  expect(
+    JSON.parse(String(assistantMessageEvent?.payload || '{}')),
+  ).toMatchObject({
+    type: 'onboarding.assistant_message',
+    workspaceAgentId: 'research',
+    source: 'gateway.chat',
+    bootstrapFile: 'BOOTSTRAP.md',
+    turnIndex: 1,
+    messageRole: 'assistant',
+    toolCallCount: 1,
+  });
+  expect(JSON.parse(String(completeEvent?.payload || '{}'))).toMatchObject({
+    type: 'onboarding.complete',
+    workspaceAgentId: 'research',
+    source: 'gateway.chat',
+    bootstrapFile: 'BOOTSTRAP.md',
+    gatewayRule: 'message_send',
+    reason: 'message sent',
+  });
 });
 
 test('handleGatewayMessage completes hatching after three turns without a message send', async () => {
@@ -418,7 +476,9 @@ test('handleGatewayMessage completes hatching after three turns without a messag
     draft.hybridai.defaultModel = 'gpt-5-mini';
     draft.hybridai.onboardingModel = 'gpt-5.5';
   });
-  const { initDatabase } = await import('../src/memory/db.ts');
+  const { getRecentStructuredAuditForSession, initDatabase } = await import(
+    '../src/memory/db.ts'
+  );
   const { handleGatewayMessage } = await import(
     '../src/gateway/gateway-chat-service.ts'
   );
@@ -479,6 +539,31 @@ test('handleGatewayMessage completes hatching after three turns without a messag
   expect(
     (runAgentMock.mock.calls[3]?.[0] as { model?: string } | undefined)?.model,
   ).toBe('gpt-5-mini');
+
+  const auditRows = getRecentStructuredAuditForSession(
+    'session-onboarding-no-message-fallback',
+    100,
+  );
+  const abortEvent = auditRows.find(
+    (row) => row.event_type === 'onboarding.abort',
+  );
+  const userReplyEvents = auditRows.filter(
+    (row) => row.event_type === 'onboarding.user_reply',
+  );
+  const assistantMessageEvents = auditRows.filter(
+    (row) => row.event_type === 'onboarding.assistant_message',
+  );
+  expect(abortEvent).toBeTruthy();
+  expect(userReplyEvents).toHaveLength(3);
+  expect(assistantMessageEvents).toHaveLength(3);
+  expect(JSON.parse(String(abortEvent?.payload || '{}'))).toMatchObject({
+    type: 'onboarding.abort',
+    workspaceAgentId: 'research',
+    source: 'gateway.chat',
+    bootstrapFile: 'BOOTSTRAP.md',
+    gatewayRule: 'hatching_no_message_limit',
+    turnsWithoutMessage: 3,
+  });
 });
 
 test('handleGatewayMessage returns to regular model after onboarding completes', async () => {


### PR DESCRIPTION
## What
- Add structured audit/observability events for BOOTSTRAP.md onboarding lifecycle: `onboarding.start`, `onboarding.quick_message`, `onboarding.user_reply`, `onboarding.assistant_message`, `onboarding.complete`, and `onboarding.abort`.
- Emit completion only after a successful `message` tool call with `action: "send"` and non-`{ ok: false }` result.
- Emit abort events when the gateway marks onboarding done by rule, including missing bootstrap and no-message-limit paths.
- Cover normal chat onboarding, bootstrap autostart, quick-message prelude, completion, and abort variants in tests.

## Why
Onboarding was flaky to diagnose because gateway lifecycle transitions were only partly visible. These events make each onboarding path auditable without logging raw user or assistant content.

## Validation
- `npm run format`
- `npm run lint`
- `./node_modules/.bin/vitest run tests/gateway-service.context-references.test.ts tests/gateway-service.bootstrap-autostart.test.ts`
- `git diff --check`