### PR TITLE
fix: scope app view tokens

### DIFF
--- a/console/src/components/live-app-frame.test.tsx
+++ b/console/src/components/live-app-frame.test.tsx
@@ -16,6 +16,9 @@ describe('LiveAppFrame', () => {
     );
     const iframe = container.querySelector('iframe');
     expect(iframe).toBeTruthy();
+    expect(iframe?.getAttribute('sandbox')).toBe(
+      'allow-scripts allow-forms allow-popups allow-modals allow-downloads',
+    );
     const target = iframe?.contentWindow;
     expect(target).toBeTruthy();
     const postMessage = vi

--- a/console/src/components/live-app-frame.tsx
+++ b/console/src/components/live-app-frame.tsx
@@ -140,7 +140,7 @@ export const LiveAppFrame = forwardRef<LiveAppFrameHandle, LiveAppFrameProps>(
         className={props.className}
         title={props.title}
         src={appViewUrl(props.appId, props.token)}
-        sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads allow-popups-to-escape-sandbox"
+        sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
         onLoad={() => {
           loadedRef.current = true;
           if (props.refreshNonce) postRefreshRequest();

--- a/console/src/lib/app-view-token.test.ts
+++ b/console/src/lib/app-view-token.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createAppViewToken } from './app-view-token';
+
+const { createAdminApiTokenMock } = vi.hoisted(() => ({
+  createAdminApiTokenMock: vi.fn(),
+}));
+
+vi.mock('../api/client', () => ({
+  createAdminApiToken: (...args: unknown[]) => createAdminApiTokenMock(...args),
+}));
+
+afterEach(() => {
+  vi.useRealTimers();
+  createAdminApiTokenMock.mockReset();
+});
+
+describe('createAppViewToken', () => {
+  it('mints a short-lived token scoped to one app view and bridge', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-08T10:00:00.000Z'));
+    createAdminApiTokenMock.mockResolvedValueOnce({ token: 'hck_app_token' });
+
+    await expect(createAppViewToken('admin-token', 'app-123')).resolves.toBe(
+      'hck_app_token',
+    );
+
+    expect(createAdminApiTokenMock).toHaveBeenCalledWith('admin-token', {
+      label: 'App view app-123',
+      claims: {
+        actions: ['apps.view', 'apps.bridge'],
+        appIds: ['app-123'],
+      },
+      expiresAt: '2026-07-08T10:30:00.000Z',
+    });
+  });
+});

--- a/console/src/lib/app-view-token.ts
+++ b/console/src/lib/app-view-token.ts
@@ -1,0 +1,19 @@
+import { createAdminApiToken } from '../api/client';
+
+const APP_VIEW_TOKEN_TTL_MS = 30 * 60 * 1000;
+
+export async function createAppViewToken(
+  authToken: string,
+  appId: string,
+): Promise<string> {
+  const expiresAt = new Date(Date.now() + APP_VIEW_TOKEN_TTL_MS).toISOString();
+  const result = await createAdminApiToken(authToken, {
+    label: `App view ${appId.slice(0, 48)}`,
+    claims: {
+      actions: ['apps.view', 'apps.bridge'],
+      appIds: [appId],
+    },
+    expiresAt,
+  });
+  return result.token;
+}

--- a/console/src/routes/apps.tsx
+++ b/console/src/routes/apps.tsx
@@ -36,6 +36,7 @@ import {
 import { MobileTopbarTrigger } from '../components/sidebar/index';
 import { useToast } from '../components/toast';
 import { buildAppSeed, buildLiveAppSeed } from '../lib/app-seed';
+import { createAppViewToken } from '../lib/app-view-token';
 import { getErrorMessage } from '../lib/error-message';
 import { formatRelativeTime } from '../lib/format';
 import styles from './apps.module.css';
@@ -147,6 +148,7 @@ export function AppsPage() {
   );
   const [newKind, setNewKind] = useState<AppKind | null>(null);
   const [viewer, setViewer] = useState<AppDetail | null>(null);
+  const [viewerToken, setViewerToken] = useState('');
   const [viewerRefreshNonce, setViewerRefreshNonce] = useState(0);
   const [confirmDelete, setConfirmDelete] = useState<AppSummary | null>(null);
   const viewerFrameRef = useRef<LiveAppFrameHandle | null>(null);
@@ -187,6 +189,16 @@ export function AppsPage() {
     });
   }
 
+  async function loadAppViewer(appId: string): Promise<AppDetail> {
+    const [result, scopedToken] = await Promise.all([
+      fetchApp(token, appId),
+      createAppViewToken(token, appId),
+    ]);
+    setViewerToken(scopedToken);
+    setViewer(result.app);
+    return result.app;
+  }
+
   async function refreshApp(app: AppSummary) {
     if (app.kind !== 'live') {
       toast.error('Only live apps can refresh connector data.');
@@ -196,8 +208,7 @@ export function AppsPage() {
       return;
     }
     try {
-      const result = await fetchApp(token, app.id);
-      setViewer(result.app);
+      await loadAppViewer(app.id);
       setViewerRefreshNonce((current) => current + 1);
     } catch (error) {
       toast.error(`Could not refresh app: ${getErrorMessage(error)}`);
@@ -208,7 +219,10 @@ export function AppsPage() {
     mutationFn: (id: string) => deleteApp(token, id),
     onSuccess: async (_, id) => {
       await queryClient.invalidateQueries({ queryKey: ['apps'] });
-      if (viewer?.id === id) setViewer(null);
+      if (viewer?.id === id) {
+        setViewer(null);
+        setViewerToken('');
+      }
       setConfirmDelete(null);
       toast.success('App deleted.');
     },
@@ -235,11 +249,15 @@ export function AppsPage() {
 
   async function openApp(summary: AppSummary) {
     try {
-      const result = await fetchApp(token, summary.id);
-      setViewer(result.app);
+      await loadAppViewer(summary.id);
     } catch (error) {
       toast.error(`Could not open app: ${getErrorMessage(error)}`);
     }
+  }
+
+  function closeViewer() {
+    setViewer(null);
+    setViewerToken('');
   }
 
   const filterLabel =
@@ -361,8 +379,8 @@ export function AppsPage() {
 
       <AppViewer
         app={viewer}
-        token={token}
-        onClose={() => setViewer(null)}
+        token={viewerToken}
+        onClose={closeViewer}
         frameRef={viewerFrameRef}
         refreshNonce={viewerRefreshNonce}
         onRefresh={viewer ? () => refreshApp(viewer) : undefined}
@@ -663,7 +681,7 @@ function AppViewer(props: {
                 <Refresh className={styles.inlineIcon} /> Refresh
               </button>
             ) : null}
-            {app ? (
+            {app && props.token ? (
               <a
                 className={styles.secondaryButton}
                 href={appViewUrl(app.id, props.token)}
@@ -682,7 +700,7 @@ function AppViewer(props: {
             </DialogClose>
           </div>
         </div>
-        {app ? (
+        {app && props.token ? (
           <LiveAppFrame
             ref={props.frameRef}
             appId={app.id}

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -167,6 +167,7 @@ vi.mock('../../api/client', () => ({
     options === undefined
       ? deleteChatSessionMock(token, sessionId)
       : deleteChatSessionMock(token, sessionId, options),
+  createAdminApiToken: vi.fn(async () => ({ token: 'hck_app_view_token' })),
   fetchAgentList: (token: string) => fetchAgentListMock(token),
   fetchModels: (token: string) => fetchModelsMock(token),
   fetchSkills: (token: string) => fetchSkillsMock(token),

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -52,6 +52,7 @@ import {
   ViewSwitchNav,
 } from '../../components/view-switch';
 import { buildAppSeed } from '../../lib/app-seed';
+import { createAppViewToken } from '../../lib/app-view-token';
 import {
   type ApprovalAction,
   buildApprovalCommand,
@@ -449,6 +450,7 @@ export function ChatPage() {
     title: string;
     kind: 'web' | 'live';
   } | null>(null);
+  const [previewAppToken, setPreviewAppToken] = useState('');
 
   const stream = useChatStream({
     token: auth.token,
@@ -462,6 +464,26 @@ export function ChatPage() {
     onAppsCaptured: (apps) => setPreviewApp(apps[apps.length - 1] ?? null),
     resolveAddressedAgentPresentation,
   });
+
+  useEffect(() => {
+    let active = true;
+    setPreviewAppToken('');
+    if (!previewApp) return;
+
+    createAppViewToken(auth.token, previewApp.id)
+      .then((token) => {
+        if (active) setPreviewAppToken(token);
+      })
+      .catch((error: unknown) => {
+        if (!active) return;
+        setPreviewApp(null);
+        setError(`Could not open app preview: ${getErrorMessage(error)}`);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [auth.token, previewApp, setError]);
 
   useEffect(() => {
     const message = errorState.message;
@@ -1439,10 +1461,10 @@ export function ChatPage() {
                 >
                   View in Apps
                 </button>
-                {previewApp ? (
+                {previewApp && previewAppToken ? (
                   <a
                     className={css.appPreviewLink}
-                    href={appViewUrl(previewApp.id, auth.token)}
+                    href={appViewUrl(previewApp.id, previewAppToken)}
                     target="_blank"
                     rel="noreferrer"
                   >
@@ -1452,12 +1474,12 @@ export function ChatPage() {
                 <DialogClose className={css.appPreviewLink}>Close</DialogClose>
               </div>
             </div>
-            {previewApp ? (
+            {previewApp && previewAppToken ? (
               <LiveAppFrame
                 appId={previewApp.id}
                 className={css.appPreviewFrame}
                 title={previewApp.title}
-                token={auth.token}
+                token={previewAppToken}
               />
             ) : null}
           </DialogContent>

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -2018,11 +2018,24 @@ function isRuntimeMSTeamsChannelConfig(
   return true;
 }
 
-function hasQueryToken(url: URL): boolean {
+function resolveQueryTokenAuthContext(url: URL): ResolvedAuthContext | null {
   const token = (url.searchParams.get('token') || '').trim();
-  if (!token) return false;
-  if (WEB_API_TOKEN && safeEqualToken(token, WEB_API_TOKEN)) return true;
-  return Boolean(GATEWAY_API_TOKEN) && safeEqualToken(token, GATEWAY_API_TOKEN);
+  if (!token) return null;
+  if (WEB_API_TOKEN && safeEqualToken(token, WEB_API_TOKEN)) {
+    return { kind: 'master', payload: null };
+  }
+  if (GATEWAY_API_TOKEN && safeEqualToken(token, GATEWAY_API_TOKEN)) {
+    return { kind: 'master', payload: null };
+  }
+  if (!isApiTokenString(token)) return null;
+  const verified = verifyApiToken(token);
+  if (!verified) return null;
+  return {
+    kind: 'apiToken',
+    payload: verified.claims,
+    tokenId: verified.id,
+    tokenLabel: verified.label,
+  };
 }
 
 function hasBearerToken(authHeader: string, token: string): boolean {
@@ -2150,8 +2163,9 @@ function resolveAuthContext(
   url?: URL,
   opts?: ResolveAuthContextOptions,
 ): ResolvedAuthContext {
-  if (opts?.allowQueryToken && url && hasQueryToken(url)) {
-    return { kind: 'master', payload: null };
+  if (opts?.allowQueryToken && url) {
+    const queryTokenAuth = resolveQueryTokenAuthContext(url);
+    if (queryTokenAuth) return queryTokenAuth;
   }
 
   const authHeader = req.headers.authorization || '';
@@ -2305,6 +2319,18 @@ function isApiTokenAllowedForRoute(
   const action = resolveAdminRbacAction(pathname, method);
   if (!action) return hasFullApiTokenWildcard(context);
   return isAdminActionAllowed(context.payload, action);
+}
+
+function isApiTokenAllowedForApp(
+  context: ResolvedAuthContext,
+  appId: string,
+): boolean {
+  if (context.kind !== 'apiToken') return true;
+  const appIds = context.payload?.appIds;
+  if (!Array.isArray(appIds)) return false;
+  return appIds.some(
+    (entry) => typeof entry === 'string' && entry.trim() === appId,
+  );
 }
 
 function enforceAdminRouteRbac(
@@ -7700,6 +7726,7 @@ async function handleApiAppBridgeTool(
   }
 
   const authContext = resolveAuthContext(req, url, {
+    allowQueryToken: true,
     allowLocalWebSession: true,
     allowSessionCookie: true,
     requireSameOrigin: true,
@@ -7711,6 +7738,10 @@ async function handleApiAppBridgeTool(
   if (
     !isApiTokenAllowedForRoute(authContext, url.pathname, req.method || 'POST')
   ) {
+    sendJson(res, 403, { error: 'Forbidden.' });
+    return;
+  }
+  if (!isApiTokenAllowedForApp(authContext, id)) {
     sendJson(res, 403, { error: 'Forbidden.' });
     return;
   }
@@ -7769,13 +7800,17 @@ async function handleApiAppView(
   if (authContext.kind === 'none') {
     sendJson(res, 401, {
       error:
-        'Unauthorized. Set `Authorization: Bearer <WEB_API_TOKEN>` or pass `?token=<WEB_API_TOKEN>`.',
+        'Unauthorized. Set `Authorization: Bearer <WEB_API_TOKEN>` or pass a valid `?token=`.',
     });
     return;
   }
   if (
     !isApiTokenAllowedForRoute(authContext, url.pathname, req.method || 'GET')
   ) {
+    sendJson(res, 403, { error: 'Forbidden.' });
+    return;
+  }
+  if (!isApiTokenAllowedForApp(authContext, id)) {
     sendJson(res, 403, { error: 'Forbidden.' });
     return;
   }
@@ -7787,6 +7822,9 @@ async function handleApiAppView(
   res.writeHead(200, {
     'Content-Type': 'text/html; charset=utf-8',
     'Cache-Control': 'no-store',
+    'Content-Security-Policy':
+      "sandbox allow-scripts allow-forms allow-popups allow-modals allow-downloads; base-uri 'none'; object-src 'none'",
+    'Referrer-Policy': 'no-referrer',
     'X-Content-Type-Options': 'nosniff',
   });
   res.end(injectLiveAppBridge(app.html, app));

--- a/src/security/admin-rbac.ts
+++ b/src/security/admin-rbac.ts
@@ -17,6 +17,10 @@ export const ADMIN_RBAC_ACTIONS = [
   'chat.send',
   'status.read',
   'agents.read',
+  'apps.read',
+  'apps.view',
+  'apps.bridge',
+  'apps.delete',
   'admin.overview.read',
   'admin.tunnel.read',
   'admin.tunnel.write',
@@ -122,6 +126,9 @@ const ADMIN_READ_ACTIONS = [
   'admin.distill.read',
   'admin.skills.read',
   'admin.jobs.read',
+  'apps.read',
+  'apps.view',
+  'apps.bridge',
 ] as const satisfies readonly AdminRbacAction[];
 
 const ADMIN_AUDITOR_ACTIONS = [
@@ -396,6 +403,20 @@ export function resolveAdminRbacAction(
     method === 'GET'
   ) {
     return 'agents.read';
+  }
+  if (pathname === '/api/apps') {
+    return method === 'GET' ? 'apps.read' : null;
+  }
+  if (pathname.startsWith('/api/apps/')) {
+    if (pathname.endsWith('/view')) {
+      return method === 'GET' ? 'apps.view' : null;
+    }
+    if (pathname.endsWith('/bridge/tool')) {
+      return method === 'POST' ? 'apps.bridge' : null;
+    }
+    if (method === 'GET') return 'apps.read';
+    if (method === 'DELETE') return 'apps.delete';
+    return null;
   }
   if (pathname === '/api/admin/tunnel') {
     if (method === 'GET') return 'admin.tunnel.read';

--- a/src/security/api-tokens.ts
+++ b/src/security/api-tokens.ts
@@ -1,4 +1,5 @@
 import { randomBytes, scryptSync, timingSafeEqual } from 'node:crypto';
+import type Database from 'better-sqlite3';
 import { withMemoryDatabase } from '../memory/db.js';
 
 export const API_TOKEN_PREFIX = 'hck';
@@ -214,6 +215,26 @@ function toMetadata(row: ApiTokenRow): ApiTokenMetadata {
   };
 }
 
+function pruneExpiredApiTokensInDatabase(
+  database: Database.Database,
+  now: Date,
+): number {
+  return database
+    .prepare(
+      `DELETE FROM api_tokens
+       WHERE expires_at IS NOT NULL
+         AND expires_at <= ?`,
+    )
+    .run(now.toISOString()).changes;
+}
+
+export function pruneExpiredApiTokens(options: { now?: Date } = {}): number {
+  const now = options.now ?? new Date();
+  return withMemoryDatabase((database) =>
+    pruneExpiredApiTokensInDatabase(database, now),
+  );
+}
+
 export function createApiToken(
   input: CreateApiTokenInput,
 ): CreateApiTokenResult {
@@ -226,6 +247,7 @@ export function createApiToken(
   const tokenHash = createApiTokenVerifier(token);
 
   return withMemoryDatabase((database) => {
+    pruneExpiredApiTokensInDatabase(database, new Date());
     database
       .prepare(
         `INSERT INTO api_tokens (

--- a/tests/admin-rbac.test.ts
+++ b/tests/admin-rbac.test.ts
@@ -174,5 +174,16 @@ describe('admin RBAC role bundles', () => {
     expect(resolveAdminRbacAction('/api/command', 'POST')).toBe('chat.send');
     expect(resolveAdminRbacAction('/api/status', 'GET')).toBe('status.read');
     expect(resolveAdminRbacAction('/api/agents', 'GET')).toBe('agents.read');
+    expect(resolveAdminRbacAction('/api/apps', 'GET')).toBe('apps.read');
+    expect(resolveAdminRbacAction('/api/apps/app-1', 'GET')).toBe('apps.read');
+    expect(resolveAdminRbacAction('/api/apps/app-1/view', 'GET')).toBe(
+      'apps.view',
+    );
+    expect(resolveAdminRbacAction('/api/apps/app-1/bridge/tool', 'POST')).toBe(
+      'apps.bridge',
+    );
+    expect(resolveAdminRbacAction('/api/apps/app-1', 'DELETE')).toBe(
+      'apps.delete',
+    );
   });
 });

--- a/tests/api-tokens.test.ts
+++ b/tests/api-tokens.test.ts
@@ -115,4 +115,26 @@ describe('api token registry', () => {
       actions: [],
     });
   });
+
+  test('prunes expired token rows when minting a new token', async () => {
+    const { tokens } = await setupRegistry();
+    const expired = tokens.createApiToken({
+      label: 'Expired view token',
+      claims: { actions: ['apps.view'], appIds: ['app-1'] },
+      expiresAt: '2000-01-01T00:00:00.000Z',
+    });
+
+    expect(tokens.listApiTokens().map((token) => token.id)).toContain(
+      expired.metadata.id,
+    );
+
+    const active = tokens.createApiToken({
+      label: 'Active view token',
+      claims: { actions: ['apps.view'], appIds: ['app-1'] },
+    });
+
+    expect(tokens.listApiTokens().map((token) => token.id)).toEqual([
+      active.metadata.id,
+    ]);
+  });
 });

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -3292,6 +3292,13 @@ describe('gateway HTTP server', () => {
     await waitForResponse(liveRes, (next) => next.writableEnded);
 
     expect(liveRes.statusCode).toBe(200);
+    expect(liveRes.headers['Referrer-Policy']).toBe('no-referrer');
+    expect(liveRes.headers['Content-Security-Policy']).toContain(
+      'sandbox allow-scripts allow-forms allow-popups allow-modals allow-downloads',
+    );
+    expect(liveRes.headers['Content-Security-Policy']).not.toContain(
+      'allow-popups-to-escape-sandbox',
+    );
     expect(liveRes.body).toContain('data-hybridclaw-live-app-bridge');
     expect(liveRes.body).toContain(`var appId = ${JSON.stringify(liveApp.id)};`);
     expect(liveRes.body).toContain('existing.callMcpTool = callTool');
@@ -3311,6 +3318,155 @@ describe('gateway HTTP server', () => {
     expect(staticRes.statusCode).toBe(200);
     expect(staticRes.body).not.toContain('data-hybridclaw-live-app-bridge');
     expect(staticRes.body).toContain('<body>static</body>');
+  });
+
+  test('requires matching appIds on scoped app view query tokens', async () => {
+    const apiToken = 'hck_app_view';
+    const apiTokens = {
+      [apiToken]: {
+        id: 'abc123abc123',
+        label: 'app-view',
+        claims: {
+          actions: ['apps.view', 'apps.bridge'],
+          appIds: [] as string[],
+        },
+      },
+    };
+    const state = await importFreshHealth({
+      apiTokens,
+    });
+    const allowedApp = state.createApp({
+      title: 'Allowed App',
+      html: '<!doctype html><html><head></head><body>allowed</body></html>',
+      kind: 'web',
+    });
+    const deniedApp = state.createApp({
+      title: 'Denied App',
+      html: '<!doctype html><html><head></head><body>denied</body></html>',
+      kind: 'web',
+    });
+    apiTokens[apiToken].claims.appIds = [allowedApp.id];
+
+    const allowedReq = makeRequest({
+      url: `/api/apps/${allowedApp.id}/view?token=${apiToken}`,
+      noAuth: true,
+      remoteAddress: '203.0.113.10',
+    });
+    const allowedRes = makeResponse();
+    state.handler(allowedReq as never, allowedRes as never);
+    await waitForResponse(allowedRes, (next) => next.writableEnded);
+
+    expect(state.verifyApiToken).toHaveBeenCalledWith(apiToken);
+    expect(allowedRes.statusCode).toBe(200);
+    expect(allowedRes.body).toContain('<body>allowed</body>');
+
+    const deniedReq = makeRequest({
+      url: `/api/apps/${deniedApp.id}/view?token=${apiToken}`,
+      noAuth: true,
+      remoteAddress: '203.0.113.10',
+    });
+    const deniedRes = makeResponse();
+    state.handler(deniedReq as never, deniedRes as never);
+    await waitForResponse(deniedRes, (next) => next.writableEnded);
+
+    expect(deniedRes.statusCode).toBe(403);
+    expect(JSON.parse(deniedRes.body)).toEqual({ error: 'Forbidden.' });
+    expect(deniedRes.body).not.toContain('denied');
+  });
+
+  test('accepts scoped hck query tokens on the live app bridge path', async () => {
+    const apiToken = 'hck_app_bridge';
+    const apiTokens = {
+      [apiToken]: {
+        id: 'def456def456',
+        label: 'app-bridge',
+        claims: {
+          actions: ['apps.bridge'],
+          appIds: [] as string[],
+        },
+      },
+    };
+    const state = await importFreshHealth({
+      apiTokens,
+    });
+    const liveApp = state.createApp({
+      title: 'Mail Wordcloud',
+      html: '<!doctype html><html><head></head><body>mail</body></html>',
+      kind: 'live',
+      sessionId: 'sess-live-app',
+      agentId: 'main',
+    });
+    apiTokens[apiToken].claims.appIds = [liveApp.id];
+    const req = makeRequest({
+      method: 'POST',
+      url: `/api/apps/${liveApp.id}/bridge/tool?token=${apiToken}`,
+      noAuth: true,
+      body: {
+        toolName: 'hybridai__microsoft_graph__send_message',
+        arguments: { id: 'message-1' },
+      },
+      remoteAddress: '203.0.113.10',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(state.verifyApiToken).toHaveBeenCalledWith(apiToken);
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({
+      ok: false,
+      error: 'Live apps can only call read-only MCP connector tools.',
+    });
+    expect(state.runAgent).not.toHaveBeenCalled();
+  });
+
+  test('uses apps.read for scoped API-token access to the apps API', async () => {
+    const readToken = 'hck_apps_read';
+    const deniedToken = 'hck_apps_denied';
+    const state = await importFreshHealth({
+      apiTokens: {
+        [readToken]: {
+          id: '111111111111',
+          label: 'apps-reader',
+          claims: { actions: ['apps.read'] },
+        },
+        [deniedToken]: {
+          id: '222222222222',
+          label: 'chat-only',
+          claims: { actions: ['chat.send'] },
+        },
+      },
+    });
+    state.createApp({
+      title: 'Listed App',
+      html: '<!doctype html><html><body>listed</body></html>',
+      kind: 'web',
+    });
+
+    const deniedReq = makeRequest({
+      url: '/api/apps',
+      headers: { authorization: `Bearer ${deniedToken}` },
+    });
+    const deniedRes = makeResponse();
+    state.handler(deniedReq as never, deniedRes as never);
+    await waitForResponse(deniedRes, (next) => next.writableEnded);
+
+    expect(deniedRes.statusCode).toBe(403);
+
+    const readReq = makeRequest({
+      url: '/api/apps',
+      headers: { authorization: `Bearer ${readToken}` },
+    });
+    const readRes = makeResponse();
+    state.handler(readReq as never, readRes as never);
+    await waitForResponse(readRes, (next) => next.writableEnded);
+
+    expect(readRes.statusCode).toBe(200);
+    expect(JSON.parse(readRes.body)).toMatchObject({
+      apps: [expect.objectContaining({ title: 'Listed App' })],
+      total: 1,
+    });
   });
 
   test('rejects mutating live app bridge tool requests before running an agent', async () => {


### PR DESCRIPTION
## Summary

- Add first-class app RBAC actions for list/detail, view, bridge, and delete routes.
- Allow app view and live bridge query-token auth to use scoped `hck_` API tokens, requiring both route action claims and a matching `appIds` claim.
- Mint short-lived console app-view tokens instead of putting the console auth token in app frame or new-tab URLs.
- Harden app views with CSP sandbox and `Referrer-Policy: no-referrer`, and remove iframe popup escape permission.
- Prune expired API-token rows when minting new tokens.

## Why

App view URLs previously reused broad console/master tokens. A leaked URL could carry broader authority than needed. The new path scopes leaked app tokens to one app, read-only bridge actions, and a short expiration window.

## Validation

- `npm run format` completed; it reported existing optional-chain warnings and applied no changes.
- `npm run lint` passed.
- `npm run typecheck` passed before commit.
- `vitest run tests/admin-rbac.test.ts tests/api-tokens.test.ts` passed.
- `vitest run tests/gateway-http-server.test.ts --testNamePattern "live app bridge|scoped app view|apps API|injects the live app bridge"` passed.
- Console targeted tests passed: `vitest run --config vitest.config.ts src/components/live-app-frame.test.tsx src/lib/app-view-token.test.ts src/routes/chat/chat-page.test.tsx` from `console/`.

## Notes

A full `tests/gateway-http-server.test.ts` run still has 4 failures in existing local/session-cookie auth expectations unrelated to the app-token path: local web-session API mutation, signed session-cookie mutations, forwarded-origin mutation, and terminal websocket local-session upgrade.