### PR TITLE
[codex] Fix onboarding audit lifecycle ordering

### DIFF
--- a/console/src/routes/audit-filters.test.ts
+++ b/console/src/routes/audit-filters.test.ts
@@ -6,6 +6,7 @@ describe('categorize', () => {
     expect(categorize('session.end')).toBe('session');
     expect(categorize('tool.call')).toBe('tool');
     expect(categorize('autonomy.decision')).toBe('autonomy');
+    expect(categorize('onboarding.complete')).toBe('onboarding');
   });
 
   it("returns 'default' for unknown prefixes", () => {

--- a/console/src/routes/audit-filters.ts
+++ b/console/src/routes/audit-filters.ts
@@ -1,6 +1,7 @@
 export const CATEGORIES = [
   'session',
   'turn',
+  'onboarding',
   'model',
   'tool',
   'autonomy',

--- a/console/src/routes/audit.module.css
+++ b/console/src/routes/audit.module.css
@@ -164,6 +164,9 @@
 .categoryChip[data-category="turn"] {
   --cat-color: #8b5cf6;
 }
+.categoryChip[data-category="onboarding"] {
+  --cat-color: #7dd3fc;
+}
 .categoryChip[data-category="model"] {
   --cat-color: #14b8a6;
 }
@@ -405,6 +408,10 @@
 
 .eventPill[data-category="turn"] {
   --cat-color: #8b5cf6;
+}
+
+.eventPill[data-category="onboarding"] {
+  --cat-color: #7dd3fc;
 }
 
 .eventPill[data-category="model"] {

--- a/console/src/routes/audit.test.tsx
+++ b/console/src/routes/audit.test.tsx
@@ -348,6 +348,21 @@ describe('AuditPage', () => {
     ).toBeTruthy();
   });
 
+  it('category chip click supports onboarding events', async () => {
+    fetchAuditMock.mockResolvedValue(
+      makeResponse([makeEntry({ eventType: 'onboarding.complete' })]),
+    );
+    renderWithProviders(<AuditPage />);
+    fireEvent.click(await screen.findByRole('button', { name: 'onboarding' }));
+    const input = screen.getByLabelText<HTMLInputElement>('Audit search');
+    await waitFor(() => {
+      expect(input.value).toBe('type:onboarding');
+    });
+    expect(
+      screen.getByRole('button', { name: 'onboarding', pressed: true }),
+    ).toBeTruthy();
+  });
+
   it('clicking the active category chip clears the type filter', async () => {
     window.history.replaceState(null, '', '/admin/audit?q=type%3Atool');
     fetchAuditMock.mockResolvedValue(makeResponse([]));

--- a/console/src/routes/chat/chat-history-query.test.ts
+++ b/console/src/routes/chat/chat-history-query.test.ts
@@ -321,6 +321,7 @@ describe('buildChatHistoryUiData', () => {
     expect(trace.finishedAt).toBe(34_000);
     expect(trace.steps).toEqual([
       { kind: 'thinking', text: 'Listing their messages' },
+      { kind: 'draft', text: 'I will check the inbox first.' },
       {
         kind: 'tool',
         toolName: 'list_messages',
@@ -331,7 +332,7 @@ describe('buildChatHistoryUiData', () => {
     ]);
   });
 
-  it('does not hydrate a trace when persisted activity only has draft steps', () => {
+  it('hydrates a trace when persisted activity only has draft steps', () => {
     const raw: ChatHistoryResponse = {
       sessionId: 'session-a',
       history: [
@@ -349,9 +350,13 @@ describe('buildChatHistoryUiData', () => {
 
     const ui = buildChatHistoryUiData(raw, 'session-a');
 
-    expect(ui.messages.some((m) => m.role === 'trace')).toBe(false);
-    expect(ui.messages).toHaveLength(1);
-    expect(ui.messages[0]?.role).toBe('assistant');
+    const trace = ui.messages.find((m) => m.role === 'trace');
+    expect(trace).toMatchObject({
+      role: 'trace',
+      steps: [{ kind: 'draft', text: 'Intermediate text.' }],
+      done: true,
+      finishedAt: 1200,
+    });
   });
 
   it('does not add a trace message when history omits activityTrace', () => {

--- a/console/src/routes/chat/chat-history-query.test.ts
+++ b/console/src/routes/chat/chat-history-query.test.ts
@@ -321,7 +321,6 @@ describe('buildChatHistoryUiData', () => {
     expect(trace.finishedAt).toBe(34_000);
     expect(trace.steps).toEqual([
       { kind: 'thinking', text: 'Listing their messages' },
-      { kind: 'draft', text: 'I will check the inbox first.' },
       {
         kind: 'tool',
         toolName: 'list_messages',
@@ -330,6 +329,29 @@ describe('buildChatHistoryUiData', () => {
         durationMs: 903,
       },
     ]);
+  });
+
+  it('does not hydrate a trace when persisted activity only has draft steps', () => {
+    const raw: ChatHistoryResponse = {
+      sessionId: 'session-a',
+      history: [
+        {
+          id: 1,
+          role: 'assistant',
+          content: 'Done.',
+          activityTrace: {
+            steps: [{ kind: 'draft', text: 'Intermediate text.' }],
+            elapsedMs: 1200,
+          },
+        },
+      ],
+    };
+
+    const ui = buildChatHistoryUiData(raw, 'session-a');
+
+    expect(ui.messages.some((m) => m.role === 'trace')).toBe(false);
+    expect(ui.messages).toHaveLength(1);
+    expect(ui.messages[0]?.role).toBe('assistant');
   });
 
   it('does not add a trace message when history omits activityTrace', () => {

--- a/console/src/routes/chat/chat-history-query.ts
+++ b/console/src/routes/chat/chat-history-query.ts
@@ -30,7 +30,7 @@ function normalizeAgentIdForComparison(agentId: string | null | undefined) {
 }
 
 // Rebuild a collapsed (done) trace message from persisted history so a reload
-// shows thinking/tool activity without replaying intermediate assistant drafts.
+// shows the same draft/thinking/tool activity the live stream rendered.
 // Positioned just before its assistant bubble by the caller.
 function hydrateActivityTrace(
   trace: ChatActivityTrace | null | undefined,
@@ -46,6 +46,7 @@ function hydrateActivityTrace(
       continue;
     }
     if (step.kind === 'draft') {
+      steps.push({ kind: 'draft', text: step.text });
       continue;
     }
     steps.push({
@@ -59,7 +60,6 @@ function hydrateActivityTrace(
         : {}),
     });
   }
-  if (steps.length === 0) return null;
   return {
     id: nextMsgId(),
     role: 'trace',

--- a/console/src/routes/chat/chat-history-query.ts
+++ b/console/src/routes/chat/chat-history-query.ts
@@ -30,8 +30,8 @@ function normalizeAgentIdForComparison(agentId: string | null | undefined) {
 }
 
 // Rebuild a collapsed (done) trace message from persisted history so a reload
-// shows the same thinking/tool activity the live stream rendered. Positioned
-// just before its assistant bubble by the caller.
+// shows thinking/tool activity without replaying intermediate assistant drafts.
+// Positioned just before its assistant bubble by the caller.
 function hydrateActivityTrace(
   trace: ChatActivityTrace | null | undefined,
   sessionId: string,
@@ -39,14 +39,16 @@ function hydrateActivityTrace(
   if (!trace || !Array.isArray(trace.steps) || trace.steps.length === 0) {
     return null;
   }
-  const steps: TraceStep[] = trace.steps.map((step): TraceStep => {
+  const steps: TraceStep[] = [];
+  for (const step of trace.steps) {
     if (step.kind === 'thinking') {
-      return { kind: 'thinking', text: step.text };
+      steps.push({ kind: 'thinking', text: step.text });
+      continue;
     }
     if (step.kind === 'draft') {
-      return { kind: 'draft', text: step.text };
+      continue;
     }
-    return {
+    steps.push({
       kind: 'tool',
       toolName: step.toolName,
       status: 'done',
@@ -55,8 +57,9 @@ function hydrateActivityTrace(
       ...(typeof step.durationMs === 'number'
         ? { durationMs: step.durationMs }
         : {}),
-    };
-  });
+    });
+  }
+  if (steps.length === 0) return null;
   return {
     id: nextMsgId(),
     role: 'trace',

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1353,9 +1353,8 @@ aside[data-state="collapsed"] .chatSidebarContent {
   }
 }
 
-/* Run-activity trace: light-grey collapsible rows (thinking and tool calls)
-   with visible interim drafts kept outside the collapsible rows. Expanded
-   while streaming, collapsed to summary rows once the run finishes. */
+/* Run-activity trace: light-grey collapsible rows (thinking and tool calls).
+   Expanded while streaming, collapsed to summary rows once the run finishes. */
 .traceSequence {
   display: flex;
   flex-direction: column;

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1353,7 +1353,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
   }
 }
 
-/* Run-activity trace: light-grey collapsible rows (thinking and tool calls).
+/* Run-activity trace: light-grey collapsible rows (drafts, thinking, and tools).
    Expanded while streaming, collapsed to summary rows once the run finishes. */
 .traceSequence {
   display: flex;

--- a/console/src/routes/chat/chat-ui-message.ts
+++ b/console/src/routes/chat/chat-ui-message.ts
@@ -32,8 +32,8 @@ export type TraceStep = TraceThinkingStep | TraceDraftStep | TraceToolStep;
 
 /**
  * Live activity trace for one assistant turn. Thinking/tool steps render as
- * collapsible grey activity rows; draft steps render as visible interim
- * assistant text between those rows.
+ * collapsible grey activity rows; legacy draft steps are ignored by the trace
+ * renderer because they are not final assistant answers.
  */
 export type TraceChatMessage = Omit<ChatMessage, 'role' | 'content'> & {
   role: 'trace';

--- a/console/src/routes/chat/chat-ui-message.ts
+++ b/console/src/routes/chat/chat-ui-message.ts
@@ -31,9 +31,8 @@ export interface TraceToolStep {
 export type TraceStep = TraceThinkingStep | TraceDraftStep | TraceToolStep;
 
 /**
- * Live activity trace for one assistant turn. Thinking/tool steps render as
- * collapsible grey activity rows; legacy draft steps are ignored by the trace
- * renderer because they are not final assistant answers.
+ * Live activity trace for one assistant turn. Draft/thinking/tool steps render
+ * expanded while the run is active and collapse once the final answer arrives.
  */
 export type TraceChatMessage = Omit<ChatMessage, 'role' | 'content'> & {
   role: 'trace';

--- a/console/src/routes/chat/trace-block.test.tsx
+++ b/console/src/routes/chat/trace-block.test.tsx
@@ -42,17 +42,13 @@ describe('TraceBlock', () => {
     );
 
     const controls = screen.getAllByRole('button');
-    expect(controls).toHaveLength(2);
+    expect(controls).toHaveLength(1);
     const firstControl = controls[0];
-    const secondControl = controls[1];
-    if (!firstControl || !secondControl) throw new Error('expected controls');
+    if (!firstControl) throw new Error('expected controls');
     expect(firstControl.getAttribute('aria-expanded')).toBe('true');
-    expect(secondControl.getAttribute('aria-expanded')).toBe('true');
     expect(screen.queryByText('exec…')).not.toBeNull();
     expect(screen.queryByText('Considering the request')).not.toBeNull();
-    expect(
-      screen.queryByText('I need to check one thing first.'),
-    ).not.toBeNull();
+    expect(screen.queryByText('I need to check one thing first.')).toBeNull();
     expect(screen.queryByText('npm test')).not.toBeNull();
   });
 
@@ -81,13 +77,11 @@ describe('TraceBlock', () => {
       'false',
     );
     expect(screen.queryByText('1 tool call · thinking · 12s')).not.toBeNull();
-    expect(
-      screen.queryByText('I need to check one thing first.'),
-    ).not.toBeNull();
+    expect(screen.queryByText('I need to check one thing first.')).toBeNull();
     expect(screen.queryByText('npm test')).toBeNull();
   });
 
-  it('keeps interim drafts outside collapsed trace segments', () => {
+  it('ignores legacy draft steps in trace rendering', () => {
     render(
       <TraceBlock
         message={makeTrace(
@@ -109,21 +103,30 @@ describe('TraceBlock', () => {
     );
 
     const controls = screen.getAllByRole('button');
-    expect(controls).toHaveLength(2);
+    expect(controls).toHaveLength(1);
     const firstControl = controls[0];
-    const secondControl = controls[1];
-    if (!firstControl || !secondControl) throw new Error('expected controls');
-    expect(firstControl.textContent).toContain('Thought');
-    expect(secondControl.textContent).toContain(
-      '1 tool call · thinking · 4.0s',
-    );
-    expect(screen.queryByText('I need a location first.')).not.toBeNull();
+    if (!firstControl) throw new Error('expected controls');
+    expect(firstControl.textContent).toContain('1 tool call · thinking · 4.0s');
+    expect(screen.queryByText('I need a location first.')).toBeNull();
     expect(screen.queryByText('Considering the request')).toBeNull();
     expect(screen.queryByText('send email')).toBeNull();
 
     fireEvent.click(firstControl);
     expect(screen.queryByText('Considering the request')).not.toBeNull();
-    expect(screen.queryByText('I need a location first.')).not.toBeNull();
+    expect(screen.queryByText('Waiting for the tool result')).not.toBeNull();
+    expect(screen.queryByText('I need a location first.')).toBeNull();
+  });
+
+  it('renders nothing for legacy draft-only traces', () => {
+    const { container } = render(
+      <TraceBlock
+        message={makeTrace([{ kind: 'draft', text: 'Intermediate text.' }], {
+          done: true,
+        })}
+      />,
+    );
+
+    expect(container.firstChild).toBeNull();
   });
 
   it('auto-collapses a manually expanded trace when the run finishes', () => {

--- a/console/src/routes/chat/trace-block.test.tsx
+++ b/console/src/routes/chat/trace-block.test.tsx
@@ -48,7 +48,9 @@ describe('TraceBlock', () => {
     expect(firstControl.getAttribute('aria-expanded')).toBe('true');
     expect(screen.queryByText('exec…')).not.toBeNull();
     expect(screen.queryByText('Considering the request')).not.toBeNull();
-    expect(screen.queryByText('I need to check one thing first.')).toBeNull();
+    expect(
+      screen.queryByText('I need to check one thing first.'),
+    ).not.toBeNull();
     expect(screen.queryByText('npm test')).not.toBeNull();
   });
 
@@ -79,9 +81,15 @@ describe('TraceBlock', () => {
     expect(screen.queryByText('1 tool call · thinking · 12s')).not.toBeNull();
     expect(screen.queryByText('I need to check one thing first.')).toBeNull();
     expect(screen.queryByText('npm test')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(
+      screen.queryByText('I need to check one thing first.'),
+    ).not.toBeNull();
+    expect(screen.queryByText('npm test')).not.toBeNull();
   });
 
-  it('ignores legacy draft steps in trace rendering', () => {
+  it('renders draft steps inside the expanded trace', () => {
     render(
       <TraceBlock
         message={makeTrace(
@@ -114,19 +122,24 @@ describe('TraceBlock', () => {
     fireEvent.click(firstControl);
     expect(screen.queryByText('Considering the request')).not.toBeNull();
     expect(screen.queryByText('Waiting for the tool result')).not.toBeNull();
-    expect(screen.queryByText('I need a location first.')).toBeNull();
+    expect(screen.queryByText('I need a location first.')).not.toBeNull();
   });
 
-  it('renders nothing for legacy draft-only traces', () => {
-    const { container } = render(
+  it('renders draft-only traces as collapsed activity', () => {
+    render(
       <TraceBlock
         message={makeTrace([{ kind: 'draft', text: 'Intermediate text.' }], {
           done: true,
+          finishedAt: 2_500,
         })}
       />,
     );
 
-    expect(container.firstChild).toBeNull();
+    expect(screen.queryByText('Agent activity · 1.5s')).not.toBeNull();
+    expect(screen.queryByText('Intermediate text.')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.queryByText('Intermediate text.')).not.toBeNull();
   });
 
   it('auto-collapses a manually expanded trace when the run finishes', () => {

--- a/console/src/routes/chat/trace-block.tsx
+++ b/console/src/routes/chat/trace-block.tsx
@@ -1,9 +1,8 @@
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { cx } from '../../lib/cx';
+import { renderMarkdown } from '../../lib/markdown';
 import css from './chat-page.module.css';
 import type { TraceChatMessage, TraceStep } from './chat-ui-message';
-
-type TraceActivityStep = Exclude<TraceStep, { kind: 'draft' }>;
 
 function formatDuration(ms: number): string {
   if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`;
@@ -17,11 +16,15 @@ function formatDuration(ms: number): string {
 
 function summaryLabel(
   message: TraceChatMessage,
-  steps: TraceActivityStep[],
+  steps: TraceStep[],
   includeDuration: boolean,
 ): string {
   if (!message.done) {
-    const last = steps[steps.length - 1];
+    const last =
+      steps
+        .slice()
+        .reverse()
+        .find((step) => step.kind !== 'draft') ?? steps[steps.length - 1];
     if (last?.kind === 'tool' && last.status === 'running') {
       return `${last.toolName}…`;
     }
@@ -36,6 +39,8 @@ function summaryLabel(
     if (thought) parts.push('thinking');
   } else if (thought) {
     parts.push('Thought');
+  } else if (steps.some((step) => step.kind === 'draft')) {
+    parts.push('Agent activity');
   }
   const elapsed = message.finishedAt
     ? message.finishedAt - message.startedAt
@@ -44,14 +49,29 @@ function summaryLabel(
   return parts.join(' · ') || 'Agent activity';
 }
 
-function activityStepsOnly(steps: TraceStep[]): TraceActivityStep[] {
-  return steps.filter(
-    (step): step is TraceActivityStep => step.kind !== 'draft',
+function TraceDraftInterim(props: { text: string }) {
+  const renderedHtml = useMemo(
+    () => renderMarkdown(props.text, { highlight: false }),
+    [props.text],
+  );
+
+  return (
+    <div className={css.traceDraftInterim}>
+      <div
+        className={css.markdownContent}
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: markdown output is rendered by marked and sanitized through sanitize-html
+        dangerouslySetInnerHTML={{ __html: renderedHtml }}
+      />
+    </div>
   );
 }
 
-function TraceStepRow(props: { step: TraceActivityStep; live: boolean }) {
+function TraceStepRow(props: { step: TraceStep; live: boolean }) {
   const { step, live } = props;
+  if (step.kind === 'draft') {
+    return <TraceDraftInterim text={step.text} />;
+  }
+
   if (step.kind === 'thinking') {
     return (
       <div className={css.traceStep}>
@@ -95,7 +115,7 @@ function TraceStepRow(props: { step: TraceActivityStep; live: boolean }) {
 
 function TraceActivityBlock(props: {
   message: TraceChatMessage;
-  steps: TraceActivityStep[];
+  steps: TraceStep[];
 }) {
   const { message, steps } = props;
   const [expandedOverride, setExpandedOverride] = useState<boolean | null>(
@@ -156,9 +176,9 @@ function TraceActivityBlock(props: {
 }
 
 /**
- * Collapsible run-activity trace (thinking + tool calls). Draft trace steps
- * are intentionally ignored: they are intermediate provider content from
- * tool-call turns, not final assistant answers.
+ * Collapsible run-activity trace. Draft trace steps are intermediate provider
+ * content from tool-call turns: visible while the run is open, then collapsed
+ * together with thinking/tool rows once the final answer arrives.
  */
 export const TraceBlock = memo(function TraceBlock(props: {
   message: TraceChatMessage;
@@ -167,12 +187,9 @@ export const TraceBlock = memo(function TraceBlock(props: {
 
   if (message.steps.length === 0) return null;
 
-  const steps = activityStepsOnly(message.steps);
-  if (steps.length === 0) return null;
-
   return (
     <div className={css.traceSequence}>
-      <TraceActivityBlock message={message} steps={steps} />
+      <TraceActivityBlock message={message} steps={message.steps} />
     </div>
   );
 });

--- a/console/src/routes/chat/trace-block.tsx
+++ b/console/src/routes/chat/trace-block.tsx
@@ -1,14 +1,9 @@
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { cx } from '../../lib/cx';
-import { renderMarkdown } from '../../lib/markdown';
 import css from './chat-page.module.css';
 import type { TraceChatMessage, TraceStep } from './chat-ui-message';
 
 type TraceActivityStep = Exclude<TraceStep, { kind: 'draft' }>;
-
-type TracePart =
-  | { kind: 'activity'; steps: TraceActivityStep[] }
-  | { kind: 'draft'; text: string };
 
 function formatDuration(ms: number): string {
   if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`;
@@ -49,29 +44,10 @@ function summaryLabel(
   return parts.join(' · ') || 'Agent activity';
 }
 
-function splitTraceParts(steps: TraceStep[]): TracePart[] {
-  const parts: TracePart[] = [];
-  let activitySteps: TraceActivityStep[] = [];
-
-  const flushActivity = () => {
-    if (activitySteps.length === 0) return;
-    parts.push({ kind: 'activity', steps: activitySteps });
-    activitySteps = [];
-  };
-
-  for (const step of steps) {
-    if (step.kind === 'draft') {
-      flushActivity();
-      if (step.text.trim()) {
-        parts.push({ kind: 'draft', text: step.text });
-      }
-      continue;
-    }
-    activitySteps.push(step);
-  }
-
-  flushActivity();
-  return parts;
+function activityStepsOnly(steps: TraceStep[]): TraceActivityStep[] {
+  return steps.filter(
+    (step): step is TraceActivityStep => step.kind !== 'draft',
+  );
 }
 
 function TraceStepRow(props: { step: TraceActivityStep; live: boolean }) {
@@ -117,29 +93,11 @@ function TraceStepRow(props: { step: TraceActivityStep; live: boolean }) {
   );
 }
 
-function TraceDraftInterim(props: { text: string }) {
-  const renderedHtml = useMemo(
-    () => renderMarkdown(props.text, { highlight: false }),
-    [props.text],
-  );
-
-  return (
-    <div className={css.traceDraftInterim}>
-      <div
-        className={css.markdownContent}
-        // biome-ignore lint/security/noDangerouslySetInnerHtml: markdown output is rendered by marked and sanitized through sanitize-html
-        dangerouslySetInnerHTML={{ __html: renderedHtml }}
-      />
-    </div>
-  );
-}
-
 function TraceActivityBlock(props: {
   message: TraceChatMessage;
   steps: TraceActivityStep[];
-  includeDuration: boolean;
 }) {
-  const { message, steps, includeDuration } = props;
+  const { message, steps } = props;
   const [expandedOverride, setExpandedOverride] = useState<boolean | null>(
     null,
   );
@@ -177,7 +135,7 @@ function TraceActivityBlock(props: {
             !message.done && css.traceSummaryLive,
           )}
         >
-          {summaryLabel(message, steps, includeDuration)}
+          {summaryLabel(message, steps, true)}
         </span>
       </button>
       {expanded ? (
@@ -198,9 +156,9 @@ function TraceActivityBlock(props: {
 }
 
 /**
- * Collapsible run-activity trace (thinking + tool calls) plus visible interim
- * assistant drafts. Drafts stay outside the collapsible grey trace so they
- * remain readable after the run finishes.
+ * Collapsible run-activity trace (thinking + tool calls). Draft trace steps
+ * are intentionally ignored: they are intermediate provider content from
+ * tool-call turns, not final assistant answers.
  */
 export const TraceBlock = memo(function TraceBlock(props: {
   message: TraceChatMessage;
@@ -209,34 +167,12 @@ export const TraceBlock = memo(function TraceBlock(props: {
 
   if (message.steps.length === 0) return null;
 
-  const parts = splitTraceParts(message.steps);
-  if (parts.length === 0) return null;
-  const activityPartCount = parts.filter(
-    (part) => part.kind === 'activity',
-  ).length;
-  let activityPartIndex = -1;
+  const steps = activityStepsOnly(message.steps);
+  if (steps.length === 0) return null;
 
   return (
     <div className={css.traceSequence}>
-      {parts.map((part, index) => {
-        if (part.kind === 'draft') {
-          return (
-            // biome-ignore lint/suspicious/noArrayIndexKey: trace parts are append-only
-            <TraceDraftInterim key={index} text={part.text} />
-          );
-        }
-
-        activityPartIndex += 1;
-        return (
-          <TraceActivityBlock
-            // biome-ignore lint/suspicious/noArrayIndexKey: trace parts are append-only
-            key={index}
-            message={message}
-            steps={part.steps}
-            includeDuration={activityPartIndex === activityPartCount - 1}
-          />
-        );
-      })}
+      <TraceActivityBlock message={message} steps={steps} />
     </div>
   );
 });

--- a/console/src/routes/chat/use-chat-stream.test.ts
+++ b/console/src/routes/chat/use-chat-stream.test.ts
@@ -1057,7 +1057,7 @@ describe('useChatStream', () => {
     });
   });
 
-  it('discards streamed assistant text from the trace when a tool starts', async () => {
+  it('keeps streamed assistant text as a draft when a tool starts', async () => {
     const harness = makeHarness();
     let resolveStream!: (value: ChatStreamResult) => void;
     let callbacks!: {
@@ -1113,6 +1113,9 @@ describe('useChatStream', () => {
     expect(harness.messages.some((msg) => msg.role === 'assistant')).toBe(
       false,
     );
+    expect(harness.messages.find((msg) => msg.role === 'draft')).toMatchObject({
+      content: 'I need a location first.',
+    });
     expect(harness.messages.find((msg) => msg.role === 'trace')).toMatchObject({
       done: false,
       steps: [
@@ -1152,6 +1155,9 @@ describe('useChatStream', () => {
       harness.messages.find((msg) => msg.role === 'assistant'),
     ).toMatchObject({
       content: 'Final answer.',
+    });
+    expect(harness.messages.find((msg) => msg.role === 'draft')).toMatchObject({
+      content: 'I need a location first.',
     });
     expect(harness.messages.find((msg) => msg.role === 'trace')).toMatchObject({
       done: true,

--- a/console/src/routes/chat/use-chat-stream.test.ts
+++ b/console/src/routes/chat/use-chat-stream.test.ts
@@ -1057,7 +1057,7 @@ describe('useChatStream', () => {
     });
   });
 
-  it('keeps streamed assistant text as a draft when a tool starts', async () => {
+  it('moves streamed assistant text into the trace when a tool starts', async () => {
     const harness = makeHarness();
     let resolveStream!: (value: ChatStreamResult) => void;
     let callbacks!: {
@@ -1113,12 +1113,11 @@ describe('useChatStream', () => {
     expect(harness.messages.some((msg) => msg.role === 'assistant')).toBe(
       false,
     );
-    expect(harness.messages.find((msg) => msg.role === 'draft')).toMatchObject({
-      content: 'I need a location first.',
-    });
+    expect(harness.messages.some((msg) => msg.role === 'draft')).toBe(false);
     expect(harness.messages.find((msg) => msg.role === 'trace')).toMatchObject({
       done: false,
       steps: [
+        { kind: 'draft', text: 'I need a location first.' },
         {
           kind: 'tool',
           toolName: 'message',
@@ -1156,12 +1155,11 @@ describe('useChatStream', () => {
     ).toMatchObject({
       content: 'Final answer.',
     });
-    expect(harness.messages.find((msg) => msg.role === 'draft')).toMatchObject({
-      content: 'I need a location first.',
-    });
+    expect(harness.messages.some((msg) => msg.role === 'draft')).toBe(false);
     expect(harness.messages.find((msg) => msg.role === 'trace')).toMatchObject({
       done: true,
       steps: [
+        { kind: 'draft', text: 'I need a location first.' },
         {
           kind: 'tool',
           toolName: 'message',

--- a/console/src/routes/chat/use-chat-stream.test.ts
+++ b/console/src/routes/chat/use-chat-stream.test.ts
@@ -1057,7 +1057,7 @@ describe('useChatStream', () => {
     });
   });
 
-  it('demotes streamed assistant text into the trace when a tool starts', async () => {
+  it('discards streamed assistant text from the trace when a tool starts', async () => {
     const harness = makeHarness();
     let resolveStream!: (value: ChatStreamResult) => void;
     let callbacks!: {
@@ -1116,7 +1116,6 @@ describe('useChatStream', () => {
     expect(harness.messages.find((msg) => msg.role === 'trace')).toMatchObject({
       done: false,
       steps: [
-        { kind: 'draft', text: 'I need a location first.' },
         {
           kind: 'tool',
           toolName: 'message',
@@ -1157,7 +1156,6 @@ describe('useChatStream', () => {
     expect(harness.messages.find((msg) => msg.role === 'trace')).toMatchObject({
       done: true,
       steps: [
-        { kind: 'draft', text: 'I need a location first.' },
         {
           kind: 'tool',
           toolName: 'message',

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -217,7 +217,7 @@ export function useChatStream(
         } satisfies ThinkingChatMessage,
       ]);
 
-      let streamId = nextMsgId();
+      const streamId = nextMsgId();
       setStreamingMsgId(streamId);
 
       const req: ActiveRequest = {
@@ -327,46 +327,17 @@ export function useChatStream(
         scheduleRender();
       };
 
-      const freezeAssistantTextBeforeTool = () => {
-        const draftText = req.assistantText;
+      const moveAssistantTextIntoTraceDraft = () => {
+        const draftText = req.assistantText.trim();
         if (!draftText.trim()) return;
-        const draftId = streamId;
-        setMessages((prev) => {
-          let foundDraft = false;
-          const next = prev
-            .filter((m) => m.id !== thinkingId)
-            .map((m) => {
-              if (m.id !== draftId) return m;
-              foundDraft = true;
-              return {
-                ...m,
-                role: 'draft' as const,
-                content: draftText,
-                pendingApproval: null,
-              };
-            });
-          if (foundDraft) return next;
-          return [
-            ...next,
-            {
-              id: draftId,
-              role: 'draft' as const,
-              content: draftText,
-              sessionId: req.sessionId,
-              artifacts: [],
-              pendingApproval: null,
-            },
-          ];
-        });
-        streamId = nextMsgId();
-        setStreamingMsgId(streamId);
+        req.trace.push({ kind: 'draft', text: draftText });
         req.assistantText = '';
         req.lastRenderedText = '';
       };
 
       const pushToolEvent = (event: ChatStreamToolEvent) => {
         if (event.phase === 'start') {
-          freezeAssistantTextBeforeTool();
+          moveAssistantTextIntoTraceDraft();
           req.trace.push({
             kind: 'tool',
             toolName: event.toolName,

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -271,8 +271,7 @@ export function useChatStream(
             : prev;
           // Trace-only update: keep the thinking dots until the answer (or an
           // approval card) actually starts, so no empty bubble flashes in. If
-          // a previously streamed assistant draft was demoted into the trace,
-          // remove its live answer bubble too.
+          // a prior tool-call-turn preview was discarded, remove its bubble too.
           if (!text && !approval) {
             return withTrace.filter((m) => m.id !== streamId);
           }
@@ -329,27 +328,13 @@ export function useChatStream(
         scheduleRender();
       };
 
-      const pushDraftText = (text: string) => {
-        const draft = text.trim();
-        if (!draft) return;
-        const last = req.trace.at(-1);
-        if (last?.kind === 'draft') {
-          last.text = `${last.text}\n\n${draft}`;
-        } else {
-          req.trace.push({ kind: 'draft', text: draft });
-        }
-        req.traceVersion += 1;
-      };
-
-      const demoteAssistantTextToDraft = () => {
-        if (!req.assistantText.trim()) return;
-        pushDraftText(req.assistantText);
+      const discardAssistantTextBeforeTool = () => {
         req.assistantText = '';
       };
 
       const pushToolEvent = (event: ChatStreamToolEvent) => {
         if (event.phase === 'start') {
-          demoteAssistantTextToDraft();
+          discardAssistantTextBeforeTool();
           req.trace.push({
             kind: 'tool',
             toolName: event.toolName,

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -217,7 +217,7 @@ export function useChatStream(
         } satisfies ThinkingChatMessage,
       ]);
 
-      const streamId = nextMsgId();
+      let streamId = nextMsgId();
       setStreamingMsgId(streamId);
 
       const req: ActiveRequest = {
@@ -270,8 +270,7 @@ export function useChatStream(
               )
             : prev;
           // Trace-only update: keep the thinking dots until the answer (or an
-          // approval card) actually starts, so no empty bubble flashes in. If
-          // a prior tool-call-turn preview was discarded, remove its bubble too.
+          // approval card) actually starts, so no empty bubble flashes in.
           if (!text && !approval) {
             return withTrace.filter((m) => m.id !== streamId);
           }
@@ -328,13 +327,46 @@ export function useChatStream(
         scheduleRender();
       };
 
-      const discardAssistantTextBeforeTool = () => {
+      const freezeAssistantTextBeforeTool = () => {
+        const draftText = req.assistantText;
+        if (!draftText.trim()) return;
+        const draftId = streamId;
+        setMessages((prev) => {
+          let foundDraft = false;
+          const next = prev
+            .filter((m) => m.id !== thinkingId)
+            .map((m) => {
+              if (m.id !== draftId) return m;
+              foundDraft = true;
+              return {
+                ...m,
+                role: 'draft' as const,
+                content: draftText,
+                pendingApproval: null,
+              };
+            });
+          if (foundDraft) return next;
+          return [
+            ...next,
+            {
+              id: draftId,
+              role: 'draft' as const,
+              content: draftText,
+              sessionId: req.sessionId,
+              artifacts: [],
+              pendingApproval: null,
+            },
+          ];
+        });
+        streamId = nextMsgId();
+        setStreamingMsgId(streamId);
         req.assistantText = '';
+        req.lastRenderedText = '';
       };
 
       const pushToolEvent = (event: ChatStreamToolEvent) => {
         if (event.phase === 'start') {
-          discardAssistantTextBeforeTool();
+          freezeAssistantTextBeforeTool();
           req.trace.push({
             kind: 'tool',
             toolName: event.toolName,

--- a/src/agent/prompt-hooks.ts
+++ b/src/agent/prompt-hooks.ts
@@ -448,6 +448,7 @@ function buildSafetyHook(context: PromptHookContext): string {
     ...(toolsSummary ? [toolsSummary, ''] : []),
     '## Tool Call Style',
     'Default: do not narrate routine, low-risk tool calls; just call the tool.',
+    'When you call any tool, emit no user-facing assistant prose in that same response. Make the tool call with empty assistant content, then write the user-facing answer after the tool result is available.',
     'Narrate only when it helps: multi-step work, complex/challenging problems, sensitive actions, or when the user explicitly asks.',
     'Keep narration brief and value-dense; avoid repeating obvious steps.',
     'If the user has already asked you to perform an action, do not ask for a separate natural-language "yes" just to trigger approvals; attempt the tool call and let the runtime approval flow interrupt if approval is required.',

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -159,6 +159,7 @@ import {
   resolveWorkspaceRelativePath,
 } from './gateway-utils.js';
 import {
+  type BootstrapHatchingTurnResult,
   recordBootstrapHatchingTerminalAudit,
   recordBootstrapHatchingTurnResult,
   recordBootstrapOnboardingAbort,
@@ -1866,6 +1867,14 @@ async function handleGatewayMessageInner(
     | 'pre-agent'
     | 'awaiting-agent-output'
     | 'processing-agent-output' = 'pre-agent';
+  let hatchingCompletion: BootstrapHatchingTurnResult | null = null;
+  const recordPendingHatchingTerminalAudit = (): void => {
+    recordBootstrapHatchingTerminalAudit({
+      audit: onboardingAuditContext,
+      result: hatchingCompletion,
+    });
+    hatchingCompletion = null;
+  };
 
   try {
     const scheduledTasks = getAllJobs({
@@ -2000,12 +2009,10 @@ async function handleGatewayMessageInner(
       media,
     );
     const toolExecutions = output.toolExecutions || [];
-    const hatchingCompletion = recordBootstrapHatchingTurnResult({
+    hatchingCompletion = recordBootstrapHatchingTurnResult({
       agentId,
       bootstrapFile: startupBootstrapFile,
       toolExecutions,
-      audit: onboardingAuditContext || undefined,
-      deferTerminalAudit: true,
     });
     if (hatchingCompletion) {
       logger.info(
@@ -2223,12 +2230,7 @@ async function handleGatewayMessageInner(
           stage: agentStage,
         },
       });
-      if (onboardingAuditContext) {
-        recordBootstrapHatchingTerminalAudit({
-          audit: onboardingAuditContext,
-          result: hatchingCompletion,
-        });
-      }
+      recordPendingHatchingTerminalAudit();
       recordAuditEvent({
         sessionId: req.sessionId,
         runId,
@@ -2405,10 +2407,7 @@ async function handleGatewayMessageInner(
         toolCallCount: toolExecutions.length,
         messageRole: output.pendingApproval ? 'approval' : 'assistant',
       });
-      recordBootstrapHatchingTerminalAudit({
-        audit: onboardingAuditContext,
-        result: hatchingCompletion,
-      });
+      recordPendingHatchingTerminalAudit();
     }
     const storedTurnMessages = buildStoredTurnMessages({
       sessionId: req.sessionId,
@@ -2538,6 +2537,7 @@ async function handleGatewayMessageInner(
         stage: agentStage,
       },
     });
+    recordPendingHatchingTerminalAudit();
     recordAuditEvent({
       sessionId: req.sessionId,
       runId,

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -159,6 +159,7 @@ import {
   resolveWorkspaceRelativePath,
 } from './gateway-utils.js';
 import {
+  recordBootstrapHatchingTerminalAudit,
   recordBootstrapHatchingTurnResult,
   recordBootstrapOnboardingAbort,
   recordBootstrapOnboardingAssistantMessage,
@@ -2004,6 +2005,7 @@ async function handleGatewayMessageInner(
       bootstrapFile: startupBootstrapFile,
       toolExecutions,
       audit: onboardingAuditContext || undefined,
+      deferTerminalAudit: true,
     });
     if (hatchingCompletion) {
       logger.info(
@@ -2221,6 +2223,12 @@ async function handleGatewayMessageInner(
           stage: agentStage,
         },
       });
+      if (onboardingAuditContext) {
+        recordBootstrapHatchingTerminalAudit({
+          audit: onboardingAuditContext,
+          result: hatchingCompletion,
+        });
+      }
       recordAuditEvent({
         sessionId: req.sessionId,
         runId,
@@ -2396,6 +2404,10 @@ async function handleGatewayMessageInner(
         messageChars: resultText.length,
         toolCallCount: toolExecutions.length,
         messageRole: output.pendingApproval ? 'approval' : 'assistant',
+      });
+      recordBootstrapHatchingTerminalAudit({
+        audit: onboardingAuditContext,
+        result: hatchingCompletion,
       });
     }
     const storedTurnMessages = buildStoredTurnMessages({

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -3275,14 +3275,21 @@ async function handleApiChatStream(
     return;
   }
 
-  // Accumulate thinking/tool events into an ordered trace, then persist it
-  // against the assistant message so a reload can replay run activity without
-  // surfacing intermediate tool-call-turn text as user-facing drafts.
+  // Accumulate draft/thinking/tool events into an ordered trace, then persist it
+  // against the assistant message so a reload can replay the same collapsed run
+  // activity the live web chat rendered.
   const traceStartedAt = Date.now();
   const traceBuilder = new ActivityTraceBuilder();
+  let streamedTextBeforeNextTool = '';
+
+  const pushStreamedTextDraft = (): void => {
+    traceBuilder.pushDraft(streamedTextBeforeNextTool);
+    streamedTextBeforeNextTool = '';
+  };
 
   const onToolProgress = (event: ToolProgressEvent): void => {
     if (event.phase === 'start') {
+      pushStreamedTextDraft();
       traceBuilder.startTool(event.toolName, event.preview);
     } else {
       traceBuilder.finishTool(event.toolName, event.durationMs, event.preview);
@@ -3300,6 +3307,7 @@ async function handleApiChatStream(
   const onTextDelta = (delta: string): void => {
     const filteredDelta = streamFilter.push(delta);
     if (!filteredDelta) return;
+    streamedTextBeforeNextTool += filteredDelta;
     sendEvent({
       type: 'text',
       delta: filteredDelta,

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -3275,21 +3275,14 @@ async function handleApiChatStream(
     return;
   }
 
-  // Accumulate the same thinking/tool events the client sees into an ordered
-  // trace, then persist it against the assistant message so a reload replays
-  // exactly what streamed.
+  // Accumulate thinking/tool events into an ordered trace, then persist it
+  // against the assistant message so a reload can replay run activity without
+  // surfacing intermediate tool-call-turn text as user-facing drafts.
   const traceStartedAt = Date.now();
   const traceBuilder = new ActivityTraceBuilder();
-  let streamedTextBeforeNextTool = '';
-
-  const pushStreamedTextDraft = (): void => {
-    traceBuilder.pushDraft(streamedTextBeforeNextTool);
-    streamedTextBeforeNextTool = '';
-  };
 
   const onToolProgress = (event: ToolProgressEvent): void => {
     if (event.phase === 'start') {
-      pushStreamedTextDraft();
       traceBuilder.startTool(event.toolName, event.preview);
     } else {
       traceBuilder.finishTool(event.toolName, event.durationMs, event.preview);
@@ -3307,7 +3300,6 @@ async function handleApiChatStream(
   const onTextDelta = (delta: string): void => {
     const filteredDelta = streamFilter.push(delta);
     if (!filteredDelta) return;
-    streamedTextBeforeNextTool += filteredDelta;
     sendEvent({
       type: 'text',
       delta: filteredDelta,

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -619,6 +619,8 @@ import {
 } from './gateway-utils.js';
 import { initializeGoalContinuationRunner } from './goal-continuation-runner.js';
 import {
+  type BootstrapHatchingTurnResult,
+  type BootstrapOnboardingAuditContext,
   recordBootstrapHatchingTerminalAudit,
   recordBootstrapHatchingTurnResult,
   recordBootstrapOnboardingAbort,
@@ -8613,6 +8615,15 @@ export async function ensureGatewayBootstrapAutostart(params: {
     return;
   }
   activeBootstrapAutostartSessions.add(lockKey);
+  let onboardingAuditContext: BootstrapOnboardingAuditContext | null = null;
+  let hatchingCompletion: BootstrapHatchingTurnResult | null = null;
+  const recordPendingHatchingTerminalAudit = (): void => {
+    recordBootstrapHatchingTerminalAudit({
+      audit: onboardingAuditContext,
+      result: hatchingCompletion,
+    });
+    hatchingCompletion = null;
+  };
 
   try {
     const markerStartedAt = new Date().toISOString();
@@ -8653,7 +8664,7 @@ export async function ensureGatewayBootstrapAutostart(params: {
     });
     const provider = resolveModelProvider(model);
     const turnIndex = Math.max(1, session.message_count + 1);
-    const onboardingAuditContext =
+    onboardingAuditContext =
       bootstrapFile === 'BOOTSTRAP.md'
         ? {
             sessionId: session.id,
@@ -9019,12 +9030,10 @@ export async function ensureGatewayBootstrapAutostart(params: {
       scheduledTasks: [],
       pluginTools: pluginManager?.getToolDefinitions() ?? [],
     });
-    const hatchingCompletion = recordBootstrapHatchingTurnResult({
+    hatchingCompletion = recordBootstrapHatchingTurnResult({
       agentId: resolved.agentId,
       bootstrapFile,
       toolExecutions: output.toolExecutions || [],
-      audit: onboardingAuditContext || undefined,
-      deferTerminalAudit: true,
     });
     if (hatchingCompletion) {
       logger.info(
@@ -9097,12 +9106,7 @@ export async function ensureGatewayBootstrapAutostart(params: {
 
     if (output.status !== 'success' || !resultText) {
       deleteMemoryValue(session.id, markerKey);
-      if (onboardingAuditContext) {
-        recordBootstrapHatchingTerminalAudit({
-          audit: onboardingAuditContext,
-          result: hatchingCompletion,
-        });
-      }
+      recordPendingHatchingTerminalAudit();
       recordAuditEvent({
         sessionId: session.id,
         runId,
@@ -9137,10 +9141,7 @@ export async function ensureGatewayBootstrapAutostart(params: {
         messageChars: resultText.length,
         toolCallCount: (output.toolExecutions || []).length,
       });
-      recordBootstrapHatchingTerminalAudit({
-        audit: onboardingAuditContext,
-        result: hatchingCompletion,
-      });
+      recordPendingHatchingTerminalAudit();
     }
     setMemoryValue(session.id, markerKey, {
       status: 'completed',
@@ -9174,6 +9175,7 @@ export async function ensureGatewayBootstrapAutostart(params: {
     });
   } catch (error) {
     deleteMemoryValue(session.id, markerKey);
+    recordPendingHatchingTerminalAudit();
     logger.warn(
       { sessionId: session.id, agentId: resolved.agentId, channelId, error },
       'Failed to run bootstrap autostart turn',

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -619,6 +619,7 @@ import {
 } from './gateway-utils.js';
 import { initializeGoalContinuationRunner } from './goal-continuation-runner.js';
 import {
+  recordBootstrapHatchingTerminalAudit,
   recordBootstrapHatchingTurnResult,
   recordBootstrapOnboardingAbort,
   recordBootstrapOnboardingAssistantMessage,
@@ -9023,6 +9024,7 @@ export async function ensureGatewayBootstrapAutostart(params: {
       bootstrapFile,
       toolExecutions: output.toolExecutions || [],
       audit: onboardingAuditContext || undefined,
+      deferTerminalAudit: true,
     });
     if (hatchingCompletion) {
       logger.info(
@@ -9095,6 +9097,12 @@ export async function ensureGatewayBootstrapAutostart(params: {
 
     if (output.status !== 'success' || !resultText) {
       deleteMemoryValue(session.id, markerKey);
+      if (onboardingAuditContext) {
+        recordBootstrapHatchingTerminalAudit({
+          audit: onboardingAuditContext,
+          result: hatchingCompletion,
+        });
+      }
       recordAuditEvent({
         sessionId: session.id,
         runId,
@@ -9128,6 +9136,10 @@ export async function ensureGatewayBootstrapAutostart(params: {
         assistantMessageId,
         messageChars: resultText.length,
         toolCallCount: (output.toolExecutions || []).length,
+      });
+      recordBootstrapHatchingTerminalAudit({
+        audit: onboardingAuditContext,
+        result: hatchingCompletion,
       });
     }
     setMemoryValue(session.id, markerKey, {

--- a/src/gateway/hatching-completion.ts
+++ b/src/gateway/hatching-completion.ts
@@ -10,6 +10,8 @@ import {
 type MessageSend = {
   recipient?: string;
   subject?: string;
+  transport?: string;
+  contentLength?: number;
 };
 
 export type BootstrapHatchingTurnResult = {
@@ -17,6 +19,7 @@ export type BootstrapHatchingTurnResult = {
   updated: boolean;
   reason: string;
   turnsWithoutMessage?: number;
+  mail?: MessageSend;
 };
 
 type BootstrapFileName = 'BOOTSTRAP.md' | 'OPENING.md';
@@ -188,6 +191,36 @@ function recordBootstrapOnboardingComplete(
   });
 }
 
+function isEmailLikeRecipient(value: string | undefined): boolean {
+  return /[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+/.test(String(value || '').trim());
+}
+
+function isOnboardingMail(send: MessageSend | undefined): send is MessageSend {
+  if (!send) return false;
+  if (send.transport?.toLowerCase() === 'email') return true;
+  return isEmailLikeRecipient(send.recipient);
+}
+
+function recordBootstrapOnboardingMail(
+  context: BootstrapOnboardingAuditContext,
+  send: MessageSend,
+): void {
+  if (context.bootstrapFile !== 'BOOTSTRAP.md') return;
+  recordAuditEvent({
+    sessionId: context.sessionId,
+    runId: context.runId,
+    event: {
+      type: 'onboarding.mail',
+      ...buildBaseOnboardingPayload(context),
+      recipient: send.recipient || null,
+      subject: send.subject || null,
+      transport: send.transport || null,
+      contentLength: send.contentLength ?? null,
+      reason: 'onboarding welcome mail sent',
+    },
+  });
+}
+
 export function recordBootstrapHatchingTerminalAudit(params: {
   audit?: BootstrapOnboardingAuditContext | null;
   result?: BootstrapHatchingTurnResult | null;
@@ -202,6 +235,9 @@ export function recordBootstrapHatchingTerminalAudit(params: {
     return;
   }
 
+  if (isOnboardingMail(params.result.mail)) {
+    recordBootstrapOnboardingMail(params.audit, params.result.mail);
+  }
   recordBootstrapOnboardingComplete(params.audit, params.result);
 }
 
@@ -228,6 +264,11 @@ function firstRecipientCandidate(...values: unknown[]): string {
   return '';
 }
 
+function readNumber(value: unknown): number | undefined {
+  const numeric = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : undefined;
+}
+
 function readSuccessfulMessageSend(
   execution: ToolExecution,
 ): MessageSend | null {
@@ -248,10 +289,17 @@ function readSuccessfulMessageSend(
   );
 
   const subject = readString(args.subject) || readString(result?.subject);
+  const transport = readString(result?.transport) || readString(args.transport);
+  const contentLength =
+    readNumber(result?.contentLength) ??
+    readNumber(args.contentLength) ??
+    readString(args.content).length;
 
   return {
     recipient,
     subject,
+    transport,
+    contentLength,
   };
 }
 
@@ -272,10 +320,13 @@ export function recordBootstrapHatchingTurnResult(params: {
     });
   }
 
-  return completeHatchingAfterMessageSend({
-    agentId: params.agentId,
-    recipient: send.recipient,
-    subject: send.subject,
-    handledAt: params.handledAt,
-  });
+  return {
+    ...completeHatchingAfterMessageSend({
+      agentId: params.agentId,
+      recipient: send.recipient,
+      subject: send.subject,
+      handledAt: params.handledAt,
+    }),
+    mail: send,
+  };
 }

--- a/src/gateway/hatching-completion.ts
+++ b/src/gateway/hatching-completion.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import { recordAuditEvent } from '../audit/audit-events.js';
 import type { ToolExecution } from '../types/execution.js';
 import {
@@ -14,12 +16,21 @@ type MessageSend = {
   contentLength?: number;
 };
 
+type OnboardingFileAction = 'write' | 'edit' | 'delete';
+
+type OnboardingFileUpdate = {
+  action: OnboardingFileAction;
+  toolName: string;
+  path: string;
+};
+
 export type BootstrapHatchingTurnResult = {
   completed: boolean;
   updated: boolean;
   reason: string;
   turnsWithoutMessage?: number;
   mail?: MessageSend;
+  files?: OnboardingFileUpdate[];
 };
 
 type BootstrapFileName = 'BOOTSTRAP.md' | 'OPENING.md';
@@ -221,11 +232,68 @@ function recordBootstrapOnboardingMail(
   });
 }
 
+function normalizeOnboardingFilePath(
+  context: BootstrapOnboardingAuditContext,
+  filePath: string,
+): string {
+  const trimmed = filePath.trim();
+  if (!trimmed || !context.workspacePath || !path.isAbsolute(trimmed)) {
+    return trimmed;
+  }
+
+  const workspacePath = path.resolve(context.workspacePath);
+  const relativePath = path.relative(workspacePath, path.resolve(trimmed));
+  if (
+    relativePath &&
+    !relativePath.startsWith('..') &&
+    !path.isAbsolute(relativePath)
+  ) {
+    return relativePath;
+  }
+  return trimmed;
+}
+
+function recordBootstrapOnboardingFiles(
+  context: BootstrapOnboardingAuditContext,
+  files: OnboardingFileUpdate[],
+): void {
+  if (context.bootstrapFile !== 'BOOTSTRAP.md') return;
+  const normalizedFiles = files
+    .map((file) => ({
+      action: file.action,
+      toolName: file.toolName,
+      path: normalizeOnboardingFilePath(context, file.path),
+    }))
+    .filter((file) => file.path);
+  if (normalizedFiles.length === 0) return;
+
+  recordAuditEvent({
+    sessionId: context.sessionId,
+    runId: context.runId,
+    event: {
+      type: 'onboarding.files',
+      ...buildBaseOnboardingPayload(context),
+      fileCount: normalizedFiles.length,
+      actions: Array.from(
+        new Set(normalizedFiles.map((file) => file.action)),
+      ).sort(),
+      files: normalizedFiles,
+      reason: 'onboarding files updated',
+    },
+  });
+}
+
 export function recordBootstrapHatchingTerminalAudit(params: {
   audit?: BootstrapOnboardingAuditContext | null;
   result?: BootstrapHatchingTurnResult | null;
 }): void {
-  if (!params.audit || !params.result?.completed) return;
+  if (!params.audit || !params.result) return;
+
+  if (params.result.files?.length) {
+    recordBootstrapOnboardingFiles(params.audit, params.result.files);
+  }
+
+  if (!params.result.completed) return;
   if (params.result.turnsWithoutMessage) {
     recordBootstrapOnboardingAbort(params.audit, {
       reason: params.result.reason,
@@ -269,6 +337,14 @@ function readNumber(value: unknown): number | undefined {
   return Number.isFinite(numeric) && numeric >= 0 ? numeric : undefined;
 }
 
+function firstPathCandidate(...values: unknown[]): string {
+  for (const value of values) {
+    const candidate = readString(value);
+    if (candidate) return candidate;
+  }
+  return '';
+}
+
 function readSuccessfulMessageSend(
   execution: ToolExecution,
 ): MessageSend | null {
@@ -303,6 +379,36 @@ function readSuccessfulMessageSend(
   };
 }
 
+function readSuccessfulFileUpdate(
+  execution: ToolExecution,
+): OnboardingFileUpdate | null {
+  if (execution.isError || execution.blocked) return null;
+
+  const args = parseJsonObject(execution.arguments);
+  if (!args) return null;
+
+  const filePath = firstPathCandidate(args.path, args.filePath, args.file_path);
+  if (!filePath) return null;
+
+  if (execution.name === 'write') {
+    return { action: 'write', toolName: execution.name, path: filePath };
+  }
+  if (execution.name === 'edit') {
+    return { action: 'edit', toolName: execution.name, path: filePath };
+  }
+  if (execution.name === 'delete') {
+    return { action: 'delete', toolName: execution.name, path: filePath };
+  }
+  if (
+    execution.name === 'memory' &&
+    readString(args.action).toLowerCase() === 'write'
+  ) {
+    return { action: 'write', toolName: execution.name, path: filePath };
+  }
+
+  return null;
+}
+
 export function recordBootstrapHatchingTurnResult(params: {
   agentId: string;
   bootstrapFile: 'BOOTSTRAP.md' | 'OPENING.md' | null;
@@ -311,13 +417,21 @@ export function recordBootstrapHatchingTurnResult(params: {
 }): BootstrapHatchingTurnResult | null {
   if (params.bootstrapFile !== 'BOOTSTRAP.md') return null;
 
+  const files = params.toolExecutions
+    .map(readSuccessfulFileUpdate)
+    .filter((candidate): candidate is OnboardingFileUpdate =>
+      Boolean(candidate),
+    );
   const send = params.toolExecutions
     .map(readSuccessfulMessageSend)
     .find((candidate): candidate is MessageSend => Boolean(candidate));
   if (!send) {
-    return recordHatchingTurnWithoutMessage({
-      agentId: params.agentId,
-    });
+    return {
+      ...recordHatchingTurnWithoutMessage({
+        agentId: params.agentId,
+      }),
+      files,
+    };
   }
 
   return {
@@ -328,5 +442,6 @@ export function recordBootstrapHatchingTurnResult(params: {
       handledAt: params.handledAt,
     }),
     mail: send,
+    files,
   };
 }

--- a/src/gateway/hatching-completion.ts
+++ b/src/gateway/hatching-completion.ts
@@ -189,10 +189,10 @@ function recordBootstrapOnboardingComplete(
 }
 
 export function recordBootstrapHatchingTerminalAudit(params: {
-  audit: BootstrapOnboardingAuditContext;
-  result: BootstrapHatchingTurnResult | null;
+  audit?: BootstrapOnboardingAuditContext | null;
+  result?: BootstrapHatchingTurnResult | null;
 }): void {
-  if (!params.result?.completed) return;
+  if (!params.audit || !params.result?.completed) return;
   if (params.result.turnsWithoutMessage) {
     recordBootstrapOnboardingAbort(params.audit, {
       reason: params.result.reason,
@@ -260,8 +260,6 @@ export function recordBootstrapHatchingTurnResult(params: {
   bootstrapFile: 'BOOTSTRAP.md' | 'OPENING.md' | null;
   toolExecutions: ToolExecution[];
   handledAt?: string;
-  audit?: BootstrapOnboardingAuditContext;
-  deferTerminalAudit?: boolean;
 }): BootstrapHatchingTurnResult | null {
   if (params.bootstrapFile !== 'BOOTSTRAP.md') return null;
 
@@ -269,29 +267,15 @@ export function recordBootstrapHatchingTurnResult(params: {
     .map(readSuccessfulMessageSend)
     .find((candidate): candidate is MessageSend => Boolean(candidate));
   if (!send) {
-    const result = recordHatchingTurnWithoutMessage({
+    return recordHatchingTurnWithoutMessage({
       agentId: params.agentId,
     });
-    if (params.audit && result.completed && !params.deferTerminalAudit) {
-      recordBootstrapHatchingTerminalAudit({
-        audit: params.audit,
-        result,
-      });
-    }
-    return result;
   }
 
-  const result = completeHatchingAfterMessageSend({
+  return completeHatchingAfterMessageSend({
     agentId: params.agentId,
     recipient: send.recipient,
     subject: send.subject,
     handledAt: params.handledAt,
   });
-  if (params.audit && result.completed && !params.deferTerminalAudit) {
-    recordBootstrapHatchingTerminalAudit({
-      audit: params.audit,
-      result,
-    });
-  }
-  return result;
 }

--- a/src/gateway/hatching-completion.ts
+++ b/src/gateway/hatching-completion.ts
@@ -1,6 +1,7 @@
 import { recordAuditEvent } from '../audit/audit-events.js';
 import type { ToolExecution } from '../types/execution.js';
 import {
+  claimWorkspaceOnboardingStart,
   completeHatchingAfterMessageSend,
   recordHatchingTurnWithoutMessage,
   type WorkspaceOnboardingTransition,
@@ -49,13 +50,22 @@ export function recordBootstrapOnboardingStart(
   context: BootstrapOnboardingAuditContext,
 ): void {
   if (context.bootstrapFile !== 'BOOTSTRAP.md') return;
+  const start = claimWorkspaceOnboardingStart({
+    agentId: context.agentId,
+  });
   recordAuditEvent({
     sessionId: context.sessionId,
     runId: context.runId,
     event: {
-      type: 'onboarding.start',
+      type: start.eventType,
       ...buildBaseOnboardingPayload(context),
-      reason: 'bootstrap hatching turn started',
+      ...(start.onboardingStartedAt
+        ? { onboardingStartedAt: start.onboardingStartedAt }
+        : {}),
+      reason:
+        start.eventType === 'onboarding.start'
+          ? 'bootstrap hatching started'
+          : 'bootstrap hatching continued',
     },
   });
 }
@@ -178,6 +188,23 @@ function recordBootstrapOnboardingComplete(
   });
 }
 
+export function recordBootstrapHatchingTerminalAudit(params: {
+  audit: BootstrapOnboardingAuditContext;
+  result: BootstrapHatchingTurnResult | null;
+}): void {
+  if (!params.result?.completed) return;
+  if (params.result.turnsWithoutMessage) {
+    recordBootstrapOnboardingAbort(params.audit, {
+      reason: params.result.reason,
+      rule: 'hatching_no_message_limit',
+      turnsWithoutMessage: params.result.turnsWithoutMessage,
+    });
+    return;
+  }
+
+  recordBootstrapOnboardingComplete(params.audit, params.result);
+}
+
 function parseJsonObject(value: string): Record<string, unknown> | null {
   try {
     const parsed = JSON.parse(value);
@@ -234,6 +261,7 @@ export function recordBootstrapHatchingTurnResult(params: {
   toolExecutions: ToolExecution[];
   handledAt?: string;
   audit?: BootstrapOnboardingAuditContext;
+  deferTerminalAudit?: boolean;
 }): BootstrapHatchingTurnResult | null {
   if (params.bootstrapFile !== 'BOOTSTRAP.md') return null;
 
@@ -244,11 +272,10 @@ export function recordBootstrapHatchingTurnResult(params: {
     const result = recordHatchingTurnWithoutMessage({
       agentId: params.agentId,
     });
-    if (params.audit && result.completed) {
-      recordBootstrapOnboardingAbort(params.audit, {
-        reason: result.reason,
-        rule: 'hatching_no_message_limit',
-        turnsWithoutMessage: result.turnsWithoutMessage,
+    if (params.audit && result.completed && !params.deferTerminalAudit) {
+      recordBootstrapHatchingTerminalAudit({
+        audit: params.audit,
+        result,
       });
     }
     return result;
@@ -260,8 +287,11 @@ export function recordBootstrapHatchingTurnResult(params: {
     subject: send.subject,
     handledAt: params.handledAt,
   });
-  if (params.audit && result.completed) {
-    recordBootstrapOnboardingComplete(params.audit, result);
+  if (params.audit && result.completed && !params.deferTerminalAudit) {
+    recordBootstrapHatchingTerminalAudit({
+      audit: params.audit,
+      result,
+    });
   }
   return result;
 }

--- a/src/types/activity-trace.ts
+++ b/src/types/activity-trace.ts
@@ -1,8 +1,7 @@
 /**
- * Ordered activity trace for one assistant turn — thinking segments and tool
- * calls the gateway streams to the web chat, in the order they occurred.
- * Draft steps are retained as a legacy persisted shape, but normal trace
- * rendering ignores them because they are not final assistant answers.
+ * Ordered activity trace for one assistant turn — intermediate assistant
+ * drafts, thinking segments, and tool calls the gateway streams to the web
+ * chat, in the order they occurred.
  *
  * Persisted per assistant message so a page reload can replay the same trace
  * the web client rendered live. The step shape mirrors the console's live
@@ -40,9 +39,10 @@ export interface ActivityTrace {
 }
 
 /**
- * Accumulates streamed thinking/tool events into an ordered trace. Consecutive
- * thinking deltas merge, and a tool `finish` collapses into the most recent
- * matching running `start` (parallel same-name tools can finish out of order).
+ * Accumulates streamed draft/thinking/tool events into an ordered trace.
+ * Consecutive thinking deltas merge, and a tool `finish` collapses into the
+ * most recent matching running `start` (parallel same-name tools can finish out
+ * of order).
  */
 export class ActivityTraceBuilder {
   private readonly steps: ActivityTraceStep[] = [];

--- a/src/types/activity-trace.ts
+++ b/src/types/activity-trace.ts
@@ -1,7 +1,8 @@
 /**
- * Ordered activity trace for one assistant turn — thinking segments,
- * intermediate assistant drafts, and tool calls the gateway streams to the web
- * chat, in the order they occurred.
+ * Ordered activity trace for one assistant turn — thinking segments and tool
+ * calls the gateway streams to the web chat, in the order they occurred.
+ * Draft steps are retained as a legacy persisted shape, but normal trace
+ * rendering ignores them because they are not final assistant answers.
  *
  * Persisted per assistant message so a page reload can replay the same trace
  * the web client rendered live. The step shape mirrors the console's live
@@ -39,10 +40,9 @@ export interface ActivityTrace {
 }
 
 /**
- * Accumulates streamed thinking/draft/tool events into an ordered trace,
- * mirroring the console's live accumulation: consecutive thinking deltas merge,
- * and a tool `finish` collapses into the most recent matching running `start`
- * (parallel same-name tools can finish out of order).
+ * Accumulates streamed thinking/tool events into an ordered trace. Consecutive
+ * thinking deltas merge, and a tool `finish` collapses into the most recent
+ * matching running `start` (parallel same-name tools can finish out of order).
  */
 export class ActivityTraceBuilder {
   private readonly steps: ActivityTraceStep[] = [];

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -494,17 +494,27 @@ function completeHatchingByRemovingBootstrap(params: {
   agentId: string;
   reason: string;
   statePatch?: Partial<WorkspaceOnboardingState>;
+  completeIfAlreadyRemoved?: boolean;
 }): { completed: boolean; updated: boolean; reason: string } {
   const wsDir = agentWorkspaceDir(params.agentId);
   const bootstrapPath = path.join(wsDir, 'BOOTSTRAP.md');
-  if (!fs.existsSync(bootstrapPath)) {
-    return { completed: false, updated: false, reason: 'BOOTSTRAP.md absent' };
-  }
-
   const statePath = resolveWorkspaceStatePath(wsDir);
   const state = readWorkspaceOnboardingState(statePath);
+  const bootstrapExists = fs.existsSync(bootstrapPath);
+  if (!bootstrapExists) {
+    if (!params.completeIfAlreadyRemoved || state.onboardingCompletedAt) {
+      return {
+        completed: false,
+        updated: false,
+        reason: 'BOOTSTRAP.md absent',
+      };
+    }
+  }
+
   try {
-    fs.unlinkSync(bootstrapPath);
+    if (bootstrapExists) {
+      fs.unlinkSync(bootstrapPath);
+    }
     writeWorkspaceOnboardingState(statePath, {
       ...state,
       ...params.statePatch,
@@ -560,6 +570,7 @@ export function completeHatchingAfterMessageSend(params: {
   const completion = completeHatchingByRemovingBootstrap({
     agentId: params.agentId,
     reason: 'message sent',
+    completeIfAlreadyRemoved: true,
   });
   return { ...completion, updated: completion.updated || updated };
 }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -121,8 +121,14 @@ export interface WorkspaceNodeModulesLinkOptions {
 interface WorkspaceOnboardingState {
   version: typeof WORKSPACE_STATE_VERSION;
   bootstrapSeededAt?: string;
+  onboardingStartedAt?: string;
   onboardingCompletedAt?: string;
   hatchingTurnsWithoutMessage?: number;
+}
+
+export interface WorkspaceOnboardingStartState {
+  eventType: 'onboarding.start' | 'onboarding.continue';
+  onboardingStartedAt?: string;
 }
 
 export interface WorkspaceOnboardingTransition {
@@ -158,6 +164,7 @@ function readWorkspaceOnboardingState(
     const raw = fs.readFileSync(statePath, 'utf-8');
     const parsed = JSON.parse(raw) as {
       bootstrapSeededAt?: unknown;
+      onboardingStartedAt?: unknown;
       onboardingCompletedAt?: unknown;
       hatchingTurnsWithoutMessage?: unknown;
     };
@@ -169,6 +176,10 @@ function readWorkspaceOnboardingState(
       bootstrapSeededAt:
         typeof parsed.bootstrapSeededAt === 'string'
           ? parsed.bootstrapSeededAt
+          : undefined,
+      onboardingStartedAt:
+        typeof parsed.onboardingStartedAt === 'string'
+          ? parsed.onboardingStartedAt
           : undefined,
       onboardingCompletedAt:
         typeof parsed.onboardingCompletedAt === 'string'
@@ -442,6 +453,41 @@ function cleanMarkdownInline(value: string | undefined): string {
     .replace(/\s+/g, ' ')
     .replace(/[<>]/g, '')
     .trim();
+}
+
+export function claimWorkspaceOnboardingStart(params: {
+  agentId: string;
+  startedAt?: string;
+}): WorkspaceOnboardingStartState {
+  const wsDir = agentWorkspaceDir(params.agentId);
+  const statePath = resolveWorkspaceStatePath(wsDir);
+  const state = readWorkspaceOnboardingState(statePath);
+  if (state.onboardingStartedAt) {
+    return {
+      eventType: 'onboarding.continue',
+      onboardingStartedAt: state.onboardingStartedAt,
+    };
+  }
+
+  const onboardingStartedAt =
+    cleanMarkdownInline(params.startedAt) || new Date().toISOString();
+  try {
+    writeWorkspaceOnboardingState(statePath, {
+      ...state,
+      version: WORKSPACE_STATE_VERSION,
+      onboardingStartedAt,
+    });
+  } catch (error) {
+    logger.warn(
+      { agentId: params.agentId, error },
+      'Failed to mark onboarding start',
+    );
+  }
+
+  return {
+    eventType: 'onboarding.start',
+    onboardingStartedAt,
+  };
 }
 
 function completeHatchingByRemovingBootstrap(params: {

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -9836,7 +9836,7 @@ describe('gateway HTTP server', () => {
     ]);
   });
 
-  test('persists streamed assistant drafts before tool calls in activity traces', async () => {
+  test('does not persist streamed assistant drafts before tool calls in activity traces', async () => {
     const state = await importFreshHealth();
     state.handleGatewayMessage.mockImplementationOnce(
       async (request: {
@@ -9905,7 +9905,6 @@ describe('gateway HTTP server', () => {
       42,
       expect.objectContaining({
         steps: [
-          { kind: 'draft', text: 'I need a location first.' },
           {
             kind: 'tool',
             toolName: 'message',

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -9836,7 +9836,7 @@ describe('gateway HTTP server', () => {
     ]);
   });
 
-  test('does not persist streamed assistant drafts before tool calls in activity traces', async () => {
+  test('persists streamed assistant drafts before tool calls in activity traces', async () => {
     const state = await importFreshHealth();
     state.handleGatewayMessage.mockImplementationOnce(
       async (request: {
@@ -9905,6 +9905,7 @@ describe('gateway HTTP server', () => {
       42,
       expect.objectContaining({
         steps: [
+          { kind: 'draft', text: 'I need a location first.' },
           {
             kind: 'tool',
             toolName: 'message',

--- a/tests/gateway-service.bootstrap-autostart.test.ts
+++ b/tests/gateway-service.bootstrap-autostart.test.ts
@@ -265,6 +265,79 @@ test('ensureGatewayBootstrapAutostart stores prelude and bootstrap opener once p
   expect(getGatewayHistory(sessionId, 10).history).toHaveLength(2);
 });
 
+test('ensureGatewayBootstrapAutostart records terminal hatching audit when a post-hatching hook throws', async () => {
+  setupHome();
+
+  runAgentMock.mockResolvedValue({
+    status: 'success',
+    result: 'I sent the welcome message.',
+    toolsUsed: ['message'],
+    toolExecutions: [
+      {
+        name: 'message',
+        arguments: JSON.stringify({
+          action: 'send',
+          to: 'ben@example.com',
+          subject: 'HybridClaw release support is ready',
+          content: 'Welcome to HybridClaw.',
+        }),
+        result: JSON.stringify({
+          ok: true,
+          action: 'send',
+          channelId: 'ben@example.com',
+          transport: 'email',
+          subject: 'HybridClaw release support is ready',
+        }),
+        durationMs: 12,
+      },
+    ],
+  });
+  pluginManagerMock.notifyMemoryWrites.mockRejectedValueOnce(
+    new Error('memory hook failed after hatching'),
+  );
+
+  const { getRecentStructuredAuditForSession, initDatabase } = await import(
+    '../src/memory/db.ts'
+  );
+  const { ensureGatewayBootstrapAutostart } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.ts');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+
+  initDatabase({ quiet: true });
+
+  const sessionId =
+    'agent:main:channel:web:chat:dm:peer:bootstrap-terminal-failure';
+  const workspaceDir = agentWorkspaceDir('main');
+  await ensureGatewayBootstrapAutostart({ sessionId });
+
+  expect(fs.existsSync(path.join(workspaceDir, 'BOOTSTRAP.md'))).toBe(false);
+  const storedSession = memoryService.getSessionById(sessionId);
+  const auditRows = getRecentStructuredAuditForSession(
+    storedSession?.id || sessionId,
+    100,
+  );
+  const completeEvents = auditRows.filter(
+    (row) => row.event_type === 'onboarding.complete',
+  );
+  const assistantMessageEvents = auditRows.filter(
+    (row) => row.event_type === 'onboarding.assistant_message',
+  );
+
+  expect(completeEvents).toHaveLength(1);
+  expect(assistantMessageEvents).toHaveLength(0);
+  expect(JSON.parse(String(completeEvents[0]?.payload || '{}'))).toMatchObject(
+    {
+      type: 'onboarding.complete',
+      workspaceAgentId: 'main',
+      source: 'gateway.bootstrap',
+      bootstrapFile: 'BOOTSTRAP.md',
+      gatewayRule: 'message_send',
+    },
+  );
+});
+
 test('ensureGatewayBootstrapAutostart records later onboarding turns as continue', async () => {
   setupHome();
 

--- a/tests/gateway-service.bootstrap-autostart.test.ts
+++ b/tests/gateway-service.bootstrap-autostart.test.ts
@@ -321,12 +321,26 @@ test('ensureGatewayBootstrapAutostart records terminal hatching audit when a pos
   const completeEvents = auditRows.filter(
     (row) => row.event_type === 'onboarding.complete',
   );
+  const mailEvents = auditRows.filter(
+    (row) => row.event_type === 'onboarding.mail',
+  );
   const assistantMessageEvents = auditRows.filter(
     (row) => row.event_type === 'onboarding.assistant_message',
   );
 
   expect(completeEvents).toHaveLength(1);
+  expect(mailEvents).toHaveLength(1);
   expect(assistantMessageEvents).toHaveLength(0);
+  expect(JSON.parse(String(mailEvents[0]?.payload || '{}'))).toMatchObject({
+    type: 'onboarding.mail',
+    workspaceAgentId: 'main',
+    source: 'gateway.bootstrap',
+    bootstrapFile: 'BOOTSTRAP.md',
+    recipient: '***EMAIL_REDACTED***',
+    subject: 'HybridClaw release support is ready',
+    transport: 'email',
+    contentLength: expect.any(Number),
+  });
   expect(JSON.parse(String(completeEvents[0]?.payload || '{}'))).toMatchObject(
     {
       type: 'onboarding.complete',
@@ -336,6 +350,7 @@ test('ensureGatewayBootstrapAutostart records terminal hatching audit when a pos
       gatewayRule: 'message_send',
     },
   );
+  expect(mailEvents[0]?.seq ?? 0).toBeLessThan(completeEvents[0]?.seq ?? 0);
 });
 
 test('ensureGatewayBootstrapAutostart records later onboarding turns as continue', async () => {

--- a/tests/gateway-service.bootstrap-autostart.test.ts
+++ b/tests/gateway-service.bootstrap-autostart.test.ts
@@ -17,10 +17,34 @@ const {
   pluginManagerMock,
 } = vi.hoisted(() => {
   const pluginManager = {
+    collectPromptContextDetails: vi.fn(async () => ({
+      sections: [],
+      pluginIds: [],
+      replacesBuiltInMemory: false,
+    })),
+    collectPromptContext: vi.fn(async () => []),
     getToolDefinitions: vi.fn(() => []),
+    getMemoryLayerBehavior: vi.fn(async () => ({
+      replacesBuiltInMemory: false,
+    })),
+    hasMiddleware: vi.fn(() => false),
+    applyMiddleware: vi.fn(async () => ({
+      userContent: '',
+      resultText: '',
+      blocked: false,
+      events: [],
+    })),
+    hasOutputGuards: vi.fn(() => false),
+    applyOutputGuards: vi.fn(async (context: { resultText: string }) => ({
+      resultText: context.resultText,
+      blocked: false,
+      events: [],
+    })),
     notifyBeforeAgentStart: vi.fn(async () => {}),
+    notifyAgentEnd: vi.fn(async () => {}),
     notifyMemoryWrites: vi.fn(async () => {}),
     notifySessionStart: vi.fn(async () => {}),
+    notifyTurnComplete: vi.fn(async () => {}),
   };
   return {
     runAgentMock: vi.fn(),
@@ -62,10 +86,19 @@ const { setupHome } = setupGatewayTest({
     fetchHybridAIAccountChatbotIdMock.mockClear();
     ensurePluginManagerInitializedMock.mockClear();
     setPluginInboundMessageDispatcherMock.mockClear();
+    pluginManagerMock.collectPromptContextDetails.mockClear();
+    pluginManagerMock.collectPromptContext.mockClear();
     pluginManagerMock.getToolDefinitions.mockClear();
+    pluginManagerMock.getMemoryLayerBehavior.mockClear();
+    pluginManagerMock.hasMiddleware.mockClear();
+    pluginManagerMock.applyMiddleware.mockClear();
+    pluginManagerMock.hasOutputGuards.mockClear();
+    pluginManagerMock.applyOutputGuards.mockClear();
     pluginManagerMock.notifyBeforeAgentStart.mockClear();
+    pluginManagerMock.notifyAgentEnd.mockClear();
     pluginManagerMock.notifyMemoryWrites.mockClear();
     pluginManagerMock.notifySessionStart.mockClear();
+    pluginManagerMock.notifyTurnComplete.mockClear();
   },
 });
 
@@ -230,6 +263,79 @@ test('ensureGatewayBootstrapAutostart stores prelude and bootstrap opener once p
   await ensureGatewayBootstrapAutostart({ sessionId });
   expect(runAgentMock).toHaveBeenCalledTimes(1);
   expect(getGatewayHistory(sessionId, 10).history).toHaveLength(2);
+});
+
+test('ensureGatewayBootstrapAutostart records later onboarding turns as continue', async () => {
+  setupHome();
+
+  runAgentMock.mockResolvedValue({
+    status: 'success',
+    result: 'Still onboarding.',
+    toolsUsed: [],
+    toolExecutions: [],
+  });
+
+  const {
+    getRecentStructuredAuditForSession,
+    getSessionById,
+    initDatabase,
+  } = await import('../src/memory/db.ts');
+  const { ensureGatewayBootstrapAutostart } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  const { handleGatewayMessage } = await import(
+    '../src/gateway/gateway-chat-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  const sessionId =
+    'agent:main:channel:web:chat:dm:peer:bootstrap-continue-audit';
+  await ensureGatewayBootstrapAutostart({ sessionId });
+  await handleGatewayMessage({
+    sessionId,
+    guildId: null,
+    channelId: 'web',
+    userId: 'user-1',
+    username: 'user',
+    agentId: 'main',
+    content: 'My email is ben@example.com',
+    chatbotId: 'bot-1',
+  });
+
+  const storedSessionId = getSessionById(sessionId)?.id || sessionId;
+  const auditRows = getRecentStructuredAuditForSession(storedSessionId, 100);
+  const onboardingTurnEvents = auditRows
+    .filter(
+      (row) =>
+        row.event_type === 'onboarding.start' ||
+        row.event_type === 'onboarding.continue',
+    )
+    .sort((left, right) => left.seq - right.seq);
+
+  expect(onboardingTurnEvents.map((row) => row.event_type)).toEqual([
+    'onboarding.start',
+    'onboarding.continue',
+  ]);
+  const startPayload = JSON.parse(
+    String(onboardingTurnEvents[0]?.payload || '{}'),
+  );
+  const continuePayload = JSON.parse(
+    String(onboardingTurnEvents[1]?.payload || '{}'),
+  );
+  expect(startPayload).toMatchObject({
+    type: 'onboarding.start',
+    workspaceAgentId: 'main',
+    source: 'gateway.bootstrap',
+    bootstrapFile: 'BOOTSTRAP.md',
+  });
+  expect(continuePayload).toMatchObject({
+    type: 'onboarding.continue',
+    workspaceAgentId: 'main',
+    source: 'gateway.chat',
+    bootstrapFile: 'BOOTSTRAP.md',
+    onboardingStartedAt: startPayload.onboardingStartedAt,
+  });
 });
 
 test('ensureGatewayBootstrapAutostart audits onboarding abort when bootstrap is already absent', async () => {

--- a/tests/gateway-service.context-references.test.ts
+++ b/tests/gateway-service.context-references.test.ts
@@ -626,7 +626,7 @@ test('handleGatewayMessage completes hatching when the agent deletes BOOTSTRAP.m
     return {
       status: 'success',
       result: 'I sent the welcome message and cleaned up onboarding.',
-      toolsUsed: ['message', 'delete'],
+      toolsUsed: ['message', 'edit', 'write', 'memory', 'delete'],
       toolExecutions: [
         {
           name: 'message',
@@ -644,6 +644,35 @@ test('handleGatewayMessage completes hatching when the agent deletes BOOTSTRAP.m
             subject: 'HybridClaw release support is ready',
           }),
           durationMs: 12,
+        },
+        {
+          name: 'edit',
+          arguments: JSON.stringify({
+            path: path.join(workspaceDir, 'USER.md'),
+            old: 'Name: TBD',
+            new: 'Name: Ben',
+          }),
+          result: 'Edited USER.md',
+          durationMs: 2,
+        },
+        {
+          name: 'write',
+          arguments: JSON.stringify({
+            path: path.join(workspaceDir, 'MEMORY.md'),
+            content: 'Remember Ben prefers release support.',
+          }),
+          result: 'Wrote MEMORY.md',
+          durationMs: 3,
+        },
+        {
+          name: 'memory',
+          arguments: JSON.stringify({
+            action: 'write',
+            file_path: 'memory/2026-07-06.md',
+            content: 'Ben completed onboarding.',
+          }),
+          result: 'Saved memory.',
+          durationMs: 4,
         },
         {
           name: 'delete',
@@ -683,13 +712,47 @@ test('handleGatewayMessage completes hatching when the agent deletes BOOTSTRAP.m
   const mailEvent = auditRows.find(
     (row) => row.event_type === 'onboarding.mail',
   );
+  const filesEvent = auditRows.find(
+    (row) => row.event_type === 'onboarding.files',
+  );
   const completeEvent = auditRows.find(
     (row) => row.event_type === 'onboarding.complete',
   );
 
   expect(assistantMessageEvent).toBeTruthy();
+  expect(filesEvent).toBeTruthy();
   expect(mailEvent).toBeTruthy();
   expect(completeEvent).toBeTruthy();
+  expect(JSON.parse(String(filesEvent?.payload || '{}'))).toMatchObject({
+    type: 'onboarding.files',
+    workspaceAgentId: 'research',
+    source: 'gateway.chat',
+    bootstrapFile: 'BOOTSTRAP.md',
+    fileCount: 4,
+    actions: ['delete', 'edit', 'write'],
+    files: [
+      {
+        action: 'edit',
+        toolName: 'edit',
+        path: 'USER.md',
+      },
+      {
+        action: 'write',
+        toolName: 'write',
+        path: 'MEMORY.md',
+      },
+      {
+        action: 'write',
+        toolName: 'memory',
+        path: 'memory/2026-07-06.md',
+      },
+      {
+        action: 'delete',
+        toolName: 'delete',
+        path: 'BOOTSTRAP.md',
+      },
+    ],
+  });
   expect(JSON.parse(String(completeEvent?.payload || '{}'))).toMatchObject({
     type: 'onboarding.complete',
     workspaceAgentId: 'research',
@@ -698,6 +761,9 @@ test('handleGatewayMessage completes hatching when the agent deletes BOOTSTRAP.m
     gatewayRule: 'message_send',
   });
   expect(assistantMessageEvent?.seq ?? 0).toBeLessThan(
+    filesEvent?.seq ?? 0,
+  );
+  expect(filesEvent?.seq ?? 0).toBeLessThan(
     mailEvent?.seq ?? 0,
   );
   expect(mailEvent?.seq ?? 0).toBeLessThan(

--- a/tests/gateway-service.context-references.test.ts
+++ b/tests/gateway-service.context-references.test.ts
@@ -457,6 +457,9 @@ test('handleGatewayMessage completes hatching after the welcome message send', a
     gatewayRule: 'message_send',
     reason: 'message sent',
   });
+  expect(assistantMessageEvent?.seq ?? 0).toBeLessThan(
+    completeEvent?.seq ?? 0,
+  );
 });
 
 test('handleGatewayMessage completes hatching after three turns without a message send', async () => {
@@ -547,6 +550,13 @@ test('handleGatewayMessage completes hatching after three turns without a messag
   const abortEvent = auditRows.find(
     (row) => row.event_type === 'onboarding.abort',
   );
+  const onboardingTurnEvents = auditRows
+    .filter(
+      (row) =>
+        row.event_type === 'onboarding.start' ||
+        row.event_type === 'onboarding.continue',
+    )
+    .sort((left, right) => left.seq - right.seq);
   const userReplyEvents = auditRows.filter(
     (row) => row.event_type === 'onboarding.user_reply',
   );
@@ -554,6 +564,30 @@ test('handleGatewayMessage completes hatching after three turns without a messag
     (row) => row.event_type === 'onboarding.assistant_message',
   );
   expect(abortEvent).toBeTruthy();
+  expect(onboardingTurnEvents.map((row) => row.event_type)).toEqual([
+    'onboarding.start',
+    'onboarding.continue',
+    'onboarding.continue',
+  ]);
+  const startPayload = JSON.parse(
+    String(onboardingTurnEvents[0]?.payload || '{}'),
+  );
+  expect(startPayload).toMatchObject({
+    type: 'onboarding.start',
+    workspaceAgentId: 'research',
+    source: 'gateway.chat',
+    bootstrapFile: 'BOOTSTRAP.md',
+  });
+  expect(startPayload.onboardingStartedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+  for (const row of onboardingTurnEvents.slice(1)) {
+    expect(JSON.parse(String(row.payload || '{}'))).toMatchObject({
+      type: 'onboarding.continue',
+      workspaceAgentId: 'research',
+      source: 'gateway.chat',
+      bootstrapFile: 'BOOTSTRAP.md',
+      onboardingStartedAt: startPayload.onboardingStartedAt,
+    });
+  }
   expect(userReplyEvents).toHaveLength(3);
   expect(assistantMessageEvents).toHaveLength(3);
   expect(JSON.parse(String(abortEvent?.payload || '{}'))).toMatchObject({

--- a/tests/gateway-service.context-references.test.ts
+++ b/tests/gateway-service.context-references.test.ts
@@ -462,6 +462,103 @@ test('handleGatewayMessage completes hatching after the welcome message send', a
   );
 });
 
+test('handleGatewayMessage records terminal hatching audit when persistence fails after completion', async () => {
+  setupHome();
+
+  runAgentMock.mockResolvedValue({
+    status: 'success',
+    result: 'I sent the welcome message.',
+    toolsUsed: ['message'],
+    toolExecutions: [
+      {
+        name: 'message',
+        arguments: JSON.stringify({
+          action: 'send',
+          to: 'ben@example.com',
+          subject: 'HybridClaw release support is ready',
+          content: 'Welcome to HybridClaw.',
+        }),
+        result: JSON.stringify({
+          ok: true,
+          action: 'send',
+          channelId: 'ben@example.com',
+          transport: 'email',
+          subject: 'HybridClaw release support is ready',
+        }),
+        durationMs: 12,
+      },
+    ],
+  });
+
+  const { getRecentStructuredAuditForSession, initDatabase } = await import(
+    '../src/memory/db.ts'
+  );
+  const { memoryService } = await import(
+    '../src/memory/memory-service.ts'
+  );
+  const { handleGatewayMessage } = await import(
+    '../src/gateway/gateway-chat-service.ts'
+  );
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.ts');
+  const { ensureBootstrapFiles } = await import('../src/workspace.ts');
+
+  initDatabase({ quiet: true });
+  ensureBootstrapFiles('research');
+
+  const workspaceDir = agentWorkspaceDir('research');
+  const bootstrapPath = path.join(workspaceDir, 'BOOTSTRAP.md');
+  const storeTurnSpy = vi
+    .spyOn(memoryService, 'storeTurn')
+    .mockImplementation(() => {
+      throw new Error('store failed after hatching');
+    });
+
+  let result: Awaited<ReturnType<typeof handleGatewayMessage>> | null = null;
+  try {
+    result = await handleGatewayMessage({
+      sessionId: 'session-onboarding-complete-store-failure',
+      guildId: null,
+      channelId: 'web',
+      userId: 'user-1',
+      username: 'user',
+      agentId: 'research',
+      content: 'I am Ben and my email is ben@example.com.',
+      chatbotId: 'bot-1',
+    });
+  } finally {
+    storeTurnSpy.mockRestore();
+  }
+
+  expect(result?.status).toBe('error');
+  expect(result?.error).toContain('store failed after hatching');
+  expect(fs.existsSync(bootstrapPath)).toBe(false);
+
+  const auditRows = getRecentStructuredAuditForSession(
+    'session-onboarding-complete-store-failure',
+    100,
+  );
+  const completeEvents = auditRows.filter(
+    (row) => row.event_type === 'onboarding.complete',
+  );
+  const assistantMessageEvents = auditRows.filter(
+    (row) => row.event_type === 'onboarding.assistant_message',
+  );
+  const turnEndEvent = auditRows.find((row) => row.event_type === 'turn.end');
+
+  expect(completeEvents).toHaveLength(1);
+  expect(assistantMessageEvents).toHaveLength(0);
+  expect(JSON.parse(String(completeEvents[0]?.payload || '{}'))).toMatchObject(
+    {
+      type: 'onboarding.complete',
+      workspaceAgentId: 'research',
+      source: 'gateway.chat',
+      bootstrapFile: 'BOOTSTRAP.md',
+      gatewayRule: 'message_send',
+    },
+  );
+  expect(completeEvents[0]?.seq ?? 0).toBeLessThan(turnEndEvent?.seq ?? 0);
+});
+
 test('handleGatewayMessage completes hatching after three turns without a message send', async () => {
   setupHome();
 

--- a/tests/gateway-service.context-references.test.ts
+++ b/tests/gateway-service.context-references.test.ts
@@ -559,6 +559,114 @@ test('handleGatewayMessage records terminal hatching audit when persistence fail
   expect(completeEvents[0]?.seq ?? 0).toBeLessThan(turnEndEvent?.seq ?? 0);
 });
 
+test('handleGatewayMessage completes hatching when the agent deletes BOOTSTRAP.md after sending the welcome message', async () => {
+  setupHome();
+
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  updateRuntimeConfig((draft) => {
+    draft.hybridai.defaultModel = 'gpt-5-mini';
+    draft.hybridai.onboardingModel = 'gpt-5.5';
+  });
+  const { getRecentStructuredAuditForSession, initDatabase } = await import(
+    '../src/memory/db.ts'
+  );
+  const { handleGatewayMessage } = await import(
+    '../src/gateway/gateway-chat-service.ts'
+  );
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.ts');
+  const { ensureBootstrapFiles } = await import('../src/workspace.ts');
+
+  initDatabase({ quiet: true });
+  ensureBootstrapFiles('research');
+
+  const workspaceDir = agentWorkspaceDir('research');
+  const bootstrapPath = path.join(workspaceDir, 'BOOTSTRAP.md');
+  const statePath = path.join(
+    workspaceDir,
+    '.hybridclaw',
+    'workspace-state.json',
+  );
+  expect(fs.existsSync(bootstrapPath)).toBe(true);
+
+  runAgentMock.mockImplementationOnce(async () => {
+    fs.unlinkSync(bootstrapPath);
+    return {
+      status: 'success',
+      result: 'I sent the welcome message and cleaned up onboarding.',
+      toolsUsed: ['message', 'delete'],
+      toolExecutions: [
+        {
+          name: 'message',
+          arguments: JSON.stringify({
+            action: 'send',
+            to: 'ben@example.com',
+            subject: 'HybridClaw release support is ready',
+            content: 'Welcome to HybridClaw.',
+          }),
+          result: JSON.stringify({
+            ok: true,
+            action: 'send',
+            channelId: 'ben@example.com',
+            transport: 'email',
+            subject: 'HybridClaw release support is ready',
+          }),
+          durationMs: 12,
+        },
+        {
+          name: 'delete',
+          arguments: JSON.stringify({ path: bootstrapPath }),
+          result: `Deleted ${bootstrapPath}`,
+          durationMs: 1,
+        },
+      ],
+    };
+  });
+
+  const result = await handleGatewayMessage({
+    sessionId: 'session-onboarding-agent-delete-complete',
+    guildId: null,
+    channelId: 'web',
+    userId: 'user-1',
+    username: 'user',
+    agentId: 'research',
+    content: 'I am Ben and my email is ben@example.com.',
+    chatbotId: 'bot-1',
+  });
+
+  expect(result.status).toBe('success');
+  expect(fs.existsSync(bootstrapPath)).toBe(false);
+  expect(JSON.parse(fs.readFileSync(statePath, 'utf-8'))).toMatchObject({
+    hatchingTurnsWithoutMessage: 0,
+    onboardingCompletedAt: expect.stringMatching(/\d{4}-\d{2}-\d{2}T/),
+  });
+
+  const auditRows = getRecentStructuredAuditForSession(
+    'session-onboarding-agent-delete-complete',
+    100,
+  );
+  const assistantMessageEvent = auditRows.find(
+    (row) => row.event_type === 'onboarding.assistant_message',
+  );
+  const completeEvent = auditRows.find(
+    (row) => row.event_type === 'onboarding.complete',
+  );
+
+  expect(assistantMessageEvent).toBeTruthy();
+  expect(completeEvent).toBeTruthy();
+  expect(JSON.parse(String(completeEvent?.payload || '{}'))).toMatchObject({
+    type: 'onboarding.complete',
+    workspaceAgentId: 'research',
+    source: 'gateway.chat',
+    bootstrapFile: 'BOOTSTRAP.md',
+    gatewayRule: 'message_send',
+  });
+  expect(assistantMessageEvent?.seq ?? 0).toBeLessThan(
+    completeEvent?.seq ?? 0,
+  );
+});
+
 test('handleGatewayMessage completes hatching after three turns without a message send', async () => {
   setupHome();
 

--- a/tests/gateway-service.context-references.test.ts
+++ b/tests/gateway-service.context-references.test.ts
@@ -418,9 +418,13 @@ test('handleGatewayMessage completes hatching after the welcome message send', a
   const assistantMessageEvent = auditRows.find(
     (row) => row.event_type === 'onboarding.assistant_message',
   );
+  const mailEvent = auditRows.find(
+    (row) => row.event_type === 'onboarding.mail',
+  );
   expect(startEvent).toBeTruthy();
   expect(userReplyEvent).toBeTruthy();
   expect(assistantMessageEvent).toBeTruthy();
+  expect(mailEvent).toBeTruthy();
   expect(completeEvent).toBeTruthy();
   expect(JSON.parse(String(startEvent?.payload || '{}'))).toMatchObject({
     type: 'onboarding.start',
@@ -457,7 +461,21 @@ test('handleGatewayMessage completes hatching after the welcome message send', a
     gatewayRule: 'message_send',
     reason: 'message sent',
   });
+  expect(JSON.parse(String(mailEvent?.payload || '{}'))).toMatchObject({
+    type: 'onboarding.mail',
+    workspaceAgentId: 'research',
+    source: 'gateway.chat',
+    bootstrapFile: 'BOOTSTRAP.md',
+    recipient: '***EMAIL_REDACTED***',
+    subject: 'HybridClaw release support is ready',
+    transport: 'email',
+    contentLength: expect.any(Number),
+    reason: 'onboarding welcome mail sent',
+  });
   expect(assistantMessageEvent?.seq ?? 0).toBeLessThan(
+    mailEvent?.seq ?? 0,
+  );
+  expect(mailEvent?.seq ?? 0).toBeLessThan(
     completeEvent?.seq ?? 0,
   );
 });
@@ -543,9 +561,13 @@ test('handleGatewayMessage records terminal hatching audit when persistence fail
   const assistantMessageEvents = auditRows.filter(
     (row) => row.event_type === 'onboarding.assistant_message',
   );
+  const mailEvents = auditRows.filter(
+    (row) => row.event_type === 'onboarding.mail',
+  );
   const turnEndEvent = auditRows.find((row) => row.event_type === 'turn.end');
 
   expect(completeEvents).toHaveLength(1);
+  expect(mailEvents).toHaveLength(1);
   expect(assistantMessageEvents).toHaveLength(0);
   expect(JSON.parse(String(completeEvents[0]?.payload || '{}'))).toMatchObject(
     {
@@ -556,6 +578,15 @@ test('handleGatewayMessage records terminal hatching audit when persistence fail
       gatewayRule: 'message_send',
     },
   );
+  expect(JSON.parse(String(mailEvents[0]?.payload || '{}'))).toMatchObject({
+    type: 'onboarding.mail',
+    workspaceAgentId: 'research',
+    source: 'gateway.chat',
+    bootstrapFile: 'BOOTSTRAP.md',
+    transport: 'email',
+    contentLength: expect.any(Number),
+  });
+  expect(mailEvents[0]?.seq ?? 0).toBeLessThan(completeEvents[0]?.seq ?? 0);
   expect(completeEvents[0]?.seq ?? 0).toBeLessThan(turnEndEvent?.seq ?? 0);
 });
 
@@ -649,11 +680,15 @@ test('handleGatewayMessage completes hatching when the agent deletes BOOTSTRAP.m
   const assistantMessageEvent = auditRows.find(
     (row) => row.event_type === 'onboarding.assistant_message',
   );
+  const mailEvent = auditRows.find(
+    (row) => row.event_type === 'onboarding.mail',
+  );
   const completeEvent = auditRows.find(
     (row) => row.event_type === 'onboarding.complete',
   );
 
   expect(assistantMessageEvent).toBeTruthy();
+  expect(mailEvent).toBeTruthy();
   expect(completeEvent).toBeTruthy();
   expect(JSON.parse(String(completeEvent?.payload || '{}'))).toMatchObject({
     type: 'onboarding.complete',
@@ -663,6 +698,9 @@ test('handleGatewayMessage completes hatching when the agent deletes BOOTSTRAP.m
     gatewayRule: 'message_send',
   });
   expect(assistantMessageEvent?.seq ?? 0).toBeLessThan(
+    mailEvent?.seq ?? 0,
+  );
+  expect(mailEvent?.seq ?? 0).toBeLessThan(
     completeEvent?.seq ?? 0,
   );
 });

--- a/tests/prompt-hooks.tool-summary.test.ts
+++ b/tests/prompt-hooks.tool-summary.test.ts
@@ -136,6 +136,9 @@ test('buildSystemPromptFromHooks adds mandatory routing instructions for availab
     'Default: do not narrate routine, low-risk tool calls; just call the tool.',
   );
   expect(prompt).toContain(
+    'When you call any tool, emit no user-facing assistant prose in that same response. Make the tool call with empty assistant content, then write the user-facing answer after the tool result is available.',
+  );
+  expect(prompt).toContain(
     'If the user has already asked you to perform an action, do not ask for a separate natural-language "yes" just to trigger approvals; attempt the tool call and let the runtime approval flow interrupt if approval is required.',
   );
   expect(prompt).toContain(

--- a/tests/workspace-bootstrap.test.ts
+++ b/tests/workspace-bootstrap.test.ts
@@ -535,6 +535,44 @@ describe('workspace bootstrap lifecycle', () => {
     expect(state.hatchingTurnsWithoutMessage).toBe(0);
   });
 
+  test('completes hatching after a message send when BOOTSTRAP.md was already deleted', async () => {
+    const homeDir = makeTempDir('hybridclaw-home-');
+    const unrelatedCwd = makeTempDir('hybridclaw-cwd-');
+    vi.stubEnv('HOME', homeDir);
+    process.chdir(unrelatedCwd);
+
+    const workspace = await import('../src/workspace.js');
+    const ipc = await import('../src/infra/ipc.js');
+
+    workspace.ensureBootstrapFiles('agent-test');
+
+    const workspaceDir = ipc.agentWorkspaceDir('agent-test');
+    const bootstrapPath = path.join(workspaceDir, 'BOOTSTRAP.md');
+    expect(fs.existsSync(bootstrapPath)).toBe(true);
+
+    fs.writeFileSync(
+      path.join(workspaceDir, 'USER.md'),
+      completedUserMarkdown(),
+      'utf-8',
+    );
+    fs.unlinkSync(bootstrapPath);
+
+    const completion = workspace.completeHatchingAfterMessageSend({
+      agentId: 'agent-test',
+      recipient: 'ben@example.com',
+      subject: 'Welcome',
+    });
+
+    expect(completion).toMatchObject({
+      completed: true,
+      reason: 'message sent',
+    });
+    expect(fs.existsSync(bootstrapPath)).toBe(false);
+    const state = readWorkspaceState(workspaceDir);
+    expect(state.onboardingCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+    expect(state.hatchingTurnsWithoutMessage).toBe(0);
+  });
+
   test('keeps BOOTSTRAP.md while the welcome message is still pending', async () => {
     const homeDir = makeTempDir('hybridclaw-home-');
     const unrelatedCwd = makeTempDir('hybridclaw-cwd-');


### PR DESCRIPTION
## Summary
- record onboarding.start once per workspace onboarding lifecycle and emit onboarding.continue for later onboarding turns
- defer onboarding.complete/onboarding.abort audit emission until after the assistant message audit
- add regression coverage for bootstrap-to-chat continuation, no-message fallback, and completion ordering

## Root Cause
onboarding.start was emitted at the start of every BOOTSTRAP.md turn, and terminal onboarding audit events were emitted as soon as hatching completion was detected before the gateway persisted and audited the assistant reply.

## Validation
- npm run lint
- ./node_modules/.bin/vitest run tests/gateway-service.context-references.test.ts -t "handleGatewayMessage completes hatching after the welcome message send"
- ./node_modules/.bin/vitest run tests/gateway-service.context-references.test.ts -t "handleGatewayMessage completes hatching after three turns without a message send"
- ./node_modules/.bin/vitest run tests/gateway-service.bootstrap-autostart.test.ts -t "ensureGatewayBootstrapAutostart records later onboarding turns as continue"
- ./node_modules/.bin/tsc --noEmit
- git diff --check