### PR TITLE
[codex] fix PDF preview blob frames

### DIFF
--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -2929,7 +2929,7 @@ function serveConsoleFile(
     ...(isIndex
       ? {
           'Content-Security-Policy':
-            "default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data: blob:; media-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ws: wss:",
+            "default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; frame-src 'self' blob:; img-src 'self' data: blob:; media-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ws: wss:",
         }
       : {}),
   });

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -2764,6 +2764,9 @@ describe('gateway HTTP server', () => {
       expect(res.headers['Content-Security-Policy']).toContain(
         "default-src 'self'",
       );
+      expect(res.headers['Content-Security-Policy']).toContain(
+        "frame-src 'self' blob:",
+      );
     }
   });
 


### PR DESCRIPTION
## What changed
- Added `frame-src 'self' blob:` to the web console index Content Security Policy.
- Added a gateway regression assertion that console pages include the blob frame allowance.

## Why
PDF artifact previews are rendered in a sandboxed `iframe` backed by a `blob:` URL. The existing CSP allowed blob URLs for images and media, but did not allow them for frames, so browsers refused to load PDF previews.

## Risk notes
This keeps `default-src`, `object-src`, and `frame-ancestors` restrictive. The new allowance is scoped to frame loads from the same origin or generated blob URLs, matching the existing image/media preview model without permitting arbitrary remote frames.

## Validation
- `npm run format`
- `npm run lint`
- `npx vitest run tests/gateway-http-server.test.ts -t "serves console index with defensive headers"`
- `git diff --check`