### PR TITLE
fix(gateway): allow blob: iframes in console CSP for PDF preview

### DIFF
--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -2929,7 +2929,7 @@ function serveConsoleFile(
     ...(isIndex
       ? {
           'Content-Security-Policy':
-            "default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data: blob:; media-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ws: wss:",
+            "default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data: blob:; media-src 'self' blob:; frame-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ws: wss:",
         }
       : {}),
   });

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -2764,6 +2764,9 @@ describe('gateway HTTP server', () => {
       expect(res.headers['Content-Security-Policy']).toContain(
         "default-src 'self'",
       );
+      expect(res.headers['Content-Security-Policy']).toContain(
+        "frame-src 'self' blob:",
+      );
     }
   });
 


### PR DESCRIPTION
## Problem
PDF previews in the web-chat console showed a broken frame. Browser console:

```
Framing 'blob:http://127.0.0.1:9090/…' violates the following Content Security Policy directive: "default-src 'self'". Note that 'frame-src' was not explicitly set, so 'default-src' is used as a fallback.
```

## Cause
The console renders PDF previews as a `blob:` URL inside an `<iframe>` (`console/src/routes/chat/message-block.tsx`). The CSP served with the console index allows `blob:` for `img-src` and `media-src`, but had no `frame-src` directive, so iframes fell back to `default-src 'self'` — which does not match `blob:` URLs.

## Fix
Add `frame-src 'self' blob:` to the console CSP and assert it in the defensive-headers test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)