### PR TITLE
Fix non-final assistant drafts leaking into chat

### DIFF
--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -135,9 +135,24 @@ export interface ChatArtifact {
   type?: string;
 }
 
+export type OutputSegmentKind =
+  | 'draft'
+  | 'final'
+  | 'tool_request'
+  | 'approval'
+  | 'status';
+export type OutputDisplaySurface = 'none' | 'assistant_bubble' | 'approval';
+
+export interface OutputPresentationMetadata {
+  segmentKind: OutputSegmentKind;
+  visible: boolean;
+  displaySurface: OutputDisplaySurface;
+}
+
 export interface ChatStreamTextDelta {
   type: 'text';
   delta: string;
+  outputPresentation?: OutputPresentationMetadata;
 }
 
 export interface ChatStreamThinkingDelta {
@@ -183,6 +198,7 @@ export interface ChatStreamResult {
   error?: string;
   /** UI role for the result message. */
   messageRole?: ChatResultMessageRole;
+  outputPresentation?: OutputPresentationMetadata;
   sessionId?: string;
   userMessageId?: number | string | null;
   assistantMessageId?: number | string | null;

--- a/console/src/lib/chat-stream.test.ts
+++ b/console/src/lib/chat-stream.test.ts
@@ -119,7 +119,7 @@ describe('requestChatStream', () => {
         [
           '{"type":"thinking","delta":"Hmm"}',
           '{"type":"tool","toolName":"exec","phase":"start"}',
-          '{"type":"text","delta":"Hi"}',
+          '{"type":"text","delta":"Hi","outputPresentation":{"segmentKind":"final","visible":true,"displaySurface":"assistant_bubble"}}',
           '{"type":"result","result":{"status":"ok","result":"Hi"}}',
         ].join('\n'),
     } as Response);
@@ -135,7 +135,15 @@ describe('requestChatStream', () => {
       }),
     ).resolves.toMatchObject({ status: 'ok', result: 'Hi' });
 
-    expect(onTextDelta).toHaveBeenCalledWith('Hi');
+    expect(onTextDelta).toHaveBeenCalledWith('Hi', {
+      type: 'text',
+      delta: 'Hi',
+      outputPresentation: {
+        segmentKind: 'final',
+        visible: true,
+        displaySurface: 'assistant_bubble',
+      },
+    });
   });
 
   it('warns when malformed NDJSON lines are ignored and still returns the final result', async () => {
@@ -164,7 +172,10 @@ describe('requestChatStream', () => {
       result: 'Done',
     });
 
-    expect(onTextDelta).toHaveBeenCalledWith('Hello');
+    expect(onTextDelta).toHaveBeenCalledWith('Hello', {
+      type: 'text',
+      delta: 'Hello',
+    });
     expect(onApproval).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith(
       'Ignoring malformed chat stream line',

--- a/console/src/lib/chat-stream.ts
+++ b/console/src/lib/chat-stream.ts
@@ -1,12 +1,13 @@
 import type {
   ChatStreamApproval,
   ChatStreamResult,
+  ChatStreamTextDelta,
   ChatStreamToolEvent,
 } from '../api/chat-types';
 import { requestHeaders, throwResponseError } from '../api/client';
 
 export interface ChatStreamCallbacks {
-  onTextDelta: (delta: string) => void;
+  onTextDelta: (delta: string, event?: ChatStreamTextDelta) => void;
   onApproval: (event: ChatStreamApproval) => void;
   onThinkingDelta?: (delta: string) => void;
   onToolEvent?: (event: ChatStreamToolEvent) => void;
@@ -51,7 +52,10 @@ export async function requestChatStream(
     if (!payload || typeof payload !== 'object') return null;
 
     if (payload.type === 'text' && typeof payload.delta === 'string') {
-      callbacks.onTextDelta(payload.delta as string);
+      callbacks.onTextDelta(
+        payload.delta as string,
+        payload as unknown as ChatStreamTextDelta,
+      );
       return null;
     }
 

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -420,7 +420,8 @@ export function useChatStream(
           },
           signal: req.controller.signal,
           callbacks: {
-            onTextDelta: (delta) => {
+            onTextDelta: (delta, event) => {
+              if (event?.outputPresentation?.visible === false) return;
               req.assistantText += delta;
               scheduleRender();
             },
@@ -475,6 +476,10 @@ export function useChatStream(
           finalRole === 'command' &&
           finalText.trim().length === 0 &&
           finalArtifacts.length === 0;
+        const isHiddenByPresentation =
+          result.outputPresentation?.visible === false &&
+          finalArtifacts.length === 0 &&
+          !finalApproval;
         const buildFinalizedMessage = (
           id: string,
           sessionId: string,
@@ -519,9 +524,9 @@ export function useChatStream(
             return m;
           };
 
-          // Drop the placeholder bubble for a silent command, but still
+          // Drop the placeholder bubble for metadata-hidden output, but still
           // finalize the user echo (e.g. its server messageId).
-          if (isSilentCommand) {
+          if (isSilentCommand || isHiddenByPresentation) {
             return withoutThinking
               .filter((m) => m.id !== streamId)
               .map(finalizeMessage);

--- a/container/src/chat-segments.ts
+++ b/container/src/chat-segments.ts
@@ -1,0 +1,73 @@
+import { parseRalphChoice, stripRalphChoiceTags } from './ralph.js';
+import type {
+  ChatMessageContent,
+  OutputPresentationMetadata,
+} from './types.js';
+
+export type AssistantChatSegmentKind = 'draft' | 'final' | 'tool_request';
+
+export interface AssistantChatSegment {
+  kind: AssistantChatSegmentKind;
+  ralphChoice: 'CONTINUE' | 'STOP' | null;
+  text: string | null;
+}
+
+export function classifyAssistantChatSegment(params: {
+  content: ChatMessageContent;
+  hasToolCalls: boolean;
+  ralphEnabled: boolean;
+}): AssistantChatSegment {
+  const ralphChoice = parseRalphChoice(params.content);
+  const text = stripRalphChoiceTags(params.content);
+
+  if (params.hasToolCalls) {
+    return { kind: 'tool_request', ralphChoice, text };
+  }
+
+  if (!params.ralphEnabled || ralphChoice === 'STOP') {
+    return { kind: 'final', ralphChoice, text };
+  }
+
+  return { kind: 'draft', ralphChoice, text };
+}
+
+export function outputPresentationForAssistantSegment(
+  segment: AssistantChatSegment,
+): OutputPresentationMetadata {
+  if (segment.kind === 'final') {
+    return finalOutputPresentation(segment.text);
+  }
+  return {
+    segmentKind: segment.kind,
+    visible: false,
+    displaySurface: 'none',
+  };
+}
+
+export function finalOutputPresentation(
+  text: string | null,
+): OutputPresentationMetadata {
+  return {
+    segmentKind: 'final',
+    visible: Boolean(text),
+    displaySurface: 'assistant_bubble',
+  };
+}
+
+export function approvalOutputPresentation(): OutputPresentationMetadata {
+  return {
+    segmentKind: 'approval',
+    visible: true,
+    displaySurface: 'approval',
+  };
+}
+
+export function statusOutputPresentation(
+  visible: boolean,
+): OutputPresentationMetadata {
+  return {
+    segmentKind: 'status',
+    visible,
+    displaySurface: visible ? 'assistant_bubble' : 'none',
+  };
+}

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -5,6 +5,13 @@ import {
   getBrowserProviderLogLabel,
 } from './browser-tools.js';
 import {
+  approvalOutputPresentation,
+  classifyAssistantChatSegment,
+  finalOutputPresentation,
+  outputPresentationForAssistantSegment,
+  statusOutputPresentation,
+} from './chat-segments.js';
+import {
   resumePendingCodexAppServerApproval,
   runCodexAppServerTurn,
 } from './codex-app-server.js';
@@ -39,12 +46,7 @@ import {
   ProviderRequestError,
   summarizeHybridAICompletionForDebug,
 } from './providers/shared.js';
-import {
-  buildRalphPrompt,
-  normalizeMessageContentToText,
-  parseRalphChoice,
-  stripRalphChoiceTags,
-} from './ralph.js';
+import { buildRalphPrompt, normalizeMessageContentToText } from './ralph.js';
 import { injectRuntimeCapabilitiesMessage } from './runtime-capabilities.js';
 import {
   resolveWorkspacePath,
@@ -625,7 +627,7 @@ function appendCompletedToolCall(params: {
 }
 
 function buildContextOverflowOutput(params: {
-  latestVisibleAssistantText: string | null;
+  latestFinalAssistantText: string | null;
   toolsUsed: string[];
   artifacts: ArtifactMetadata[];
   toolExecutions: ToolExecution[];
@@ -634,11 +636,14 @@ function buildContextOverflowOutput(params: {
 }): ContainerOutput {
   const overflowMessage =
     'Context window exhausted inside the container tool loop after repeated in-loop compaction attempts. Compact or reset the session and retry.';
-  if (params.latestVisibleAssistantText) {
+  if (params.latestFinalAssistantText) {
     return {
       status: 'success',
-      result: `${params.latestVisibleAssistantText}\n\n[${overflowMessage}]`,
+      result: `${params.latestFinalAssistantText}\n\n[${overflowMessage}]`,
       toolsUsed: [...new Set(params.toolsUsed)],
+      outputPresentation: finalOutputPresentation(
+        params.latestFinalAssistantText,
+      ),
       ...(params.artifacts.length > 0 ? { artifacts: params.artifacts } : {}),
       toolExecutions: params.toolExecutions,
       tokenUsage: params.tokenUsage,
@@ -1050,7 +1055,7 @@ async function processRequest(
   let ralphExtraIterations = 0;
   let stalledTurns = 0;
   let emptyVisibleCompletionRetries = 0;
-  let latestVisibleAssistantText: string | null = null;
+  let latestFinalAssistantText: string | null = null;
   let compactionRetries = 0;
   const tokenEstimateCache = createTokenEstimateCache();
   const promptOverheadTokens = estimateRoutedPromptOverheadTokens({
@@ -1162,6 +1167,7 @@ async function processRequest(
         status: 'success',
         result: prompt,
         toolsUsed: [approvedToolCall.toolName],
+        outputPresentation: approvalOutputPresentation(),
         toolExecutions: [
           buildApprovalRequiredToolExecution({
             toolName: approvedToolCall.toolName,
@@ -1239,7 +1245,7 @@ async function processRequest(
     if (guardResult.tier3Triggered) {
       if (compactionRetries >= maxContextGuardRetries) {
         const overflow = buildContextOverflowOutput({
-          latestVisibleAssistantText,
+          latestFinalAssistantText,
           toolsUsed,
           artifacts,
           toolExecutions,
@@ -1289,7 +1295,7 @@ async function processRequest(
       });
       if (!compacted.changed) {
         const overflow = buildContextOverflowOutput({
-          latestVisibleAssistantText,
+          latestFinalAssistantText,
           toolsUsed,
           artifacts,
           toolExecutions,
@@ -1317,6 +1323,11 @@ async function processRequest(
     tokenUsage.estimatedPromptTokens += estimatedPromptTokensForCall;
 
     let response: Awaited<ReturnType<typeof callHybridAIWithRetry>>;
+    // Provider chunks are suppressed until this turn is classified as final.
+    const suppressTextDelta = (_delta: string): void => {};
+    const emitFinalTextDelta = (text: string | null): void => {
+      if (streamTextDeltas && text) emitStreamDelta(text);
+    };
     try {
       response = await callHybridAIWithRetry({
         sessionId,
@@ -1330,9 +1341,7 @@ async function processRequest(
         requestHeaders,
         history,
         tools,
-        onTextDelta: streamTextDeltas
-          ? (delta) => emitStreamDelta(delta)
-          : undefined,
+        onTextDelta: streamTextDeltas ? suppressTextDelta : undefined,
         onThinkingDelta: streamTextDeltas
           ? (delta) => emitStreamThinkingDelta(delta)
           : undefined,
@@ -1435,7 +1444,12 @@ async function processRequest(
       });
       return failed;
     }
-    const branchChoice = parseRalphChoice(choice.message.content);
+    const assistantSegment = classifyAssistantChatSegment({
+      content: choice.message.content,
+      hasToolCalls: toolCalls.length > 0,
+      ralphEnabled,
+    });
+    const branchChoice = assistantSegment.ralphChoice;
     if (
       provider === 'hybridai' &&
       branchChoice === null &&
@@ -1495,22 +1509,22 @@ async function processRequest(
     }
 
     history.push(assistantMessage);
-    const visibleAssistantText = stripRalphChoiceTags(choice.message.content);
-    if (visibleAssistantText) {
-      latestVisibleAssistantText = visibleAssistantText;
-    }
     if (toolCalls.length === 0) {
       if (ralphEnabled) {
-        if (branchChoice === 'STOP') {
+        if (assistantSegment.kind === 'final') {
           collectRequestedArtifacts({
             artifacts,
             artifactPaths,
             startedAtMs: processStartedAt,
           });
+          latestFinalAssistantText = assistantSegment.text;
+          emitFinalTextDelta(latestFinalAssistantText);
           const completed: ContainerOutput = {
             status: 'success',
-            result: latestVisibleAssistantText,
+            result: latestFinalAssistantText,
             toolsUsed: [...new Set(toolsUsed)],
+            outputPresentation:
+              outputPresentationForAssistantSegment(assistantSegment),
             ...(artifacts.length > 0 ? { artifacts } : {}),
             toolExecutions,
             tokenUsage: finalizeTokenUsage(tokenUsage),
@@ -1546,6 +1560,13 @@ async function processRequest(
           );
           continue;
         }
+
+        stalledTurns = advanceStalledTurnCount({
+          current: stalledTurns,
+          toolCalls: 0,
+          successfulToolCalls: 0,
+        });
+        break;
       }
 
       collectRequestedArtifacts({
@@ -1555,7 +1576,7 @@ async function processRequest(
       });
       if (
         shouldRetryEmptyFinalResponse({
-          visibleAssistantText: latestVisibleAssistantText,
+          visibleAssistantText: assistantSegment.text,
           toolExecutionCount: toolExecutions.length,
           artifactCount: artifacts.length,
         })
@@ -1574,10 +1595,14 @@ async function processRequest(
         continue;
       }
 
+      latestFinalAssistantText = assistantSegment.text;
+      emitFinalTextDelta(latestFinalAssistantText);
       const completed: ContainerOutput = {
         status: 'success',
-        result: latestVisibleAssistantText,
+        result: latestFinalAssistantText,
         toolsUsed: [...new Set(toolsUsed)],
+        outputPresentation:
+          outputPresentationForAssistantSegment(assistantSegment),
         ...(artifacts.length > 0 ? { artifacts } : {}),
         toolExecutions,
         tokenUsage: finalizeTokenUsage(tokenUsage),
@@ -1744,6 +1769,7 @@ async function processRequest(
           status: 'success',
           result: prompt,
           toolsUsed: [...new Set(toolsUsed)],
+          outputPresentation: approvalOutputPresentation(),
           ...(artifacts.length > 0 ? { artifacts } : {}),
           toolExecutions,
           pendingApproval,
@@ -1773,6 +1799,7 @@ async function processRequest(
           status: 'success',
           result: denialText,
           toolsUsed: [...new Set(toolsUsed)],
+          outputPresentation: statusOutputPresentation(true),
           ...(artifacts.length > 0 ? { artifacts } : {}),
           toolExecutions,
           tokenUsage: finalizeTokenUsage(tokenUsage),
@@ -1822,9 +1849,12 @@ async function processRequest(
   const completed: ContainerOutput = {
     status: 'success',
     result:
-      latestVisibleAssistantText ||
+      latestFinalAssistantText ||
       `No successful tool progress for ${maxStalledTurns} consecutive model turns.`,
     toolsUsed: [...new Set(toolsUsed)],
+    outputPresentation: latestFinalAssistantText
+      ? finalOutputPresentation(latestFinalAssistantText)
+      : statusOutputPresentation(true),
     ...(artifacts.length > 0 ? { artifacts } : {}),
     toolExecutions,
     codexRuntime,

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -407,10 +407,25 @@ export interface ArtifactMetadata {
   mimeType: string;
 }
 
+export type OutputSegmentKind =
+  | 'draft'
+  | 'final'
+  | 'tool_request'
+  | 'approval'
+  | 'status';
+export type OutputDisplaySurface = 'none' | 'assistant_bubble' | 'approval';
+
+export interface OutputPresentationMetadata {
+  segmentKind: OutputSegmentKind;
+  visible: boolean;
+  displaySurface: OutputDisplaySurface;
+}
+
 export interface ContainerOutput {
   status: 'success' | 'error';
   result: string | null;
   toolsUsed: string[];
+  outputPresentation?: OutputPresentationMetadata;
   codexRuntime?: CodexTurnRuntime;
   artifacts?: ArtifactMetadata[];
   toolExecutions?: ToolExecution[];

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -2301,6 +2301,7 @@ async function handleGatewayMessageInner(
       status: 'success',
       result: unnormalizedResultText,
       toolsUsed: output.toolsUsed || [],
+      outputPresentation: output.outputPresentation,
       toolExecutions,
     });
     let resultText = String(normalizedResult.result || unnormalizedResultText);
@@ -2465,6 +2466,7 @@ async function handleGatewayMessageInner(
       result: resultText,
       messageRole: output.pendingApproval ? 'approval' : 'assistant',
       toolsUsed: output.toolsUsed || [],
+      outputPresentation: normalizedResult.outputPresentation,
       pluginsUsed,
       skillUsed: observedSkillName ?? undefined,
       agentId,

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -3304,6 +3304,11 @@ async function handleApiChatStream(
   };
 
   const streamFilter = createSilentReplyStreamFilter();
+  const assistantBubblePresentation = {
+    segmentKind: 'final' as const,
+    visible: true,
+    displaySurface: 'assistant_bubble' as const,
+  };
   const onTextDelta = (delta: string): void => {
     const filteredDelta = streamFilter.push(delta);
     if (!filteredDelta) return;
@@ -3311,6 +3316,7 @@ async function handleApiChatStream(
     sendEvent({
       type: 'text',
       delta: filteredDelta,
+      outputPresentation: assistantBubblePresentation,
     });
   };
   const onThinkingDelta = (delta: string): void => {
@@ -3350,6 +3356,7 @@ async function handleApiChatStream(
         sendEvent({
           type: 'text',
           delta: bufferedDelta,
+          outputPresentation: assistantBubblePresentation,
         });
       }
       if (streamFilter.isSilent() && hasMessageSendToolExecution(result)) {

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -38,7 +38,11 @@ import type {
 } from '../skills/skills.js';
 import type { SkillGuardFinding } from '../skills/skills-guard.js';
 import type { TunnelState } from '../tunnel/tunnel-provider.js';
-import type { AddressEnvelope, MediaContextItem } from '../types/container.js';
+import type {
+  AddressEnvelope,
+  MediaContextItem,
+  OutputPresentationMetadata,
+} from '../types/container.js';
 import type {
   ArtifactMetadata,
   PendingApproval,
@@ -85,6 +89,7 @@ export interface GatewayChatResult {
   status: 'success' | 'error';
   result: string | null;
   toolsUsed: string[];
+  outputPresentation?: OutputPresentationMetadata;
   /**
    * UI presentation role for the result message. This is separate from persisted
    * history roles and avoids inferring rendering from command/approval metadata.
@@ -129,6 +134,7 @@ export interface GatewayChatToolProgressEvent {
 export interface GatewayChatTextDeltaEvent {
   type: 'text';
   delta: string;
+  outputPresentation?: OutputPresentationMetadata;
 }
 
 export interface GatewayChatThinkingDeltaEvent {

--- a/src/types/container.ts
+++ b/src/types/container.ts
@@ -116,6 +116,7 @@ export interface ContainerOutput {
   status: 'success' | 'error';
   result: string | null;
   toolsUsed: string[];
+  outputPresentation?: OutputPresentationMetadata;
   codexRuntime?: CodexTurnRuntime;
   artifacts?: ArtifactMetadata[];
   memoryCitations?: MemoryCitation[];
@@ -128,4 +129,18 @@ export interface ContainerOutput {
     schedules?: ScheduleSideEffect[];
     delegations?: DelegationSideEffect[];
   };
+}
+
+export type OutputSegmentKind =
+  | 'draft'
+  | 'final'
+  | 'tool_request'
+  | 'approval'
+  | 'status';
+export type OutputDisplaySurface = 'none' | 'assistant_bubble' | 'approval';
+
+export interface OutputPresentationMetadata {
+  segmentKind: OutputSegmentKind;
+  visible: boolean;
+  displaySurface: OutputDisplaySurface;
 }

--- a/tests/container.ralph.test.ts
+++ b/tests/container.ralph.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'vitest';
 
 import {
+  approvalOutputPresentation,
+  classifyAssistantChatSegment,
+  outputPresentationForAssistantSegment,
+} from '../container/src/chat-segments.js';
+import {
   parseRalphChoice,
   stripRalphChoiceTags,
 } from '../container/src/ralph.js';
@@ -22,5 +27,85 @@ describe('container ralph helpers', () => {
 
   test('preserves ordinary text that has no choice tags', () => {
     expect(stripRalphChoiceTags('Nice to meet you.')).toBe('Nice to meet you.');
+  });
+
+  test('classifies Ralph STOP text as final chat text', () => {
+    expect(
+      classifyAssistantChatSegment({
+        content: 'Done.\n\n<choice>STOP</choice>',
+        hasToolCalls: false,
+        ralphEnabled: true,
+      }),
+    ).toEqual({
+      kind: 'final',
+      ralphChoice: 'STOP',
+      text: 'Done.',
+    });
+  });
+
+  test('classifies Ralph text without STOP as a draft', () => {
+    expect(
+      classifyAssistantChatSegment({
+        content: 'I will use the memory tool next.',
+        hasToolCalls: false,
+        ralphEnabled: true,
+      }),
+    ).toEqual({
+      kind: 'draft',
+      ralphChoice: null,
+      text: 'I will use the memory tool next.',
+    });
+  });
+
+  test('classifies structured tool-call turns outside the final bubble', () => {
+    expect(
+      classifyAssistantChatSegment({
+        content: 'Let me update memory.',
+        hasToolCalls: true,
+        ralphEnabled: true,
+      }),
+    ).toEqual({
+      kind: 'tool_request',
+      ralphChoice: null,
+      text: 'Let me update memory.',
+    });
+  });
+
+  test('marks only final assistant segments for assistant-bubble display', () => {
+    expect(
+      outputPresentationForAssistantSegment(
+        classifyAssistantChatSegment({
+          content: 'Done.\n\n<choice>STOP</choice>',
+          hasToolCalls: false,
+          ralphEnabled: true,
+        }),
+      ),
+    ).toEqual({
+      segmentKind: 'final',
+      visible: true,
+      displaySurface: 'assistant_bubble',
+    });
+
+    expect(
+      outputPresentationForAssistantSegment(
+        classifyAssistantChatSegment({
+          content: 'Let me update memory.',
+          hasToolCalls: true,
+          ralphEnabled: true,
+        }),
+      ),
+    ).toEqual({
+      segmentKind: 'tool_request',
+      visible: false,
+      displaySurface: 'none',
+    });
+  });
+
+  test('marks approval prompts with approval display metadata', () => {
+    expect(approvalOutputPresentation()).toEqual({
+      segmentKind: 'approval',
+      visible: true,
+      displaySurface: 'approval',
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes a chat-boundary bug where non-final assistant draft text could be surfaced as the assistant bubble when the tool loop continued or stalled.

## Root Cause

This was not a real final message with a STOP marker. The container loop cached stripped assistant text before deciding whether the turn was a Ralph STOP, a continuation draft, or a tool-request turn. The stalled/overflow fallback then reused that cached draft as `output.result`, and streamed text deltas could cross the gateway boundary before final classification.

## Changes

- Adds explicit assistant segment classification: `draft`, `tool_request`, or `final`.
- Adds `outputPresentation` metadata to container output, gateway chat results, and streamed text events so rendering is driven by metadata rather than output-string heuristics.
- Suppresses provider text deltas until the model turn is classified as final, then emits only the sanitized final segment text with `assistant_bubble` metadata.
- Tracks `latestFinalAssistantText` separately and uses it for overflow/stalled fallback output.
- Updates the console stream client to pass text-event metadata through and hide metadata-hidden outputs without parsing message text.
- Removes the previous Codex-specific tool-markup parser approach from this PR.
- Adds Ralph boundary and metadata tests for STOP/final, draft/no-STOP, tool-request, approval, and assistant-bubble presentation.

## Validation

- `hybridclaw gateway status`
- `./node_modules/.bin/vitest run tests/container.ralph.test.ts tests/openai-codex-provider.test.ts tests/tool-call-normalizer.test.ts tests/gateway-client.test.ts`
- `npm --workspace console test -- src/lib/chat-stream.test.ts src/routes/chat/use-chat-stream.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `npm --workspace console run typecheck`
- `npm run format`
- `npm run lint`
- `npm run check`

Note: `npm run format` / `npm run check` still report existing optional-chain suggestions and exit 0; no unrelated optional-chain rewrites were included.