### PR TITLE
[codex] Dispatch inbound A2A inbox messages

### DIFF
--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -193,6 +193,19 @@ export type ChatStreamEvent =
 
 export type ChatResultMessageRole = 'assistant' | 'approval' | 'command';
 
+export type A2ADeliveryState = 'pending' | 'delivered' | 'failed' | 'unknown';
+
+/**
+ * Describes an outbound A2A message a chat send produced, so the UI can render
+ * a live delivery-status chip and poll for its final state.
+ */
+export interface A2ADeliveryDescriptor {
+  messageId: string;
+  threadId: string;
+  recipientAgentId: string;
+  status: A2ADeliveryState;
+}
+
 export interface ChatStreamResult {
   status?: string;
   error?: string;
@@ -214,6 +227,7 @@ export interface ChatStreamResult {
   artifacts?: ChatArtifact[];
   apps?: Array<{ id: string; title: string; kind: 'web' | 'live' }>;
   toolsUsed?: string[];
+  a2aDelivery?: A2ADeliveryDescriptor | null;
 }
 
 export interface MediaItem {
@@ -260,4 +274,5 @@ export interface ChatMessage {
   addressedAgentPresentation?: AssistantPresentation | null;
   responseRating?: ResponseRatingValue | null;
   branchKey?: string | null;
+  a2aDelivery?: A2ADeliveryDescriptor | null;
 }

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -1,4 +1,5 @@
 import type {
+  A2ADeliveryStatusResponse,
   AdminA2AInboxResponse,
   AdminA2APairingPreviewResponse,
   AdminA2APairingStartRequest,
@@ -574,6 +575,17 @@ export function fetchA2AInbox(
   return requestJson<AdminA2AInboxResponse>(`/api/admin/a2a/inbox${search}`, {
     token,
   });
+}
+
+export function fetchA2ADeliveryStatus(
+  token: string,
+  messageId: string,
+): Promise<A2ADeliveryStatusResponse> {
+  const search = new URLSearchParams({ messageId }).toString();
+  return requestJson<A2ADeliveryStatusResponse>(
+    `/api/admin/a2a/outbox/status?${search}`,
+    { token },
+  );
 }
 
 export function revokeA2ATrustPeer(

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -1686,6 +1686,17 @@ export interface AdminA2AInboxResponse {
   messages: AdminA2AThreadMessage[];
 }
 
+export interface A2ADeliveryStatusResponse {
+  status: 'pending' | 'delivered' | 'failed' | 'unknown';
+  attempts?: number;
+  maxAttempts?: number;
+  lastError?: string;
+  lastStatusCode?: number;
+  deliveredAt?: string;
+  failedAt?: string;
+  nextAttemptAt?: string;
+}
+
 export interface AdminApprovalAgent {
   id: string;
   name: string | null;

--- a/console/src/routes/chat/a2a-delivery-chip.tsx
+++ b/console/src/routes/chat/a2a-delivery-chip.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import type {
+  A2ADeliveryDescriptor,
+  A2ADeliveryState,
+} from '../../api/chat-types';
+import { fetchA2ADeliveryStatus } from '../../api/client';
+import { cx } from '../../lib/cx';
+import css from './chat-page.module.css';
+
+const POLL_INTERVAL_MS = 2_000;
+// Stop polling after ~2 minutes; outbox retries back off well beyond a chat
+// viewer's attention span, and a page reload re-reads the persisted state.
+const MAX_POLLS = 60;
+
+function isTerminal(state: A2ADeliveryState): boolean {
+  return state === 'delivered' || state === 'failed';
+}
+
+const LABELS: Record<A2ADeliveryState, string> = {
+  pending: 'Sending…',
+  delivered: 'Delivered',
+  failed: 'Delivery failed',
+  unknown: 'Sent',
+};
+
+/**
+ * Live delivery-status chip for an outbound A2A chat send. Starts from the
+ * status the send returned and polls the outbox until the message reaches a
+ * terminal state, so the bubble stops looking like a dead end.
+ */
+export function A2ADeliveryChip(props: {
+  descriptor: A2ADeliveryDescriptor;
+  token: string;
+}) {
+  const { descriptor, token } = props;
+  const [state, setState] = useState<A2ADeliveryState>(descriptor.status);
+  const [detail, setDetail] = useState<string | null>(null);
+
+  useEffect(() => {
+    setState(descriptor.status);
+  }, [descriptor.status]);
+
+  useEffect(() => {
+    if (isTerminal(state)) return;
+    let cancelled = false;
+    let polls = 0;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const poll = async (): Promise<void> => {
+      polls += 1;
+      try {
+        const status = await fetchA2ADeliveryStatus(
+          token,
+          descriptor.messageId,
+        );
+        if (cancelled) return;
+        if (status.status !== 'unknown') {
+          setState(status.status);
+          setDetail(
+            status.status === 'failed'
+              ? status.lastError ||
+                  (status.lastStatusCode
+                    ? `HTTP ${status.lastStatusCode}`
+                    : null)
+              : null,
+          );
+        }
+        if (isTerminal(status.status) || polls >= MAX_POLLS) return;
+      } catch {
+        if (cancelled || polls >= MAX_POLLS) return;
+      }
+      timer = setTimeout(() => void poll(), POLL_INTERVAL_MS);
+    };
+
+    timer = setTimeout(() => void poll(), POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+    // descriptor.messageId identifies the send; state drives the terminal guard.
+  }, [descriptor.messageId, token, state]);
+
+  return (
+    <div
+      className={cx(
+        css.a2aDeliveryChip,
+        state === 'delivered' && css.a2aDeliveryChipDelivered,
+        state === 'failed' && css.a2aDeliveryChipFailed,
+      )}
+      role="status"
+      aria-live="polite"
+      title={detail ?? undefined}
+    >
+      <span
+        className={cx(
+          css.a2aDeliveryDot,
+          !isTerminal(state) && css.a2aDeliveryDotPulse,
+        )}
+      />
+      <span>{LABELS[state]}</span>
+      {detail ? (
+        <span className={css.a2aDeliveryDetail}>· {detail}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -2151,3 +2151,63 @@ aside[data-state="collapsed"] .chatSidebarContent {
     animation: none;
   }
 }
+
+/* Live delivery-status chip for outbound A2A chat sends. Sits under the command
+   bubble so the send stops reading as a dead end. */
+.a2aDeliveryChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-family: var(--font-sans, system-ui, sans-serif);
+  background: var(--accent-soft);
+  color: var(--muted-foreground);
+  border: 1px solid var(--line-strong);
+}
+
+.a2aDeliveryChipDelivered {
+  background: var(--success-soft);
+  color: var(--success-foreground);
+  border-color: var(--success-border);
+}
+
+.a2aDeliveryChipFailed {
+  background: var(--danger-soft);
+  color: var(--danger);
+  border-color: var(--danger-border);
+}
+
+.a2aDeliveryDot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: currentColor;
+  flex: none;
+}
+
+.a2aDeliveryDotPulse {
+  animation: a2aDeliveryPulse 1.2s ease-in-out infinite;
+}
+
+@keyframes a2aDeliveryPulse {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+.a2aDeliveryDetail {
+  opacity: 0.8;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .a2aDeliveryDotPulse {
+    animation: none;
+  }
+}

--- a/console/src/routes/chat/message-block.tsx
+++ b/console/src/routes/chat/message-block.tsx
@@ -20,6 +20,7 @@ import { stripAppBuildDirective } from '../../lib/app-seed';
 import { type ApprovalAction, copyToClipboard } from '../../lib/chat-helpers';
 import { cx } from '../../lib/cx';
 import { renderMarkdown } from '../../lib/markdown';
+import { A2ADeliveryChip } from './a2a-delivery-chip';
 import { findAgentMentions } from './agent-mention-display';
 import { ApprovalCard } from './approval-card';
 import css from './chat-page.module.css';
@@ -535,6 +536,9 @@ export const MessageBlock = memo(function MessageBlock(props: {
           ) : (
             msg.content
           )}
+          {msg.a2aDelivery ? (
+            <A2ADeliveryChip descriptor={msg.a2aDelivery} token={token} />
+          ) : null}
         </div>
       ) : null}
 

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -484,6 +484,7 @@ export function useChatStream(
           pendingApproval: finalApproval,
           responseRating: null,
           replayRequest: { content, media },
+          a2aDelivery: result.a2aDelivery ?? null,
         });
 
         setMessages((prev) => {

--- a/src/a2a/a2a-inbound.ts
+++ b/src/a2a/a2a-inbound.ts
@@ -3,8 +3,13 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import { getAgentById, listAgents } from '../agents/agent-registry.js';
 import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
+import { getRuntimeConfig } from '../config/runtime-config.js';
 import { GatewayRequestError } from '../errors/gateway-request-error.js';
 import { readRequestBody, sendJson } from '../gateway/gateway-http-utils.js';
+import {
+  normalizeHttpOrigin,
+  resolveForwardedRequestOrigin,
+} from '../gateway/gateway-url-utils.js';
 import {
   AgentIdentityValidationError,
   parseAgentIdentity,
@@ -152,6 +157,25 @@ function extractBearerToken(authorization: string | null | undefined): string {
 
 function normalizeAudience(url: URL): string {
   return new URL(url.pathname, url.origin).toString();
+}
+
+/**
+ * Resolve the delegation-token audience expected for an inbound A2A request.
+ *
+ * The HTTP router builds `url` from a fixed `http://localhost` base, but
+ * senders sign the token audience against our advertised Agent Card URL. Behind
+ * a TLS-terminating tunnel that URL uses the public `https://<host>` origin, so
+ * we must reconstruct the same origin the Agent Card advertises
+ * (`deployment.public_url` when set, otherwise the forwarded request origin)
+ * instead of trusting the localhost base. Otherwise the audience never matches
+ * and every inbound message is rejected with `JWT audience does not match`.
+ */
+function resolveInboundAudience(req: IncomingMessage, url: URL): string {
+  const configuredOrigin = normalizeHttpOrigin(
+    getRuntimeConfig().deployment.public_url,
+  );
+  const origin = configuredOrigin ?? resolveForwardedRequestOrigin(req);
+  return normalizeAudience(new URL(url.pathname, origin));
 }
 
 function localCanonicalRecipientCacheKey(agents = listAgents()): string {
@@ -827,7 +851,7 @@ async function handleA2AInbound(
     const result = accept({
       rawBody,
       authorization: readHeader(req.headers, 'authorization'),
-      audience: normalizeAudience(url),
+      audience: resolveInboundAudience(req, url),
       mtlsPublicKeyPem: extractA2AMtlsPublicKeyPem(req),
     });
     sendJson(res, result.statusCode, result.body);

--- a/src/a2a/a2a-inbox-dispatch-store.ts
+++ b/src/a2a/a2a-inbox-dispatch-store.ts
@@ -1,0 +1,284 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+
+import {
+  getRuntimeAssetRevisionState,
+  listRuntimeAssetRevisionStates,
+  type RuntimeConfigChangeMeta,
+  syncRuntimeAssetRevisionState,
+} from '../config/runtime-config-revisions.js';
+import { DEFAULT_RUNTIME_HOME_DIR } from '../config/runtime-paths.js';
+import { logger } from '../logger.js';
+import { type A2AEnvelope, validateA2AEnvelope } from './envelope.js';
+import { isRecord, normalizePositiveInteger } from './utils.js';
+
+const A2A_INBOX_DISPATCH_SCHEMA_VERSION = 1;
+export const A2A_INBOX_DISPATCH_DEFAULT_MAX_ATTEMPTS = 3;
+
+const A2A_INBOX_DISPATCH_ASSET_PREFIX = path.join(
+  DEFAULT_RUNTIME_HOME_DIR,
+  'a2a',
+  'inbox-dispatch',
+);
+
+export type A2AInboxDispatchStatus =
+  | 'pending'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'ignored'
+  | 'suppressed';
+
+export interface A2AInboxDispatchItem {
+  schemaVersion: typeof A2A_INBOX_DISPATCH_SCHEMA_VERSION;
+  id: string;
+  status: A2AInboxDispatchStatus;
+  envelope: A2AEnvelope;
+  attempts: number;
+  maxAttempts: number;
+  nextAttemptAt: string;
+  createdAt: string;
+  updatedAt: string;
+  actor?: string;
+  source?: string;
+  sessionId?: string;
+  runId?: string;
+  dispatchSessionId?: string;
+  dispatchRunId?: string;
+  startedAt?: string;
+  completedAt?: string;
+  failedAt?: string;
+  ignoredAt?: string;
+  suppressedAt?: string;
+  lastError?: string;
+}
+
+export interface A2AInboxDispatchListOptions {
+  status?: A2AInboxDispatchStatus | readonly A2AInboxDispatchStatus[];
+  threadId?: string;
+}
+
+export interface A2AInboxDispatchEnqueueOptions {
+  actor?: string;
+  source?: string;
+  sessionId?: string;
+  runId?: string;
+  maxAttempts?: number;
+  now?: Date;
+}
+
+export function a2aInboxDispatchId(envelope: A2AEnvelope): string {
+  const normalized = validateA2AEnvelope(envelope);
+  return createHash('sha256')
+    .update(normalized.thread_id)
+    .update('\0')
+    .update(normalized.id)
+    .update('\0')
+    .update(normalized.sender_instance_id ?? '')
+    .digest('hex');
+}
+
+function dispatchAssetPath(id: string): string {
+  return path.join(A2A_INBOX_DISPATCH_ASSET_PREFIX, `${id}.json`);
+}
+
+function nowIso(now: Date): string {
+  return now.toISOString();
+}
+
+function isA2AInboxDispatchStatus(
+  value: unknown,
+): value is A2AInboxDispatchStatus {
+  return (
+    value === 'pending' ||
+    value === 'running' ||
+    value === 'succeeded' ||
+    value === 'failed' ||
+    value === 'ignored' ||
+    value === 'suppressed'
+  );
+}
+
+function optionalString(
+  record: Record<string, unknown>,
+  field: keyof A2AInboxDispatchItem,
+): string | undefined {
+  const value = record[field];
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function parseDispatchItem(
+  raw: string,
+  assetPath: string,
+): A2AInboxDispatchItem | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRecord(parsed)) return null;
+    if (parsed.schemaVersion !== A2A_INBOX_DISPATCH_SCHEMA_VERSION) {
+      return null;
+    }
+    if (typeof parsed.id !== 'string' || !parsed.id.trim()) return null;
+    if (!isA2AInboxDispatchStatus(parsed.status)) return null;
+    const envelope = validateA2AEnvelope(parsed.envelope);
+    const attempts =
+      typeof parsed.attempts === 'number' &&
+      Number.isSafeInteger(parsed.attempts) &&
+      parsed.attempts >= 0
+        ? parsed.attempts
+        : 0;
+    const maxAttempts = normalizePositiveInteger(
+      parsed.maxAttempts,
+      A2A_INBOX_DISPATCH_DEFAULT_MAX_ATTEMPTS,
+    );
+    const nextAttemptAt =
+      typeof parsed.nextAttemptAt === 'string' && parsed.nextAttemptAt.trim()
+        ? parsed.nextAttemptAt
+        : new Date(0).toISOString();
+    const createdAt =
+      typeof parsed.createdAt === 'string' && parsed.createdAt.trim()
+        ? parsed.createdAt
+        : nextAttemptAt;
+    const updatedAt =
+      typeof parsed.updatedAt === 'string' && parsed.updatedAt.trim()
+        ? parsed.updatedAt
+        : createdAt;
+    const actor = optionalString(parsed, 'actor');
+    const source = optionalString(parsed, 'source');
+    const sessionId = optionalString(parsed, 'sessionId');
+    const runId = optionalString(parsed, 'runId');
+    const dispatchSessionId = optionalString(parsed, 'dispatchSessionId');
+    const dispatchRunId = optionalString(parsed, 'dispatchRunId');
+    const startedAt = optionalString(parsed, 'startedAt');
+    const completedAt = optionalString(parsed, 'completedAt');
+    const failedAt = optionalString(parsed, 'failedAt');
+    const ignoredAt = optionalString(parsed, 'ignoredAt');
+    const suppressedAt = optionalString(parsed, 'suppressedAt');
+    const lastError = optionalString(parsed, 'lastError');
+
+    return {
+      schemaVersion: A2A_INBOX_DISPATCH_SCHEMA_VERSION,
+      id: parsed.id,
+      status: parsed.status,
+      envelope,
+      attempts,
+      maxAttempts,
+      nextAttemptAt,
+      createdAt,
+      updatedAt,
+      ...(actor ? { actor } : {}),
+      ...(source ? { source } : {}),
+      ...(sessionId ? { sessionId } : {}),
+      ...(runId ? { runId } : {}),
+      ...(dispatchSessionId ? { dispatchSessionId } : {}),
+      ...(dispatchRunId ? { dispatchRunId } : {}),
+      ...(startedAt ? { startedAt } : {}),
+      ...(completedAt ? { completedAt } : {}),
+      ...(failedAt ? { failedAt } : {}),
+      ...(ignoredAt ? { ignoredAt } : {}),
+      ...(suppressedAt ? { suppressedAt } : {}),
+      ...(lastError ? { lastError } : {}),
+    };
+  } catch (error) {
+    logger.warn(
+      { assetPath, err: error },
+      'Dropped invalid A2A inbox dispatch item',
+    );
+    return null;
+  }
+}
+
+function matchesStatus(
+  item: A2AInboxDispatchItem,
+  status: A2AInboxDispatchListOptions['status'],
+): boolean {
+  if (!status) return true;
+  if (Array.isArray(status)) return status.includes(item.status);
+  return item.status === status;
+}
+
+function persistMeta(): RuntimeConfigChangeMeta {
+  return {
+    route: 'a2a.inbox.dispatch',
+    source: 'a2a-inbox-dispatch',
+  };
+}
+
+export function persistA2AInboxDispatchItem(item: A2AInboxDispatchItem): void {
+  syncRuntimeAssetRevisionState(
+    'a2a',
+    dispatchAssetPath(item.id),
+    persistMeta(),
+    {
+      exists: true,
+      content: JSON.stringify(item),
+    },
+  );
+}
+
+export function getA2AInboxDispatchItem(
+  id: string,
+): A2AInboxDispatchItem | null {
+  const state = getRuntimeAssetRevisionState('a2a', dispatchAssetPath(id));
+  return state ? parseDispatchItem(state.content, dispatchAssetPath(id)) : null;
+}
+
+export function getA2AInboxDispatchItemForEnvelope(
+  envelope: A2AEnvelope,
+): A2AInboxDispatchItem | null {
+  return getA2AInboxDispatchItem(a2aInboxDispatchId(envelope));
+}
+
+export function listA2AInboxDispatchItems(
+  options: A2AInboxDispatchListOptions = {},
+): A2AInboxDispatchItem[] {
+  return listRuntimeAssetRevisionStates('a2a', {
+    assetPathPrefix: A2A_INBOX_DISPATCH_ASSET_PREFIX,
+  })
+    .map((state) => parseDispatchItem(state.content, state.assetPath))
+    .filter(
+      (item): item is A2AInboxDispatchItem =>
+        item !== null &&
+        matchesStatus(item, options.status) &&
+        (!options.threadId || item.envelope.thread_id === options.threadId),
+    )
+    .sort((left, right) => {
+      const nextAttemptOrder = left.nextAttemptAt.localeCompare(
+        right.nextAttemptAt,
+      );
+      if (nextAttemptOrder !== 0) return nextAttemptOrder;
+      return left.id.localeCompare(right.id);
+    });
+}
+
+export function enqueueA2AInboxDispatch(
+  envelope: A2AEnvelope,
+  options: A2AInboxDispatchEnqueueOptions = {},
+): A2AInboxDispatchItem {
+  const normalizedEnvelope = validateA2AEnvelope(envelope);
+  const id = a2aInboxDispatchId(normalizedEnvelope);
+  const existing = getA2AInboxDispatchItem(id);
+  if (existing) return existing;
+
+  const now = options.now ?? new Date();
+  const timestamp = nowIso(now);
+  const item: A2AInboxDispatchItem = {
+    schemaVersion: A2A_INBOX_DISPATCH_SCHEMA_VERSION,
+    id,
+    status: 'pending',
+    envelope: normalizedEnvelope,
+    attempts: 0,
+    maxAttempts: normalizePositiveInteger(
+      options.maxAttempts,
+      A2A_INBOX_DISPATCH_DEFAULT_MAX_ATTEMPTS,
+    ),
+    nextAttemptAt: timestamp,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    ...(options.actor ? { actor: options.actor } : {}),
+    ...(options.source ? { source: options.source } : {}),
+    ...(options.sessionId ? { sessionId: options.sessionId } : {}),
+    ...(options.runId ? { runId: options.runId } : {}),
+  };
+  persistA2AInboxDispatchItem(item);
+  return item;
+}

--- a/src/a2a/a2a-inbox-dispatcher.ts
+++ b/src/a2a/a2a-inbox-dispatcher.ts
@@ -1,4 +1,7 @@
-import { listAgents } from '../agents/agent-registry.js';
+import {
+  listAgents,
+  resolveAgentEscalationTarget,
+} from '../agents/agent-registry.js';
 import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
 import {
   parseAgentIdentity,
@@ -14,8 +17,13 @@ import {
   persistA2AInboxDispatchItem,
 } from './a2a-inbox-dispatch-store.js';
 import { getA2AAuditSessionId, recordA2AMessageAudit } from './audit.js';
-import { type A2AEnvelope, summarizeA2AEnvelopeForAudit } from './envelope.js';
+import {
+  type A2AEnvelope,
+  createA2AEnvelope,
+  summarizeA2AEnvelopeForAudit,
+} from './envelope.js';
 import { resolveA2AAgentId } from './identity.js';
+import { sendMessage } from './runtime.js';
 import { normalizePositiveInteger } from './utils.js';
 
 export const A2A_INBOX_DISPATCH_CONCURRENCY = 2;
@@ -305,6 +313,77 @@ function markTerminal(params: {
       : 'failed';
 }
 
+/**
+ * Send the addressed agent's response back to the original sender as an
+ * outbound A2A message on the same thread, so a remote chat sees the reply
+ * (store-and-forward, not live streaming).
+ *
+ * Guards keep any agent<->agent exchange bounded: we only reply to `chat`
+ * intents, only when the agent produced text, and never to a message that is
+ * itself a reply (`parent_message_id` set). That caps a symmetric two-agent
+ * conversation at one round trip, in addition to the per-thread loop budget.
+ */
+function enqueueA2AReply(params: {
+  inbound: A2AEnvelope;
+  recipientLocalAgentId: string;
+  replyText: string | null | undefined;
+  dispatchRunId: string;
+  dispatchSessionId: string;
+}): void {
+  const text = params.replyText?.trim();
+  if (!text) return;
+  if (params.inbound.intent !== 'chat') return;
+  if (params.inbound.parent_message_id) return;
+
+  try {
+    const replyEnvelope = createA2AEnvelope({
+      sender_agent_id: params.inbound.recipient_agent_id,
+      recipient_agent_id: params.inbound.sender_agent_id,
+      thread_id: params.inbound.thread_id,
+      intent: 'chat',
+      content: text,
+      parent_message_id: params.inbound.id,
+    });
+    const confirmation = sendMessage(replyEnvelope, {
+      actor: params.inbound.recipient_agent_id,
+      auditRole: 'sender',
+      sessionId: params.dispatchSessionId,
+      auditRunId: params.dispatchRunId,
+      peerDescriptor: {
+        transport: 'a2a',
+        canonicalId: params.inbound.sender_agent_id,
+      },
+      escalationTarget: resolveAgentEscalationTarget(
+        params.recipientLocalAgentId,
+      ),
+    });
+    if (confirmation.delivered === false) {
+      logger.warn(
+        {
+          reason: confirmation.failure_reason,
+          threadId: params.inbound.thread_id,
+          recipient: params.inbound.sender_agent_id,
+        },
+        'A2A reply-back could not be delivered',
+      );
+      return;
+    }
+    logger.info(
+      {
+        messageId: confirmation.message_id,
+        threadId: confirmation.thread_id,
+        recipient: confirmation.recipient_agent_id,
+      },
+      'A2A reply-back enqueued',
+    );
+  } catch (error) {
+    logger.warn(
+      { err: error, threadId: params.inbound.thread_id },
+      'Failed to enqueue A2A reply-back',
+    );
+  }
+}
+
 async function processA2AInboxDispatchItem(
   item: A2AInboxDispatchItem,
   opts: Required<
@@ -421,6 +500,13 @@ async function processA2AInboxDispatchItem(
       source: 'a2a-inbox-dispatcher',
       transport: 'internal',
       attempts: succeeded.attempts,
+    });
+    enqueueA2AReply({
+      inbound: succeeded.envelope,
+      recipientLocalAgentId: recipient.agentId,
+      replyText: result?.result,
+      dispatchRunId,
+      dispatchSessionId: invocation.sessionId,
     });
     return 'dispatched';
   } catch (error) {

--- a/src/a2a/a2a-inbox-dispatcher.ts
+++ b/src/a2a/a2a-inbox-dispatcher.ts
@@ -23,7 +23,6 @@ import {
   summarizeA2AEnvelopeForAudit,
 } from './envelope.js';
 import { resolveA2AAgentId } from './identity.js';
-import { sendMessage } from './runtime.js';
 import { normalizePositiveInteger } from './utils.js';
 
 export const A2A_INBOX_DISPATCH_CONCURRENCY = 2;
@@ -323,19 +322,23 @@ function markTerminal(params: {
  * itself a reply (`parent_message_id` set). That caps a symmetric two-agent
  * conversation at one round trip, in addition to the per-thread loop budget.
  */
-function enqueueA2AReply(params: {
+async function enqueueA2AReply(params: {
   inbound: A2AEnvelope;
   recipientLocalAgentId: string;
   replyText: string | null | undefined;
   dispatchRunId: string;
   dispatchSessionId: string;
-}): void {
+}): Promise<void> {
   const text = params.replyText?.trim();
   if (!text) return;
   if (params.inbound.intent !== 'chat') return;
   if (params.inbound.parent_message_id) return;
 
   try {
+    // Imported lazily so the reply path stays a runtime side-effect rather than
+    // pulling the transport registry into the dispatcher's static import graph
+    // (which callers like the gateway load eagerly).
+    const { sendMessage } = await import('./runtime.js');
     const replyEnvelope = createA2AEnvelope({
       sender_agent_id: params.inbound.recipient_agent_id,
       recipient_agent_id: params.inbound.sender_agent_id,
@@ -501,7 +504,9 @@ async function processA2AInboxDispatchItem(
       transport: 'internal',
       attempts: succeeded.attempts,
     });
-    enqueueA2AReply({
+    // Best-effort reply back to the sender; failures are logged inside and must
+    // never fail the (already successful) dispatch.
+    void enqueueA2AReply({
       inbound: succeeded.envelope,
       recipientLocalAgentId: recipient.agentId,
       replyText: result?.result,

--- a/src/a2a/a2a-inbox-dispatcher.ts
+++ b/src/a2a/a2a-inbox-dispatcher.ts
@@ -1,0 +1,567 @@
+import { listAgents } from '../agents/agent-registry.js';
+import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
+import {
+  parseAgentIdentity,
+  resolveLocalInstanceId,
+} from '../identity/agent-id.js';
+import { logger } from '../logger.js';
+import { buildSessionKey } from '../session/session-key.js';
+import type { AddressEnvelope } from '../types/container.js';
+import {
+  type A2AInboxDispatchItem,
+  getA2AInboxDispatchItem,
+  listA2AInboxDispatchItems,
+  persistA2AInboxDispatchItem,
+} from './a2a-inbox-dispatch-store.js';
+import { getA2AAuditSessionId, recordA2AMessageAudit } from './audit.js';
+import { type A2AEnvelope, summarizeA2AEnvelopeForAudit } from './envelope.js';
+import { resolveA2AAgentId } from './identity.js';
+import { normalizePositiveInteger } from './utils.js';
+
+export const A2A_INBOX_DISPATCH_CONCURRENCY = 2;
+export const A2A_INBOX_DISPATCH_DRAIN_INTERVAL_MS = 5_000;
+export const A2A_INBOX_DISPATCH_RETRY_BASE_DELAY_MS = 1_000;
+export const A2A_INBOX_DISPATCH_RETRY_MAX_DELAY_MS = 5 * 60_000;
+export const A2A_INBOX_DISPATCH_LOOP_WINDOW_MS = 60_000;
+export const A2A_INBOX_DISPATCH_LOOP_MAX_PER_THREAD = 20;
+
+export interface A2AInboxDispatchInvocation {
+  item: A2AInboxDispatchItem;
+  envelope: A2AEnvelope;
+  agentId: string;
+  sessionId: string;
+  channelId: 'a2a';
+  userId: string;
+  username: string;
+  source: 'a2a.dispatch';
+  content: string;
+  addressEnvelope: AddressEnvelope;
+}
+
+export type A2AInboxDispatchHandlerResult =
+  | { status: 'success'; result?: string | null }
+  | { status: 'error'; error?: string | null };
+
+export type A2AInboxDispatchHandler = (
+  invocation: A2AInboxDispatchInvocation,
+) => Promise<A2AInboxDispatchHandlerResult | undefined>;
+
+export interface A2AInboxDispatchProcessOptions {
+  dispatch: A2AInboxDispatchHandler;
+  now?: () => Date;
+  concurrency?: number;
+  loopWindowMs?: number;
+  loopMaxPerThread?: number;
+}
+
+export interface A2AInboxDispatchProcessResult {
+  processed: number;
+  dispatched: number;
+  ignored: number;
+  suppressed: number;
+  retried: number;
+  failed: number;
+}
+
+type DispatchOutcome =
+  | 'dispatched'
+  | 'ignored'
+  | 'suppressed'
+  | 'retried'
+  | 'failed'
+  | 'skipped';
+
+let a2aInboxDispatchProcessorTimer: ReturnType<typeof setInterval> | null =
+  null;
+let a2aInboxDispatchProcessorRunning = false;
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function clampErrorMessage(error: unknown): string {
+  return errorMessage(error).slice(0, 2_000);
+}
+
+function recordDispatchAudit(params: {
+  item: A2AInboxDispatchItem;
+  eventType:
+    | 'a2a.dispatch.start'
+    | 'a2a.dispatch.success'
+    | 'a2a.dispatch.retry'
+    | 'a2a.dispatch.failed'
+    | 'a2a.dispatch.ignored'
+    | 'a2a.dispatch.suppressed';
+  dispatchRunId?: string;
+  dispatchSessionId?: string;
+  agentId?: string;
+  reason?: string;
+  attempts?: number;
+  nextAttemptAt?: string;
+}): void {
+  let actor: { type: 'agent'; id: string } | undefined;
+  try {
+    actor = {
+      type: 'agent',
+      id: parseAgentIdentity(params.item.envelope.sender_agent_id).id,
+    };
+  } catch {
+    actor = undefined;
+  }
+
+  recordAuditEvent({
+    sessionId:
+      params.dispatchSessionId ||
+      params.item.dispatchSessionId ||
+      params.item.sessionId ||
+      getA2AAuditSessionId(params.item.envelope),
+    runId:
+      params.dispatchRunId ||
+      params.item.dispatchRunId ||
+      params.item.runId ||
+      makeAuditRunId('a2a-dispatch'),
+    event: {
+      type: params.eventType,
+      ...(actor ? { actor } : {}),
+      dispatchId: params.item.id,
+      recipientAgentId: params.item.envelope.recipient_agent_id,
+      recipientLocalAgentId: params.agentId ?? null,
+      attempts: params.attempts ?? params.item.attempts,
+      ...(params.nextAttemptAt ? { nextAttemptAt: params.nextAttemptAt } : {}),
+      ...(params.reason ? { reason: params.reason } : {}),
+      envelope: summarizeA2AEnvelopeForAudit(params.item.envelope),
+    },
+  });
+}
+
+function retryDelayMs(attempts: number): number {
+  const exponent = Math.max(0, attempts - 1);
+  return Math.min(
+    A2A_INBOX_DISPATCH_RETRY_BASE_DELAY_MS * 2 ** exponent,
+    A2A_INBOX_DISPATCH_RETRY_MAX_DELAY_MS,
+  );
+}
+
+function dueAtOrBefore(item: A2AInboxDispatchItem, now: Date): boolean {
+  const dueAt = Date.parse(item.nextAttemptAt);
+  return Number.isNaN(dueAt) || dueAt <= now.getTime();
+}
+
+function resolveLocalRecipientAgentId(
+  envelope: A2AEnvelope,
+): { agentId: string } | { reason: string } {
+  let recipient: ReturnType<typeof parseAgentIdentity>;
+  try {
+    recipient = parseAgentIdentity(envelope.recipient_agent_id);
+  } catch (error) {
+    return { reason: errorMessage(error) };
+  }
+  if (recipient.instanceId !== resolveLocalInstanceId()) {
+    return {
+      reason: 'recipient_agent_id instance-id does not match this instance',
+    };
+  }
+
+  for (const agent of listAgents()) {
+    try {
+      if (resolveA2AAgentId(agent.id) === envelope.recipient_agent_id) {
+        return { agentId: agent.id };
+      }
+    } catch {
+      // Ignore malformed local agent records here; registry validation surfaces
+      // those separately.
+    }
+  }
+  return { reason: 'recipient_agent_id does not resolve to a local agent' };
+}
+
+function buildA2ADispatchSessionId(params: {
+  agentId: string;
+  envelope: A2AEnvelope;
+}): string {
+  return buildSessionKey(
+    params.agentId,
+    'a2a',
+    'thread',
+    params.envelope.sender_agent_id,
+    { threadId: params.envelope.thread_id },
+  );
+}
+
+export function buildA2AInboxDispatchPrompt(envelope: A2AEnvelope): string {
+  return [
+    'You received an A2A message addressed to you.',
+    '',
+    `Intent: ${envelope.intent}`,
+    `Sender: ${envelope.sender_agent_id}`,
+    `Recipient: ${envelope.recipient_agent_id}`,
+    `Thread: ${envelope.thread_id}`,
+    `Message ID: ${envelope.id}`,
+    envelope.parent_message_id
+      ? `Parent message ID: ${envelope.parent_message_id}`
+      : '',
+    '',
+    'Handle this as the addressed agent. For handoffs, take ownership of the work. For escalations, treat it as urgent. For chat, respond or act on the request.',
+    '',
+    envelope.content,
+  ]
+    .filter((line) => line !== '')
+    .join('\n');
+}
+
+function buildDispatchInvocation(params: {
+  item: A2AInboxDispatchItem;
+  agentId: string;
+}): A2AInboxDispatchInvocation {
+  const sessionId = buildA2ADispatchSessionId({
+    agentId: params.agentId,
+    envelope: params.item.envelope,
+  });
+  return {
+    item: params.item,
+    envelope: params.item.envelope,
+    agentId: params.agentId,
+    sessionId,
+    channelId: 'a2a',
+    userId: params.item.envelope.sender_agent_id,
+    username: params.item.envelope.sender_agent_id,
+    source: 'a2a.dispatch',
+    content: buildA2AInboxDispatchPrompt(params.item.envelope),
+    addressEnvelope: {
+      to: params.agentId,
+      from: params.item.envelope.sender_agent_id,
+    },
+  };
+}
+
+function recentDispatchedThreadCount(params: {
+  item: A2AInboxDispatchItem;
+  now: Date;
+  windowMs: number;
+}): number {
+  const cutoff = params.now.getTime() - params.windowMs;
+  return listA2AInboxDispatchItems({
+    threadId: params.item.envelope.thread_id,
+    status: ['running', 'succeeded'],
+  }).filter((entry) => {
+    if (entry.id === params.item.id) return false;
+    const timestamp = Date.parse(
+      entry.startedAt || entry.completedAt || entry.updatedAt,
+    );
+    return !Number.isNaN(timestamp) && timestamp >= cutoff;
+  }).length;
+}
+
+function shouldSuppressLoop(params: {
+  item: A2AInboxDispatchItem;
+  now: Date;
+  loopWindowMs: number;
+  loopMaxPerThread: number;
+}): boolean {
+  if (params.loopMaxPerThread < 1) return true;
+  return (
+    recentDispatchedThreadCount({
+      item: params.item,
+      now: params.now,
+      windowMs: params.loopWindowMs,
+    }) >= params.loopMaxPerThread
+  );
+}
+
+function markTerminal(params: {
+  item: A2AInboxDispatchItem;
+  status: 'ignored' | 'suppressed' | 'failed';
+  now: Date;
+  reason: string;
+  agentId?: string;
+}): DispatchOutcome {
+  const timestamp = params.now.toISOString();
+  const next: A2AInboxDispatchItem = {
+    ...params.item,
+    status: params.status,
+    updatedAt: timestamp,
+    nextAttemptAt: timestamp,
+    lastError: params.reason,
+    ...(params.status === 'ignored' ? { ignoredAt: timestamp } : {}),
+    ...(params.status === 'suppressed' ? { suppressedAt: timestamp } : {}),
+    ...(params.status === 'failed' ? { failedAt: timestamp } : {}),
+  };
+  persistA2AInboxDispatchItem(next);
+  recordDispatchAudit({
+    item: next,
+    eventType:
+      params.status === 'ignored'
+        ? 'a2a.dispatch.ignored'
+        : params.status === 'suppressed'
+          ? 'a2a.dispatch.suppressed'
+          : 'a2a.dispatch.failed',
+    agentId: params.agentId,
+    reason: params.reason,
+  });
+  return params.status === 'ignored'
+    ? 'ignored'
+    : params.status === 'suppressed'
+      ? 'suppressed'
+      : 'failed';
+}
+
+async function processA2AInboxDispatchItem(
+  item: A2AInboxDispatchItem,
+  opts: Required<
+    Pick<
+      A2AInboxDispatchProcessOptions,
+      'dispatch' | 'loopWindowMs' | 'loopMaxPerThread'
+    >
+  > & { now: Date },
+): Promise<DispatchOutcome> {
+  const latest = getA2AInboxDispatchItem(item.id);
+  if (!latest) {
+    return 'skipped';
+  }
+  if (latest.status !== 'pending' || !dueAtOrBefore(latest, opts.now)) {
+    return 'skipped';
+  }
+
+  if (latest.envelope.intent === 'ack') {
+    return markTerminal({
+      item: latest,
+      status: 'ignored',
+      now: opts.now,
+      reason: 'ack envelopes are stored but not auto-dispatched',
+    });
+  }
+  if (latest.envelope.intent === 'policy.update') {
+    return markTerminal({
+      item: latest,
+      status: 'ignored',
+      now: opts.now,
+      reason: 'policy.update envelopes are handled by the policy pipeline',
+    });
+  }
+
+  const recipient = resolveLocalRecipientAgentId(latest.envelope);
+  if ('reason' in recipient) {
+    return markTerminal({
+      item: latest,
+      status: 'failed',
+      now: opts.now,
+      reason: recipient.reason,
+    });
+  }
+
+  if (
+    shouldSuppressLoop({
+      item: latest,
+      now: opts.now,
+      loopWindowMs: opts.loopWindowMs,
+      loopMaxPerThread: opts.loopMaxPerThread,
+    })
+  ) {
+    return markTerminal({
+      item: latest,
+      status: 'suppressed',
+      now: opts.now,
+      agentId: recipient.agentId,
+      reason: 'A2A dispatch loop budget exceeded for this thread',
+    });
+  }
+
+  const invocation = buildDispatchInvocation({
+    item: latest,
+    agentId: recipient.agentId,
+  });
+  const dispatchRunId = makeAuditRunId('a2a-dispatch');
+  const startedAt = opts.now.toISOString();
+  const running: A2AInboxDispatchItem = {
+    ...latest,
+    status: 'running',
+    attempts: latest.attempts + 1,
+    updatedAt: startedAt,
+    startedAt,
+    dispatchSessionId: invocation.sessionId,
+    dispatchRunId,
+  };
+  persistA2AInboxDispatchItem(running);
+  recordDispatchAudit({
+    item: running,
+    eventType: 'a2a.dispatch.start',
+    dispatchRunId,
+    dispatchSessionId: invocation.sessionId,
+    agentId: recipient.agentId,
+  });
+
+  try {
+    const result = await opts.dispatch({ ...invocation, item: running });
+    if (result?.status === 'error') {
+      throw new Error(result.error || 'A2A recipient agent returned an error');
+    }
+    const completedAt = new Date().toISOString();
+    const succeeded: A2AInboxDispatchItem = {
+      ...running,
+      status: 'succeeded',
+      updatedAt: completedAt,
+      completedAt,
+      nextAttemptAt: completedAt,
+    };
+    persistA2AInboxDispatchItem(succeeded);
+    recordDispatchAudit({
+      item: succeeded,
+      eventType: 'a2a.dispatch.success',
+      dispatchRunId,
+      dispatchSessionId: invocation.sessionId,
+      agentId: recipient.agentId,
+    });
+    recordA2AMessageAudit({
+      type: 'a2a.deliver',
+      envelope: succeeded.envelope,
+      sessionId: invocation.sessionId,
+      runId: dispatchRunId,
+      actor: succeeded.envelope.sender_agent_id,
+      route: 'a2a.inbox.dispatch',
+      source: 'a2a-inbox-dispatcher',
+      transport: 'internal',
+      attempts: succeeded.attempts,
+    });
+    return 'dispatched';
+  } catch (error) {
+    const reason = clampErrorMessage(error);
+    const retry = running.attempts < running.maxAttempts;
+    const finishedAt = new Date();
+    const nextAttemptAt = retry
+      ? new Date(finishedAt.getTime() + retryDelayMs(running.attempts))
+      : finishedAt;
+    const next: A2AInboxDispatchItem = {
+      ...running,
+      status: retry ? 'pending' : 'failed',
+      updatedAt: finishedAt.toISOString(),
+      nextAttemptAt: nextAttemptAt.toISOString(),
+      lastError: reason,
+      ...(retry ? {} : { failedAt: finishedAt.toISOString() }),
+    };
+    persistA2AInboxDispatchItem(next);
+    recordDispatchAudit({
+      item: next,
+      eventType: retry ? 'a2a.dispatch.retry' : 'a2a.dispatch.failed',
+      dispatchRunId,
+      dispatchSessionId: invocation.sessionId,
+      agentId: recipient.agentId,
+      reason,
+      attempts: next.attempts,
+      nextAttemptAt: retry ? next.nextAttemptAt : undefined,
+    });
+    return retry ? 'retried' : 'failed';
+  }
+}
+
+export async function processA2AInboxDispatchQueue(
+  opts: A2AInboxDispatchProcessOptions,
+): Promise<A2AInboxDispatchProcessResult> {
+  const now = opts.now?.() ?? new Date();
+  const concurrency = normalizePositiveInteger(
+    opts.concurrency,
+    A2A_INBOX_DISPATCH_CONCURRENCY,
+  );
+  const loopWindowMs = normalizePositiveInteger(
+    opts.loopWindowMs,
+    A2A_INBOX_DISPATCH_LOOP_WINDOW_MS,
+  );
+  const loopMaxPerThread =
+    typeof opts.loopMaxPerThread === 'number' &&
+    Number.isSafeInteger(opts.loopMaxPerThread) &&
+    opts.loopMaxPerThread >= 0
+      ? opts.loopMaxPerThread
+      : A2A_INBOX_DISPATCH_LOOP_MAX_PER_THREAD;
+  const due = listA2AInboxDispatchItems({ status: 'pending' }).filter((item) =>
+    dueAtOrBefore(item, now),
+  );
+  const result: A2AInboxDispatchProcessResult = {
+    processed: 0,
+    dispatched: 0,
+    ignored: 0,
+    suppressed: 0,
+    retried: 0,
+    failed: 0,
+  };
+
+  for (let index = 0; index < due.length; index += concurrency) {
+    const batch = due.slice(index, index + concurrency);
+    result.processed += batch.length;
+    const outcomes = await Promise.allSettled(
+      batch.map((item) =>
+        processA2AInboxDispatchItem(item, {
+          dispatch: opts.dispatch,
+          now,
+          loopWindowMs,
+          loopMaxPerThread,
+        }),
+      ),
+    );
+    for (const outcome of outcomes) {
+      if (outcome.status === 'fulfilled') {
+        if (outcome.value !== 'skipped') {
+          result[outcome.value] += 1;
+        }
+      } else {
+        result.failed += 1;
+        logger.warn(
+          { err: outcome.reason },
+          'A2A inbox dispatch rejected unexpectedly',
+        );
+      }
+    }
+  }
+
+  return result;
+}
+
+async function drainA2AInboxDispatch(
+  source: 'startup' | 'interval',
+  dispatch: A2AInboxDispatchHandler,
+): Promise<void> {
+  if (a2aInboxDispatchProcessorRunning) {
+    logger.debug(
+      { source },
+      'A2A inbox dispatch drain skipped because a previous drain is still running',
+    );
+    return;
+  }
+  a2aInboxDispatchProcessorRunning = true;
+  try {
+    const result = await processA2AInboxDispatchQueue({ dispatch });
+    if (result.processed > 0) {
+      logger.info({ source, ...result }, 'A2A inbox dispatch queue drained');
+    }
+  } catch (error) {
+    logger.warn({ source, error }, 'A2A inbox dispatch drain failed');
+  } finally {
+    a2aInboxDispatchProcessorRunning = false;
+  }
+}
+
+export function startA2AInboxDispatchProcessor(
+  dispatch: A2AInboxDispatchHandler,
+  intervalMs = A2A_INBOX_DISPATCH_DRAIN_INTERVAL_MS,
+): void {
+  stopA2AInboxDispatchProcessor();
+  const normalizedIntervalMs = normalizePositiveInteger(
+    intervalMs,
+    A2A_INBOX_DISPATCH_DRAIN_INTERVAL_MS,
+  );
+  void drainA2AInboxDispatch('startup', dispatch);
+  a2aInboxDispatchProcessorTimer = setInterval(() => {
+    void drainA2AInboxDispatch('interval', dispatch);
+  }, normalizedIntervalMs);
+  logger.info(
+    { intervalMs: normalizedIntervalMs },
+    'A2A inbox dispatch processor started',
+  );
+}
+
+export function stopA2AInboxDispatchProcessor(): void {
+  if (a2aInboxDispatchProcessorTimer) {
+    clearInterval(a2aInboxDispatchProcessorTimer);
+    a2aInboxDispatchProcessorTimer = null;
+    logger.info('A2A inbox dispatch processor stopped');
+  }
+  a2aInboxDispatchProcessorRunning = false;
+}

--- a/src/a2a/a2a-outbox-persistence.ts
+++ b/src/a2a/a2a-outbox-persistence.ts
@@ -193,6 +193,43 @@ export function listA2AOutboxItems(
     });
 }
 
+export interface A2AOutboxDeliveryStatus {
+  status: A2AOutboundStatus | 'unknown';
+  attempts?: number;
+  maxAttempts?: number;
+  lastError?: string;
+  lastStatusCode?: number;
+  deliveredAt?: string;
+  failedAt?: string;
+  nextAttemptAt?: string;
+}
+
+/**
+ * Look up the current delivery state of an outbound A2A message by its envelope
+ * message id. Returns `unknown` when no outbox item is found (e.g. the message
+ * was delivered in-process to a local recipient and never entered the outbox).
+ */
+export function getA2AOutboxDeliveryStatus(
+  messageId: string,
+): A2AOutboxDeliveryStatus {
+  const id = messageId.trim();
+  if (!id) return { status: 'unknown' };
+  const item = listA2AOutboxItems().find((entry) => entry.envelope.id === id);
+  if (!item) return { status: 'unknown' };
+  return {
+    status: item.status,
+    attempts: item.attempts,
+    maxAttempts: item.maxAttempts,
+    ...(item.lastError ? { lastError: item.lastError } : {}),
+    ...(item.lastStatusCode !== undefined
+      ? { lastStatusCode: item.lastStatusCode }
+      : {}),
+    ...(item.deliveredAt ? { deliveredAt: item.deliveredAt } : {}),
+    ...(item.failedAt ? { failedAt: item.failedAt } : {}),
+    nextAttemptAt: item.nextAttemptAt,
+  };
+}
+
 function makeOutboxItem(
   envelope: A2AEnvelope,
   descriptor: Partial<

--- a/src/a2a/runtime.ts
+++ b/src/a2a/runtime.ts
@@ -5,6 +5,7 @@ import {
 import { IDENTITY_DISCOVERY_ZONE_ENV } from '../identity/resolver.js';
 import { logger } from '../logger.js';
 import type { EscalationTarget } from '../types/execution.js';
+import { enqueueA2AInboxDispatch } from './a2a-inbox-dispatch-store.js';
 import { enqueueUnresolvedA2AEnvelope } from './a2a-outbound.js';
 import { recordA2AMessageAudit } from './audit.js';
 import {
@@ -204,6 +205,15 @@ export function sendMessage(
     actor: meta?.actor,
     route: 'a2a.sendMessage',
     source: 'a2a-runtime',
+  });
+  enqueueA2AInboxDispatch(deliveredEnvelope, {
+    actor: meta?.actor,
+    source:
+      (meta?.auditRole ?? 'sender') === 'receiver'
+        ? 'a2a.inbound'
+        : 'a2a.runtime',
+    sessionId: meta?.sessionId,
+    runId: meta?.auditRunId,
   });
   recordSendAudits({
     envelope: deliveredEnvelope,

--- a/src/gateway/a2a-inbox-dispatch.ts
+++ b/src/gateway/a2a-inbox-dispatch.ts
@@ -1,0 +1,33 @@
+import type {
+  A2AInboxDispatchHandler,
+  A2AInboxDispatchHandlerResult,
+} from '../a2a/a2a-inbox-dispatcher.js';
+import { handleGatewayMessage } from './gateway-chat-service.js';
+
+export const dispatchA2AInboxItemToGateway: A2AInboxDispatchHandler = async (
+  invocation,
+): Promise<A2AInboxDispatchHandlerResult> => {
+  const result = await handleGatewayMessage({
+    sessionId: invocation.sessionId,
+    guildId: null,
+    channelId: invocation.channelId,
+    userId: invocation.userId,
+    username: invocation.username,
+    content: invocation.content,
+    agentId: invocation.agentId,
+    addressEnvelope: invocation.addressEnvelope,
+    source: invocation.source,
+  });
+
+  if (result.status === 'error') {
+    return {
+      status: 'error',
+      error: result.error || result.result || 'A2A recipient agent failed',
+    };
+  }
+
+  return {
+    status: 'success',
+    result: result.result,
+  };
+};

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -909,6 +909,12 @@ async function handleGatewayMessageInner(
       toolsUsed: [],
       messageRole: 'command',
       addressEnvelope: addressed.envelope,
+      a2aDelivery: {
+        messageId: confirmation.message_id,
+        threadId: confirmation.thread_id,
+        recipientAgentId: confirmation.recipient_agent_id,
+        status: confirmation.delivered === true ? 'delivered' : 'pending',
+      },
     });
   }
   if (addressed.kind === 'agent') {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -12,6 +12,7 @@ import {
   handleA2AJsonRpcInbound,
   resolveA2AAgentCardPeerTrust,
 } from '../a2a/a2a-inbound.js';
+import { getA2AOutboxDeliveryStatus } from '../a2a/a2a-outbox-persistence.js';
 import { handleA2APairingRequestInbound } from '../a2a/pairing.js';
 import {
   handleA2AWebhookInbound,
@@ -5314,6 +5315,25 @@ function handleApiAdminA2AInbox(res: ServerResponse, url: URL): void {
   }
 }
 
+function handleApiAdminA2AOutboxStatus(res: ServerResponse, url: URL): void {
+  const messageId = (url.searchParams.get('messageId') || '').trim();
+  if (!messageId) {
+    sendJson(res, 400, { error: 'messageId query parameter is required' });
+    return;
+  }
+  try {
+    sendJson(res, 200, getA2AOutboxDeliveryStatus(messageId));
+  } catch (error) {
+    sendJson(
+      res,
+      error instanceof GatewayRequestError ? error.statusCode : 400,
+      {
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+}
+
 async function handleApiAdminSignalLink(
   req: IncomingMessage,
   res: ServerResponse,
@@ -8488,6 +8508,10 @@ export function startGatewayHttpServer(): GatewayHttpServer {
           }
           if (pathname === '/api/admin/a2a/inbox' && method === 'GET') {
             handleApiAdminA2AInbox(res, url);
+            return;
+          }
+          if (pathname === '/api/admin/a2a/outbox/status' && method === 'GET') {
+            handleApiAdminA2AOutboxStatus(res, url);
             return;
           }
           if (

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -85,6 +85,13 @@ export interface GatewayAssistantPresentation {
 export type GatewayChatResultMessageRole = 'assistant' | 'approval' | 'command';
 export type GatewayAddressEnvelope = AddressEnvelope;
 
+export interface GatewayA2ADeliveryDescriptor {
+  messageId: string;
+  threadId: string;
+  recipientAgentId: string;
+  status: 'pending' | 'delivered' | 'failed';
+}
+
 export interface GatewayChatResult {
   status: 'success' | 'error';
   result: string | null;
@@ -99,6 +106,7 @@ export interface GatewayChatResult {
   skillUsed?: string;
   agentId?: string;
   addressEnvelope?: GatewayAddressEnvelope;
+  a2aDelivery?: GatewayA2ADeliveryDescriptor;
   assistantPresentation?: GatewayAssistantPresentation;
   model?: string;
   provider?: string;

--- a/src/gateway/gateway-url-utils.ts
+++ b/src/gateway/gateway-url-utils.ts
@@ -1,3 +1,5 @@
+import type { IncomingMessage } from 'node:http';
+
 export function normalizeHttpBaseUrl(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   const trimmed = value.trim().replace(/\/+$/, '');
@@ -17,6 +19,38 @@ export function normalizeHttpOrigin(value: unknown): string | undefined {
   const baseUrl = normalizeHttpBaseUrl(value);
   if (!baseUrl) return undefined;
   return new URL(baseUrl).origin;
+}
+
+/**
+ * Whether the request reached us over HTTPS, honoring the `X-Forwarded-Proto`
+ * header set by TLS-terminating proxies/tunnels (e.g. ngrok) before falling
+ * back to the socket's own encryption state.
+ */
+export function requestUsesHttps(req: IncomingMessage): boolean {
+  const forwardedProto = String(req.headers['x-forwarded-proto'] || '')
+    .split(',')[0]
+    ?.trim()
+    .toLowerCase();
+  if (forwardedProto) return forwardedProto === 'https';
+  return (req.socket as { encrypted?: boolean }).encrypted === true;
+}
+
+/**
+ * Reconstruct the public origin a request arrived on, honoring the
+ * `X-Forwarded-Host`/`X-Forwarded-Proto` headers a TLS-terminating tunnel adds.
+ * This mirrors how the Agent Card advertises its own origin so that inbound
+ * audience checks agree with the URL senders sign against.
+ */
+export function resolveForwardedRequestOrigin(
+  req: IncomingMessage,
+  fallbackHost = '127.0.0.1',
+): string {
+  const forwardedHost = String(req.headers['x-forwarded-host'] || '')
+    .split(',')[0]
+    ?.trim();
+  const proto = requestUsesHttps(req) ? 'https' : 'http';
+  const host = forwardedHost || req.headers.host || fallbackHost;
+  return `${proto}://${host}`;
 }
 
 export function isPrivateHttpBaseUrl(value: string): boolean {

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -2,6 +2,10 @@ import fs from 'node:fs';
 import { AttachmentBuilder } from 'discord.js';
 import { resolveEffectiveTimezone } from '../../container/shared/workspace-time.js';
 import {
+  startA2AInboxDispatchProcessor,
+  stopA2AInboxDispatchProcessor,
+} from '../a2a/a2a-inbox-dispatcher.js';
+import {
   startA2AOutboxProcessor,
   stopA2AOutboxProcessor,
 } from '../a2a/a2a-outbound.js';
@@ -175,6 +179,7 @@ import {
   startTokenUsageBuffer,
   stopTokenUsageBuffer,
 } from '../usage/token-usage-buffer.js';
+import { dispatchA2AInboxItemToGateway } from './a2a-inbox-dispatch.js';
 import { buildApprovalConfirmationComponents } from './approval-confirmation.js';
 import {
   type ApprovalPresentation,
@@ -709,7 +714,7 @@ function isLocalIMessageSelfChatContext(context: {
   };
 }): boolean {
   const inbound = context.inbound;
-  if (!inbound || inbound.backend !== 'local' || inbound.isGroup) {
+  if (inbound?.backend !== 'local' || inbound.isGroup) {
     return false;
   }
   const rawEvent =
@@ -3254,6 +3259,7 @@ function setupShutdown(broadcastShutdown: () => void): void {
     );
     stopHeartbeat();
     stopPeriodicCloudMemorySync();
+    stopA2AInboxDispatchProcessor();
     stopA2AOutboxProcessor();
     stopWebhookOutboxProcessor();
     stopObservabilityIngest();
@@ -3559,6 +3565,7 @@ async function main(): Promise<void> {
   startPeriodicCloudMemorySync({
     resolveAgentIds: () => listAgents().map((agent) => agent.id),
   });
+  startA2AInboxDispatchProcessor(dispatchA2AInboxItemToGateway);
   startA2AOutboxProcessor();
   startWebhookOutboxProcessor();
   startObservabilityIngest();

--- a/tests/a2a-inbox-dispatcher.test.ts
+++ b/tests/a2a-inbox-dispatcher.test.ts
@@ -1,0 +1,241 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const ORIGINAL_DATA_DIR = process.env.HYBRIDCLAW_DATA_DIR;
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_INSTANCE_ID = process.env.HYBRIDCLAW_INSTANCE_ID;
+const LOCAL_MAIN_AGENT_ID = 'main@team@local-dev';
+
+let tmpDir: string;
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-a2a-inbox-dispatch-'));
+  process.env.HYBRIDCLAW_DATA_DIR = tmpDir;
+  process.env.HOME = tmpDir;
+  process.env.HYBRIDCLAW_INSTANCE_ID = 'local-dev';
+  vi.resetModules();
+});
+
+afterEach(() => {
+  restoreEnvVar('HYBRIDCLAW_DATA_DIR', ORIGINAL_DATA_DIR);
+  restoreEnvVar('HOME', ORIGINAL_HOME);
+  restoreEnvVar('HYBRIDCLAW_INSTANCE_ID', ORIGINAL_INSTANCE_ID);
+  vi.resetModules();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function loadDispatchModules() {
+  const [db, runtimeConfig, runtime, dispatchStore, dispatcher] =
+    await Promise.all([
+      import('../src/memory/db.ts'),
+      import('../src/config/runtime-config.ts'),
+      import('../src/a2a/runtime.ts'),
+      import('../src/a2a/a2a-inbox-dispatch-store.ts'),
+      import('../src/a2a/a2a-inbox-dispatcher.ts'),
+    ]);
+
+  db.initDatabase({ quiet: true });
+  runtimeConfig.updateRuntimeConfig((draft) => {
+    draft.agents.list = [
+      { id: 'main', owner: 'team', role: 'lead' },
+      { id: 'writer', owner: 'team', role: 'writer' },
+    ];
+  });
+
+  return { runtime, dispatchStore, dispatcher };
+}
+
+function a2aEnvelope(
+  id: string,
+  overrides: Partial<{
+    sender_agent_id: string;
+    recipient_agent_id: string;
+    thread_id: string;
+    intent: 'chat' | 'handoff' | 'escalate' | 'ack' | 'policy.update';
+    content: string;
+    created_at: string;
+  }> = {},
+) {
+  return {
+    id,
+    sender_agent_id: overrides.sender_agent_id ?? 'remote@team@peer-instance',
+    recipient_agent_id: overrides.recipient_agent_id ?? LOCAL_MAIN_AGENT_ID,
+    thread_id: overrides.thread_id ?? 'thread-a2a-dispatch',
+    intent: overrides.intent ?? ('chat' as const),
+    content: overrides.content ?? `Dispatch payload ${id}`,
+    created_at: overrides.created_at ?? '2026-05-01T10:00:00.000Z',
+  };
+}
+
+describe('A2A inbox dispatch processor', () => {
+  test('dispatches delivered A2A envelopes to the addressed local agent', async () => {
+    const { runtime, dispatchStore, dispatcher } = await loadDispatchModules();
+    runtime.sendMessage(
+      a2aEnvelope('msg-dispatch-1', { recipient_agent_id: 'main' }),
+      {
+        actor: 'remote@team@peer-instance',
+        sessionId: 'a2a:inbound:peer',
+        auditRunId: 'run-a2a-inbound',
+        auditRole: 'receiver',
+      },
+    );
+
+    expect(
+      dispatchStore.listA2AInboxDispatchItems({ status: 'pending' }),
+    ).toHaveLength(1);
+
+    const dispatch = vi.fn(async () => ({ status: 'success' as const }));
+    await expect(
+      dispatcher.processA2AInboxDispatchQueue({ dispatch }),
+    ).resolves.toMatchObject({
+      processed: 1,
+      dispatched: 1,
+      failed: 0,
+    });
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch.mock.calls[0]?.[0]).toMatchObject({
+      agentId: 'main',
+      channelId: 'a2a',
+      userId: 'remote@team@peer-instance',
+      source: 'a2a.dispatch',
+      addressEnvelope: {
+        to: 'main',
+        from: 'remote@team@peer-instance',
+      },
+    });
+    expect(dispatch.mock.calls[0]?.[0].content).toContain(
+      'Dispatch payload msg-dispatch-1',
+    );
+    expect(dispatch.mock.calls[0]?.[0].content).toContain(
+      'Intent: chat',
+    );
+    expect(
+      dispatchStore.listA2AInboxDispatchItems({ status: 'succeeded' }),
+    ).toHaveLength(1);
+  });
+
+  test('does not redispatch an already processed envelope', async () => {
+    const { dispatchStore, dispatcher } = await loadDispatchModules();
+    const envelope = a2aEnvelope('msg-dispatch-idempotent');
+
+    const first = dispatchStore.enqueueA2AInboxDispatch(envelope);
+    const second = dispatchStore.enqueueA2AInboxDispatch(envelope);
+    expect(second.id).toBe(first.id);
+
+    const dispatch = vi.fn(async () => ({ status: 'success' as const }));
+    await dispatcher.processA2AInboxDispatchQueue({ dispatch });
+    await dispatcher.processA2AInboxDispatchQueue({ dispatch });
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(
+      dispatchStore.listA2AInboxDispatchItems({ status: 'succeeded' }),
+    ).toHaveLength(1);
+  });
+
+  test('fails closed when the recipient does not resolve to a local agent', async () => {
+    const { dispatchStore, dispatcher } = await loadDispatchModules();
+    dispatchStore.enqueueA2AInboxDispatch(
+      a2aEnvelope('msg-dispatch-unknown', {
+        recipient_agent_id: 'unknown@team@local-dev',
+      }),
+    );
+
+    const dispatch = vi.fn(async () => ({ status: 'success' as const }));
+    await expect(
+      dispatcher.processA2AInboxDispatchQueue({ dispatch }),
+    ).resolves.toMatchObject({
+      processed: 1,
+      failed: 1,
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+    const [failed] = dispatchStore.listA2AInboxDispatchItems({
+      status: 'failed',
+    });
+    expect(failed?.lastError).toContain(
+      'recipient_agent_id does not resolve to a local agent',
+    );
+  });
+
+  test('retries failed recipient runs and then marks exhausted dispatches failed', async () => {
+    const { dispatchStore, dispatcher } = await loadDispatchModules();
+    dispatchStore.enqueueA2AInboxDispatch(a2aEnvelope('msg-dispatch-fails'), {
+      maxAttempts: 1,
+    });
+
+    const dispatch = vi.fn(async () => ({
+      status: 'error' as const,
+      error: 'recipient runtime crashed',
+    }));
+    await expect(
+      dispatcher.processA2AInboxDispatchQueue({ dispatch }),
+    ).resolves.toMatchObject({
+      processed: 1,
+      failed: 1,
+    });
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const [failed] = dispatchStore.listA2AInboxDispatchItems({
+      status: 'failed',
+    });
+    expect(failed).toMatchObject({
+      attempts: 1,
+      lastError: 'recipient runtime crashed',
+    });
+  });
+
+  test('stores ack envelopes without auto-dispatching them', async () => {
+    const { dispatchStore, dispatcher } = await loadDispatchModules();
+    dispatchStore.enqueueA2AInboxDispatch(
+      a2aEnvelope('msg-dispatch-ack', { intent: 'ack' }),
+    );
+
+    const dispatch = vi.fn(async () => ({ status: 'success' as const }));
+    await expect(
+      dispatcher.processA2AInboxDispatchQueue({ dispatch }),
+    ).resolves.toMatchObject({
+      processed: 1,
+      ignored: 1,
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(
+      dispatchStore.listA2AInboxDispatchItems({ status: 'ignored' }),
+    ).toHaveLength(1);
+  });
+
+  test('suppresses dispatch when the thread loop budget is exhausted', async () => {
+    const { dispatchStore, dispatcher } = await loadDispatchModules();
+    dispatchStore.enqueueA2AInboxDispatch(
+      a2aEnvelope('msg-dispatch-loop', { thread_id: 'thread-loop' }),
+    );
+
+    const dispatch = vi.fn(async () => ({ status: 'success' as const }));
+    await expect(
+      dispatcher.processA2AInboxDispatchQueue({
+        dispatch,
+        loopMaxPerThread: 0,
+      }),
+    ).resolves.toMatchObject({
+      processed: 1,
+      suppressed: 1,
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(
+      dispatchStore.listA2AInboxDispatchItems({ status: 'suppressed' }),
+    ).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- add a durable A2A inbox dispatch queue for persisted local deliveries
- dispatch pending inbound A2A messages to the addressed local agent through the normal gateway message path
- add idempotency, retry/backoff, terminal failure/ignored/suppressed states, audit events, and thread loop suppression
- cover dispatch, duplicate delivery, unknown recipient, failed recipient run, ignored ack, and loop suppression behavior

## Validation

- `npx vitest run tests/a2a-inbox-dispatcher.test.ts --reporter=dot`
- `npx vitest run tests/a2a-inbox-dispatcher.test.ts tests/a2a-runtime.integration.test.ts tests/a2a-inbound.test.ts tests/gateway-service.a2a-inbox.test.ts --reporter=dot`
- `npm run typecheck`
- `npm run lint`

Closes #716
