### PR TITLE
fix: scope config watcher to gateway and add stat-polling fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Config watcher scope and EMFILE resilience**: The runtime-config file
+  watcher now starts only in the long-running gateway process instead of in
+  every CLI invocation, so one-shot commands such as `hybridclaw gateway
+  status` no longer create `fs.watch` handles or interleave
+  `[runtime-config] watcher error: EMFILE` retry noise into their output.
+  When the gateway's watcher does fail (for example `EMFILE: too many open
+  files`), config hot-reload now falls back to descriptor-free stat polling
+  instead of going dark after ten failed watcher restarts.
+
+  `Manifesto: Principle VIII - A coworker doesn't break overnight.`
+
 ## [0.27.2](https://github.com/HybridAIOne/hybridclaw/tree/v0.27.2) - 2026-07-06
 
 ### Fixed

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -6,8 +6,12 @@ sidebar_position: 3
 
 # Configuration
 
-HybridClaw creates `~/.hybridclaw/config.json` on first run and hot-reloads
-most runtime settings.
+HybridClaw creates `~/.hybridclaw/config.json` on first run, and the running
+gateway hot-reloads most runtime settings when the file changes. If the
+gateway's file watcher cannot run (for example under file-descriptor
+pressure), it falls back to detecting config changes via periodic stat
+polling. One-shot CLI commands read the config once at startup and do not
+watch the file.
 
 Use `config.example.json` as the reference shape when you need to inspect the
 full runtime config surface before editing your local file.

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -2117,9 +2117,11 @@ const WATCHER_RETRY_BASE_DELAY_MS = 1_000;
 const WATCHER_RETRY_MAX_DELAY_MS = 60_000;
 const WATCHER_RETRY_MAX_ATTEMPTS = 10;
 const WATCHER_STABLE_RESET_DELAY_MS = 1_000;
+const WATCHER_POLL_FALLBACK_INTERVAL_MS = 2_000;
 let watcherRetryAttempt = 0;
 let watcherRestartTimer: ReturnType<typeof setTimeout> | null = null;
 let watcherStableTimer: ReturnType<typeof setTimeout> | null = null;
+let watcherPollFallbackActive = false;
 
 function detachTimer(timer: ReturnType<typeof setTimeout>): void {
   if (
@@ -8583,6 +8585,31 @@ function scheduleReload(trigger: string): void {
   }, 120);
 }
 
+function handleWatcherPollTick(curr: fs.Stats, prev: fs.Stats): void {
+  if (curr.mtimeMs === prev.mtimeMs && curr.size === prev.size) return;
+  scheduleReload('poll');
+}
+
+function startWatcherPollFallback(reason: string): void {
+  if (isRuntimeConfigWatcherDisabled()) return;
+  if (watcherPollFallbackActive) return;
+  watcherPollFallbackActive = true;
+  fs.watchFile(
+    CONFIG_PATH,
+    { persistent: false, interval: WATCHER_POLL_FALLBACK_INTERVAL_MS },
+    handleWatcherPollTick,
+  );
+  console.warn(
+    `[runtime-config] watching config via ${WATCHER_POLL_FALLBACK_INTERVAL_MS}ms stat polling until fs.watch recovers (${reason})`,
+  );
+}
+
+function stopWatcherPollFallback(): void {
+  if (!watcherPollFallbackActive) return;
+  watcherPollFallbackActive = false;
+  fs.unwatchFile(CONFIG_PATH, handleWatcherPollTick);
+}
+
 function scheduleWatcherRestart(reason: string): void {
   if (isRuntimeConfigWatcherDisabled()) return;
   if (watcherRestartTimer) return;
@@ -8592,7 +8619,7 @@ function scheduleWatcherRestart(reason: string): void {
   }
   if (watcherRetryAttempt >= WATCHER_RETRY_MAX_ATTEMPTS) {
     console.warn(
-      `[runtime-config] watcher disabled after ${WATCHER_RETRY_MAX_ATTEMPTS} retries (${reason})`,
+      `[runtime-config] watcher disabled after ${WATCHER_RETRY_MAX_ATTEMPTS} retries (${reason})${watcherPollFallbackActive ? '; config file changes are still detected via stat polling' : ''}`,
     );
     return;
   }
@@ -8614,6 +8641,7 @@ function scheduleWatcherRestart(reason: string): void {
 function markWatcherStable(activeWatcher: fs.FSWatcher): void {
   if (configWatcher !== activeWatcher) return;
   watcherRetryAttempt = 0;
+  stopWatcherPollFallback();
   if (watcherStableTimer) {
     clearTimeout(watcherStableTimer);
     watcherStableTimer = null;
@@ -8656,11 +8684,13 @@ function startWatcher(): void {
         watcherStableTimer = null;
       }
       console.warn(`[runtime-config] watcher error: ${reason}`);
+      startWatcherPollFallback(`watcher error: ${reason}`);
       scheduleWatcherRestart(`watcher error: ${reason}`);
     });
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     console.warn(`[runtime-config] watcher setup failed: ${reason}`);
+    startWatcherPollFallback(`watcher setup failed: ${reason}`);
     scheduleWatcherRestart(`watcher setup failed: ${reason}`);
   }
 }
