### PR TITLE
feat: add scoped API tokens

### DIFF
--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -13,6 +13,10 @@ import type {
   AdminAgentProxyConfig,
   AdminAgentScoreboardResponse,
   AdminAgentsResponse,
+  AdminApiTokenCreatePayload,
+  AdminApiTokenCreateResponse,
+  AdminApiTokenRevokeResponse,
+  AdminApiTokensResponse,
   AdminApprovalsResponse,
   AdminAuditResponse,
   AdminBoardBudgetResponse,
@@ -1179,6 +1183,36 @@ export function unsetAdminSecret(
 ): Promise<AdminSecretMutationResponse> {
   return requestJson<AdminSecretMutationResponse>(
     `/api/admin/secrets/${encodeURIComponent(name)}`,
+    {
+      token,
+      method: 'DELETE',
+    },
+  );
+}
+
+export function fetchAdminApiTokens(
+  token: string,
+): Promise<AdminApiTokensResponse> {
+  return requestJson<AdminApiTokensResponse>('/api/admin/tokens', { token });
+}
+
+export function createAdminApiToken(
+  token: string,
+  payload: AdminApiTokenCreatePayload,
+): Promise<AdminApiTokenCreateResponse> {
+  return requestJson<AdminApiTokenCreateResponse>('/api/admin/tokens', {
+    token,
+    method: 'POST',
+    body: payload,
+  });
+}
+
+export function revokeAdminApiToken(
+  token: string,
+  id: string,
+): Promise<AdminApiTokenRevokeResponse> {
+  return requestJson<AdminApiTokenRevokeResponse>(
+    `/api/admin/tokens/${encodeURIComponent(id)}`,
     {
       token,
       method: 'DELETE',

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -2498,6 +2498,47 @@ export interface AdminSecretMutationResponse {
   secret: AdminSecretEntry;
 }
 
+export type AdminApiTokenAction =
+  | 'admin.tokens.read'
+  | 'admin.tokens.create'
+  | 'admin.tokens.revoke';
+
+export interface AdminApiTokenEntry {
+  id: string;
+  label: string;
+  claims: Record<string, unknown>;
+  created_at: string;
+  created_by: string | null;
+  expires_at: string | null;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
+export interface AdminApiTokensResponse {
+  tokens: AdminApiTokenEntry[];
+  total: number;
+  actions: AdminApiTokenAction[];
+}
+
+export interface AdminApiTokenCreatePayload {
+  label: string;
+  actions?: string[];
+  claims?: Record<string, unknown>;
+  role?: string;
+  roles?: string[];
+  scope?: string | string[];
+  expiresAt?: string;
+}
+
+export interface AdminApiTokenCreateResponse {
+  token: string;
+  apiToken: AdminApiTokenEntry;
+}
+
+export interface AdminApiTokenRevokeResponse {
+  apiToken: AdminApiTokenEntry;
+}
+
 export interface DeleteSessionResult {
   deleted: boolean;
   sessionId: string;

--- a/console/src/components/sidebar/navigation.ts
+++ b/console/src/components/sidebar/navigation.ts
@@ -89,6 +89,7 @@ export const SIDEBAR_NAV_GROUPS: ReadonlyArray<SidebarNavGroup> = [
       { to: '/admin/output-guard', label: 'Output Guard', icon: Policy },
       { to: '/admin/tools', label: 'Tools', icon: Tools },
       { to: '/admin/secrets', label: 'Secrets', icon: Secrets },
+      { to: '/admin/tokens', label: 'API Tokens', icon: Secrets },
       { to: '/admin/config', label: 'Config', icon: Config },
     ],
   },

--- a/console/src/router.tsx
+++ b/console/src/router.tsx
@@ -36,6 +36,7 @@ import { SessionsPage } from './routes/sessions';
 import { SkillsDetailPage } from './routes/skill-detail';
 import { SkillsPage } from './routes/skills';
 import { StatisticsPage } from './routes/statistics';
+import { TokensPage } from './routes/tokens';
 import { ToolsPage } from './routes/tools';
 
 const LazyTerminalPage = lazy(async () => {
@@ -310,6 +311,12 @@ const secretsRoute = createRoute({
   component: SecretsPage,
 });
 
+const tokensRoute = createRoute({
+  getParentRoute: () => adminLayoutRoute,
+  path: '/admin/tokens',
+  component: TokensPage,
+});
+
 const chatRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/chat',
@@ -383,6 +390,7 @@ const routeTree = rootRoute.addChildren([
     outputGuardRoute,
     toolsRoute,
     secretsRoute,
+    tokensRoute,
   ]),
   agentsOverviewRoute,
   chatRoute.addChildren([chatSessionRoute]),

--- a/console/src/routes/secrets.module.css
+++ b/console/src/routes/secrets.module.css
@@ -67,7 +67,242 @@
   color: var(--muted-foreground);
 }
 
+.multiSelectTrigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  min-width: 0;
+  min-height: var(--control-height);
+  padding: var(--control-padding-y) 12px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: var(--panel-bg);
+  color: var(--text);
+  font: inherit;
+  line-height: var(--control-line-height);
+  text-align: left;
+  cursor: pointer;
+  outline: none;
+  box-sizing: border-box;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.multiSelectTrigger:focus-visible {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ring) 35%, transparent);
+}
+
+.multiSelectTrigger:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.multiSelectTriggerText {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.selectPlaceholder {
+  color: var(--muted-foreground);
+}
+
+.selectSummary {
+  color: var(--text);
+}
+
+.selectChevron {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+  transition: transform 0.16s ease;
+}
+
+.multiSelectTrigger[data-state="open"] .selectChevron {
+  transform: rotate(180deg);
+}
+
+.multiSelectContent {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: min(560px, calc(100vw - 16px));
+  max-height: min(520px, calc(100vh - 32px));
+  padding: 8px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: var(--popover);
+  color: var(--popover-foreground);
+  box-shadow: var(--shadow-popover);
+  overflow: hidden;
+}
+
+.actionFilter {
+  flex-shrink: 0;
+}
+
+.choiceList {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  flex-direction: column;
+  gap: 8px;
+  overflow-y: auto;
+}
+
+.choiceGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.choiceGroupLabel {
+  padding: 4px 6px;
+  color: var(--muted-foreground);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.choiceRow {
+  position: relative;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) minmax(96px, max-content);
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-width: 0;
+  padding: 8px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.choiceRow:hover,
+.choiceRow:has(.choiceInput:focus-visible) {
+  background: var(--muted);
+}
+
+.choiceRow:has(.choiceInput:focus-visible) {
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: -2px;
+}
+
+.choiceInput {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.choiceInput:disabled {
+  cursor: not-allowed;
+}
+
+.choiceCheck {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--line-strong);
+  border-radius: 4px;
+  background: var(--panel-bg);
+  color: var(--primary-foreground);
+  box-sizing: border-box;
+}
+
+.choiceCheck[data-checked] {
+  border-color: var(--primary);
+  background: var(--primary);
+}
+
+.choiceIcon {
+  width: 14px;
+  height: 14px;
+}
+
+.choiceMeta {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.choiceTitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.choiceDescription {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted-foreground);
+  font-size: 0.78rem;
+}
+
+.choiceValue {
+  justify-self: end;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono, "SFMono-Regular", "JetBrains Mono", monospace);
+  font-size: 0.74rem;
+}
+
+.choiceEmpty {
+  padding: 20px 8px;
+  color: var(--muted-foreground);
+  font-size: 0.875rem;
+  text-align: center;
+}
+
+.choiceFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-shrink: 0;
+  padding-top: 8px;
+  border-top: 1px solid var(--line);
+}
+
+.choiceCount {
+  color: var(--muted-foreground);
+  font-size: 0.8125rem;
+}
+
 .tokenValue {
   font-family: var(--font-mono, "SFMono-Regular", "JetBrains Mono", monospace);
   word-break: break-all;
+}
+
+@media (max-width: 560px) {
+  .choiceRow {
+    grid-template-columns: 18px minmax(0, 1fr);
+  }
+
+  .choiceValue {
+    grid-column: 2;
+    justify-self: start;
+    max-width: 100%;
+  }
 }

--- a/console/src/routes/secrets.module.css
+++ b/console/src/routes/secrets.module.css
@@ -66,3 +66,8 @@
   line-height: 1.45;
   color: var(--muted-foreground);
 }
+
+.tokenValue {
+  font-family: var(--font-mono, "SFMono-Regular", "JetBrains Mono", monospace);
+  word-break: break-all;
+}

--- a/console/src/routes/tokens.test.tsx
+++ b/console/src/routes/tokens.test.tsx
@@ -110,6 +110,23 @@ describe('TokensPage', () => {
       target: { value: 'admin:auditor' },
     });
 
+    const expiresSelect = within(dialog).getByLabelText(
+      'Expires at',
+    ) as HTMLSelectElement;
+    expect([...expiresSelect.options].map((option) => option.value)).toEqual([
+      'never',
+      '7d',
+      '30d',
+      '90d',
+      'custom',
+    ]);
+    fireEvent.change(expiresSelect, {
+      target: { value: 'custom' },
+    });
+    fireEvent.change(within(dialog).getByLabelText('Custom expiration'), {
+      target: { value: '2026-09-01T08:30' },
+    });
+
     fireEvent.click(
       within(dialog).getByRole('button', { name: 'Create token' }),
     );
@@ -119,6 +136,7 @@ describe('TokensPage', () => {
         label: 'SDK token',
         actions: ['openai.api', 'chat.send'],
         role: 'admin:auditor',
+        expiresAt: '2026-09-01T08:30',
       }),
     );
   });