@@ -8768,10 +8798,16 @@ function initializeRuntimeConfig(): void {
   ensureInitialConfigFile();
   migrateConfigSchemaOnStartup();
   reloadFromDisk('startup');
-  startWatcher();
 }
 
 initializeRuntimeConfig();
+
+// Watching is opt-in for long-running processes (the gateway). One-shot CLI
+// invocations must not hold fs.watch/FSEvents resources they never benefit
+// from — watcher failures (e.g. EMFILE) would only pollute their output.
+export function startRuntimeConfigWatcher(): void {
+  startWatcher();
+}
 
 export function runtimeConfigPath(): string {
   return CONFIG_PATH;

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -128,7 +128,10 @@ import {
   SLACK_BOT_TOKEN,
   TWILIO_AUTH_TOKEN,
 } from '../config/config.js';
-import type { RuntimeConfig } from '../config/runtime-config.js';
+import {
+  type RuntimeConfig,
+  startRuntimeConfigWatcher,
+} from '../config/runtime-config.js';
 import { resolveLocalInstanceId } from '../identity/agent-id.js';
 import { logger } from '../logger.js';
 import {
@@ -3523,6 +3526,7 @@ async function main(): Promise<void> {
   await initSentry();
   await initOtel();
   logger.info('Starting HybridClaw gateway');
+  startRuntimeConfigWatcher();
   ensureA2AInstanceKeypair();
   logger.info(
     { instanceId: resolveLocalInstanceId() },

--- a/tests/runtime-config.migration-logging.test.ts
+++ b/tests/runtime-config.migration-logging.test.ts
@@ -52,10 +52,14 @@ function writeRuntimeConfig(
   fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
 }
 
-async function importFreshRuntimeConfig(homeDir: string): Promise<void> {
+type RuntimeConfigModule = typeof import('../src/config/runtime-config.ts');
+
+async function importFreshRuntimeConfig(
+  homeDir: string,
+): Promise<RuntimeConfigModule> {
   process.env.HOME = homeDir;
   vi.resetModules();
-  await import('../src/config/runtime-config.ts');
+  return import('../src/config/runtime-config.ts');
 }
 
 type FakeWatcher = EventEmitter &
@@ -67,6 +71,33 @@ function createFakeWatcher(): FakeWatcher {
   const watcher = new EventEmitter() as FakeWatcher;
   watcher.close = vi.fn();
   return watcher;
+}
+
+type WatchFilePollListener = (curr: fs.Stats, prev: fs.Stats) => void;
+
+function stubWatchFilePolling() {
+  const watchedPaths: string[] = [];
+  let pollListener: WatchFilePollListener | undefined;
+  const watchFileSpy = vi.spyOn(fs, 'watchFile').mockImplementation(((
+    watchedPath: fs.PathLike,
+    _options: unknown,
+    onTick: WatchFilePollListener,
+  ) => {
+    watchedPaths.push(String(watchedPath));
+    pollListener = onTick;
+    return {} as fs.StatWatcher;
+  }) as unknown as typeof fs.watchFile);
+  const unwatchFileSpy = vi
+    .spyOn(fs, 'unwatchFile')
+    .mockImplementation(() => {});
+  return {
+    watchFileSpy,
+    unwatchFileSpy,
+    watchedPaths,
+    emitPollTick: (curr: Partial<fs.Stats>, prev: Partial<fs.Stats>) => {
+      pollListener?.(curr as fs.Stats, prev as fs.Stats);
+    },
+  };
 }
 
 afterEach(() => {
@@ -466,18 +497,38 @@ describe('runtime config migration logging', () => {
     expect(stored.msteams.appPassword).toBeUndefined();
   });
 
+  it('does not start the fs watcher at module import, only on explicit start', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir);
+    delete process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+    const fakeWatcher = createFakeWatcher();
+    const watchSpy = vi
+      .spyOn(fs, 'watch')
+      .mockImplementation(() => fakeWatcher as unknown as fs.FSWatcher);
+
+    const configMod = await importFreshRuntimeConfig(homeDir);
+
+    expect(watchSpy).not.toHaveBeenCalled();
+
+    configMod.startRuntimeConfigWatcher();
+    configMod.startRuntimeConfigWatcher();
+
+    expect(watchSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('does not start the fs watcher when watcher disable env is set', async () => {
     const homeDir = makeTempHome();
     writeRuntimeConfig(homeDir);
     process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
     const watchSpy = vi.spyOn(fs, 'watch');
 
-    await importFreshRuntimeConfig(homeDir);
+    const configMod = await importFreshRuntimeConfig(homeDir);
+    configMod.startRuntimeConfigWatcher();
 
     expect(watchSpy).not.toHaveBeenCalled();
   });
 
-  it('unrefs watcher startup timers so one-shot commands can exit promptly', async () => {
+  it('unrefs watcher timers so the watcher never keeps a process alive', async () => {
     const homeDir = makeTempHome();
     writeRuntimeConfig(homeDir);
     delete process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
@@ -507,7 +558,8 @@ describe('runtime config migration logging', () => {
     );
 
     try {
-      await importFreshRuntimeConfig(homeDir);
+      const configMod = await importFreshRuntimeConfig(homeDir);
+      configMod.startRuntimeConfigWatcher();
     } finally {
       vi.stubGlobal('setTimeout', originalSetTimeout);
       vi.stubGlobal('clearTimeout', originalClearTimeout);
@@ -534,9 +586,11 @@ describe('runtime config migration logging', () => {
       watchers.push(watcher);
       return watcher as unknown as fs.FSWatcher;
     });
+    stubWatchFilePolling();
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    await importFreshRuntimeConfig(homeDir);
+    const configMod = await importFreshRuntimeConfig(homeDir);
+    configMod.startRuntimeConfigWatcher();
 
     setTimeout(() => {
       watchers[0]?.emit('error', retryableError);
@@ -581,9 +635,11 @@ describe('runtime config migration logging', () => {
       watchers.push(watcher);
       return watcher as unknown as fs.FSWatcher;
     });
+    stubWatchFilePolling();
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    await importFreshRuntimeConfig(homeDir);
+    const configMod = await importFreshRuntimeConfig(homeDir);
+    configMod.startRuntimeConfigWatcher();
 
     setTimeout(() => {
       watchers[0]?.emit('error', retryableError);
@@ -610,5 +666,98 @@ describe('runtime config migration logging', () => {
     expect(
       restartLogs.filter((message) => message.includes('attempt 2/10')),
     ).toHaveLength(0);
+  });
+
+  it('falls back to stat polling when watcher setup fails and reloads config on poll ticks', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir);
+    delete process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+    vi.useFakeTimers();
+    vi.spyOn(fs, 'watch').mockImplementation(() => {
+      throw Object.assign(new Error('EMFILE: too many open files, watch'), {
+        code: 'EMFILE',
+      });
+    });
+    const polling = stubWatchFilePolling();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const configMod = await importFreshRuntimeConfig(homeDir);
+    configMod.startRuntimeConfigWatcher();
+
+    expect(polling.watchFileSpy).toHaveBeenCalledTimes(1);
+    expect(polling.watchedPaths).toEqual([
+      path.join(homeDir, '.hybridclaw', 'config.json'),
+    ]);
+    expect(
+      warnSpy.mock.calls.some(([message]) =>
+        String(message).includes('stat polling'),
+      ),
+    ).toBe(true);
+
+    writeRuntimeConfig(homeDir, (config) => {
+      config.container.maxConcurrent = 7;
+    });
+    polling.emitPollTick({ mtimeMs: 2, size: 2 }, { mtimeMs: 1, size: 1 });
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(configMod.getRuntimeConfig().container.maxConcurrent).toBe(7);
+  });
+
+  it('stops stat polling once a restarted watcher becomes stable', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir);
+    delete process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+    vi.useFakeTimers();
+    let watchCalls = 0;
+    vi.spyOn(fs, 'watch').mockImplementation(() => {
+      watchCalls += 1;
+      if (watchCalls === 1) {
+        throw Object.assign(new Error('EMFILE: too many open files, watch'), {
+          code: 'EMFILE',
+        });
+      }
+      return createFakeWatcher() as unknown as fs.FSWatcher;
+    });
+    const polling = stubWatchFilePolling();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const configMod = await importFreshRuntimeConfig(homeDir);
+    configMod.startRuntimeConfigWatcher();
+
+    expect(polling.watchFileSpy).toHaveBeenCalledTimes(1);
+    expect(polling.unwatchFileSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(watchCalls).toBe(2);
+    expect(polling.unwatchFileSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps stat polling active after watcher retries are exhausted', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir);
+    delete process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+    vi.useFakeTimers();
+    vi.spyOn(fs, 'watch').mockImplementation(() => {
+      throw Object.assign(new Error('EMFILE: too many open files, watch'), {
+        code: 'EMFILE',
+      });
+    });
+    const polling = stubWatchFilePolling();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const configMod = await importFreshRuntimeConfig(homeDir);
+    configMod.startRuntimeConfigWatcher();
+
+    await vi.advanceTimersByTimeAsync(600_000);
+
+    const disabledLog = warnSpy.mock.calls
+      .map(([message]) => String(message))
+      .find((message) => message.includes('watcher disabled after 10 retries'));
+    expect(disabledLog).toBeDefined();
+    expect(disabledLog).toContain('stat polling');
+    expect(polling.watchFileSpy).toHaveBeenCalledTimes(1);
+    expect(polling.unwatchFileSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Problem: `src/config/runtime-config.ts` started a persistent `fs.watch` as a module-import side effect, so every one-shot CLI invocation created a watcher it never used. Under file-descriptor pressure, `hybridclaw gateway status` interleaved `[runtime-config] watcher error: EMFILE` retry noise into its output, and a long-running gateway hitting the same failure permanently lost config hot-reload after ten watcher restarts.
- Why it matters: one-shot command output stays clean and parseable, and the gateway keeps applying external `config.json` edits even when `fs.watch` cannot run.
- What changed: the watcher is now opt-in via a new `startRuntimeConfigWatcher()` export, called only from the gateway bootstrap (`src/gateway/gateway.ts` `main()`). While `fs.watch` is down (setup failure or error event), the gateway falls back to descriptor-free `fs.watchFile` stat polling (2s interval, unref'd, non-persistent) and stops polling once a restarted watcher proves stable; if all restart attempts are exhausted, polling stays active.
- What did not change: module import still seeds/migrates/loads `config.json` exactly as before; the watcher retry/backoff ladder, its log lines, and the `HYBRIDCLAW_DISABLE_CONFIG_WATCHER` kill switch (which also disables the polling fallback) are unchanged. In-process config updates (`hybridclaw config set`, gateway config API) never depended on the watcher and are unaffected.

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Docs
- [x] Tests
- [ ] Refactor required for the fix
- [ ] Tooling or workflow
- [ ] Security hardening

## Linked Context

- Closes #
- Related #

## Manifesto Principle

- Principle: VIII - A coworker doesn't break overnight.
- Changelog tag added or updated: `Manifesto: Principle VIII - A coworker doesn't break overnight.`

## Validation

```bash
npm run lint
npm run check          # biome: changed files clean; 27 pre-existing warnings elsewhere
npx vitest run tests/runtime-config.migration-logging.test.ts tests/config-reload.integration.test.ts   # 43/43 pass
npm run test:unit      # failure set byte-identical to unmodified main (pre-existing, env-dependent)
```

- Verified manually: against the compiled `dist/`, importing `runtime-config.js` makes zero `fs.watch` calls and `startRuntimeConfigWatcher()` makes exactly one; with `fs.watch` monkey-patched to always throw EMFILE, a real on-disk `config.json` edit was picked up via the live stat-polling fallback within one 2s tick while the retry ladder kept running; `node dist/cli.js gateway status` against a scratch data dir prints no watcher lines and exits in ~0.2s.
- Edge cases checked: repeated `startRuntimeConfigWatcher()` calls start one watcher (idempotent); polling stops via `fs.unwatchFile` once a restarted watcher survives the 1s stability window; polling remains active after the 10-attempt retry ladder is exhausted, and the "watcher disabled" log line now says stat polling still covers config changes; `HYBRIDCLAW_DISABLE_CONFIG_WATCHER=1` suppresses both the watcher and the fallback.
- Skipped checks and why: full gateway boot smoke test skipped — the only gateway change is a one-line `startRuntimeConfigWatcher()` call in `main()`, covered by typecheck and dist inspection; `npm run test:integration`/`e2e` not run (no CI-visible surface beyond unit scope touched).

## Docs And Config Impact

- [x] README, docs, or examples updated
- [x] Config or environment behavior changed
- [ ] Templates or workspace bootstrap files changed
- [ ] No docs or config impact

`docs/content/reference/configuration.md` now states that hot-reload is a gateway behavior with a stat-polling fallback, and that one-shot CLI commands read config once. No `templates/` changes.

## Risk Notes

- Security-sensitive paths touched? (`No`)
- Gateway, audit, approval, or container boundaries touched? (`Yes` — one-line watcher start in `src/gateway/gateway.ts` `main()`; `src/config/runtime-config.ts` carries the behavior change)
- Failure mode: if the gateway missed calling the new start function, external `config.json` edits would stop hot-reloading (in-process updates unaffected). Tested via a new unit test asserting import alone starts no watcher plus dist-level verification that the gateway bundle contains exactly one `startRuntimeConfigWatcher()` call; the EMFILE failure mode itself is covered by three new boundary tests (fallback engages, fallback reloads from disk, fallback survives retry exhaustion).

## Secret Handling Checklist

Not applicable — no credential material is read, stored, injected, displayed, logged, or documented by this change.

## Evidence

- [x] Failing output before and passing output after
- [ ] Screenshot or recording
- [x] Log snippet
- [x] New or updated test coverage

Before (user-visible symptom, `hybridclaw gateway status` on a stock build):

```
Gateway API reachable: yes (http://127.0.0.1:9292)
[runtime-config] watcher error: EMFILE: too many open files, watch
[runtime-config] watcher restart in 2000ms (attempt 2/10)
Uptime: 421s | Sessions: 1 | Sandbox: host (0 active)
```

After (this branch, `fs.watch` forced to persistently throw EMFILE in a gateway-like process): the fallback engages and a real config edit still reloads —

```
[runtime-config] watcher setup failed: EMFILE: too many open files, watch
[runtime-config] watching config via 2000ms stat polling until fs.watch recovers (watcher setup failed: EMFILE: too many open files, watch)
[runtime-config] watcher restart in 1000ms (attempt 1/10)
maxConcurrent before poll: 5
maxConcurrent after poll: 9
PASS: polling fallback reloaded config from disk
```

One-shot commands on this branch print no watcher lines at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)