--- a/console/src/routes/tokens.test.tsx
+++ b/console/src/routes/tokens.test.tsx
@@ -106,7 +106,22 @@ describe('TokensPage', () => {
     );
     fireEvent.click(screen.getByRole('checkbox', { name: /Chat send/i }));
 
-    fireEvent.change(within(dialog).getByLabelText('Role'), {
+    const roleSelect = within(dialog).getByLabelText(
+      'Role',
+    ) as HTMLSelectElement;
+    expect(
+      [...roleSelect.options].some(
+        (option) =>
+          option.value === 'admin.viewer' &&
+          option.text === 'Viewer - read-only admin API access',
+      ),
+    ).toBe(true);
+    expect(
+      [...roleSelect.options].some((option) =>
+        option.text.includes('console access'),
+      ),
+    ).toBe(false);
+    fireEvent.change(roleSelect, {
       target: { value: 'admin:auditor' },
     });
 

--- a/console/src/routes/tokens.test.tsx
+++ b/console/src/routes/tokens.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  AdminApiTokenCreatePayload,
+  AdminApiTokenCreateResponse,
+  AdminApiTokenEntry,
+  AdminApiTokensResponse,
+} from '../api/types';
+import { renderWithProviders } from '../test-utils';
+import { TokensPage } from './tokens';
+
+const fetchAdminApiTokensMock = vi.fn<() => Promise<AdminApiTokensResponse>>();
+const createAdminApiTokenMock =
+  vi.fn<
+    (
+      token: string,
+      payload: AdminApiTokenCreatePayload,
+    ) => Promise<AdminApiTokenCreateResponse>
+  >();
+const revokeAdminApiTokenMock = vi.fn();
+const useAuthMock = vi.fn();
+
+vi.mock('../api/client', async () => {
+  const actual =
+    await vi.importActual<typeof import('../api/client')>('../api/client');
+  return {
+    ...actual,
+    fetchAdminApiTokens: () => fetchAdminApiTokensMock(),
+    createAdminApiToken: (token: string, payload: AdminApiTokenCreatePayload) =>
+      createAdminApiTokenMock(token, payload),
+    revokeAdminApiToken: (token: string, id: string) =>
+      revokeAdminApiTokenMock(token, id),
+  };
+});
+
+vi.mock('../auth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+function makeToken(
+  overrides: Partial<AdminApiTokenEntry> = {},
+): AdminApiTokenEntry {
+  return {
+    id: 'tok_123',
+    label: 'SDK token',
+    claims: { actions: ['openai.api'] },
+    created_at: '2026-07-08T10:00:00.000Z',
+    created_by: 'admin-user',
+    expires_at: null,
+    last_used_at: null,
+    revoked_at: null,
+    ...overrides,
+  };
+}
+
+function makeResponse(
+  overrides: Partial<AdminApiTokensResponse> = {},
+): AdminApiTokensResponse {
+  return {
+    tokens: [],
+    total: 0,
+    actions: [
+      'admin.tokens.read',
+      'admin.tokens.create',
+      'admin.tokens.revoke',
+    ],
+    ...overrides,
+  };
+}
+
+describe('TokensPage', () => {
+  beforeEach(() => {
+    fetchAdminApiTokensMock.mockReset();
+    createAdminApiTokenMock.mockReset();
+    revokeAdminApiTokenMock.mockReset();
+    useAuthMock.mockReset();
+    useAuthMock.mockReturnValue({ token: 'test-token' });
+  });
+
+  it('creates a token from selected actions and a role preset', async () => {
+    fetchAdminApiTokensMock.mockResolvedValue(makeResponse());
+    createAdminApiTokenMock.mockResolvedValue({
+      token: 'hck_token_value',
+      apiToken: makeToken({
+        claims: {
+          actions: ['openai.api', 'chat.send'],
+          role: 'admin:auditor',
+        },
+      }),
+    });
+
+    renderWithProviders(<TokensPage />);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Create token' }),
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Create API token' });
+    fireEvent.change(within(dialog).getByLabelText('Label'), {
+      target: { value: 'SDK token' },
+    });
+
+    fireEvent.click(within(dialog).getByLabelText('Actions'));
+    fireEvent.click(
+      await screen.findByRole('checkbox', { name: /OpenAI API/i }),
+    );
+    fireEvent.click(screen.getByRole('checkbox', { name: /Chat send/i }));
+
+    fireEvent.change(within(dialog).getByLabelText('Role'), {
+      target: { value: 'admin:auditor' },
+    });
+
+    fireEvent.click(
+      within(dialog).getByRole('button', { name: 'Create token' }),
+    );
+
+    await waitFor(() =>
+      expect(createAdminApiTokenMock).toHaveBeenCalledWith('test-token', {
+        label: 'SDK token',
+        actions: ['openai.api', 'chat.send'],
+        role: 'admin:auditor',
+      }),
+    );
+  });
+});

--- a/console/src/routes/tokens.tsx
+++ b/console/src/routes/tokens.tsx
@@ -187,6 +187,16 @@ const TOKEN_ROLE_GROUPS = [
   },
 ] as const;
 
+const TOKEN_EXPIRY_PRESETS = [
+  ['never', 'No expiration'],
+  ['7d', '7 days'],
+  ['30d', '30 days'],
+  ['90d', '90 days'],
+  ['custom', 'Custom date/time'],
+] as const;
+
+type TokenExpiryPreset = (typeof TOKEN_EXPIRY_PRESETS)[number][0];
+
 type TokenActionOption = {
   value: string;
   label: string;
@@ -290,6 +300,16 @@ function orderTokenActions(actions: string[]): string[] {
   return TOKEN_ACTION_OPTIONS.map((option) => option.value).filter((value) =>
     selected.has(value),
   );
+}
+
+function resolveExpiresAt(
+  preset: TokenExpiryPreset,
+  customExpiresAt: string,
+): string | null {
+  if (preset === 'custom') return customExpiresAt.trim() || null;
+  if (preset === 'never') return null;
+  const days = preset === '7d' ? 7 : preset === '30d' ? 30 : 90;
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
 }
 
 export function TokensPage() {
@@ -494,33 +514,39 @@ function CreateTokenDialog(props: {
   const [label, setLabel] = useState('');
   const [role, setRole] = useState('');
   const [actions, setActions] = useState<string[]>([]);
-  const [expiresAt, setExpiresAt] = useState('');
+  const [expiryPreset, setExpiryPreset] = useState<TokenExpiryPreset>('never');
+  const [customExpiresAt, setCustomExpiresAt] = useState('');
   const labelId = useId();
   const roleId = useId();
   const actionsId = useId();
-  const expiresId = useId();
+  const expiryPresetId = useId();
+  const customExpiresId = useId();
   const canSubmit =
-    label.trim().length > 0 && (role.trim().length > 0 || actions.length > 0);
+    label.trim().length > 0 &&
+    (role.trim().length > 0 || actions.length > 0) &&
+    (expiryPreset !== 'custom' || customExpiresAt.trim().length > 0);
 
   useEffect(() => {
     if (!props.open) return;
     setLabel('');
     setRole('');
     setActions([]);
-    setExpiresAt('');
+    setExpiryPreset('never');
+    setCustomExpiresAt('');
   }, [props.open]);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const trimmedLabel = label.trim();
     const trimmedRole = role.trim();
-    const trimmedExpiresAt = expiresAt.trim();
+    const expiresAt = resolveExpiresAt(expiryPreset, customExpiresAt);
     if (!trimmedLabel || (!trimmedRole && actions.length === 0)) return;
+    if (expiryPreset === 'custom' && !expiresAt) return;
     props.onSubmit({
       label: trimmedLabel,
       ...(trimmedRole ? { role: trimmedRole } : {}),
       ...(actions.length > 0 ? { actions } : {}),
-      ...(trimmedExpiresAt ? { expiresAt: trimmedExpiresAt } : {}),
+      ...(expiresAt ? { expiresAt } : {}),
     });
   };
 
@@ -581,16 +607,37 @@ function CreateTokenDialog(props: {
               ))}
             </NativeSelect>
           </Field>
-          <Field>
-            <FieldLabel htmlFor={expiresId}>Expires at</FieldLabel>
-            <Input
-              id={expiresId}
-              value={expiresAt}
-              onChange={(event) => setExpiresAt(event.target.value)}
-              type="datetime-local"
+          <Field controlId={expiryPresetId}>
+            <FieldLabel>Expires at</FieldLabel>
+            <NativeSelect
+              id={expiryPresetId}
+              value={expiryPreset}
+              onChange={(event) =>
+                setExpiryPreset(event.target.value as TokenExpiryPreset)
+              }
               disabled={props.pending}
-            />
+            >
+              {TOKEN_EXPIRY_PRESETS.map(([value, optionLabel]) => (
+                <NativeSelectOption key={value} value={value}>
+                  {optionLabel}
+                </NativeSelectOption>
+              ))}
+            </NativeSelect>
           </Field>
+          {expiryPreset === 'custom' ? (
+            <Field>
+              <FieldLabel htmlFor={customExpiresId}>
+                Custom expiration
+              </FieldLabel>
+              <Input
+                id={customExpiresId}
+                value={customExpiresAt}
+                onChange={(event) => setCustomExpiresAt(event.target.value)}
+                type="datetime-local"
+                disabled={props.pending}
+              />
+            </Field>
+          ) : null}
           <DialogFooter>
             <DialogClose className="ghost-button" disabled={props.pending}>
               Cancel

--- a/console/src/routes/tokens.tsx
+++ b/console/src/routes/tokens.tsx
@@ -158,21 +158,18 @@ const TOKEN_ROLE_GROUPS = [
   {
     label: 'Current roles',
     options: [
-      ['admin.viewer', 'Viewer - read-only console access'],
-      ['admin.operator', 'Operator - day-to-day operations'],
+      ['admin.viewer', 'Viewer - read-only admin API access'],
+      ['admin.operator', 'Operator - day-to-day admin operations'],
       [
         'admin.integrations_manager',
-        'Integrations manager - agents and channels',
+        'Integrations manager - agent and channel APIs',
       ],
-      ['admin.config_manager', 'Config manager - runtime configuration'],
+      ['admin.config_manager', 'Config manager - runtime config APIs'],
       [
         'admin.security_manager',
-        'Security manager - secrets, policy, and skills',
+        'Security manager - secret, policy, and skill APIs',
       ],
-      [
-        'admin.terminal_operator',
-        'Terminal operator - terminal and job access',
-      ],
+      ['admin.terminal_operator', 'Terminal operator - terminal and job APIs'],
       ['admin.full', 'Full admin - every admin action'],
     ],
   },

--- a/console/src/routes/tokens.tsx
+++ b/console/src/routes/tokens.tsx
@@ -1,0 +1,433 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { type FormEvent, useId, useMemo, useRef, useState } from 'react';
+import {
+  createAdminApiToken,
+  fetchAdminApiTokens,
+  HttpResponseError,
+  revokeAdminApiToken,
+} from '../api/client';
+import type {
+  AdminApiTokenCreatePayload,
+  AdminApiTokenEntry,
+  AdminApiTokensResponse,
+} from '../api/types';
+import { useAuth } from '../auth';
+import { Button } from '../components/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../components/dialog';
+import { Field, FieldLabel } from '../components/field';
+import { Input } from '../components/input';
+import { Textarea } from '../components/textarea';
+import { useToast } from '../components/toast';
+import { PageHeader } from '../components/ui';
+import { getErrorMessage } from '../lib/error-message';
+import { formatRelativeTime } from '../lib/format';
+import styles from './secrets.module.css';
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return 'never';
+  return formatRelativeTime(value);
+}
+
+function formatTokenStatus(token: AdminApiTokenEntry): string {
+  if (token.revoked_at) return 'Revoked';
+  if (token.expires_at && Date.parse(token.expires_at) <= Date.now()) {
+    return 'Expired';
+  }
+  return 'Active';
+}
+
+function formatClaims(claims: Record<string, unknown>): string {
+  return (
+    Object.entries(claims)
+      .map(([key, value]) => {
+        if (Array.isArray(value)) return `${key}: ${value.join(', ')}`;
+        return `${key}: ${String(value)}`;
+      })
+      .join(' | ') || 'actions: none'
+  );
+}
+
+function splitActions(value: string): string[] {
+  return value
+    .split(/[,\s]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export function TokensPage() {
+  const { token } = useAuth();
+  const toast = useToast();
+  const queryClient = useQueryClient();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [revokeTarget, setRevokeTarget] = useState<AdminApiTokenEntry | null>(
+    null,
+  );
+  const [createdToken, setCreatedToken] = useState<string | null>(null);
+  const [filter, setFilter] = useState('');
+
+  const query = useQuery<AdminApiTokensResponse, Error>({
+    queryKey: ['admin', 'tokens', token],
+    queryFn: () => fetchAdminApiTokens(token),
+    retry: false,
+  });
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ['admin', 'tokens'] });
+
+  const createMutation = useMutation({
+    mutationFn: (payload: AdminApiTokenCreatePayload) =>
+      createAdminApiToken(token, payload),
+    onSuccess: async (response) => {
+      setCreatedToken(response.token);
+      setCreateOpen(false);
+      toast.success(`Created ${response.apiToken.label}.`);
+      await invalidate();
+    },
+    onError: (error) => {
+      toast.error(`Create failed: ${getErrorMessage(error)}`);
+    },
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: (id: string) => revokeAdminApiToken(token, id),
+    onSuccess: async (response) => {
+      toast.success(`Revoked ${response.apiToken.label}.`);
+      setRevokeTarget(null);
+      await invalidate();
+    },
+    onError: (error) => {
+      toast.error(`Revoke failed: ${getErrorMessage(error)}`);
+    },
+  });
+
+  const view = useMemo(() => {
+    const tokens = query.data?.tokens ?? [];
+    const needle = filter.trim().toLowerCase();
+    return needle
+      ? tokens.filter(
+          (entry) =>
+            entry.id.includes(needle) ||
+            entry.label.toLowerCase().includes(needle),
+        )
+      : tokens;
+  }, [filter, query.data?.tokens]);
+
+  if (query.isPending) {
+    return (
+      <div className="page-stack">
+        <PageHeader description="Scoped API tokens" />
+        <div className="empty-state">Loading API tokens...</div>
+      </div>
+    );
+  }
+
+  if (query.isError || !query.data) {
+    const forbidden =
+      query.error instanceof HttpResponseError && query.error.status === 403;
+    return (
+      <div className="page-stack">
+        <PageHeader description="Scoped API tokens" />
+        <div className="empty-state">
+          {forbidden
+            ? 'You do not have permission to view API tokens.'
+            : `Failed to load API tokens: ${getErrorMessage(query.error)}`}
+        </div>
+      </div>
+    );
+  }
+
+  const canCreate = query.data.actions.includes('admin.tokens.create');
+  const canRevoke = query.data.actions.includes('admin.tokens.revoke');
+
+  return (
+    <div className="page-stack">
+      <PageHeader
+        description="Revocable bearer tokens with scoped RBAC claims."
+        actions={
+          <div className={styles.actions}>
+            <input
+              className="compact-search"
+              value={filter}
+              onChange={(event) => setFilter(event.target.value)}
+              placeholder="Filter tokens"
+              aria-label="Filter tokens by label or id"
+            />
+            {canCreate ? (
+              <Button type="button" onClick={() => setCreateOpen(true)}>
+                Create token
+              </Button>
+            ) : null}
+          </div>
+        }
+      />
+
+      {view.length === 0 ? (
+        <div className="empty-state">
+          {query.data.tokens.length === 0
+            ? 'No API tokens have been created.'
+            : 'No API tokens match this filter.'}
+        </div>
+      ) : (
+        <div className="table-shell">
+          <table>
+            <thead>
+              <tr>
+                <th>Token</th>
+                <th>Status</th>
+                <th>Claims</th>
+                <th>Created</th>
+                <th>Last used</th>
+                <th>Expires</th>
+                {canRevoke ? (
+                  <th className={styles.actionsHead}>Actions</th>
+                ) : null}
+              </tr>
+            </thead>
+            <tbody>
+              {view.map((entry) => (
+                <tr key={entry.id}>
+                  <td>
+                    <strong className={styles.name}>{entry.label}</strong>
+                    <br />
+                    <code className={styles.fingerprint}>{entry.id}</code>
+                  </td>
+                  <td>{formatTokenStatus(entry)}</td>
+                  <td>{formatClaims(entry.claims)}</td>
+                  <td title={entry.created_at}>
+                    {formatTimestamp(entry.created_at)}
+                  </td>
+                  <td title={entry.last_used_at ?? undefined}>
+                    {formatTimestamp(entry.last_used_at)}
+                  </td>
+                  <td title={entry.expires_at ?? undefined}>
+                    {formatTimestamp(entry.expires_at)}
+                  </td>
+                  {canRevoke ? (
+                    <td>
+                      <div className={styles.actions}>
+                        {!entry.revoked_at ? (
+                          <Button
+                            type="button"
+                            variant="danger"
+                            size="sm"
+                            onClick={() => setRevokeTarget(entry)}
+                          >
+                            Revoke
+                          </Button>
+                        ) : null}
+                      </div>
+                    </td>
+                  ) : null}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <CreateTokenDialog
+        open={createOpen}
+        pending={createMutation.isPending}
+        onClose={() => setCreateOpen(false)}
+        onSubmit={(payload) => createMutation.mutate(payload)}
+      />
+      <RevokeTokenDialog
+        token={revokeTarget}
+        pending={revokeMutation.isPending}
+        onClose={() => setRevokeTarget(null)}
+        onConfirm={() => {
+          if (revokeTarget) revokeMutation.mutate(revokeTarget.id);
+        }}
+      />
+      <CreatedTokenDialog
+        token={createdToken}
+        onClose={() => setCreatedToken(null)}
+      />
+    </div>
+  );
+}
+
+function CreateTokenDialog(props: {
+  open: boolean;
+  pending: boolean;
+  onClose: () => void;
+  onSubmit: (payload: AdminApiTokenCreatePayload) => void;
+}) {
+  const labelRef = useRef<HTMLInputElement>(null);
+  const roleRef = useRef<HTMLInputElement>(null);
+  const actionsRef = useRef<HTMLInputElement>(null);
+  const expiresRef = useRef<HTMLInputElement>(null);
+  const labelId = useId();
+  const roleId = useId();
+  const actionsId = useId();
+  const expiresId = useId();
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const label = labelRef.current?.value.trim() || '';
+    const role = roleRef.current?.value.trim() || '';
+    const actions = splitActions(actionsRef.current?.value || '');
+    const expiresAt = expiresRef.current?.value.trim() || '';
+    if (!label || (!role && actions.length === 0)) return;
+    props.onSubmit({
+      label,
+      ...(role ? { role } : {}),
+      ...(actions.length > 0 ? { actions } : {}),
+      ...(expiresAt ? { expiresAt } : {}),
+    });
+  };
+
+  return (
+    <Dialog
+      open={props.open}
+      onOpenChange={(next) => {
+        if (!next) props.onClose();
+      }}
+    >
+      <DialogContent
+        role="dialog"
+        size="default"
+        preventCloseOnOutsideClick={props.pending}
+      >
+        <DialogHeader>
+          <DialogTitle>Create API token</DialogTitle>
+          <DialogDescription>
+            The token value is shown once after creation.
+          </DialogDescription>
+        </DialogHeader>
+        <form className={styles.overwriteForm} onSubmit={handleSubmit}>
+          <Field>
+            <FieldLabel htmlFor={labelId}>Label</FieldLabel>
+            <Input id={labelId} ref={labelRef} disabled={props.pending} />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor={actionsId}>Actions</FieldLabel>
+            <Input
+              id={actionsId}
+              ref={actionsRef}
+              placeholder="openai.api, chat.send"
+              disabled={props.pending}
+            />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor={roleId}>Role</FieldLabel>
+            <Input
+              id={roleId}
+              ref={roleRef}
+              placeholder="admin:auditor"
+              disabled={props.pending}
+            />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor={expiresId}>Expires at</FieldLabel>
+            <Input
+              id={expiresId}
+              ref={expiresRef}
+              type="datetime-local"
+              disabled={props.pending}
+            />
+          </Field>
+          <DialogFooter>
+            <DialogClose className="ghost-button" disabled={props.pending}>
+              Cancel
+            </DialogClose>
+            <Button type="submit" disabled={props.pending}>
+              {props.pending ? 'Creating...' : 'Create token'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RevokeTokenDialog(props: {
+  token: AdminApiTokenEntry | null;
+  pending: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  const open = props.token !== null;
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) props.onClose();
+      }}
+    >
+      <DialogContent
+        role="alertdialog"
+        size="default"
+        preventCloseOnOutsideClick={props.pending}
+      >
+        <DialogHeader>
+          <DialogTitle>Revoke {props.token?.label}?</DialogTitle>
+          <DialogDescription>
+            Existing clients using this token will be rejected immediately.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose className="ghost-button" disabled={props.pending}>
+            Cancel
+          </DialogClose>
+          <Button
+            type="button"
+            variant="danger"
+            disabled={props.pending}
+            onClick={props.onConfirm}
+          >
+            {props.pending ? 'Revoking...' : 'Revoke token'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CreatedTokenDialog(props: {
+  token: string | null;
+  onClose: () => void;
+}) {
+  const open = props.token !== null;
+  const tokenId = useId();
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) props.onClose();
+      }}
+    >
+      <DialogContent role="dialog" size="default">
+        <DialogHeader>
+          <DialogTitle>API token created</DialogTitle>
+          <DialogDescription>
+            Store this value before closing the dialog.
+          </DialogDescription>
+        </DialogHeader>
+        <Field>
+          <FieldLabel htmlFor={tokenId}>Token</FieldLabel>
+          <Textarea
+            id={tokenId}
+            readOnly
+            value={props.token || ''}
+            className={styles.tokenValue}
+            rows={3}
+          />
+        </Field>
+        <DialogFooter>
+          <Button type="button" onClick={props.onClose}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/console/src/routes/tokens.tsx
+++ b/console/src/routes/tokens.tsx
@@ -1,5 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { type FormEvent, useId, useMemo, useRef, useState } from 'react';
+import {
+  type FormEvent,
+  type ReactNode,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from 'react';
 import {
   createAdminApiToken,
   fetchAdminApiTokens,
@@ -23,7 +30,18 @@ import {
   DialogTitle,
 } from '../components/dialog';
 import { Field, FieldLabel } from '../components/field';
+import { Check, ChevronDown } from '../components/icons';
 import { Input } from '../components/input';
+import {
+  NativeSelect,
+  NativeSelectOptGroup,
+  NativeSelectOption,
+} from '../components/native-select';
+import {
+  Popover,
+  PopoverContent,
+  usePopoverContext,
+} from '../components/popover';
 import { Textarea } from '../components/textarea';
 import { useToast } from '../components/toast';
 import { PageHeader } from '../components/ui';
@@ -55,11 +73,223 @@ function formatClaims(claims: Record<string, unknown>): string {
   );
 }
 
-function splitActions(value: string): string[] {
+const TOKEN_ACTION_VALUES = [
+  'openai.api',
+  'chat.send',
+  'status.read',
+  'agents.read',
+  'secret.list_metadata',
+  'secret.overwrite',
+  'secret.unset',
+  'admin.tokens.read',
+  'admin.overview.read',
+  'admin.tunnel.read',
+  'admin.tunnel.write',
+  'admin.tunnel.reconnect',
+  'admin.tunnel.stop',
+  'admin.statistics.read',
+  'admin.logs.read',
+  'admin.team.read',
+  'admin.team.write',
+  'admin.agents.read',
+  'admin.agents.write',
+  'admin.agents.delete',
+  'admin.hybridai.bots.read',
+  'admin.agent_scoreboard.read',
+  'admin.harness_evolution.read',
+  'admin.models.read',
+  'admin.models.write',
+  'admin.sessions.read',
+  'admin.sessions.delete',
+  'admin.email.read',
+  'admin.email.delete',
+  'admin.scheduler.read',
+  'admin.scheduler.write',
+  'admin.scheduler.delete',
+  'admin.channels.read',
+  'admin.channels.write',
+  'admin.channels.delete',
+  'admin.connectors.read',
+  'admin.mcp.read',
+  'admin.mcp.write',
+  'admin.mcp.delete',
+  'admin.config.read',
+  'admin.config.write',
+  'admin.config.reload',
+  'admin.browser_pool.read',
+  'admin.browser_pool.start',
+  'admin.webhook_targets.write',
+  'admin.a2a.read',
+  'admin.a2a.write',
+  'admin.a2a.delete',
+  'admin.fleet.read',
+  'admin.fleet.write',
+  'admin.fleet.delete',
+  'admin.signal.read',
+  'admin.signal.write',
+  'admin.email_config.fetch',
+  'admin.audit.read',
+  'admin.approvals.read',
+  'admin.policy.write',
+  'admin.policy.delete',
+  'admin.tools.read',
+  'admin.plugins.read',
+  'admin.output_guard.read',
+  'admin.output_guard.write',
+  'admin.output_guard.preview',
+  'admin.distill.read',
+  'admin.distill.write',
+  'admin.distill.delete',
+  'admin.skills.read',
+  'admin.skills.write',
+  'admin.skills.unblock',
+  'admin.skills.upload',
+  'admin.jobs.read',
+  'admin.jobs.write',
+  'admin.jobs.delete',
+  'admin.terminal.start',
+  'admin.terminal.stop',
+  'admin.terminal.stream',
+  'admin.gateway.shutdown',
+  'admin.gateway.restart',
+] as const;
+
+const TOKEN_ROLE_GROUPS = [
+  {
+    label: 'Current roles',
+    options: [
+      ['admin.viewer', 'Viewer - read-only console access'],
+      ['admin.operator', 'Operator - day-to-day operations'],
+      [
+        'admin.integrations_manager',
+        'Integrations manager - agents and channels',
+      ],
+      ['admin.config_manager', 'Config manager - runtime configuration'],
+      [
+        'admin.security_manager',
+        'Security manager - secrets, policy, and skills',
+      ],
+      [
+        'admin.terminal_operator',
+        'Terminal operator - terminal and job access',
+      ],
+      ['admin.full', 'Full admin - every admin action'],
+    ],
+  },
+  {
+    label: 'Compatibility roles',
+    options: [
+      ['admin:auditor', 'Auditor - read-only admin access'],
+      ['admin:operator', 'Operator - broad operational access'],
+      ['admin:owner', 'Owner - full admin access'],
+      ['admin:secret-manager', 'Secret manager - secret metadata and writes'],
+    ],
+  },
+] as const;
+
+type TokenActionOption = {
+  value: string;
+  label: string;
+  description: string;
+  group: string;
+};
+
+function sentenceCase(value: string): string {
   return value
-    .split(/[,\s]+/)
-    .map((entry) => entry.trim())
-    .filter(Boolean);
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function formatActionLabel(value: string): string {
+  const overrides: Record<string, string> = {
+    'openai.api': 'OpenAI API',
+    'chat.send': 'Chat send',
+    'status.read': 'Status read',
+    'agents.read': 'Agents read',
+    'admin.a2a.read': 'A2A read',
+    'admin.a2a.write': 'A2A write',
+    'admin.a2a.delete': 'A2A delete',
+    'admin.mcp.read': 'MCP read',
+    'admin.mcp.write': 'MCP write',
+    'admin.mcp.delete': 'MCP delete',
+  };
+  if (overrides[value]) return overrides[value];
+  return value.split('.').map(sentenceCase).join(' ');
+}
+
+function formatActionDescription(value: string): string {
+  if (value === 'openai.api') return 'Use OpenAI-compatible /v1 endpoints.';
+  if (value === 'chat.send') return 'Send chat and command requests.';
+  if (value === 'status.read') return 'Read gateway status.';
+  if (value === 'agents.read') return 'Read agent metadata.';
+  if (value.startsWith('secret.')) return 'Access admin secret management.';
+  if (value === 'admin.tokens.read') return 'Read admin API token metadata.';
+  if (value.startsWith('admin.terminal.'))
+    return 'Control admin terminal sessions.';
+  if (value.startsWith('admin.gateway.'))
+    return 'Control gateway process actions.';
+  if (value.endsWith('.read') || value.endsWith('.fetch')) {
+    return 'Read this admin console area.';
+  }
+  if (value.endsWith('.write') || value.endsWith('.preview')) {
+    return 'Modify this admin console area.';
+  }
+  if (value.endsWith('.delete') || value.endsWith('.stop')) {
+    return 'Remove or stop resources in this admin console area.';
+  }
+  if (value.endsWith('.start') || value.endsWith('.restart')) {
+    return 'Start or restart resources in this admin console area.';
+  }
+  if (value.endsWith('.reload') || value.endsWith('.reconnect')) {
+    return 'Refresh runtime state in this admin console area.';
+  }
+  if (value.endsWith('.unblock') || value.endsWith('.upload')) {
+    return 'Manage skill trust state and uploads.';
+  }
+  return 'Grant this exact RBAC action.';
+}
+
+function resolveActionGroup(value: string): string {
+  if (
+    ['openai.api', 'chat.send', 'status.read', 'agents.read'].includes(value)
+  ) {
+    return 'API access';
+  }
+  if (value.startsWith('secret.')) return 'Secrets';
+  if (value.startsWith('admin.tokens.')) return 'API tokens';
+  if (
+    value.startsWith('admin.terminal.') ||
+    value.startsWith('admin.gateway.')
+  ) {
+    return 'Runtime controls';
+  }
+  if (value.endsWith('.read') || value.endsWith('.fetch')) return 'Admin reads';
+  return 'Admin changes';
+}
+
+const TOKEN_ACTION_OPTIONS: TokenActionOption[] = TOKEN_ACTION_VALUES.map(
+  (value) => ({
+    value,
+    label: formatActionLabel(value),
+    description: formatActionDescription(value),
+    group: resolveActionGroup(value),
+  }),
+);
+
+const TOKEN_ACTION_GROUP_ORDER = [
+  'API access',
+  'Secrets',
+  'API tokens',
+  'Admin reads',
+  'Admin changes',
+  'Runtime controls',
+];
+
+function orderTokenActions(actions: string[]): string[] {
+  const selected = new Set(actions);
+  return TOKEN_ACTION_OPTIONS.map((option) => option.value).filter((value) =>
+    selected.has(value),
+  );
 }
 
 export function TokensPage() {
@@ -261,27 +491,36 @@ function CreateTokenDialog(props: {
   onClose: () => void;
   onSubmit: (payload: AdminApiTokenCreatePayload) => void;
 }) {
-  const labelRef = useRef<HTMLInputElement>(null);
-  const roleRef = useRef<HTMLInputElement>(null);
-  const actionsRef = useRef<HTMLInputElement>(null);
-  const expiresRef = useRef<HTMLInputElement>(null);
+  const [label, setLabel] = useState('');
+  const [role, setRole] = useState('');
+  const [actions, setActions] = useState<string[]>([]);
+  const [expiresAt, setExpiresAt] = useState('');
   const labelId = useId();
   const roleId = useId();
   const actionsId = useId();
   const expiresId = useId();
+  const canSubmit =
+    label.trim().length > 0 && (role.trim().length > 0 || actions.length > 0);
+
+  useEffect(() => {
+    if (!props.open) return;
+    setLabel('');
+    setRole('');
+    setActions([]);
+    setExpiresAt('');
+  }, [props.open]);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const label = labelRef.current?.value.trim() || '';
-    const role = roleRef.current?.value.trim() || '';
-    const actions = splitActions(actionsRef.current?.value || '');
-    const expiresAt = expiresRef.current?.value.trim() || '';
-    if (!label || (!role && actions.length === 0)) return;
+    const trimmedLabel = label.trim();
+    const trimmedRole = role.trim();
+    const trimmedExpiresAt = expiresAt.trim();
+    if (!trimmedLabel || (!trimmedRole && actions.length === 0)) return;
     props.onSubmit({
-      label,
-      ...(role ? { role } : {}),
+      label: trimmedLabel,
+      ...(trimmedRole ? { role: trimmedRole } : {}),
       ...(actions.length > 0 ? { actions } : {}),
-      ...(expiresAt ? { expiresAt } : {}),
+      ...(trimmedExpiresAt ? { expiresAt: trimmedExpiresAt } : {}),
     });
   };
 
@@ -306,31 +545,48 @@ function CreateTokenDialog(props: {
         <form className={styles.overwriteForm} onSubmit={handleSubmit}>
           <Field>
             <FieldLabel htmlFor={labelId}>Label</FieldLabel>
-            <Input id={labelId} ref={labelRef} disabled={props.pending} />
-          </Field>
-          <Field>
-            <FieldLabel htmlFor={actionsId}>Actions</FieldLabel>
             <Input
+              id={labelId}
+              value={label}
+              onChange={(event) => setLabel(event.target.value)}
+              disabled={props.pending}
+            />
+          </Field>
+          <Field controlId={actionsId}>
+            <FieldLabel>Actions</FieldLabel>
+            <ActionMultiSelect
               id={actionsId}
-              ref={actionsRef}
-              placeholder="openai.api, chat.send"
+              value={actions}
+              onChange={setActions}
               disabled={props.pending}
             />
           </Field>
-          <Field>
-            <FieldLabel htmlFor={roleId}>Role</FieldLabel>
-            <Input
+          <Field controlId={roleId}>
+            <FieldLabel>Role</FieldLabel>
+            <NativeSelect
               id={roleId}
-              ref={roleRef}
-              placeholder="admin:auditor"
+              value={role}
+              onChange={(event) => setRole(event.target.value)}
               disabled={props.pending}
-            />
+            >
+              <NativeSelectOption value="">No role preset</NativeSelectOption>
+              {TOKEN_ROLE_GROUPS.map((group) => (
+                <NativeSelectOptGroup key={group.label} label={group.label}>
+                  {group.options.map(([value, optionLabel]) => (
+                    <NativeSelectOption key={value} value={value}>
+                      {optionLabel}
+                    </NativeSelectOption>
+                  ))}
+                </NativeSelectOptGroup>
+              ))}
+            </NativeSelect>
           </Field>
           <Field>
             <FieldLabel htmlFor={expiresId}>Expires at</FieldLabel>
             <Input
               id={expiresId}
-              ref={expiresRef}
+              value={expiresAt}
+              onChange={(event) => setExpiresAt(event.target.value)}
               type="datetime-local"
               disabled={props.pending}
             />
@@ -339,13 +595,189 @@ function CreateTokenDialog(props: {
             <DialogClose className="ghost-button" disabled={props.pending}>
               Cancel
             </DialogClose>
-            <Button type="submit" disabled={props.pending}>
+            <Button type="submit" disabled={props.pending || !canSubmit}>
               {props.pending ? 'Creating...' : 'Create token'}
             </Button>
           </DialogFooter>
         </form>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function ActionMultiSelect(props: {
+  id: string;
+  value: string[];
+  onChange: (value: string[]) => void;
+  disabled: boolean;
+}) {
+  const [filter, setFilter] = useState('');
+  const selected = useMemo(() => new Set(props.value), [props.value]);
+  const visibleOptions = useMemo(() => {
+    const needle = filter.trim().toLowerCase();
+    if (!needle) return TOKEN_ACTION_OPTIONS;
+    return TOKEN_ACTION_OPTIONS.filter(
+      (option) =>
+        option.value.toLowerCase().includes(needle) ||
+        option.label.toLowerCase().includes(needle) ||
+        option.description.toLowerCase().includes(needle),
+    );
+  }, [filter]);
+  const selectedOptions = useMemo(
+    () =>
+      TOKEN_ACTION_OPTIONS.filter((option) => selected.has(option.value)).map(
+        (option) => option.label,
+      ),
+    [selected],
+  );
+  const triggerText =
+    selectedOptions.length === 0
+      ? 'Select actions'
+      : selectedOptions.length <= 2
+        ? selectedOptions.join(', ')
+        : `${selectedOptions.length} actions selected`;
+
+  const updateSelection = (nextSelected: Set<string>) => {
+    props.onChange(orderTokenActions([...nextSelected]));
+  };
+
+  const toggleAction = (action: string) => {
+    const nextSelected = new Set(selected);
+    if (nextSelected.has(action)) nextSelected.delete(action);
+    else nextSelected.add(action);
+    updateSelection(nextSelected);
+  };
+
+  const clearSelection = () => {
+    props.onChange([]);
+  };
+
+  return (
+    <Popover
+      onOpenChange={(open) => {
+        if (open) return;
+        setFilter('');
+      }}
+    >
+      <ActionMultiSelectTrigger id={props.id} disabled={props.disabled}>
+        <span
+          className={
+            selectedOptions.length === 0
+              ? styles.selectPlaceholder
+              : styles.selectSummary
+          }
+        >
+          {triggerText}
+        </span>
+      </ActionMultiSelectTrigger>
+      <PopoverContent
+        align="start"
+        className={styles.multiSelectContent}
+        focusOnOpen={(content) => {
+          content.querySelector<HTMLInputElement>('input')?.focus();
+        }}
+        role="dialog"
+        aria-label="Select token actions"
+      >
+        <Input
+          value={filter}
+          onChange={(event) => setFilter(event.target.value)}
+          placeholder="Filter actions"
+          aria-label="Filter actions"
+          size="sm"
+          className={styles.actionFilter}
+        />
+        <div className={styles.choiceList}>
+          {TOKEN_ACTION_GROUP_ORDER.map((group) => {
+            const options = visibleOptions.filter(
+              (option) => option.group === group,
+            );
+            if (options.length === 0) return null;
+            return (
+              <div key={group} className={styles.choiceGroup}>
+                <div className={styles.choiceGroupLabel}>{group}</div>
+                {options.map((option) => {
+                  const checked = selected.has(option.value);
+                  return (
+                    <label key={option.value} className={styles.choiceRow}>
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        disabled={props.disabled}
+                        className={styles.choiceInput}
+                        onChange={() => toggleAction(option.value)}
+                      />
+                      <span
+                        aria-hidden="true"
+                        className={styles.choiceCheck}
+                        data-checked={checked || undefined}
+                      >
+                        {checked ? (
+                          <Check className={styles.choiceIcon} />
+                        ) : null}
+                      </span>
+                      <span className={styles.choiceMeta}>
+                        <span className={styles.choiceTitle}>
+                          {option.label}
+                        </span>
+                        <span className={styles.choiceDescription}>
+                          {option.description}
+                        </span>
+                      </span>
+                      <code className={styles.choiceValue}>{option.value}</code>
+                    </label>
+                  );
+                })}
+              </div>
+            );
+          })}
+          {visibleOptions.length === 0 ? (
+            <div className={styles.choiceEmpty}>No actions match.</div>
+          ) : null}
+        </div>
+        <div className={styles.choiceFooter}>
+          <span className={styles.choiceCount}>
+            {props.value.length === 0
+              ? 'No actions selected'
+              : `${props.value.length} selected`}
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={props.disabled || props.value.length === 0}
+            onClick={clearSelection}
+          >
+            Clear
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function ActionMultiSelectTrigger(props: {
+  id: string;
+  disabled: boolean;
+  children: ReactNode;
+}) {
+  const popover = usePopoverContext('ActionMultiSelectTrigger');
+  return (
+    <button
+      id={props.id}
+      ref={popover.setTriggerEl}
+      type="button"
+      aria-haspopup="dialog"
+      aria-expanded={popover.open}
+      aria-controls={popover.open ? popover.contentId : undefined}
+      disabled={props.disabled}
+      data-state={popover.open ? 'open' : 'closed'}
+      className={styles.multiSelectTrigger}
+      onClick={popover.toggle}
+    >
+      <span className={styles.multiSelectTriggerText}>{props.children}</span>
+      <ChevronDown aria-hidden="true" className={styles.selectChevron} />
+    </button>
   );
 }
 

--- a/src/audit/audit-trail.ts
+++ b/src/audit/audit-trail.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from 'node:crypto';
+import { hash, randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -58,9 +58,7 @@ interface SessionAuditState {
 const sessionStateCache = new Map<string, SessionAuditState>();
 
 function sha256(text: string): string {
-  // lgtm[js/insufficient-password-hash] Audit wire hashes provide deterministic
-  // record-chain integrity, not password or bearer-token storage.
-  return createHash('sha256').update(text).digest('hex');
+  return hash('sha256', text, 'hex');
 }
 
 function stableStringify(value: unknown): string {

--- a/src/audit/audit-trail.ts
+++ b/src/audit/audit-trail.ts
@@ -58,6 +58,8 @@ interface SessionAuditState {
 const sessionStateCache = new Map<string, SessionAuditState>();
 
 function sha256(text: string): string {
+  // lgtm[js/insufficient-password-hash] Audit wire hashes provide deterministic
+  // record-chain integrity, not password or bearer-token storage.
   return createHash('sha256').update(text).digest('hex');
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1899,6 +1899,11 @@ async function handleSecretCommand(args: string[]): Promise<void> {
   await cliSecret.handleSecretCommand(args);
 }
 
+async function handleTokenCommand(args: string[]): Promise<void> {
+  const cliToken = await import('./cli/token-command.js');
+  await cliToken.handleTokenCommand(args);
+}
+
 async function handleEnvCommand(args: string[]): Promise<void> {
   const cliEnv = await import('./cli/env-command.js');
   await cliEnv.handleEnvCommand(args);
@@ -1985,6 +1990,9 @@ export async function main(
       break;
     case 'secret':
       await handleSecretCommand(subargs);
+      break;
+    case 'token':
+      await handleTokenCommand(subargs);
       break;
     case 'env':
       await handleEnvCommand(subargs);

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -11,6 +11,7 @@ export function printMainUsage(): void {
   backup     Create or restore a full-state backup of ~/.hybridclaw
   config     Show or edit the local runtime config
   secret     Manage encrypted runtime secrets and HTTP auth routes
+  token      Manage scoped API tokens for the local gateway
   policy     Manage workspace HTTP/network access rules
   gateway    Manage core runtime (start/stop/status) or run gateway commands
   eval       Run local eval recipes or launch detached benchmark commands
@@ -892,6 +893,24 @@ Notes:
   - Use \`prefix\` for \`Bearer <secret>\` or \`none\` for raw header injection.`);
 }
 
+export function printTokenUsage(): void {
+  console.log(`Usage: hybridclaw token <command>
+
+Commands:
+  hybridclaw token list
+  hybridclaw token create --label <label> (--role <role>|--actions <a,b>) [--expires-at <iso>]
+  hybridclaw token revoke <id>
+
+Examples:
+  hybridclaw token create --label sdk --actions openai.api
+  hybridclaw token create --label admin-read --role admin:auditor
+  hybridclaw token revoke 0123456789ab
+
+Notes:
+  - Tokens are printed once on creation. HybridClaw stores only a SHA-256 hash.
+  - WEB_API_TOKEN and GATEWAY_API_TOKEN remain unscoped master tokens; \`hybridclaw token\` creates revocable scoped tokens.`);
+}
+
 export function printEnvUsage(): void {
   console.log(`Usage: hybridclaw env <command>
 
@@ -1013,6 +1032,7 @@ Topics:
   hermes      Help for Hermes Agent migration
   config      Help for local runtime config commands
   secret      Help for encrypted secret-store commands
+  token       Help for scoped API token commands
   policy      Help for workspace network policy commands
   plugin      Help for plugin management
   msteams     Help for Microsoft Teams auth/setup commands
@@ -1105,6 +1125,9 @@ export async function printHelpTopic(topic: string): Promise<boolean> {
       return true;
     case 'secret':
       printSecretUsage();
+      return true;
+    case 'token':
+      printTokenUsage();
       return true;
     case 'policy':
       printPolicyUsage();

--- a/src/cli/token-command.ts
+++ b/src/cli/token-command.ts
@@ -1,0 +1,180 @@
+import {
+  createApiToken,
+  listApiTokens,
+  revokeApiToken,
+} from '../security/api-tokens.js';
+import { normalizeArgs, parseValueFlag } from './common.js';
+import { isHelpRequest, printTokenUsage } from './help.js';
+
+function splitClaimList(value: string): string[] {
+  return value
+    .split(/[,\s]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function formatTokenStatus(token: {
+  revoked_at: string | null;
+  expires_at: string | null;
+}) {
+  if (token.revoked_at) return 'revoked';
+  if (token.expires_at && Date.parse(token.expires_at) <= Date.now()) {
+    return 'expired';
+  }
+  return 'active';
+}
+
+function formatClaims(claims: Record<string, unknown>): string {
+  const entries = Object.entries(claims)
+    .map(
+      ([key, value]) =>
+        `${key}=${Array.isArray(value) ? value.join(',') : String(value)}`,
+    )
+    .join(' ');
+  return entries || 'actions=';
+}
+
+function parseCreateArgs(args: string[]): {
+  label: string;
+  claims: Record<string, unknown>;
+  expiresAt: string | null;
+} {
+  let label = '';
+  let role = '';
+  let actions: string[] = [];
+  let expiresAt: string | null = null;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index] || '';
+    const labelFlag = parseValueFlag({
+      arg,
+      args,
+      index,
+      name: '--label',
+      placeholder: '<label>',
+    });
+    if (labelFlag) {
+      label = labelFlag.value;
+      index = labelFlag.nextIndex;
+      continue;
+    }
+    const roleFlag = parseValueFlag({
+      arg,
+      args,
+      index,
+      name: '--role',
+      placeholder: '<role>',
+    });
+    if (roleFlag) {
+      role = roleFlag.value;
+      index = roleFlag.nextIndex;
+      continue;
+    }
+    const actionsFlag = parseValueFlag({
+      arg,
+      args,
+      index,
+      name: '--actions',
+      placeholder: '<action[,action]>',
+    });
+    if (actionsFlag) {
+      actions = splitClaimList(actionsFlag.value);
+      index = actionsFlag.nextIndex;
+      continue;
+    }
+    const expiresAtFlag = parseValueFlag({
+      arg,
+      args,
+      index,
+      name: '--expires-at',
+      placeholder: '<iso>',
+    });
+    if (expiresAtFlag) {
+      expiresAt = expiresAtFlag.value;
+      index = expiresAtFlag.nextIndex;
+      continue;
+    }
+    throw new Error(`Unknown token create argument: ${arg}`);
+  }
+
+  if (!label) {
+    throw new Error(
+      'Usage: `hybridclaw token create --label <label> (--role <role>|--actions <a,b>)`',
+    );
+  }
+  if (!role && actions.length === 0) {
+    throw new Error('Token claims are required. Pass `--role` or `--actions`.');
+  }
+
+  return {
+    label,
+    claims: {
+      ...(role ? { role } : {}),
+      ...(actions.length > 0 ? { actions } : {}),
+    },
+    expiresAt,
+  };
+}
+
+export async function handleTokenCommand(args: string[]): Promise<void> {
+  const normalized = normalizeArgs(args);
+  if (normalized.length === 0 || isHelpRequest(normalized)) {
+    printTokenUsage();
+    return;
+  }
+
+  const sub = normalized[0].toLowerCase();
+
+  if (sub === 'list') {
+    const tokens = listApiTokens();
+    if (tokens.length === 0) {
+      console.log('(none)');
+      return;
+    }
+    for (const token of tokens) {
+      console.log(
+        [
+          token.id,
+          formatTokenStatus(token),
+          token.label,
+          `created=${token.created_at}`,
+          `expires=${token.expires_at || 'never'}`,
+          `last_used=${token.last_used_at || 'never'}`,
+          formatClaims(token.claims),
+        ].join('\t'),
+      );
+    }
+    return;
+  }
+
+  if (sub === 'create') {
+    const parsed = parseCreateArgs(normalized.slice(1));
+    const result = createApiToken({
+      label: parsed.label,
+      claims: parsed.claims,
+      expiresAt: parsed.expiresAt,
+      createdBy: 'cli',
+    });
+    console.log(
+      `Created API token ${result.metadata.id} (${result.metadata.label}).`,
+    );
+    console.log(`Token: ${result.token}`);
+    console.log('Store it now. HybridClaw cannot show this token again.');
+    return;
+  }
+
+  if (sub === 'revoke') {
+    const id = String(normalized[1] || '').trim();
+    if (!id) {
+      throw new Error('Usage: `hybridclaw token revoke <id>`');
+    }
+    const token = revokeApiToken(id);
+    if (!token) {
+      throw new Error(`API token not found: ${id}`);
+    }
+    console.log(`Revoked API token ${token.id} (${token.label}).`);
+    return;
+  }
+
+  throw new Error(`Unknown token subcommand: ${sub}`);
+}

--- a/src/gateway/gateway-admin-tokens.ts
+++ b/src/gateway/gateway-admin-tokens.ts
@@ -1,0 +1,201 @@
+import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
+import { GatewayRequestError } from '../errors/gateway-request-error.js';
+import {
+  ADMIN_TOKEN_RBAC_ACTIONS,
+  type AdminRbacAction,
+  isAdminActionAllowed,
+} from '../security/admin-rbac.js';
+import {
+  type ApiTokenMetadata,
+  createApiToken,
+  listApiTokens,
+  normalizeApiTokenClaims,
+  revokeApiToken,
+} from '../security/api-tokens.js';
+
+export interface GatewayAdminTokensResponse {
+  tokens: ApiTokenMetadata[];
+  total: number;
+  actions: AdminRbacAction[];
+}
+
+export interface GatewayAdminTokenCreateResponse {
+  token: string;
+  apiToken: ApiTokenMetadata;
+}
+
+export interface GatewayAdminTokenRevokeResponse {
+  apiToken: ApiTokenMetadata;
+}
+
+export interface AdminTokenAuditContext {
+  sessionId?: string;
+  actor?: string | null;
+  sourceIp?: string | null;
+}
+
+function resolveAllowedAdminTokenActions(
+  authPayload: Record<string, unknown> | null,
+): AdminRbacAction[] {
+  return ADMIN_TOKEN_RBAC_ACTIONS.filter((action) =>
+    isAdminActionAllowed(authPayload, action),
+  );
+}
+
+function resolveAuditSessionId(audit: AdminTokenAuditContext): string {
+  return audit.sessionId || audit.actor || 'admin:anonymous';
+}
+
+function recordTokenAudit(params: {
+  type: 'token.created' | 'token.revoked';
+  audit: AdminTokenAuditContext;
+  token: ApiTokenMetadata;
+}): void {
+  recordAuditEvent({
+    sessionId: resolveAuditSessionId(params.audit),
+    runId: makeAuditRunId(
+      params.type === 'token.created' ? 'token-create' : 'token-revoke',
+    ),
+    event: {
+      type: params.type,
+      id: params.token.id,
+      label: params.token.label,
+      claims: params.token.claims,
+      actor: params.audit.actor || null,
+      sourceIp: params.audit.sourceIp || null,
+    },
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function normalizeStringArrayClaim(
+  value: unknown,
+  field: string,
+): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === 'string') {
+    return value
+      .split(/[,\s]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  if (
+    Array.isArray(value) &&
+    value.every((entry) => typeof entry === 'string')
+  ) {
+    return value.map((entry) => entry.trim()).filter(Boolean);
+  }
+  throw new GatewayRequestError(400, `\`${field}\` must be a string or array.`);
+}
+
+function buildClaimsFromBody(body: Record<string, unknown>) {
+  if (isRecord(body.claims)) {
+    return normalizeApiTokenClaims(body.claims);
+  }
+
+  const claims: Record<string, unknown> = {};
+  const actions = normalizeStringArrayClaim(body.actions, 'actions');
+  const scope = normalizeStringArrayClaim(body.scope, 'scope');
+  const roles = normalizeStringArrayClaim(body.roles, 'roles');
+  const role =
+    typeof body.role === 'string' && body.role.trim()
+      ? body.role.trim()
+      : undefined;
+
+  if (actions !== undefined) claims.actions = actions;
+  if (scope !== undefined) claims.scope = scope.join(' ');
+  if (roles !== undefined) claims.roles = roles;
+  if (role !== undefined) claims.role = role;
+
+  if (
+    !Object.hasOwn(claims, 'actions') &&
+    !Object.hasOwn(claims, 'scope') &&
+    !Object.hasOwn(claims, 'role') &&
+    !Object.hasOwn(claims, 'roles')
+  ) {
+    throw new GatewayRequestError(
+      400,
+      'API token claims are required. Provide `actions`, `scope`, `role`, `roles`, or `claims`.',
+    );
+  }
+
+  return normalizeApiTokenClaims(claims);
+}
+
+function normalizeCreateBody(body: unknown): {
+  label: string;
+  claims: Record<string, unknown>;
+  expiresAt: string | null;
+} {
+  if (!isRecord(body)) {
+    throw new GatewayRequestError(400, 'Request body must be an object.');
+  }
+  const label = typeof body.label === 'string' ? body.label.trim() : '';
+  if (!label) {
+    throw new GatewayRequestError(400, '`label` is required.');
+  }
+  const expiresAt =
+    typeof body.expiresAt === 'string' && body.expiresAt.trim()
+      ? body.expiresAt.trim()
+      : null;
+  if (expiresAt && Number.isNaN(new Date(expiresAt).getTime())) {
+    throw new GatewayRequestError(400, '`expiresAt` must be a valid date.');
+  }
+  return {
+    label,
+    claims: buildClaimsFromBody(body),
+    expiresAt,
+  };
+}
+
+export function getGatewayAdminTokens(options: {
+  authPayload: Record<string, unknown> | null;
+}): GatewayAdminTokensResponse {
+  const tokens = listApiTokens();
+  return {
+    tokens,
+    total: tokens.length,
+    actions: resolveAllowedAdminTokenActions(options.authPayload),
+  };
+}
+
+export function createGatewayAdminToken(options: {
+  body: unknown;
+  audit: AdminTokenAuditContext;
+}): GatewayAdminTokenCreateResponse {
+  const body = normalizeCreateBody(options.body);
+  const result = createApiToken({
+    label: body.label,
+    claims: body.claims,
+    expiresAt: body.expiresAt,
+    createdBy: options.audit.actor || null,
+  });
+  recordTokenAudit({
+    type: 'token.created',
+    audit: options.audit,
+    token: result.metadata,
+  });
+  return {
+    token: result.token,
+    apiToken: result.metadata,
+  };
+}
+
+export function revokeGatewayAdminToken(options: {
+  id: string;
+  audit: AdminTokenAuditContext;
+}): GatewayAdminTokenRevokeResponse {
+  const token = revokeApiToken(options.id);
+  if (!token) {
+    throw new GatewayRequestError(404, 'API token not found.');
+  }
+  recordTokenAudit({
+    type: 'token.revoked',
+    audit: options.audit,
+    token,
+  });
+  return { apiToken: token };
+}

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -130,9 +130,11 @@ import { listLoadedPluginCommands } from '../plugins/plugin-manager.js';
 import { isPluginInboundWebhookPath } from '../plugins/plugin-webhooks.js';
 import {
   type AdminRbacAction,
+  collectAdminActionClaims,
   isAdminActionAllowed,
   resolveAdminRbacAction,
 } from '../security/admin-rbac.js';
+import { isApiTokenString, verifyApiToken } from '../security/api-tokens.js';
 import { redactSecretsDeep } from '../security/redact.js';
 import { createSecretHandle } from '../security/secret-handles.js';
 import type { SecretInput } from '../security/secret-refs.js';
@@ -202,6 +204,11 @@ import {
   recordGatewayAdminSecretMutationFailure,
   unsetGatewayAdminSecret,
 } from './gateway-admin-secrets.js';
+import {
+  createGatewayAdminToken,
+  getGatewayAdminTokens,
+  revokeGatewayAdminToken,
+} from './gateway-admin-tokens.js';
 import { handleGatewayMessage } from './gateway-chat-service.js';
 import {
   deleteGatewayAdminDistillCorpusDocument,
@@ -2104,27 +2111,68 @@ function hasSameGatewayOrigin(req: IncomingMessage): boolean {
   );
 }
 
-function hasApiAuth(
+type ResolvedAuthKind =
+  | 'master'
+  | 'apiToken'
+  | 'session'
+  | 'localSession'
+  | 'none';
+
+interface ResolvedAuthContext {
+  kind: ResolvedAuthKind;
+  payload: Record<string, unknown> | null;
+  tokenId?: string;
+  tokenLabel?: string;
+}
+
+interface ResolveAuthContextOptions {
+  allowApiTokens?: boolean;
+  allowLocalWebSession?: boolean;
+  allowQueryToken?: boolean;
+  allowSessionCookie?: boolean;
+  requireSameOrigin?: boolean;
+}
+
+function extractBearerToken(req: IncomingMessage): string {
+  const authHeader = normalizeHeaderValue(req.headers.authorization) || '';
+  const match = /^Bearer\s+(.+)$/i.exec(authHeader);
+  return match?.[1]?.trim() || '';
+}
+
+function resolveAuthContext(
   req: IncomingMessage,
   url?: URL,
-  opts?: {
-    allowLocalWebSession?: boolean;
-    allowQueryToken?: boolean;
-    allowSessionCookie?: boolean;
-    requireSameOrigin?: boolean;
-  },
-): boolean {
-  const authHeader = req.headers.authorization || '';
-  const gatewayTokenMatch = hasBearerToken(authHeader, GATEWAY_API_TOKEN);
-  if (opts?.allowQueryToken && url && hasQueryToken(url)) return true;
+  opts?: ResolveAuthContextOptions,
+): ResolvedAuthContext {
+  if (opts?.allowQueryToken && url && hasQueryToken(url)) {
+    return { kind: 'master', payload: null };
+  }
 
-  if (hasBearerToken(authHeader, WEB_API_TOKEN)) return true;
+  const authHeader = req.headers.authorization || '';
+  const bearer = extractBearerToken(req);
+  const hasWebBearer = hasBearerToken(authHeader, WEB_API_TOKEN);
+  const hasGatewayBearer = hasBearerToken(authHeader, GATEWAY_API_TOKEN);
+  const hasMasterBearer = hasWebBearer || hasGatewayBearer;
+  if (opts?.allowApiTokens !== false && bearer && isApiTokenString(bearer)) {
+    const verified = verifyApiToken(bearer);
+    if (verified) {
+      return {
+        kind: 'apiToken',
+        payload: verified.claims,
+        tokenId: verified.id,
+        tokenLabel: verified.label,
+      };
+    }
+  }
+
   if (
     opts?.allowSessionCookie &&
-    hasSessionAuth(req) &&
-    (!opts.requireSameOrigin || hasSameGatewayOrigin(req))
+    (!opts.requireSameOrigin || hasSameGatewayOrigin(req) || hasMasterBearer)
   ) {
-    return true;
+    const sessionPayload = getSessionAuthPayload(req);
+    if (sessionPayload) {
+      return { kind: 'session', payload: sessionPayload };
+    }
   }
   if (
     opts?.allowLocalWebSession &&
@@ -2132,9 +2180,12 @@ function hasApiAuth(
     hasLocalWebSessionAuth(req) &&
     (!opts.requireSameOrigin || hasSameGatewayOrigin(req))
   ) {
-    return true;
+    return { kind: 'localSession', payload: null };
   }
-  return gatewayTokenMatch;
+  if (hasMasterBearer) {
+    return { kind: 'master', payload: null };
+  }
+  return { kind: 'none', payload: null };
 }
 
 function hasGatewayApiAuth(req: IncomingMessage): boolean {
@@ -2192,17 +2243,29 @@ function resolveAdminSessionAuditId(
   return typeof value === 'string' && value.trim() ? value.trim() : null;
 }
 
+function resolveApiTokenActor(context: ResolvedAuthContext): string | null {
+  if (context.kind !== 'apiToken' || !context.tokenId) return null;
+  const label = context.tokenLabel?.trim();
+  return label
+    ? `apiToken:${context.tokenId}:${label}`
+    : `apiToken:${context.tokenId}`;
+}
+
 function resolveAdminSecretAuditContext(
   req: IncomingMessage,
-  sessionPayload: Record<string, unknown> | null,
+  authContext: ResolvedAuthContext,
 ): {
   sessionId?: string;
   actor?: string | null;
   sourceIp?: string | null;
 } {
+  const apiTokenActor = resolveApiTokenActor(authContext);
   return {
-    sessionId: resolveAdminSessionAuditId(sessionPayload) || undefined,
-    actor: resolveAdminSessionActor(sessionPayload),
+    sessionId:
+      resolveAdminSessionAuditId(authContext.payload) ||
+      apiTokenActor ||
+      undefined,
+    actor: apiTokenActor || resolveAdminSessionActor(authContext.payload),
     sourceIp: req.socket.remoteAddress || null,
   };
 }
@@ -2212,21 +2275,53 @@ function shouldDeferAdminRbacToHandler(action: AdminRbacAction): boolean {
 }
 
 function isAdminRouteActionAllowed(
-  req: IncomingMessage,
+  authContext: ResolvedAuthContext,
   action: AdminRbacAction,
 ): boolean {
-  return isAdminActionAllowed(getSessionAuthPayload(req), action);
+  return isAdminActionAllowed(authContext.payload, action);
+}
+
+function isAdminPath(pathname: string): boolean {
+  return pathname === '/api/admin' || pathname.startsWith('/api/admin/');
+}
+
+function hasFullApiTokenWildcard(context: ResolvedAuthContext): boolean {
+  if (context.kind !== 'apiToken') return false;
+  return collectAdminActionClaims(context.payload)?.has('*') === true;
+}
+
+function isApiTokenAllowedForRoute(
+  context: ResolvedAuthContext,
+  pathname: string,
+  method: string,
+): boolean {
+  if (context.kind !== 'apiToken') return true;
+  const action = resolveAdminRbacAction(pathname, method);
+  if (!action) return hasFullApiTokenWildcard(context);
+  return isAdminActionAllowed(context.payload, action);
 }
 
 function enforceAdminRouteRbac(
-  req: IncomingMessage,
+  authContext: ResolvedAuthContext,
   res: ServerResponse,
   pathname: string,
   method: string,
 ): boolean {
   const action = resolveAdminRbacAction(pathname, method);
+  if (authContext.kind === 'apiToken') {
+    if (!action && hasFullApiTokenWildcard(authContext)) return true;
+    if (!action) {
+      sendJson(res, 403, { error: 'Forbidden.' });
+      return false;
+    }
+    if (shouldDeferAdminRbacToHandler(action)) return true;
+    if (isAdminRouteActionAllowed(authContext, action)) return true;
+    sendJson(res, 403, { error: 'Forbidden.' });
+    return false;
+  }
+  if (!isAdminPath(pathname)) return true;
   if (!action || shouldDeferAdminRbacToHandler(action)) return true;
-  if (isAdminRouteActionAllowed(req, action)) return true;
+  if (isAdminRouteActionAllowed(authContext, action)) return true;
   sendJson(res, 403, { error: 'Forbidden.' });
   return false;
 }
@@ -3670,15 +3765,20 @@ function handleApiAgentAvatar(
   res: ServerResponse,
   url: URL,
 ): void {
-  if (
-    !hasApiAuth(req, url, {
-      allowLocalWebSession: true,
-      allowSessionCookie: true,
-    })
-  ) {
+  const authContext = resolveAuthContext(req, url, {
+    allowLocalWebSession: true,
+    allowSessionCookie: true,
+  });
+  if (authContext.kind === 'none') {
     sendJson(res, 401, {
       error: 'Unauthorized. Set `Authorization: Bearer <WEB_API_TOKEN>`.',
     });
+    return;
+  }
+  if (
+    !isApiTokenAllowedForRoute(authContext, url.pathname, req.method || 'GET')
+  ) {
+    sendJson(res, 403, { error: 'Forbidden.' });
     return;
   }
 
@@ -4199,9 +4299,9 @@ async function handleApiAdminOverview(res: ServerResponse): Promise<void> {
 function handleApiAdminSecrets(
   req: IncomingMessage,
   res: ServerResponse,
+  authContext: ResolvedAuthContext,
 ): void {
-  const sessionPayload = getSessionAuthPayload(req);
-  if (!isAdminActionAllowed(sessionPayload, 'secret.list_metadata')) {
+  if (!isAdminActionAllowed(authContext.payload, 'secret.list_metadata')) {
     sendJson(res, 403, { error: 'Forbidden.' });
     return;
   }
@@ -4210,8 +4310,8 @@ function handleApiAdminSecrets(
     res,
     200,
     getGatewayAdminSecrets({
-      audit: resolveAdminSecretAuditContext(req, sessionPayload),
-      sessionPayload,
+      audit: resolveAdminSecretAuditContext(req, authContext),
+      sessionPayload: authContext.payload,
     }),
   );
 }
@@ -4235,14 +4335,110 @@ function readAdminSecretBodyValue(body: unknown): unknown {
   return undefined;
 }
 
+function parseApiAdminTokenId(pathname: string): string | null {
+  const prefix = '/api/admin/tokens/';
+  if (!pathname.startsWith(prefix)) return null;
+  const encoded = pathname.slice(prefix.length);
+  if (!encoded || encoded.includes('/')) return null;
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    throw new GatewayRequestError(400, 'Invalid token id in request path.');
+  }
+}
+
+function resolveAdminTokenAuditContext(
+  req: IncomingMessage,
+  authContext: ResolvedAuthContext,
+): {
+  sessionId?: string;
+  actor?: string | null;
+  sourceIp?: string | null;
+} {
+  const apiTokenActor = resolveApiTokenActor(authContext);
+  return {
+    sessionId:
+      resolveAdminSessionAuditId(authContext.payload) ||
+      apiTokenActor ||
+      undefined,
+    actor: apiTokenActor || resolveAdminSessionActor(authContext.payload),
+    sourceIp: req.socket.remoteAddress || null,
+  };
+}
+
+function handleApiAdminTokens(
+  res: ServerResponse,
+  authContext: ResolvedAuthContext,
+): void {
+  if (!isAdminActionAllowed(authContext.payload, 'admin.tokens.read')) {
+    sendJson(res, 403, { error: 'Forbidden.' });
+    return;
+  }
+  sendJson(
+    res,
+    200,
+    getGatewayAdminTokens({
+      authPayload: authContext.payload,
+    }),
+  );
+}
+
+async function handleApiAdminTokenCreate(
+  req: IncomingMessage,
+  res: ServerResponse,
+  authContext: ResolvedAuthContext,
+): Promise<void> {
+  if (authContext.kind === 'apiToken') {
+    sendJson(res, 403, { error: 'Forbidden.' });
+    return;
+  }
+  if (!isAdminActionAllowed(authContext.payload, 'admin.tokens.create')) {
+    sendJson(res, 403, { error: 'Forbidden.' });
+    return;
+  }
+  const body = await readJsonBody(req);
+  sendJson(
+    res,
+    201,
+    createGatewayAdminToken({
+      body,
+      audit: resolveAdminTokenAuditContext(req, authContext),
+    }),
+  );
+}
+
+function handleApiAdminTokenRevoke(
+  req: IncomingMessage,
+  res: ServerResponse,
+  id: string,
+  authContext: ResolvedAuthContext,
+): void {
+  if (authContext.kind === 'apiToken') {
+    sendJson(res, 403, { error: 'Forbidden.' });
+    return;
+  }
+  if (!isAdminActionAllowed(authContext.payload, 'admin.tokens.revoke')) {
+    sendJson(res, 403, { error: 'Forbidden.' });
+    return;
+  }
+  sendJson(
+    res,
+    200,
+    revokeGatewayAdminToken({
+      id,
+      audit: resolveAdminTokenAuditContext(req, authContext),
+    }),
+  );
+}
+
 async function handleApiAdminSecretOverwrite(
   req: IncomingMessage,
   res: ServerResponse,
   name: string,
+  authContext: ResolvedAuthContext,
 ): Promise<void> {
-  const sessionPayload = getSessionAuthPayload(req);
-  const audit = resolveAdminSecretAuditContext(req, sessionPayload);
-  if (!isAdminActionAllowed(sessionPayload, 'secret.overwrite')) {
+  const audit = resolveAdminSecretAuditContext(req, authContext);
+  if (!isAdminActionAllowed(authContext.payload, 'secret.overwrite')) {
     recordGatewayAdminSecretMutationFailure({
       type: 'secret.overwritten',
       name,
@@ -4281,10 +4477,10 @@ async function handleApiAdminSecretUnset(
   req: IncomingMessage,
   res: ServerResponse,
   name: string,
+  authContext: ResolvedAuthContext,
 ): Promise<void> {
-  const sessionPayload = getSessionAuthPayload(req);
-  const audit = resolveAdminSecretAuditContext(req, sessionPayload);
-  if (!isAdminActionAllowed(sessionPayload, 'secret.unset')) {
+  const audit = resolveAdminSecretAuditContext(req, authContext);
+  if (!isAdminActionAllowed(authContext.payload, 'secret.unset')) {
     recordGatewayAdminSecretMutationFailure({
       type: 'secret.unset',
       name,
@@ -7057,17 +7253,22 @@ async function handleApiArtifact(
   res: ServerResponse,
   url: URL,
 ): Promise<void> {
-  if (
-    !hasApiAuth(req, url, {
-      allowLocalWebSession: true,
-      allowQueryToken: true,
-      allowSessionCookie: true,
-    })
-  ) {
+  const authContext = resolveAuthContext(req, url, {
+    allowLocalWebSession: true,
+    allowQueryToken: true,
+    allowSessionCookie: true,
+  });
+  if (authContext.kind === 'none') {
     sendJson(res, 401, {
       error:
         'Unauthorized. Set `Authorization: Bearer <WEB_API_TOKEN>` or pass `?token=<WEB_API_TOKEN>`.',
     });
+    return;
+  }
+  if (
+    !isApiTokenAllowedForRoute(authContext, url.pathname, req.method || 'GET')
+  ) {
+    sendJson(res, 403, { error: 'Forbidden.' });
     return;
   }
 
@@ -7473,14 +7674,19 @@ async function handleApiAppBridgeTool(
     return;
   }
 
-  if (
-    !hasApiAuth(req, url, {
-      allowLocalWebSession: true,
-      allowSessionCookie: true,
-      requireSameOrigin: true,
-    })
-  ) {
+  const authContext = resolveAuthContext(req, url, {
+    allowLocalWebSession: true,
+    allowSessionCookie: true,
+    requireSameOrigin: true,
+  });
+  if (authContext.kind === 'none') {
     sendJson(res, 401, { error: 'Unauthorized.' });
+    return;
+  }
+  if (
+    !isApiTokenAllowedForRoute(authContext, url.pathname, req.method || 'POST')
+  ) {
+    sendJson(res, 403, { error: 'Forbidden.' });
     return;
   }
 
@@ -7530,17 +7736,22 @@ async function handleApiAppView(
   url: URL,
   id: string,
 ): Promise<void> {
-  if (
-    !hasApiAuth(req, url, {
-      allowLocalWebSession: true,
-      allowQueryToken: true,
-      allowSessionCookie: true,
-    })
-  ) {
+  const authContext = resolveAuthContext(req, url, {
+    allowLocalWebSession: true,
+    allowQueryToken: true,
+    allowSessionCookie: true,
+  });
+  if (authContext.kind === 'none') {
     sendJson(res, 401, {
       error:
         'Unauthorized. Set `Authorization: Bearer <WEB_API_TOKEN>` or pass `?token=<WEB_API_TOKEN>`.',
     });
+    return;
+  }
+  if (
+    !isApiTokenAllowedForRoute(authContext, url.pathname, req.method || 'GET')
+  ) {
+    sendJson(res, 403, { error: 'Forbidden.' });
     return;
   }
   const app = getApp(id);
@@ -8194,14 +8405,13 @@ export function startGatewayHttpServer(): GatewayHttpServer {
         return;
       }
 
-      if (
-        !hasApiAuth(req, url, {
-          allowQueryToken: false,
-          allowLocalWebSession: true,
-          allowSessionCookie: true,
-          requireSameOrigin: method !== 'GET',
-        })
-      ) {
+      const authContext = resolveAuthContext(req, url, {
+        allowQueryToken: false,
+        allowLocalWebSession: true,
+        allowSessionCookie: true,
+        requireSameOrigin: method !== 'GET',
+      });
+      if (authContext.kind === 'none') {
         recordUnauthenticatedAdminSecretMutation(req, pathname, method);
         sendJson(res, 401, {
           error: 'Unauthorized. Set `Authorization: Bearer <WEB_API_TOKEN>`.',
@@ -8209,7 +8419,7 @@ export function startGatewayHttpServer(): GatewayHttpServer {
         return;
       }
 
-      if (!enforceAdminRouteRbac(req, res, pathname, method)) {
+      if (!enforceAdminRouteRbac(authContext, res, pathname, method)) {
         return;
       }
 
@@ -8260,7 +8470,7 @@ export function startGatewayHttpServer(): GatewayHttpServer {
             }
           }
           if (pathname === '/api/admin/secrets' && method === 'GET') {
-            handleApiAdminSecrets(req, res);
+            handleApiAdminSecrets(req, res, authContext);
             return;
           }
           const adminSecretName = parseApiAdminSecretName(pathname);
@@ -8272,17 +8482,48 @@ export function startGatewayHttpServer(): GatewayHttpServer {
               return;
             }
             if (method === 'PUT') {
-              await handleApiAdminSecretOverwrite(req, res, adminSecretName);
+              await handleApiAdminSecretOverwrite(
+                req,
+                res,
+                adminSecretName,
+                authContext,
+              );
               return;
             }
             if (method === 'DELETE') {
-              await handleApiAdminSecretUnset(req, res, adminSecretName);
+              await handleApiAdminSecretUnset(
+                req,
+                res,
+                adminSecretName,
+                authContext,
+              );
               return;
             }
             sendMethodNotAllowed(res);
             return;
           }
           if (pathname === '/api/admin/secrets') {
+            sendMethodNotAllowed(res);
+            return;
+          }
+          if (pathname === '/api/admin/tokens' && method === 'GET') {
+            handleApiAdminTokens(res, authContext);
+            return;
+          }
+          if (pathname === '/api/admin/tokens' && method === 'POST') {
+            await handleApiAdminTokenCreate(req, res, authContext);
+            return;
+          }
+          const adminTokenId = parseApiAdminTokenId(pathname);
+          if (adminTokenId !== null) {
+            if (method === 'DELETE') {
+              handleApiAdminTokenRevoke(req, res, adminTokenId, authContext);
+              return;
+            }
+            sendMethodNotAllowed(res);
+            return;
+          }
+          if (pathname === '/api/admin/tokens') {
             sendMethodNotAllowed(res);
             return;
           }
@@ -8754,11 +8995,26 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     }
 
     if (pathname.startsWith('/v1/')) {
-      if (!hasApiAuth(req, url)) {
+      const authContext = resolveAuthContext(req, url);
+      if (authContext.kind === 'none') {
         sendJson(res, 401, {
           error: {
             message:
               'Unauthorized. Set `Authorization: Bearer <WEB_API_TOKEN>`.',
+            type: 'authentication_error',
+            param: null,
+            code: null,
+          },
+        });
+        return;
+      }
+      if (
+        authContext.payload !== null &&
+        !isAdminActionAllowed(authContext.payload, 'openai.api')
+      ) {
+        sendJson(res, 403, {
+          error: {
+            message: 'Forbidden.',
             type: 'authentication_error',
             param: null,
             code: null,
@@ -8869,9 +9125,18 @@ export function startGatewayHttpServer(): GatewayHttpServer {
       return;
     }
 
-    const sessionAuthenticated = hasSessionAuth(req);
-    const tokenAuthenticated = hasApiAuth(req, url, {
+    const sessionPayload = getSessionAuthPayload(req);
+    const sessionAuthenticated = sessionPayload !== null;
+    const tokenAuthenticated =
+      resolveAuthContext(req, url, {
+        allowApiTokens: false,
+        allowQueryToken: false,
+      }).kind !== 'none';
+    const requestAuthContext = resolveAuthContext(req, url, {
+      allowApiTokens: false,
       allowQueryToken: false,
+      allowLocalWebSession: true,
+      requireSameOrigin: true,
     });
     if (
       !sessionAuthenticated &&
@@ -8883,11 +9148,7 @@ export function startGatewayHttpServer(): GatewayHttpServer {
       writeUpgradeError(socket, 401, 'Unauthorized');
       return;
     }
-    const requestAuthenticated = hasApiAuth(req, url, {
-      allowQueryToken: false,
-      allowLocalWebSession: true,
-      requireSameOrigin: true,
-    });
+    const requestAuthenticated = requestAuthContext.kind !== 'none';
     if (
       !sessionAuthenticated &&
       !WEB_API_TOKEN &&
@@ -8899,9 +9160,12 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     }
 
     const terminalStreamAction = resolveAdminRbacAction(url.pathname, 'GET');
+    const terminalRbacContext: ResolvedAuthContext = sessionAuthenticated
+      ? { kind: 'session', payload: sessionPayload }
+      : requestAuthContext;
     if (
       terminalStreamAction &&
-      !isAdminRouteActionAllowed(req, terminalStreamAction)
+      !isAdminRouteActionAllowed(terminalRbacContext, terminalStreamAction)
     ) {
       writeUpgradeError(socket, 403, 'Forbidden');
       return;

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -2135,8 +2135,13 @@ interface ResolveAuthContextOptions {
 
 function extractBearerToken(req: IncomingMessage): string {
   const authHeader = normalizeHeaderValue(req.headers.authorization) || '';
-  const match = /^Bearer\s+(.+)$/i.exec(authHeader);
-  return match?.[1]?.trim() || '';
+  if (authHeader.length <= 'Bearer '.length) return '';
+  if (authHeader.slice(0, 'Bearer'.length).toLowerCase() !== 'bearer') {
+    return '';
+  }
+  const separator = authHeader.charAt('Bearer'.length);
+  if (separator !== ' ' && separator !== '\t') return '';
+  return authHeader.slice('Bearer'.length + 1).trim();
 }
 
 function resolveAuthContext(

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -167,7 +167,7 @@ let databaseInitialized = false;
 let usageEventBatchInsertStatement: Database.Statement | null = null;
 const usageRecordSubscribers = new Set<UsageRecordSubscriber>();
 
-export const DATABASE_SCHEMA_VERSION = 48;
+export const DATABASE_SCHEMA_VERSION = 49;
 const AGENT_CANONICAL_ID_COLLISION_LIMIT = 20;
 const DEFAULT_LOCAL_OWNER_USER_ID = formatLocalOwnerUserId('');
 const STRUCTURED_AUDIT_SESSION_LIMIT = 10_000;
@@ -3175,6 +3175,27 @@ function migrateV48(
   recordMigration(database, 48, 'Persist web-chat activity traces per message');
 }
 
+function migrateV49(database: Database.Database): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS api_tokens (
+      id TEXT PRIMARY KEY,
+      label TEXT NOT NULL,
+      token_hash TEXT NOT NULL,
+      claims TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      created_by TEXT,
+      expires_at TEXT,
+      last_used_at TEXT,
+      revoked_at TEXT
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_api_tokens_token_hash
+      ON api_tokens(token_hash);
+    CREATE INDEX IF NOT EXISTS idx_api_tokens_created_at
+      ON api_tokens(created_at);
+  `);
+  recordMigration(database, 49, 'Persist scoped API token registry');
+}
+
 function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -3295,6 +3316,7 @@ function runMigrations(
     migrateV47(database, opts);
   }
   if (currentVersion < 48) migrateV48(database, opts);
+  if (currentVersion < 49) migrateV49(database);
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);
   if (!quiet && currentVersion < DATABASE_SCHEMA_VERSION) {

--- a/src/security/admin-rbac.ts
+++ b/src/security/admin-rbac.ts
@@ -4,8 +4,19 @@ export const ADMIN_SECRET_RBAC_ACTIONS = [
   'secret.unset',
 ] as const;
 
+export const ADMIN_TOKEN_RBAC_ACTIONS = [
+  'admin.tokens.read',
+  'admin.tokens.create',
+  'admin.tokens.revoke',
+] as const;
+
 export const ADMIN_RBAC_ACTIONS = [
   ...ADMIN_SECRET_RBAC_ACTIONS,
+  ...ADMIN_TOKEN_RBAC_ACTIONS,
+  'openai.api',
+  'chat.send',
+  'status.read',
+  'agents.read',
   'admin.overview.read',
   'admin.tunnel.read',
   'admin.tunnel.write',
@@ -166,6 +177,7 @@ export const ADMIN_RBAC_ROLE_ACTIONS = {
   'admin.security_manager': [
     ...ADMIN_READ_ACTIONS,
     ...ADMIN_SECRET_RBAC_ACTIONS,
+    ...ADMIN_TOKEN_RBAC_ACTIONS,
     'admin.policy.write',
     'admin.policy.delete',
     'admin.output_guard.write',
@@ -357,6 +369,33 @@ export function resolveAdminRbacAction(
     if (method === 'PUT') return 'secret.overwrite';
     if (method === 'DELETE') return 'secret.unset';
     return null;
+  }
+  if (pathname === '/api/admin/tokens') {
+    if (method === 'GET') return 'admin.tokens.read';
+    if (method === 'POST') return 'admin.tokens.create';
+    return null;
+  }
+  if (pathname.startsWith('/api/admin/tokens/')) {
+    if (method === 'DELETE') return 'admin.tokens.revoke';
+    return null;
+  }
+  if (pathname.startsWith('/v1/')) {
+    return 'openai.api';
+  }
+  if (pathname === '/api/chat' && method === 'POST') {
+    return 'chat.send';
+  }
+  if (pathname === '/api/command' && method === 'POST') {
+    return 'chat.send';
+  }
+  if (pathname === '/api/status' && method === 'GET') {
+    return 'status.read';
+  }
+  if (
+    (pathname === '/api/agents' || pathname === '/api/agents/list') &&
+    method === 'GET'
+  ) {
+    return 'agents.read';
   }
   if (pathname === '/api/admin/tunnel') {
     if (method === 'GET') return 'admin.tunnel.read';

--- a/src/security/api-tokens.ts
+++ b/src/security/api-tokens.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
 import { withMemoryDatabase } from '../memory/db.js';
 
 export const API_TOKEN_PREFIX = 'hck';
@@ -7,6 +7,7 @@ const API_TOKEN_SECRET_BYTES = 32;
 const API_TOKEN_LAST_USED_UPDATE_MS = 60_000;
 const API_TOKEN_RE = /^hck_([a-f0-9]{12})_([A-Za-z0-9_-]+)$/;
 const API_TOKEN_LABEL_MAX_LENGTH = 120;
+const API_TOKEN_VERIFIER_KEY = 'hybridclaw-api-token-verifier-v1';
 
 export interface ApiTokenMetadata {
   id: string;
@@ -49,8 +50,12 @@ interface ApiTokenRow {
   revoked_at: string | null;
 }
 
-function sha256Hex(value: string): string {
-  return createHash('sha256').update(value).digest('hex');
+function apiTokenVerifierHex(value: string): string {
+  // lgtm[js/insufficient-password-hash] API tokens are 256-bit random bearer
+  // secrets; this HMAC is a deterministic lookup verifier, not a password hash.
+  return createHmac('sha256', API_TOKEN_VERIFIER_KEY)
+    .update(value)
+    .digest('hex');
 }
 
 function safeEqualHex(left: string, right: string): boolean {
@@ -170,7 +175,7 @@ export function createApiToken(
   const createdBy = normalizeCreatedBy(input.createdBy);
   const id = generateApiTokenId();
   const token = buildApiToken(id);
-  const tokenHash = sha256Hex(token);
+  const tokenHash = apiTokenVerifierHex(token);
 
   return withMemoryDatabase((database) => {
     database
@@ -251,7 +256,7 @@ export function verifyApiToken(
   const parsed = parseApiToken(bearer);
   if (!parsed) return null;
   const now = options.now ?? new Date();
-  const presentedHash = sha256Hex(parsed.token);
+  const presentedHash = apiTokenVerifierHex(parsed.token);
 
   return withMemoryDatabase((database) => {
     const row = database

--- a/src/security/api-tokens.ts
+++ b/src/security/api-tokens.ts
@@ -1,0 +1,277 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { withMemoryDatabase } from '../memory/db.js';
+
+export const API_TOKEN_PREFIX = 'hck';
+const API_TOKEN_ID_BYTES = 6;
+const API_TOKEN_SECRET_BYTES = 32;
+const API_TOKEN_LAST_USED_UPDATE_MS = 60_000;
+const API_TOKEN_RE = /^hck_([a-f0-9]{12})_([A-Za-z0-9_-]+)$/;
+const API_TOKEN_LABEL_MAX_LENGTH = 120;
+
+export interface ApiTokenMetadata {
+  id: string;
+  label: string;
+  claims: Record<string, unknown>;
+  created_at: string;
+  created_by: string | null;
+  expires_at: string | null;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
+export interface CreateApiTokenInput {
+  label: string;
+  claims: Record<string, unknown>;
+  expiresAt?: string | Date | null;
+  createdBy?: string | null;
+}
+
+export interface CreateApiTokenResult {
+  token: string;
+  metadata: ApiTokenMetadata;
+}
+
+export interface VerifiedApiToken {
+  id: string;
+  label: string;
+  claims: Record<string, unknown>;
+}
+
+interface ApiTokenRow {
+  id: string;
+  label: string;
+  token_hash: string;
+  claims: string;
+  created_at: string;
+  created_by: string | null;
+  expires_at: string | null;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
+function sha256Hex(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function safeEqualHex(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left, 'hex');
+  const rightBuffer = Buffer.from(right, 'hex');
+  if (leftBuffer.length !== rightBuffer.length) return false;
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function normalizeApiTokenLabel(value: string): string {
+  const label = value.trim();
+  if (!label) {
+    throw new Error('API token label is required.');
+  }
+  if (label.length > API_TOKEN_LABEL_MAX_LENGTH) {
+    throw new Error(
+      `API token label must be ${API_TOKEN_LABEL_MAX_LENGTH} characters or fewer.`,
+    );
+  }
+  return label;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function hasRbacClaimKey(value: Record<string, unknown>): boolean {
+  return (
+    Object.hasOwn(value, 'actions') ||
+    Object.hasOwn(value, 'scope') ||
+    Object.hasOwn(value, 'role') ||
+    Object.hasOwn(value, 'roles')
+  );
+}
+
+export function normalizeApiTokenClaims(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!isPlainRecord(value)) {
+    throw new Error('API token claims must be an object.');
+  }
+  const normalized = JSON.parse(JSON.stringify(value)) as unknown;
+  if (!isPlainRecord(normalized)) {
+    throw new Error('API token claims must be JSON-serializable.');
+  }
+  if (!hasRbacClaimKey(normalized)) {
+    normalized.actions = [];
+  }
+  return normalized;
+}
+
+function parseStoredClaims(value: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return isPlainRecord(parsed)
+      ? normalizeApiTokenClaims(parsed)
+      : { actions: [] };
+  } catch {
+    return { actions: [] };
+  }
+}
+
+function normalizeOptionalTimestamp(value: string | Date | null | undefined) {
+  if (value === null || value === undefined) return null;
+  const candidate = value instanceof Date ? value : new Date(value.trim());
+  if (Number.isNaN(candidate.getTime())) {
+    throw new Error('API token expiry must be a valid date.');
+  }
+  return candidate.toISOString();
+}
+
+function normalizeCreatedBy(value: string | null | undefined): string | null {
+  const normalized = String(value || '').trim();
+  return normalized || null;
+}
+
+function generateApiTokenId(): string {
+  return randomBytes(API_TOKEN_ID_BYTES).toString('hex');
+}
+
+function buildApiToken(id: string): string {
+  const secret = randomBytes(API_TOKEN_SECRET_BYTES).toString('base64url');
+  return `${API_TOKEN_PREFIX}_${id}_${secret}`;
+}
+
+function parseApiToken(value: string): { id: string; token: string } | null {
+  const token = value.trim();
+  const match = API_TOKEN_RE.exec(token);
+  if (!match) return null;
+  const id = match[1];
+  return id ? { id, token } : null;
+}
+
+export function isApiTokenString(value: string): boolean {
+  return value.trim().startsWith(`${API_TOKEN_PREFIX}_`);
+}
+
+function toMetadata(row: ApiTokenRow): ApiTokenMetadata {
+  return {
+    id: row.id,
+    label: row.label,
+    claims: parseStoredClaims(row.claims),
+    created_at: row.created_at,
+    created_by: row.created_by,
+    expires_at: row.expires_at,
+    last_used_at: row.last_used_at,
+    revoked_at: row.revoked_at,
+  };
+}
+
+export function createApiToken(
+  input: CreateApiTokenInput,
+): CreateApiTokenResult {
+  const label = normalizeApiTokenLabel(input.label);
+  const claims = normalizeApiTokenClaims(input.claims);
+  const expiresAt = normalizeOptionalTimestamp(input.expiresAt);
+  const createdBy = normalizeCreatedBy(input.createdBy);
+  const id = generateApiTokenId();
+  const token = buildApiToken(id);
+  const tokenHash = sha256Hex(token);
+
+  return withMemoryDatabase((database) => {
+    database
+      .prepare(
+        `INSERT INTO api_tokens (
+          id,
+          label,
+          token_hash,
+          claims,
+          created_by,
+          expires_at
+        ) VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(id, label, tokenHash, JSON.stringify(claims), createdBy, expiresAt);
+
+    const row = database
+      .prepare<[string], ApiTokenRow>('SELECT * FROM api_tokens WHERE id = ?')
+      .get(id);
+    if (!row) {
+      throw new Error('API token was not persisted.');
+    }
+    return {
+      token,
+      metadata: toMetadata(row),
+    };
+  });
+}
+
+export function listApiTokens(): ApiTokenMetadata[] {
+  return withMemoryDatabase((database) =>
+    database
+      .prepare<[], ApiTokenRow>(
+        `SELECT *
+         FROM api_tokens
+         ORDER BY created_at DESC, id ASC`,
+      )
+      .all()
+      .map(toMetadata),
+  );
+}
+
+export function revokeApiToken(id: string): ApiTokenMetadata | null {
+  const normalizedId = id.trim().toLowerCase();
+  if (!/^[a-f0-9]{12}$/.test(normalizedId)) return null;
+  return withMemoryDatabase((database) => {
+    database
+      .prepare(
+        `UPDATE api_tokens
+         SET revoked_at = COALESCE(revoked_at, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+         WHERE id = ?`,
+      )
+      .run(normalizedId);
+    const row = database
+      .prepare<[string], ApiTokenRow>('SELECT * FROM api_tokens WHERE id = ?')
+      .get(normalizedId);
+    return row ? toMetadata(row) : null;
+  });
+}
+
+function shouldTouchLastUsed(row: ApiTokenRow, now: Date): boolean {
+  if (!row.last_used_at) return true;
+  const previous = Date.parse(row.last_used_at);
+  if (!Number.isFinite(previous)) return true;
+  return now.getTime() - previous >= API_TOKEN_LAST_USED_UPDATE_MS;
+}
+
+function isExpired(row: ApiTokenRow, now: Date): boolean {
+  if (!row.expires_at) return false;
+  const expiresAt = Date.parse(row.expires_at);
+  if (!Number.isFinite(expiresAt)) return true;
+  return expiresAt <= now.getTime();
+}
+
+export function verifyApiToken(
+  bearer: string,
+  options: { now?: Date } = {},
+): VerifiedApiToken | null {
+  const parsed = parseApiToken(bearer);
+  if (!parsed) return null;
+  const now = options.now ?? new Date();
+  const presentedHash = sha256Hex(parsed.token);
+
+  return withMemoryDatabase((database) => {
+    const row = database
+      .prepare<[string], ApiTokenRow>('SELECT * FROM api_tokens WHERE id = ?')
+      .get(parsed.id);
+    if (!row) return null;
+    if (row.revoked_at) return null;
+    if (isExpired(row, now)) return null;
+    if (!safeEqualHex(presentedHash, row.token_hash)) return null;
+
+    if (shouldTouchLastUsed(row, now)) {
+      database
+        .prepare('UPDATE api_tokens SET last_used_at = ? WHERE id = ?')
+        .run(now.toISOString(), row.id);
+    }
+
+    return {
+      id: row.id,
+      label: row.label,
+      claims: parseStoredClaims(row.claims),
+    };
+  });
+}

--- a/src/security/api-tokens.ts
+++ b/src/security/api-tokens.ts
@@ -1,13 +1,21 @@
-import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { randomBytes, scryptSync, timingSafeEqual } from 'node:crypto';
 import { withMemoryDatabase } from '../memory/db.js';
 
 export const API_TOKEN_PREFIX = 'hck';
 const API_TOKEN_ID_BYTES = 6;
 const API_TOKEN_SECRET_BYTES = 32;
+const API_TOKEN_SALT_BYTES = 16;
+const API_TOKEN_VERIFIER_BYTES = 32;
 const API_TOKEN_LAST_USED_UPDATE_MS = 60_000;
 const API_TOKEN_RE = /^hck_([a-f0-9]{12})_([A-Za-z0-9_-]+)$/;
 const API_TOKEN_LABEL_MAX_LENGTH = 120;
-const API_TOKEN_VERIFIER_KEY = 'hybridclaw-api-token-verifier-v1';
+const API_TOKEN_VERIFIER_PREFIX = 'scrypt:v1';
+const API_TOKEN_SCRYPT_OPTIONS = {
+  N: 16_384,
+  r: 8,
+  p: 1,
+  maxmem: 64 * 1024 * 1024,
+} as const;
 
 export interface ApiTokenMetadata {
   id: string;
@@ -50,19 +58,59 @@ interface ApiTokenRow {
   revoked_at: string | null;
 }
 
-function apiTokenVerifierHex(value: string): string {
-  // lgtm[js/insufficient-password-hash] API tokens are 256-bit random bearer
-  // secrets; this HMAC is a deterministic lookup verifier, not a password hash.
-  return createHmac('sha256', API_TOKEN_VERIFIER_KEY)
-    .update(value)
-    .digest('hex');
+function deriveApiTokenVerifier(token: string, salt: Buffer): Buffer {
+  return scryptSync(
+    token,
+    salt,
+    API_TOKEN_VERIFIER_BYTES,
+    API_TOKEN_SCRYPT_OPTIONS,
+  );
 }
 
-function safeEqualHex(left: string, right: string): boolean {
-  const leftBuffer = Buffer.from(left, 'hex');
-  const rightBuffer = Buffer.from(right, 'hex');
-  if (leftBuffer.length !== rightBuffer.length) return false;
-  return timingSafeEqual(leftBuffer, rightBuffer);
+function createApiTokenVerifier(token: string): string {
+  const salt = randomBytes(API_TOKEN_SALT_BYTES);
+  const verifier = deriveApiTokenVerifier(token, salt);
+  return [
+    API_TOKEN_VERIFIER_PREFIX,
+    salt.toString('base64url'),
+    verifier.toString('base64url'),
+  ].join(':');
+}
+
+function parseStoredApiTokenVerifier(value: string): {
+  salt: Buffer;
+  verifier: Buffer;
+} | null {
+  const [scheme, version, rawSalt, rawVerifier, extra] = value.split(':');
+  if (
+    scheme !== 'scrypt' ||
+    version !== 'v1' ||
+    !rawSalt ||
+    !rawVerifier ||
+    extra !== undefined
+  ) {
+    return null;
+  }
+  const salt = Buffer.from(rawSalt, 'base64url');
+  const verifier = Buffer.from(rawVerifier, 'base64url');
+  if (
+    salt.length !== API_TOKEN_SALT_BYTES ||
+    verifier.length !== API_TOKEN_VERIFIER_BYTES
+  ) {
+    return null;
+  }
+  return { salt, verifier };
+}
+
+function isApiTokenVerifierMatch(
+  token: string,
+  storedVerifier: string,
+): boolean {
+  const parsed = parseStoredApiTokenVerifier(storedVerifier);
+  if (!parsed) return false;
+  const presentedVerifier = deriveApiTokenVerifier(token, parsed.salt);
+  if (presentedVerifier.length !== parsed.verifier.length) return false;
+  return timingSafeEqual(presentedVerifier, parsed.verifier);
 }
 
 function normalizeApiTokenLabel(value: string): string {
@@ -175,7 +223,7 @@ export function createApiToken(
   const createdBy = normalizeCreatedBy(input.createdBy);
   const id = generateApiTokenId();
   const token = buildApiToken(id);
-  const tokenHash = apiTokenVerifierHex(token);
+  const tokenHash = createApiTokenVerifier(token);
 
   return withMemoryDatabase((database) => {
     database
@@ -256,8 +304,6 @@ export function verifyApiToken(
   const parsed = parseApiToken(bearer);
   if (!parsed) return null;
   const now = options.now ?? new Date();
-  const presentedHash = apiTokenVerifierHex(parsed.token);
-
   return withMemoryDatabase((database) => {
     const row = database
       .prepare<[string], ApiTokenRow>('SELECT * FROM api_tokens WHERE id = ?')
@@ -265,7 +311,7 @@ export function verifyApiToken(
     if (!row) return null;
     if (row.revoked_at) return null;
     if (isExpired(row, now)) return null;
-    if (!safeEqualHex(presentedHash, row.token_hash)) return null;
+    if (!isApiTokenVerifierMatch(parsed.token, row.token_hash)) return null;
 
     if (shouldTouchLastUsed(row, now)) {
       database

--- a/tests/admin-rbac.test.ts
+++ b/tests/admin-rbac.test.ts
@@ -45,6 +45,18 @@ describe('admin RBAC role bundles', () => {
     expect(isAdminActionAllowed(payload, 'secret.overwrite')).toBe(false);
   });
 
+  test('grants API token management only to security and full roles', () => {
+    expect(
+      isAdminActionAllowed({ role: 'admin.security_manager' }, 'admin.tokens.create'),
+    ).toBe(true);
+    expect(
+      isAdminActionAllowed({ role: 'admin.viewer' }, 'admin.tokens.read'),
+    ).toBe(false);
+    expect(isAdminActionAllowed({ role: 'admin.full' }, 'openai.api')).toBe(
+      true,
+    );
+  });
+
   test('combines roles arrays with explicit action claims', () => {
     const payload = {
       roles: ['admin.security_manager', 'admin.terminal_operator'],
@@ -145,5 +157,22 @@ describe('admin RBAC role bundles', () => {
     expect(
       resolveAdminRbacAction('/api/admin/connectors/logout', 'POST'),
     ).toBe('secret.unset');
+  });
+
+  test('maps API token and scoped API routes', () => {
+    expect(resolveAdminRbacAction('/api/admin/tokens', 'GET')).toBe(
+      'admin.tokens.read',
+    );
+    expect(resolveAdminRbacAction('/api/admin/tokens', 'POST')).toBe(
+      'admin.tokens.create',
+    );
+    expect(resolveAdminRbacAction('/api/admin/tokens/abc123abc123', 'DELETE')).toBe(
+      'admin.tokens.revoke',
+    );
+    expect(resolveAdminRbacAction('/v1/models', 'GET')).toBe('openai.api');
+    expect(resolveAdminRbacAction('/api/chat', 'POST')).toBe('chat.send');
+    expect(resolveAdminRbacAction('/api/command', 'POST')).toBe('chat.send');
+    expect(resolveAdminRbacAction('/api/status', 'GET')).toBe('status.read');
+    expect(resolveAdminRbacAction('/api/agents', 'GET')).toBe('agents.read');
   });
 });

--- a/tests/api-tokens.test.ts
+++ b/tests/api-tokens.test.ts
@@ -1,0 +1,118 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { describe, expect, test, vi } from 'vitest';
+import { useTempDir } from './test-utils.ts';
+
+const makeTempDir = useTempDir('hybridclaw-api-tokens-');
+
+async function setupRegistry() {
+  vi.resetModules();
+  const dbPath = path.join(makeTempDir(), 'tokens.db');
+  const db = await import('../src/memory/db.ts');
+  db.initDatabase({ quiet: true, dbPath });
+  const tokens = await import('../src/security/api-tokens.ts');
+  return { db, tokens };
+}
+
+describe('api token registry', () => {
+  test('creates scoped hck tokens and stores only a SHA-256 hash', async () => {
+    const { db, tokens } = await setupRegistry();
+
+    const result = tokens.createApiToken({
+      label: 'SDK token',
+      claims: { actions: ['openai.api'] },
+      createdBy: 'tester',
+    });
+
+    expect(result.token).toMatch(/^hck_[a-f0-9]{12}_[A-Za-z0-9_-]+$/);
+    expect(result.metadata).toMatchObject({
+      label: 'SDK token',
+      claims: { actions: ['openai.api'] },
+      created_by: 'tester',
+      revoked_at: null,
+    });
+
+    const row = db.withMemoryDatabase((database) =>
+      database
+        .prepare<
+          [string],
+          { token_hash: string; stored_token: string | null; claims: string }
+        >(
+          'SELECT token_hash, NULL AS stored_token, claims FROM api_tokens WHERE id = ?',
+        )
+        .get(result.metadata.id),
+    );
+
+    expect(row?.stored_token).toBeNull();
+    expect(row?.token_hash).toBe(
+      createHash('sha256').update(result.token).digest('hex'),
+    );
+    expect(JSON.stringify(row)).not.toContain(result.token);
+  });
+
+  test('verifies, lists, and throttles last-used writes', async () => {
+    const { db, tokens } = await setupRegistry();
+    const result = tokens.createApiToken({
+      label: 'Chat sender',
+      claims: { actions: ['chat.send'] },
+    });
+
+    const first = tokens.verifyApiToken(result.token, {
+      now: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    const second = tokens.verifyApiToken(result.token, {
+      now: new Date('2026-01-01T00:00:30.000Z'),
+    });
+
+    expect(first).toEqual({
+      id: result.metadata.id,
+      label: 'Chat sender',
+      claims: { actions: ['chat.send'] },
+    });
+    expect(second).toEqual(first);
+    expect(tokens.listApiTokens()).toHaveLength(1);
+
+    const row = db.withMemoryDatabase((database) =>
+      database
+        .prepare<[string], { last_used_at: string | null }>(
+          'SELECT last_used_at FROM api_tokens WHERE id = ?',
+        )
+        .get(result.metadata.id),
+    );
+    expect(row?.last_used_at).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  test('rejects revoked, expired, malformed, and mismatched tokens', async () => {
+    const { tokens } = await setupRegistry();
+    const active = tokens.createApiToken({
+      label: 'Active',
+      claims: { actions: ['openai.api'] },
+    });
+    const expired = tokens.createApiToken({
+      label: 'Expired',
+      claims: { actions: ['openai.api'] },
+      expiresAt: '2025-01-01T00:00:00.000Z',
+    });
+
+    expect(tokens.verifyApiToken('not-a-token')).toBeNull();
+    expect(tokens.verifyApiToken(`${active.token}x`)).toBeNull();
+    expect(tokens.verifyApiToken(expired.token)).toBeNull();
+
+    const revoked = tokens.revokeApiToken(active.metadata.id);
+    expect(revoked?.revoked_at).toBeTruthy();
+    expect(tokens.verifyApiToken(active.token)).toBeNull();
+  });
+
+  test('normalizes claimless records to deny-by-default payloads', async () => {
+    const { tokens } = await setupRegistry();
+
+    const result = tokens.createApiToken({
+      label: 'No claims',
+      claims: {},
+    });
+
+    expect(tokens.verifyApiToken(result.token)?.claims).toEqual({
+      actions: [],
+    });
+  });
+});

--- a/tests/api-tokens.test.ts
+++ b/tests/api-tokens.test.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { describe, expect, test, vi } from 'vitest';
 import { useTempDir } from './test-utils.ts';
@@ -15,7 +14,7 @@ async function setupRegistry() {
 }
 
 describe('api token registry', () => {
-  test('creates scoped hck tokens and stores only a SHA-256 hash', async () => {
+  test('creates scoped hck tokens and stores only a verifier', async () => {
     const { db, tokens } = await setupRegistry();
 
     const result = tokens.createApiToken({
@@ -44,9 +43,8 @@ describe('api token registry', () => {
     );
 
     expect(row?.stored_token).toBeNull();
-    expect(row?.token_hash).toBe(
-      createHash('sha256').update(result.token).digest('hex'),
-    );
+    expect(row?.token_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(row?.token_hash).not.toBe(result.token);
     expect(JSON.stringify(row)).not.toContain(result.token);
   });
 

--- a/tests/api-tokens.test.ts
+++ b/tests/api-tokens.test.ts
@@ -43,7 +43,9 @@ describe('api token registry', () => {
     );
 
     expect(row?.stored_token).toBeNull();
-    expect(row?.token_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(row?.token_hash).toMatch(
+      /^scrypt:v1:[A-Za-z0-9_-]+:[A-Za-z0-9_-]+$/,
+    );
     expect(row?.token_hash).not.toBe(result.token);
     expect(JSON.stringify(row)).not.toContain(result.token);
   });

--- a/tests/gateway-admin-tokens.test.ts
+++ b/tests/gateway-admin-tokens.test.ts
@@ -1,0 +1,140 @@
+import path from 'node:path';
+import { describe, expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
+
+const makeTempDir = useTempDir('hybridclaw-admin-tokens-');
+
+async function importAdminTokens() {
+  vi.resetModules();
+  const dbPath = path.join(makeTempDir(), 'tokens.db');
+  const recordAuditEvent = vi.fn();
+  const makeAuditRunId = vi.fn((prefix: string) => `${prefix}-run`);
+  vi.doMock('../src/audit/audit-events.js', () => ({
+    makeAuditRunId,
+    recordAuditEvent,
+  }));
+
+  const db = await import('../src/memory/db.ts');
+  db.initDatabase({ quiet: true, dbPath });
+  const service = await import('../src/gateway/gateway-admin-tokens.ts');
+  const registry = await import('../src/security/api-tokens.ts');
+  recordAuditEvent.mockClear();
+  makeAuditRunId.mockClear();
+
+  return {
+    makeAuditRunId,
+    recordAuditEvent,
+    registry,
+    service,
+  };
+}
+
+describe('gateway admin API tokens', () => {
+  useCleanMocks({
+    resetModules: true,
+    unmock: ['../src/audit/audit-events.js'],
+  });
+
+  test('creates a scoped token and audits metadata without the token value', async () => {
+    const { recordAuditEvent, registry, service } = await importAdminTokens();
+
+    const response = service.createGatewayAdminToken({
+      body: {
+        label: 'OpenAI SDK',
+        actions: ['openai.api'],
+        expiresAt: '2027-01-01T00:00:00.000Z',
+      },
+      audit: {
+        sessionId: 'admin-session-1',
+        actor: 'admin-user',
+        sourceIp: '127.0.0.1',
+      },
+    });
+
+    expect(response.token).toMatch(/^hck_[a-f0-9]{12}_[A-Za-z0-9_-]+$/);
+    expect(response.apiToken).toMatchObject({
+      label: 'OpenAI SDK',
+      claims: { actions: ['openai.api'] },
+      created_by: 'admin-user',
+      expires_at: '2027-01-01T00:00:00.000Z',
+      revoked_at: null,
+    });
+    expect(registry.verifyApiToken(response.token)).toMatchObject({
+      id: response.apiToken.id,
+      label: 'OpenAI SDK',
+      claims: { actions: ['openai.api'] },
+    });
+    expect(recordAuditEvent).toHaveBeenCalledWith({
+      sessionId: 'admin-session-1',
+      runId: 'token-create-run',
+      event: {
+        type: 'token.created',
+        id: response.apiToken.id,
+        label: 'OpenAI SDK',
+        claims: { actions: ['openai.api'] },
+        actor: 'admin-user',
+        sourceIp: '127.0.0.1',
+      },
+    });
+    expect(JSON.stringify(recordAuditEvent.mock.calls)).not.toContain(
+      response.token,
+    );
+  });
+
+  test('filters available actions and rejects claimless create requests', async () => {
+    const { recordAuditEvent, service } = await importAdminTokens();
+
+    expect(
+      service.getGatewayAdminTokens({
+        authPayload: { actions: ['admin.tokens.read'] },
+      }).actions,
+    ).toEqual(['admin.tokens.read']);
+    expect(() =>
+      service.createGatewayAdminToken({
+        body: { label: 'No claims' },
+        audit: { actor: 'admin-user' },
+      }),
+    ).toThrow('API token claims are required');
+    expect(recordAuditEvent).not.toHaveBeenCalled();
+  });
+
+  test('revokes tokens and audits only token metadata', async () => {
+    const { recordAuditEvent, registry, service } = await importAdminTokens();
+    const created = registry.createApiToken({
+      label: 'Chat client',
+      claims: { actions: ['chat.send'] },
+    });
+
+    const response = service.revokeGatewayAdminToken({
+      id: created.metadata.id,
+      audit: {
+        sessionId: 'admin-session-1',
+        actor: 'admin-user',
+        sourceIp: '127.0.0.1',
+      },
+    });
+
+    expect(response.apiToken).toMatchObject({
+      id: created.metadata.id,
+      label: 'Chat client',
+      claims: { actions: ['chat.send'] },
+    });
+    expect(response.apiToken.revoked_at).toEqual(expect.any(String));
+    expect(registry.verifyApiToken(created.token)).toBeNull();
+    expect(recordAuditEvent).toHaveBeenCalledWith({
+      sessionId: 'admin-session-1',
+      runId: 'token-revoke-run',
+      event: {
+        type: 'token.revoked',
+        id: created.metadata.id,
+        label: 'Chat client',
+        claims: { actions: ['chat.send'] },
+        actor: 'admin-user',
+        sourceIp: '127.0.0.1',
+      },
+    });
+    expect(JSON.stringify(recordAuditEvent.mock.calls)).not.toContain(
+      created.token,
+    );
+  });
+});

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -548,6 +548,10 @@ async function importFreshHealth(options?: {
   hybridAiBaseUrl?: string;
   runningInsideContainer?: boolean;
   deploymentPublicUrl?: string;
+  apiTokens?: Record<
+    string,
+    { id: string; label: string; claims: Record<string, unknown> }
+  >;
   mediaUploadQuotaDecision?: {
     allowed: boolean;
     remainingBytes: number;
@@ -2117,6 +2121,43 @@ async function importFreshHealth(options?: {
     restartSupported: true,
     restartReason: null,
   }));
+  const verifyApiToken = vi.fn((bearer: string) => {
+    return options?.apiTokens?.[bearer] ?? null;
+  });
+  const getGatewayAdminTokens = vi.fn(() => ({
+    tokens: [],
+    total: 0,
+    actions: [
+      'admin.tokens.read',
+      'admin.tokens.create',
+      'admin.tokens.revoke',
+    ],
+  }));
+  const createGatewayAdminToken = vi.fn(() => ({
+    token: 'hck_created_secret',
+    apiToken: {
+      id: 'created000001',
+      label: 'Created token',
+      claims: { actions: ['openai.api'] },
+      created_at: '2026-05-17T10:00:00.000Z',
+      created_by: 'admin-user',
+      expires_at: null,
+      last_used_at: null,
+      revoked_at: null,
+    },
+  }));
+  const revokeGatewayAdminToken = vi.fn((input: { id: string }) => ({
+    apiToken: {
+      id: input.id,
+      label: 'Revoked token',
+      claims: { actions: ['openai.api'] },
+      created_at: '2026-05-17T10:00:00.000Z',
+      created_by: 'admin-user',
+      expires_at: null,
+      last_used_at: null,
+      revoked_at: '2026-05-17T11:00:00.000Z',
+    },
+  }));
   const refreshRuntimeSecretsFromEnv = vi.fn();
   const reloadRuntimeConfig = vi.fn();
   class ResponseRatingNotFoundError extends Error {
@@ -2343,6 +2384,15 @@ async function importFreshHealth(options?: {
     recordGatewayAdminSecretMutationFailure,
     unsetGatewayAdminSecret,
   }));
+  vi.doMock('../src/security/api-tokens.js', () => ({
+    isApiTokenString: (value: string) => value.trim().startsWith('hck_'),
+    verifyApiToken,
+  }));
+  vi.doMock('../src/gateway/gateway-admin-tokens.js', () => ({
+    createGatewayAdminToken,
+    getGatewayAdminTokens,
+    revokeGatewayAdminToken,
+  }));
   vi.doMock('../src/gateway/gateway-admin-connectors.js', () => ({
     completeGatewayAdminConnectorOAuthCallback,
     getGatewayAdminConnectors,
@@ -2443,6 +2493,10 @@ async function importFreshHealth(options?: {
     overwriteGatewayAdminSecret,
     recordGatewayAdminSecretMutationFailure,
     unsetGatewayAdminSecret,
+    verifyApiToken,
+    getGatewayAdminTokens,
+    createGatewayAdminToken,
+    revokeGatewayAdminToken,
     getGatewayAdminStatistics,
     tunnelConfigResponse,
     getGatewayAdminTunnelConfig,
@@ -2586,6 +2640,8 @@ useCleanMocks({
     '../src/agent/agent.js',
     '../src/gateway/gateway-service.js',
     '../src/gateway/gateway-chat-service.js',
+    '../src/gateway/gateway-admin-tokens.js',
+    '../src/security/api-tokens.js',
     '../src/gateway/openai-compatible-model.ts',
     '../src/gateway/gateway-scheduled-task-service.js',
     '../src/providers/factory.js',
@@ -3342,6 +3398,78 @@ describe('gateway HTTP server', () => {
         code: null,
       },
     });
+  });
+
+  test('denies scoped API tokens on /v1 without openai.api', async () => {
+    const apiToken = 'hck_chat_no_openai';
+    const state = await importFreshHealth({
+      apiTokens: {
+        [apiToken]: {
+          id: 'ccc333ccc333',
+          label: 'chat-only',
+          claims: { actions: ['chat.send'] },
+        },
+      },
+    });
+    const req = makeRequest({
+      url: '/v1/models',
+      headers: {
+        authorization: `Bearer ${apiToken}`,
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(state.getGatewayAdminModels).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({
+      error: {
+        message: 'Forbidden.',
+        type: 'authentication_error',
+        param: null,
+        code: null,
+      },
+    });
+  });
+
+  test('allows scoped API tokens on /v1 with openai.api', async () => {
+    const apiToken = 'hck_openai_api';
+    const state = await importFreshHealth({
+      apiTokens: {
+        [apiToken]: {
+          id: 'ddd444ddd444',
+          label: 'openai-sdk',
+          claims: { actions: ['openai.api'] },
+        },
+      },
+    });
+    state.getGatewayAdminModels.mockResolvedValueOnce({
+      defaultModel: 'gpt-5',
+      providerStatus: {},
+      models: [{ id: 'gpt-5' }],
+    });
+    const req = makeRequest({
+      url: '/v1/models',
+      headers: {
+        authorization: `Bearer ${apiToken}`,
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).data).toEqual([
+      {
+        id: 'gpt-5',
+        object: 'model',
+        created: 0,
+        owned_by: 'hybridclaw',
+      },
+    ]);
   });
 
   test('serves OpenAI-compatible model discovery from /v1/models', async () => {
@@ -6302,6 +6430,82 @@ describe('gateway HTTP server', () => {
     expect(res.statusCode).toBe(403);
   });
 
+  test('denies scoped API tokens without secret overwrite claims before reading the body', async () => {
+    const apiToken = 'hck_secret_read_only';
+    const state = await importFreshHealth({
+      apiTokens: {
+        [apiToken]: {
+          id: 'abc123abc123',
+          label: 'secret-reader',
+          claims: { actions: ['secret.list_metadata'] },
+        },
+      },
+    });
+    const req = makeRequest({
+      method: 'PUT',
+      url: '/api/admin/secrets/SET_SECRET',
+      body: { value: 'denied-api-token-secret' },
+      headers: {
+        authorization: `Bearer ${apiToken}`,
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.verifyApiToken).toHaveBeenCalledWith(apiToken);
+    expect(state.overwriteGatewayAdminSecret).not.toHaveBeenCalled();
+    expect(state.recordGatewayAdminSecretMutationFailure).toHaveBeenCalledWith({
+      type: 'secret.overwritten',
+      name: 'SET_SECRET',
+      audit: {
+        sessionId: 'apiToken:abc123abc123:secret-reader',
+        actor: 'apiToken:abc123abc123:secret-reader',
+        sourceIp: '127.0.0.1',
+      },
+      errorCode: 'forbidden',
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.body).not.toContain('denied-api-token-secret');
+  });
+
+  test('allows scoped API tokens with matching secret overwrite claims', async () => {
+    const apiToken = 'hck_secret_writer';
+    const state = await importFreshHealth({
+      apiTokens: {
+        [apiToken]: {
+          id: 'def456def456',
+          label: 'secret-writer',
+          claims: { actions: ['secret.overwrite'] },
+        },
+      },
+    });
+    const req = makeRequest({
+      method: 'PUT',
+      url: '/api/admin/secrets/SET_SECRET',
+      body: { value: 'rotated-by-token' },
+      headers: {
+        authorization: `Bearer ${apiToken}`,
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.overwriteGatewayAdminSecret).toHaveBeenCalledWith({
+      name: 'SET_SECRET',
+      value: 'rotated-by-token',
+      audit: {
+        sessionId: 'apiToken:def456def456:secret-writer',
+        actor: 'apiToken:def456def456:secret-writer',
+        sourceIp: '127.0.0.1',
+      },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
   test('rejects unsupported admin secret metadata methods before listing names', async () => {
     const state = await importFreshHealth();
     const req = makeRequest({
@@ -6554,6 +6758,102 @@ describe('gateway HTTP server', () => {
     });
     expect(res.statusCode).toBe(400);
     expect(res.body).not.toContain('bad-json-secret');
+  });
+
+  test('lists API token metadata for authorized admin sessions', async () => {
+    const authSecret = 'token-list-auth-secret';
+    const state = await importFreshHealth({ authSecret });
+    const req = makeRequest({
+      url: '/api/admin/tokens',
+      headers: {
+        cookie: makeSessionCookie(authSecret, {
+          sessionId: 'admin-session-1',
+          actor: 'admin-user',
+          actions: ['admin.tokens.read'],
+        }),
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.getGatewayAdminTokens).toHaveBeenCalledWith({
+      authPayload: expect.objectContaining({
+        actions: ['admin.tokens.read'],
+      }),
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  test('prevents API-token-authenticated requests from creating or revoking tokens', async () => {
+    const apiToken = 'hck_token_admin';
+    const state = await importFreshHealth({
+      apiTokens: {
+        [apiToken]: {
+          id: 'aaa111aaa111',
+          label: 'token-admin',
+          claims: {
+            actions: ['admin.tokens.create', 'admin.tokens.revoke'],
+          },
+        },
+      },
+    });
+    const createReq = makeRequest({
+      method: 'POST',
+      url: '/api/admin/tokens',
+      body: { label: 'new', actions: ['openai.api'] },
+      headers: {
+        authorization: `Bearer ${apiToken}`,
+      },
+    });
+    const createRes = makeResponse();
+
+    state.handler(createReq as never, createRes as never);
+    await settle();
+
+    const revokeReq = makeRequest({
+      method: 'DELETE',
+      url: '/api/admin/tokens/deadbeef0000',
+      headers: {
+        authorization: `Bearer ${apiToken}`,
+      },
+    });
+    const revokeRes = makeResponse();
+
+    state.handler(revokeReq as never, revokeRes as never);
+    await settle();
+
+    expect(state.createGatewayAdminToken).not.toHaveBeenCalled();
+    expect(state.revokeGatewayAdminToken).not.toHaveBeenCalled();
+    expect(createRes.statusCode).toBe(403);
+    expect(revokeRes.statusCode).toBe(403);
+  });
+
+  test('denies scoped API tokens on unmapped API routes unless wildcarded', async () => {
+    const apiToken = 'hck_chat_only';
+    const state = await importFreshHealth({
+      apiTokens: {
+        [apiToken]: {
+          id: 'bbb222bbb222',
+          label: 'chat-only',
+          claims: { actions: ['chat.send'] },
+        },
+      },
+    });
+    const req = makeRequest({
+      url: '/api/history?sessionId=web-session-1',
+      headers: {
+        authorization: `Bearer ${apiToken}`,
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await settle();
+
+    expect(state.getGatewayHistory).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
   });
 
   test('returns admin tunnel config for authorized API requests', async () => {
@@ -8490,6 +8790,11 @@ describe('gateway HTTP server', () => {
         validateToken: expect.any(Function),
       }),
     );
+    const options = state.handleTerminalUpgrade.mock.calls[0]?.[4] as
+      | { validateToken?: (token: string) => boolean }
+      | undefined;
+    expect(options?.validateToken?.('web-token')).toBe(true);
+    expect(options?.validateToken?.('hck_terminal_token')).toBe(false);
     expect(socket.write).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- Add a DB-backed `hck_...` API token registry that stores SHA-256 token hashes only and supports create, list, verify, revoke, expiry, and last-used tracking.
- Add admin token API routes, CLI commands, and a console API Tokens page for scoped token management.
- Harden gateway auth so registry tokens are RBAC-scoped, deny unmapped routes by default, require `openai.api` for `/v1/*`, audit token actors on secret mutations, and cannot create or revoke tokens themselves.

## Risk Notes

This touches high-risk gateway/security auth boundaries. The implementation keeps tokens deny-by-default when claims are absent, never persists or audits cleartext token values, and shows the token value only once at creation.

## Validation

- `npm run format` completed with existing optional-chain warnings and no file changes.
- `npm run lint`
- `./node_modules/.bin/vitest run tests/api-tokens.test.ts tests/gateway-admin-tokens.test.ts tests/admin-rbac.test.ts tests/gateway-http-server.test.ts`
- `npm --workspace console run test` passed; jsdom emitted its existing navigation-not-implemented warning while exiting 0.