### PR TITLE
fix: stabilize local A2A chat replies

### DIFF
--- a/console/src/routes/chat/a2a-delivery-chip.tsx
+++ b/console/src/routes/chat/a2a-delivery-chip.tsx
@@ -8,19 +8,26 @@ import { cx } from '../../lib/cx';
 import css from './chat-page.module.css';
 
 const POLL_INTERVAL_MS = 2_000;
+const RECEIVED_HOLD_MS = 1_200;
 // Stop polling after ~2 minutes; outbox retries back off well beyond a chat
 // viewer's attention span, and a page reload re-reads the persisted state.
 const MAX_POLLS = 60;
+
+type A2ADeliveryDisplayState =
+  | 'sending'
+  | 'received'
+  | 'waiting'
+  | 'failed';
 
 function isTerminal(state: A2ADeliveryState): boolean {
   return state === 'delivered' || state === 'failed';
 }
 
-const LABELS: Record<A2ADeliveryState, string> = {
-  pending: 'Sending…',
-  delivered: 'Delivered',
+const LABELS: Record<A2ADeliveryDisplayState, string> = {
+  sending: 'Sending',
+  received: 'Received',
+  waiting: 'Waiting',
   failed: 'Delivery failed',
-  unknown: 'Sent',
 };
 
 /**
@@ -34,11 +41,35 @@ export function A2ADeliveryChip(props: {
 }) {
   const { descriptor, token } = props;
   const [state, setState] = useState<A2ADeliveryState>(descriptor.status);
+  const [displayState, setDisplayState] = useState<A2ADeliveryDisplayState>(
+    descriptor.status === 'failed'
+      ? 'failed'
+      : descriptor.status === 'delivered'
+        ? 'received'
+        : 'sending',
+  );
   const [detail, setDetail] = useState<string | null>(null);
 
   useEffect(() => {
     setState(descriptor.status);
   }, [descriptor.status]);
+
+  useEffect(() => {
+    if (state === 'failed') {
+      setDisplayState('failed');
+      return;
+    }
+    if (state !== 'delivered') {
+      setDisplayState('sending');
+      return;
+    }
+    setDisplayState('received');
+    const timer = window.setTimeout(
+      () => setDisplayState('waiting'),
+      RECEIVED_HOLD_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [state]);
 
   useEffect(() => {
     if (isTerminal(state)) return;
@@ -84,8 +115,8 @@ export function A2ADeliveryChip(props: {
     <div
       className={cx(
         css.a2aDeliveryChip,
-        state === 'delivered' && css.a2aDeliveryChipDelivered,
-        state === 'failed' && css.a2aDeliveryChipFailed,
+        displayState === 'received' && css.a2aDeliveryChipDelivered,
+        displayState === 'failed' && css.a2aDeliveryChipFailed,
       )}
       role="status"
       aria-live="polite"
@@ -94,10 +125,11 @@ export function A2ADeliveryChip(props: {
       <span
         className={cx(
           css.a2aDeliveryDot,
-          !isTerminal(state) && css.a2aDeliveryDotPulse,
+          (displayState === 'sending' || displayState === 'waiting') &&
+            css.a2aDeliveryDotPulse,
         )}
       />
-      <span>{LABELS[state]}</span>
+      <span>{LABELS[displayState]}</span>
       {detail ? (
         <span className={css.a2aDeliveryDetail}>· {detail}</span>
       ) : null}

--- a/console/src/routes/chat/a2a-delivery-chip.tsx
+++ b/console/src/routes/chat/a2a-delivery-chip.tsx
@@ -9,6 +9,7 @@ import css from './chat-page.module.css';
 
 const POLL_INTERVAL_MS = 2_000;
 const RECEIVED_HOLD_MS = 1_200;
+const DELIVERY_STATUS_CACHE_MAX_ENTRIES = 200;
 // Stop polling after ~2 minutes; outbox retries back off well beyond a chat
 // viewer's attention span, and a page reload re-reads the persisted state.
 const MAX_POLLS = 60;
@@ -30,6 +31,64 @@ const LABELS: Record<A2ADeliveryDisplayState, string> = {
   failed: 'Delivery failed',
 };
 
+interface A2ADeliveryStatusSnapshot {
+  state: A2ADeliveryState;
+  displayState: A2ADeliveryDisplayState;
+  detail: string | null;
+}
+
+const deliveryStatusCache = new Map<string, A2ADeliveryStatusSnapshot>();
+
+function cacheDeliveryStatus(
+  messageId: string,
+  snapshot: A2ADeliveryStatusSnapshot,
+): void {
+  if (deliveryStatusCache.has(messageId)) {
+    deliveryStatusCache.delete(messageId);
+  }
+  deliveryStatusCache.set(messageId, snapshot);
+  while (deliveryStatusCache.size > DELIVERY_STATUS_CACHE_MAX_ENTRIES) {
+    const oldestKey = deliveryStatusCache.keys().next().value;
+    if (!oldestKey) break;
+    deliveryStatusCache.delete(oldestKey);
+  }
+}
+
+function mergeDeliveryState(
+  descriptorState: A2ADeliveryState,
+  cachedState: A2ADeliveryState | null,
+): A2ADeliveryState {
+  if (descriptorState === 'failed' || cachedState === 'failed') return 'failed';
+  if (descriptorState === 'delivered' || cachedState === 'delivered') {
+    return 'delivered';
+  }
+  if (descriptorState === 'pending' || cachedState === 'pending') {
+    return 'pending';
+  }
+  return 'unknown';
+}
+
+function initialDisplayState(
+  state: A2ADeliveryState,
+  cached: A2ADeliveryStatusSnapshot | null,
+): A2ADeliveryDisplayState {
+  if (state === 'failed') return 'failed';
+  if (state !== 'delivered') return 'sending';
+  return cached?.state === 'delivered' ? cached.displayState : 'received';
+}
+
+function initialStatusSnapshot(
+  descriptor: A2ADeliveryDescriptor,
+): A2ADeliveryStatusSnapshot {
+  const cached = deliveryStatusCache.get(descriptor.messageId) ?? null;
+  const state = mergeDeliveryState(descriptor.status, cached?.state ?? null);
+  return {
+    state,
+    displayState: initialDisplayState(state, cached),
+    detail: state === cached?.state ? cached.detail : null,
+  };
+}
+
 /**
  * Live delivery-status chip for an outbound A2A chat send. Starts from the
  * status the send returned and polls the outbox until the message reaches a
@@ -40,42 +99,69 @@ export function A2ADeliveryChip(props: {
   token: string;
 }) {
   const { descriptor, token } = props;
-  const [state, setState] = useState<A2ADeliveryState>(descriptor.status);
+  const [initialSnapshot] = useState(() => initialStatusSnapshot(descriptor));
+  const [state, setState] = useState<A2ADeliveryState>(initialSnapshot.state);
   const [displayState, setDisplayState] = useState<A2ADeliveryDisplayState>(
-    descriptor.status === 'failed'
-      ? 'failed'
-      : descriptor.status === 'delivered'
-        ? 'received'
-        : 'sending',
+    initialSnapshot.displayState,
   );
-  const [detail, setDetail] = useState<string | null>(null);
+  const [detail, setDetail] = useState<string | null>(initialSnapshot.detail);
 
   useEffect(() => {
-    setState(descriptor.status);
-  }, [descriptor.status]);
+    const snapshot = initialStatusSnapshot(descriptor);
+    setState(snapshot.state);
+    setDisplayState(snapshot.displayState);
+    setDetail(snapshot.detail);
+  }, [descriptor.messageId, descriptor.status]);
 
   useEffect(() => {
     if (state === 'failed') {
       setDisplayState('failed');
+      cacheDeliveryStatus(descriptor.messageId, {
+        state,
+        displayState: 'failed',
+        detail,
+      });
       return;
     }
     if (state !== 'delivered') {
       setDisplayState('sending');
+      cacheDeliveryStatus(descriptor.messageId, {
+        state,
+        displayState: 'sending',
+        detail,
+      });
+      return;
+    }
+    const cached = deliveryStatusCache.get(descriptor.messageId);
+    if (cached?.state === 'delivered' && cached.displayState === 'waiting') {
+      setDisplayState('waiting');
       return;
     }
     setDisplayState('received');
+    cacheDeliveryStatus(descriptor.messageId, {
+      state,
+      displayState: 'received',
+      detail,
+    });
     const timer = window.setTimeout(
-      () => setDisplayState('waiting'),
+      () => {
+        setDisplayState('waiting');
+        cacheDeliveryStatus(descriptor.messageId, {
+          state,
+          displayState: 'waiting',
+          detail,
+        });
+      },
       RECEIVED_HOLD_MS,
     );
     return () => window.clearTimeout(timer);
-  }, [state]);
+  }, [descriptor.messageId, detail, state]);
 
   useEffect(() => {
     if (isTerminal(state)) return;
     let cancelled = false;
     let polls = 0;
-    let timer: ReturnType<typeof setTimeout>;
+    let timer: ReturnType<typeof setTimeout> | null = null;
 
     const poll = async (): Promise<void> => {
       polls += 1;
@@ -87,14 +173,19 @@ export function A2ADeliveryChip(props: {
         if (cancelled) return;
         if (status.status !== 'unknown') {
           setState(status.status);
-          setDetail(
+          const nextDetail =
             status.status === 'failed'
               ? status.lastError ||
                   (status.lastStatusCode
                     ? `HTTP ${status.lastStatusCode}`
                     : null)
-              : null,
-          );
+              : null;
+          setDetail(nextDetail);
+          cacheDeliveryStatus(descriptor.messageId, {
+            state: status.status,
+            displayState: initialDisplayState(status.status, null),
+            detail: nextDetail,
+          });
         }
         if (isTerminal(status.status) || polls >= MAX_POLLS) return;
       } catch {
@@ -103,10 +194,10 @@ export function A2ADeliveryChip(props: {
       timer = setTimeout(() => void poll(), POLL_INTERVAL_MS);
     };
 
-    timer = setTimeout(() => void poll(), POLL_INTERVAL_MS);
+    void poll();
     return () => {
       cancelled = true;
-      clearTimeout(timer);
+      if (timer) clearTimeout(timer);
     };
     // descriptor.messageId identifies the send; state drives the terminal guard.
   }, [descriptor.messageId, token, state]);

--- a/console/src/routes/chat/a2a-delivery-chip.tsx
+++ b/console/src/routes/chat/a2a-delivery-chip.tsx
@@ -14,11 +14,7 @@ const DELIVERY_STATUS_CACHE_MAX_ENTRIES = 200;
 // viewer's attention span, and a page reload re-reads the persisted state.
 const MAX_POLLS = 60;
 
-type A2ADeliveryDisplayState =
-  | 'sending'
-  | 'received'
-  | 'waiting'
-  | 'failed';
+type A2ADeliveryDisplayState = 'sending' | 'received' | 'waiting' | 'failed';
 
 function isTerminal(state: A2ADeliveryState): boolean {
   return state === 'delivered' || state === 'failed';
@@ -78,10 +74,11 @@ function initialDisplayState(
 }
 
 function initialStatusSnapshot(
-  descriptor: A2ADeliveryDescriptor,
+  messageId: string,
+  descriptorState: A2ADeliveryState,
 ): A2ADeliveryStatusSnapshot {
-  const cached = deliveryStatusCache.get(descriptor.messageId) ?? null;
-  const state = mergeDeliveryState(descriptor.status, cached?.state ?? null);
+  const cached = deliveryStatusCache.get(messageId) ?? null;
+  const state = mergeDeliveryState(descriptorState, cached?.state ?? null);
   return {
     state,
     displayState: initialDisplayState(state, cached),
@@ -99,7 +96,10 @@ export function A2ADeliveryChip(props: {
   token: string;
 }) {
   const { descriptor, token } = props;
-  const [initialSnapshot] = useState(() => initialStatusSnapshot(descriptor));
+  const { messageId, status: descriptorStatus } = descriptor;
+  const [initialSnapshot] = useState(() =>
+    initialStatusSnapshot(messageId, descriptorStatus),
+  );
   const [state, setState] = useState<A2ADeliveryState>(initialSnapshot.state);
   const [displayState, setDisplayState] = useState<A2ADeliveryDisplayState>(
     initialSnapshot.displayState,
@@ -107,16 +107,16 @@ export function A2ADeliveryChip(props: {
   const [detail, setDetail] = useState<string | null>(initialSnapshot.detail);
 
   useEffect(() => {
-    const snapshot = initialStatusSnapshot(descriptor);
+    const snapshot = initialStatusSnapshot(messageId, descriptorStatus);
     setState(snapshot.state);
     setDisplayState(snapshot.displayState);
     setDetail(snapshot.detail);
-  }, [descriptor.messageId, descriptor.status]);
+  }, [messageId, descriptorStatus]);
 
   useEffect(() => {
     if (state === 'failed') {
       setDisplayState('failed');
-      cacheDeliveryStatus(descriptor.messageId, {
+      cacheDeliveryStatus(messageId, {
         state,
         displayState: 'failed',
         detail,
@@ -125,37 +125,34 @@ export function A2ADeliveryChip(props: {
     }
     if (state !== 'delivered') {
       setDisplayState('sending');
-      cacheDeliveryStatus(descriptor.messageId, {
+      cacheDeliveryStatus(messageId, {
         state,
         displayState: 'sending',
         detail,
       });
       return;
     }
-    const cached = deliveryStatusCache.get(descriptor.messageId);
+    const cached = deliveryStatusCache.get(messageId);
     if (cached?.state === 'delivered' && cached.displayState === 'waiting') {
       setDisplayState('waiting');
       return;
     }
     setDisplayState('received');
-    cacheDeliveryStatus(descriptor.messageId, {
+    cacheDeliveryStatus(messageId, {
       state,
       displayState: 'received',
       detail,
     });
-    const timer = window.setTimeout(
-      () => {
-        setDisplayState('waiting');
-        cacheDeliveryStatus(descriptor.messageId, {
-          state,
-          displayState: 'waiting',
-          detail,
-        });
-      },
-      RECEIVED_HOLD_MS,
-    );
+    const timer = window.setTimeout(() => {
+      setDisplayState('waiting');
+      cacheDeliveryStatus(messageId, {
+        state,
+        displayState: 'waiting',
+        detail,
+      });
+    }, RECEIVED_HOLD_MS);
     return () => window.clearTimeout(timer);
-  }, [descriptor.messageId, detail, state]);
+  }, [detail, messageId, state]);
 
   useEffect(() => {
     if (isTerminal(state)) return;
@@ -166,22 +163,17 @@ export function A2ADeliveryChip(props: {
     const poll = async (): Promise<void> => {
       polls += 1;
       try {
-        const status = await fetchA2ADeliveryStatus(
-          token,
-          descriptor.messageId,
-        );
+        const status = await fetchA2ADeliveryStatus(token, messageId);
         if (cancelled) return;
         if (status.status !== 'unknown') {
           setState(status.status);
           const nextDetail =
             status.status === 'failed'
               ? status.lastError ||
-                  (status.lastStatusCode
-                    ? `HTTP ${status.lastStatusCode}`
-                    : null)
+                (status.lastStatusCode ? `HTTP ${status.lastStatusCode}` : null)
               : null;
           setDetail(nextDetail);
-          cacheDeliveryStatus(descriptor.messageId, {
+          cacheDeliveryStatus(messageId, {
             state: status.status,
             displayState: initialDisplayState(status.status, null),
             detail: nextDetail,
@@ -200,7 +192,7 @@ export function A2ADeliveryChip(props: {
       if (timer) clearTimeout(timer);
     };
     // descriptor.messageId identifies the send; state drives the terminal guard.
-  }, [descriptor.messageId, token, state]);
+  }, [messageId, token, state]);
 
   return (
     <div

--- a/console/src/routes/chat/chat-history-query.test.ts
+++ b/console/src/routes/chat/chat-history-query.test.ts
@@ -294,6 +294,70 @@ describe('buildChatHistoryUiData', () => {
     });
   });
 
+  it('keeps A2A delivery status messages while no peer reply is present', () => {
+    const raw: ChatHistoryResponse = {
+      sessionId: 'session-a',
+      history: [
+        { id: 1, role: 'user', content: '@main@local@inst-i2 Who are you?' },
+        {
+          id: 2,
+          role: 'assistant',
+          content: [
+            'Queued for delivery to `main@local@inst-i2`.',
+            'Message: `a2a-message-1`',
+            'Thread: `session-a`',
+          ].join('\n'),
+        },
+      ],
+    };
+
+    const ui = buildChatHistoryUiData(raw, 'session-a');
+
+    expect(ui.messages.map((message) => message.content)).toContain(
+      [
+        'Queued for delivery to `main@local@inst-i2`.',
+        'Message: `a2a-message-1`',
+        'Thread: `session-a`',
+      ].join('\n'),
+    );
+  });
+
+  it('removes A2A delivery status messages once the peer reply is present', () => {
+    const raw: ChatHistoryResponse = {
+      sessionId: 'session-a',
+      history: [
+        { id: 1, role: 'user', content: '@main@local@inst-i2 Who are you?' },
+        {
+          id: 2,
+          role: 'assistant',
+          content: [
+            'Queued for delivery to `main@local@inst-i2`.',
+            'Message: `a2a-message-1`',
+            'Thread: `session-a`',
+          ].join('\n'),
+        },
+        {
+          id: 3,
+          role: 'assistant',
+          agent_id: 'main@local@inst-i2',
+          content: 'I am the remote assistant.',
+          assistantPresentation: {
+            agentId: 'main@local@inst-i2',
+            displayName: 'main@local@inst-i2',
+            imageUrl: null,
+          },
+        },
+      ],
+    };
+
+    const ui = buildChatHistoryUiData(raw, 'session-a');
+
+    expect(ui.messages.map((message) => message.content)).toEqual([
+      '@main@local@inst-i2 Who are you?',
+      'I am the remote assistant.',
+    ]);
+  });
+
   it('returns resolvedSessionId from the response when present, even if it differs from the request', () => {
     const raw: ChatHistoryResponse = {
       sessionId: 'session-canonical',

--- a/console/src/routes/chat/chat-history-query.test.ts
+++ b/console/src/routes/chat/chat-history-query.test.ts
@@ -242,6 +242,58 @@ describe('buildChatHistoryUiData', () => {
     ]);
   });
 
+  it('hydrates A2A delivery metadata from persisted queued cards', () => {
+    const raw: ChatHistoryResponse = {
+      sessionId: 'session-a',
+      history: [
+        {
+          id: 1,
+          role: 'assistant',
+          content: [
+            'Queued for delivery to `main@local@inst-i2`.',
+            'Message: `156149ba-490a-4c5e-b2cc-bb79d8c2c976`',
+            'Thread: `sess_20260708_102409_9f38dec6`',
+          ].join('\n'),
+        },
+      ],
+    };
+
+    const ui = buildChatHistoryUiData(raw, 'session-a');
+
+    expect(ui.messages[0]?.a2aDelivery).toEqual({
+      messageId: '156149ba-490a-4c5e-b2cc-bb79d8c2c976',
+      threadId: 'sess_20260708_102409_9f38dec6',
+      recipientAgentId: 'main@local@inst-i2',
+      status: 'pending',
+    });
+  });
+
+  it('hydrates delivered A2A cards as terminal delivery metadata', () => {
+    const raw: ChatHistoryResponse = {
+      sessionId: 'session-a',
+      history: [
+        {
+          id: 1,
+          role: 'assistant',
+          content: [
+            'Delivered to `remote@team@peer-instance`.',
+            'Message: `a2a-message-1`',
+            'Thread: `session-a`',
+          ].join('\n'),
+        },
+      ],
+    };
+
+    const ui = buildChatHistoryUiData(raw, 'session-a');
+
+    expect(ui.messages[0]?.a2aDelivery).toEqual({
+      messageId: 'a2a-message-1',
+      threadId: 'session-a',
+      recipientAgentId: 'remote@team@peer-instance',
+      status: 'delivered',
+    });
+  });
+
   it('returns resolvedSessionId from the response when present, even if it differs from the request', () => {
     const raw: ChatHistoryResponse = {
       sessionId: 'session-canonical',

--- a/console/src/routes/chat/chat-history-query.ts
+++ b/console/src/routes/chat/chat-history-query.ts
@@ -30,9 +30,7 @@ function normalizeAgentIdForComparison(agentId: string | null | undefined) {
     .toLowerCase();
 }
 
-function hydrateA2ADelivery(
-  content: string,
-): A2ADeliveryDescriptor | null {
+function hydrateA2ADelivery(content: string): A2ADeliveryDescriptor | null {
   const lines = content
     .trim()
     .split(/\r?\n/)

--- a/console/src/routes/chat/chat-history-query.ts
+++ b/console/src/routes/chat/chat-history-query.ts
@@ -59,6 +59,38 @@ function hydrateA2ADelivery(
   };
 }
 
+function removeResolvedA2ADeliveryStatusMessages(
+  messages: ChatUiMessage[],
+): ChatUiMessage[] {
+  const pendingDeliveryIndexesByRecipient = new Map<string, number[]>();
+  const resolvedDeliveryIndexes = new Set<number>();
+
+  messages.forEach((message, index) => {
+    if (message.a2aDelivery) {
+      const recipient = normalizeAgentIdForComparison(
+        message.a2aDelivery.recipientAgentId,
+      );
+      if (!recipient) return;
+      const indexes = pendingDeliveryIndexesByRecipient.get(recipient) ?? [];
+      indexes.push(index);
+      pendingDeliveryIndexesByRecipient.set(recipient, indexes);
+      return;
+    }
+    if (message.role !== 'assistant') return;
+    const sender = normalizeAgentIdForComparison(
+      message.assistantPresentation?.agentId,
+    );
+    if (!sender) return;
+    const pendingIndexes = pendingDeliveryIndexesByRecipient.get(sender);
+    const deliveryIndex = pendingIndexes?.shift();
+    if (deliveryIndex === undefined) return;
+    resolvedDeliveryIndexes.add(deliveryIndex);
+  });
+
+  if (resolvedDeliveryIndexes.size === 0) return messages;
+  return messages.filter((_, index) => !resolvedDeliveryIndexes.has(index));
+}
+
 // Rebuild a collapsed (done) trace message from persisted history so a reload
 // shows the same draft/thinking/tool activity the live stream rendered.
 // Positioned just before its assistant bubble by the caller.
@@ -183,7 +215,7 @@ export function buildChatHistoryUiData(
   });
 
   return {
-    messages,
+    messages: removeResolvedA2ADeliveryStatusMessages(messages),
     branchFamilies,
     requestedSessionId,
     resolvedSessionId,

--- a/console/src/routes/chat/chat-history-query.ts
+++ b/console/src/routes/chat/chat-history-query.ts
@@ -1,5 +1,6 @@
 import { fetchChatHistory } from '../../api/chat';
 import type {
+  A2ADeliveryDescriptor,
   BranchVariant,
   ChatActivityTrace,
   ChatHistoryResponse,
@@ -27,6 +28,35 @@ function normalizeAgentIdForComparison(agentId: string | null | undefined) {
   return String(agentId ?? '')
     .trim()
     .toLowerCase();
+}
+
+function hydrateA2ADelivery(
+  content: string,
+): A2ADeliveryDescriptor | null {
+  const lines = content
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => line.trim());
+  const deliveryMatch = lines[0]?.match(
+    /^(Delivered|Queued for delivery) to `([^`]+)`\.$/,
+  );
+  if (!deliveryMatch) return null;
+  const messageMatch = lines
+    .find((line) => line.startsWith('Message: '))
+    ?.match(/^Message: `([^`]+)`$/);
+  const threadMatch = lines
+    .find((line) => line.startsWith('Thread: '))
+    ?.match(/^Thread: `([^`]+)`$/);
+  const recipientAgentId = deliveryMatch[2]?.trim();
+  const messageId = messageMatch?.[1]?.trim();
+  const threadId = threadMatch?.[1]?.trim();
+  if (!recipientAgentId || !messageId || !threadId) return null;
+  return {
+    messageId,
+    threadId,
+    recipientAgentId,
+    status: deliveryMatch[1] === 'Delivered' ? 'delivered' : 'pending',
+  };
 }
 
 // Rebuild a collapsed (done) trace message from persisted history so a reload
@@ -142,6 +172,8 @@ export function buildChatHistoryUiData(
         msg.id !== undefined && msg.id !== null
           ? (branchKeysByMessageId.get(msg.id) ?? null)
           : null,
+      a2aDelivery:
+        msg.role === 'assistant' ? hydrateA2ADelivery(msg.content) : null,
     };
     if (msg.role === 'assistant') {
       const trace = hydrateActivityTrace(msg.activityTrace, resolvedSessionId);

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -772,6 +772,21 @@ aside[data-state="collapsed"] .chatSidebarContent {
   color: var(--terminal-foreground);
 }
 
+.bubbleA2AStatus {
+  align-self: flex-start;
+  display: inline-flex;
+  max-width: 85%;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: 1;
+}
+
 .markdownContent {
   line-height: 1.6;
   max-width: 100%;
@@ -2152,13 +2167,11 @@ aside[data-state="collapsed"] .chatSidebarContent {
   }
 }
 
-/* Live delivery-status chip for outbound A2A chat sends. Sits under the command
-   bubble so the send stops reading as a dead end. */
+/* Live delivery-status chip for outbound A2A chat sends. */
 .a2aDeliveryChip {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  margin-top: 0.5rem;
   padding: 0.15rem 0.55rem;
   border-radius: 999px;
   font-size: 0.75rem;

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -2170,7 +2170,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 
 .a2aDeliveryChipDelivered {
   background: var(--success-soft);
-  color: var(--success-foreground);
+  color: var(--success);
   border-color: var(--success-border);
 }
 

--- a/console/src/routes/chat/message-block.test.tsx
+++ b/console/src/routes/chat/message-block.test.tsx
@@ -15,6 +15,7 @@ const fetchArtifactBlobMock =
   vi.fn<(token: string, artifactPath: string) => Promise<Blob>>();
 const fetchAgentAvatarBlobMock =
   vi.fn<(token: string, imageUrl: string) => Promise<Blob>>();
+const fetchA2ADeliveryStatusMock = vi.fn();
 const renderMarkdownMock =
   vi.fn<(content: string, options?: { highlight?: boolean }) => string>();
 
@@ -23,6 +24,11 @@ vi.mock('../../api/chat', () => ({
     fetchAgentAvatarBlobMock(token, imageUrl),
   fetchArtifactBlob: (token: string, artifactPath: string) =>
     fetchArtifactBlobMock(token, artifactPath),
+}));
+
+vi.mock('../../api/client', () => ({
+  fetchA2ADeliveryStatus: (token: string, messageId: string) =>
+    fetchA2ADeliveryStatusMock(token, messageId),
 }));
 
 vi.mock('../../lib/markdown', () => ({
@@ -771,6 +777,11 @@ describe('MessageBlock command vs system output', () => {
     renderMarkdownMock.mockReset();
     renderMarkdownMock.mockImplementation((content) => `<p>${content}</p>`);
     fetchAgentAvatarBlobMock.mockReset();
+    fetchA2ADeliveryStatusMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   function renderRole(role: ChatMessage['role'], content: string) {
@@ -824,6 +835,82 @@ describe('MessageBlock command vs system output', () => {
     expect(screen.getByText('Error: network exploded')).not.toBeNull();
     expect(container.querySelector('[class*="bubbleSystem"]')).not.toBeNull();
     expect(container.querySelector('[class*="bubbleCommand"]')).toBeNull();
+  });
+
+  it('renders A2A delivery output as a compact transient status chip', () => {
+    renderMarkdownMock.mockClear();
+    const { container } = render(
+      <MessageBlock
+        message={makeMessage([], {
+          role: 'command',
+          content: [
+            'Queued for delivery to `main@local@inst-i2`.',
+            'Message: `a2a-message-1`',
+            'Thread: `session-a`',
+          ].join('\n'),
+          a2aDelivery: {
+            messageId: 'a2a-message-1',
+            threadId: 'session-a',
+            recipientAgentId: 'main@local@inst-i2',
+            status: 'pending',
+          },
+        })}
+        token="test-token"
+        isStreaming={false}
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={vi.fn()}
+        approvalBusy={false}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('status').textContent).toContain('Sending');
+    expect(screen.queryByText(/Queued for delivery/)).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Copy message' })).toBeNull();
+    expect(renderMarkdownMock).not.toHaveBeenCalled();
+    expect(container.querySelector('[class*="bubbleA2AStatus"]')).not.toBeNull();
+  });
+
+  it('moves a received A2A delivery chip into the waiting state', () => {
+    vi.useFakeTimers();
+    render(
+      <MessageBlock
+        message={makeMessage([], {
+          role: 'command',
+          content: [
+            'Delivered to `main@local@inst-i2`.',
+            'Message: `a2a-message-1`',
+            'Thread: `session-a`',
+          ].join('\n'),
+          a2aDelivery: {
+            messageId: 'a2a-message-1',
+            threadId: 'session-a',
+            recipientAgentId: 'main@local@inst-i2',
+            status: 'delivered',
+          },
+        })}
+        token="test-token"
+        isStreaming={false}
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={vi.fn()}
+        approvalBusy={false}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('status').textContent).toContain('Received');
+
+    act(() => {
+      vi.advanceTimersByTime(1200);
+    });
+
+    expect(screen.getByRole('status').textContent).toContain('Waiting');
   });
 });
 

--- a/console/src/routes/chat/message-block.test.tsx
+++ b/console/src/routes/chat/message-block.test.tsx
@@ -778,6 +778,7 @@ describe('MessageBlock command vs system output', () => {
     renderMarkdownMock.mockImplementation((content) => `<p>${content}</p>`);
     fetchAgentAvatarBlobMock.mockReset();
     fetchA2ADeliveryStatusMock.mockReset();
+    fetchA2ADeliveryStatusMock.mockResolvedValue({ status: 'unknown' });
   });
 
   afterEach(() => {
@@ -909,6 +910,76 @@ describe('MessageBlock command vs system output', () => {
     act(() => {
       vi.advanceTimersByTime(1200);
     });
+
+    expect(screen.getByRole('status').textContent).toContain('Waiting');
+  });
+
+  it('does not replay delivery states when history refetch remounts a queued A2A card', () => {
+    vi.useFakeTimers();
+    const deliveredMessage = makeMessage([], {
+      role: 'command',
+      content: [
+        'Delivered to `main@local@inst-i2`.',
+        'Message: `a2a-message-stable`',
+        'Thread: `session-a`',
+      ].join('\n'),
+      a2aDelivery: {
+        messageId: 'a2a-message-stable',
+        threadId: 'session-a',
+        recipientAgentId: 'main@local@inst-i2',
+        status: 'delivered',
+      },
+    });
+    const queuedHistoryMessage = {
+      ...deliveredMessage,
+      content: [
+        'Queued for delivery to `main@local@inst-i2`.',
+        'Message: `a2a-message-stable`',
+        'Thread: `session-a`',
+      ].join('\n'),
+      a2aDelivery: {
+        messageId: 'a2a-message-stable',
+        threadId: 'session-a',
+        recipientAgentId: 'main@local@inst-i2',
+        status: 'pending' as const,
+      },
+    };
+
+    const first = render(
+      <MessageBlock
+        message={deliveredMessage}
+        token="test-token"
+        isStreaming={false}
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={vi.fn()}
+        approvalBusy={false}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1200);
+    });
+    expect(screen.getByRole('status').textContent).toContain('Waiting');
+
+    first.unmount();
+    render(
+      <MessageBlock
+        message={queuedHistoryMessage}
+        token="test-token"
+        isStreaming={false}
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={vi.fn()}
+        approvalBusy={false}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
 
     expect(screen.getByRole('status').textContent).toContain('Waiting');
   });

--- a/console/src/routes/chat/message-block.test.tsx
+++ b/console/src/routes/chat/message-block.test.tsx
@@ -872,7 +872,9 @@ describe('MessageBlock command vs system output', () => {
     expect(screen.queryByText(/Queued for delivery/)).toBeNull();
     expect(screen.queryByRole('button', { name: 'Copy message' })).toBeNull();
     expect(renderMarkdownMock).not.toHaveBeenCalled();
-    expect(container.querySelector('[class*="bubbleA2AStatus"]')).not.toBeNull();
+    expect(
+      container.querySelector('[class*="bubbleA2AStatus"]'),
+    ).not.toBeNull();
   });
 
   it('moves a received A2A delivery chip into the waiting state', () => {

--- a/console/src/routes/chat/message-block.tsx
+++ b/console/src/routes/chat/message-block.tsx
@@ -419,12 +419,14 @@ export const MessageBlock = memo(function MessageBlock(props: {
 
   const isApproval = msg.role === 'approval';
   const isDraft = msg.role === 'draft';
+  const isA2ADeliveryStatus = Boolean(msg.a2aDelivery);
   const shouldRenderApprovalCard = isApproval && Boolean(msg.pendingApproval);
   const isMarkdownMessage =
-    msg.role === 'assistant' ||
-    isDraft ||
-    msg.role === 'command' ||
-    (isApproval && !shouldRenderApprovalCard);
+    !isA2ADeliveryStatus &&
+    (msg.role === 'assistant' ||
+      isDraft ||
+      msg.role === 'command' ||
+      (isApproval && !shouldRenderApprovalCard));
   const renderedHtml = useRenderedMarkdown(
     msg.content,
     isMarkdownMessage,
@@ -473,6 +475,7 @@ export const MessageBlock = memo(function MessageBlock(props: {
   const isAssistant = msg.role === 'assistant';
   const shouldRenderBubble =
     isUser ||
+    isA2ADeliveryStatus ||
     msg.content.trim().length > 0 ||
     artifactEntries.length === 0 ||
     isApproval;
@@ -494,11 +497,12 @@ export const MessageBlock = memo(function MessageBlock(props: {
     isApproval && css.bubbleApproval,
     msg.role === 'system' && css.bubbleSystem,
     msg.role === 'command' && css.bubbleCommand,
+    isA2ADeliveryStatus && css.bubbleA2AStatus,
   );
 
   return (
     <div className={blockClass}>
-      {isAssistant ? (
+      {isAssistant && !isA2ADeliveryStatus ? (
         <div className={css.agentLabel}>
           {avatarUrl ? (
             <img className={css.agentAvatar} src={avatarUrl} alt="" />
@@ -513,7 +517,9 @@ export const MessageBlock = memo(function MessageBlock(props: {
 
       {shouldRenderBubble ? (
         <div className={bubbleClass}>
-          {shouldRenderApprovalCard && msg.pendingApproval ? (
+          {isA2ADeliveryStatus && msg.a2aDelivery ? (
+            <A2ADeliveryChip descriptor={msg.a2aDelivery} token={token} />
+          ) : shouldRenderApprovalCard && msg.pendingApproval ? (
             <ApprovalCard
               approval={msg.pendingApproval}
               busy={props.approvalBusy}
@@ -536,9 +542,6 @@ export const MessageBlock = memo(function MessageBlock(props: {
           ) : (
             msg.content
           )}
-          {msg.a2aDelivery ? (
-            <A2ADeliveryChip descriptor={msg.a2aDelivery} token={token} />
-          ) : null}
         </div>
       ) : null}
 
@@ -546,7 +549,7 @@ export const MessageBlock = memo(function MessageBlock(props: {
         <ArtifactCard key={key} artifact={artifact} token={token} />
       ))}
 
-      {!props.isStreaming ? (
+      {!props.isStreaming && !isA2ADeliveryStatus ? (
         <div className={css.messageActions}>
           {isAssistant && msg.replayRequest ? (
             <Button

--- a/console/src/routes/chat/use-chat-stream.test.ts
+++ b/console/src/routes/chat/use-chat-stream.test.ts
@@ -361,6 +361,95 @@ describe('useChatStream', () => {
     });
   });
 
+  it('keeps a sent message when the initial history fetch resolves late', async () => {
+    const harness = makeHarness();
+    let resolveHistory!: (data: ChatHistoryUiData) => void;
+    const lateHistory = new Promise<ChatHistoryUiData>((resolve) => {
+      resolveHistory = resolve;
+    });
+    const lateHistoryFetch = harness.queryClient
+      .fetchQuery({
+        queryKey: chatHistoryQueryKey(TOKEN, SESSION_ID),
+        queryFn: () => lateHistory,
+        staleTime: 0,
+      })
+      .catch(() => null);
+
+    requestChatStreamMock.mockResolvedValue({
+      status: 'ok',
+      sessionId: SESSION_ID,
+      userMessageId: 'server-user-1',
+      assistantMessageId: 'assistant-1',
+      result: 'Queued for delivery to `remote@team@peer-instance`.',
+      messageRole: 'command',
+      a2aDelivery: {
+        messageId: 'a2a-message-1',
+        threadId: SESSION_ID,
+        recipientAgentId: 'remote@team@peer-instance',
+        status: 'pending',
+      },
+    });
+
+    const { result } = renderHook(
+      () =>
+        useChatStream({
+          token: TOKEN,
+          userId: 'web-user-1',
+          getSessionId: () => SESSION_ID,
+          setError: harness.setError,
+          refreshRecent: vi.fn(),
+          onSessionIdCorrection: harness.correctionMock,
+        }),
+      { wrapper: harness.wrapper },
+    );
+
+    await act(async () => {
+      await result.current.sendMessage('@remote@team@peer-instance hello', []);
+    });
+
+    expect(harness.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'user',
+          content: '@remote@team@peer-instance hello',
+        }),
+        expect.objectContaining({
+          role: 'command',
+          a2aDelivery: expect.objectContaining({
+            messageId: 'a2a-message-1',
+          }),
+        }),
+      ]),
+    );
+
+    await act(async () => {
+      resolveHistory({
+        messages: [],
+        branchFamilies: new Map(),
+        requestedSessionId: SESSION_ID,
+        resolvedSessionId: SESSION_ID,
+        agentId: null,
+        bootstrapAutostart: null,
+      });
+      await lateHistoryFetch;
+    });
+
+    expect(harness.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'user',
+          content: '@remote@team@peer-instance hello',
+        }),
+        expect.objectContaining({
+          role: 'command',
+          a2aDelivery: expect.objectContaining({
+            messageId: 'a2a-message-1',
+          }),
+        }),
+      ]),
+    );
+  });
+
   it('does not duplicate an existing addressed mention on finalize', async () => {
     const harness = makeHarness();
 

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -24,6 +24,10 @@ import type {
   TraceToolStep,
 } from './chat-ui-message';
 
+const A2A_REPLY_HISTORY_REFRESH_DELAYS_MS = [
+  3000, 8000, 16_000, 30_000, 60_000,
+];
+
 interface ActiveRequest {
   controller: AbortController;
   sessionId: string;
@@ -572,6 +576,17 @@ export function useChatStream(
           void queryClient.invalidateQueries({
             queryKey: ['agents-list', token],
           });
+        }
+        if (result.a2aDelivery) {
+          const historyKey = chatHistoryQueryKey(
+            token,
+            result.sessionId ?? targetSessionId,
+          );
+          for (const delayMs of A2A_REPLY_HISTORY_REFRESH_DELAYS_MS) {
+            window.setTimeout(() => {
+              void queryClient.invalidateQueries({ queryKey: historyKey });
+            }, delayMs);
+          }
         }
       } catch (err) {
         if (req.renderFrame) cancelAnimationFrame(req.renderFrame);

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -175,7 +175,32 @@ export function useChatStream(
         updater: ChatUiMessage[] | ((prev: ChatUiMessage[]) => ChatUiMessage[]),
       ) => writeMessages(targetSessionId, updater);
       const userMsgId = !opts?.hideUser ? nextMsgId() : null;
+      const thinkingId = nextMsgId();
+      const traceId = nextMsgId();
+      const streamId = nextMsgId();
+      const req: ActiveRequest = {
+        controller: new AbortController(),
+        sessionId: targetSessionId,
+        messageRole: 'assistant',
+        assistantText: '',
+        lastRenderedText: '',
+        pendingApproval: null,
+        trace: [],
+        traceVersion: 0,
+        lastRenderedTraceVersion: 0,
+        renderFrame: 0,
+        stopping: false,
+      };
+      activeRequestRef.current = req;
       setError('');
+      setStreamingMsgId(streamId);
+      setActiveSessionId(targetSessionId);
+      setIsStreaming(true);
+
+      void queryClient.cancelQueries({
+        queryKey: chatHistoryQueryKey(token, targetSessionId),
+        exact: true,
+      });
 
       if (userMsgId) {
         const addressedAgentPresentation =
@@ -194,8 +219,6 @@ export function useChatStream(
         setMessages((prev) => [...prev, userMsg]);
       }
 
-      const thinkingId = nextMsgId();
-      const traceId = nextMsgId();
       // The trace block precedes the thinking dots (and later the answer
       // bubble): activity rows stream in above the "still working" indicator.
       setMessages((prev) => [
@@ -216,26 +239,6 @@ export function useChatStream(
           sessionId: targetSessionId,
         } satisfies ThinkingChatMessage,
       ]);
-
-      const streamId = nextMsgId();
-      setStreamingMsgId(streamId);
-
-      const req: ActiveRequest = {
-        controller: new AbortController(),
-        sessionId: targetSessionId,
-        messageRole: 'assistant',
-        assistantText: '',
-        lastRenderedText: '',
-        pendingApproval: null,
-        trace: [],
-        traceVersion: 0,
-        lastRenderedTraceVersion: 0,
-        renderFrame: 0,
-        stopping: false,
-      };
-      activeRequestRef.current = req;
-      setActiveSessionId(targetSessionId);
-      setIsStreaming(true);
 
       const doRender = () => {
         req.renderFrame = 0;

--- a/console/src/routes/chat/use-chat-stream.ts
+++ b/console/src/routes/chat/use-chat-stream.ts
@@ -25,7 +25,7 @@ import type {
 } from './chat-ui-message';
 
 const A2A_REPLY_HISTORY_REFRESH_DELAYS_MS = [
-  3000, 8000, 16_000, 30_000, 60_000,
+  2000, 5000, 8000, 12_000, 16_000, 20_000, 24_000, 30_000, 45_000, 60_000,
 ];
 
 interface ActiveRequest {

--- a/docs/content/channels/admin-console.md
+++ b/docs/content/channels/admin-console.md
@@ -173,3 +173,4 @@ scoped to the built-in allowlist and is not a general workspace file browser.
 - [Overview](./overview.md)
 - [Local Config And Secrets](./local-config-and-secrets.md)
 - [Policies And Allowlists](./policies-and-allowlists.md)
+- [A2A Peer Pairing](../guides/a2a-peer-pairing.md)

--- a/docs/content/guides/README.md
+++ b/docs/content/guides/README.md
@@ -15,6 +15,8 @@ These pages focus on common operator workflows after the base install works.
   and live connector-backed apps
 - [Remote Access](./remote-access.md) for SSH tunnels, Tailscale, and
   persistent macOS LaunchAgent forwarding
+- [A2A Peer Pairing](./a2a-peer-pairing.md) for connecting two HybridClaw
+  instances and sending a chat message to a remote agent
 - [Tailscale Funnel](./tailscale-funnel.md) for managed public `*.ts.net`
   gateway URLs
 - [TUI MCP Quickstart](./tui-mcp.md) for host-mode MCP server setup

--- a/docs/content/guides/a2a-peer-pairing.md
+++ b/docs/content/guides/a2a-peer-pairing.md
@@ -1,0 +1,260 @@
+---
+title: A2A Peer Pairing
+description: Connect two HybridClaw instances so agents can address each other from chat and receive replies in the same thread.
+sidebar_position: 8
+---
+
+# A2A Peer Pairing
+
+A2A lets one HybridClaw instance send an agent-to-agent message to another
+trusted HybridClaw instance. After pairing, an operator can address a remote
+agent from `/chat` and receive the remote reply in the same chat thread.
+
+Canonical A2A agent IDs use this format:
+
+```text
+agent-slug@user-slug@instance-id
+```
+
+For example, `main@local@inst-i2` means:
+
+- `main`: the agent slug on the peer instance
+- `local`: the owner or user routing namespace
+- `inst-i2`: the peer HybridClaw instance id
+
+The leading `@` in chat is only mention syntax. To message that remote agent,
+type:
+
+```text
+@main@local@inst-i2 Who are you?
+```
+
+## Before You Start
+
+You need:
+
+- two running HybridClaw gateways
+- a stable base URL for each gateway that the other gateway can reach
+- admin access to both gateways
+- the peer's Agent Card endpoint reachable at `/.well-known/agent.json`
+
+For same-machine testing, different loopback ports are enough, for example
+`http://127.0.0.1:9191` and `http://127.0.0.1:9292`. For two machines, use
+Tailscale, SSH forwarding, a private network, or another trusted HTTPS route.
+See [Remote Access](./remote-access.md) for exposure patterns.
+
+Set `deployment.public_url` on each instance before requesting peer
+notification. HybridClaw uses that URL when it asks the peer to create the
+reverse pairing request.
+
+## Pair Two Instances In The Browser
+
+1. Open the admin console for instance 1:
+
+   ```text
+   http://127.0.0.1:9191/admin
+   ```
+
+2. Open the admin console for instance 2:
+
+   ```text
+   http://127.0.0.1:9292/admin
+   ```
+
+3. On instance 1, open `/admin/a2a-trust`.
+
+4. Enter instance 2's base URL or Agent Card URL:
+
+   ```text
+   http://127.0.0.1:9292
+   ```
+
+   or:
+
+   ```text
+   http://127.0.0.1:9292/.well-known/agent.json
+   ```
+
+5. Preview the pairing. Check the peer id and public-key fingerprint before
+   trusting it.
+
+6. Start pairing with peer notification enabled. Instance 1 trusts instance 2,
+   then sends a pairing request to instance 2.
+
+7. On instance 2, open `/admin/a2a-trust` and approve the incoming request from
+   instance 1. This reverse approval is what lets instance 2 send replies back
+   to instance 1.
+
+8. Confirm both trust pages show the other instance as `trusted`.
+
+9. On instance 1, open `/chat` and send a message to the remote agent:
+
+   ```text
+   @main@local@inst-i2 Who are you?
+   ```
+
+10. The chat shows the A2A delivery status while the message is sent, then the
+    reply from `main@local@inst-i2` appears in the same thread.
+
+## Local Smoke Test With Curl
+
+Use this when you want a deterministic two-instance test on one machine.
+
+### 1. Prepare Two Runtime Homes
+
+Use separate data directories and stable instance IDs. Reusing one data
+directory for both instances will make trust and identity confusing.
+
+```bash
+export I1_DIR=/tmp/hc-i1
+export I2_DIR=/tmp/hc-i2
+export I1_URL=http://127.0.0.1:9191
+export I2_URL=http://127.0.0.1:9292
+export I1_TOKEN="$(openssl rand -base64 32)"
+export I2_TOKEN="$(openssl rand -base64 32)"
+```
+
+### 2. Configure Ports, Public URLs, And Browser Tokens
+
+```bash
+HYBRIDCLAW_DATA_DIR="$I1_DIR" hybridclaw config set ops.healthPort 9191
+HYBRIDCLAW_DATA_DIR="$I1_DIR" hybridclaw config set deployment.public_url "$I1_URL"
+HYBRIDCLAW_DATA_DIR="$I1_DIR" hybridclaw secret set WEB_API_TOKEN "$I1_TOKEN"
+
+HYBRIDCLAW_DATA_DIR="$I2_DIR" hybridclaw config set ops.healthPort 9292
+HYBRIDCLAW_DATA_DIR="$I2_DIR" hybridclaw config set deployment.public_url "$I2_URL"
+HYBRIDCLAW_DATA_DIR="$I2_DIR" hybridclaw secret set WEB_API_TOKEN "$I2_TOKEN"
+```
+
+### 3. Start Both Gateways
+
+Use two terminals, or run one command and then the other when using managed
+restart mode.
+
+```bash
+HYBRIDCLAW_DATA_DIR="$I1_DIR" HYBRIDCLAW_INSTANCE_ID=inst-i1 hybridclaw gateway restart --sandbox=host
+HYBRIDCLAW_DATA_DIR="$I2_DIR" HYBRIDCLAW_INSTANCE_ID=inst-i2 hybridclaw gateway restart --sandbox=host
+```
+
+Check that each gateway reports the expected port and package root:
+
+```bash
+HYBRIDCLAW_DATA_DIR="$I1_DIR" hybridclaw gateway status
+HYBRIDCLAW_DATA_DIR="$I2_DIR" hybridclaw gateway status
+```
+
+### 4. Pair Instance 1 To Instance 2
+
+```bash
+curl -sS -X POST "$I1_URL/api/admin/a2a/pairing" \
+  -H "Authorization: Bearer $I1_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"peerUrl\":\"$I2_URL\",\"reason\":\"local A2A smoke test\",\"notifyPeer\":true}" \
+  | jq
+```
+
+The response should include:
+
+- `proposal.peerId` equal to `inst-i2`
+- a trusted peer entry for `inst-i2`
+- `remoteNotification.status` equal to `sent`
+
+If `remoteNotification.status` is `failed` with `local public URL unavailable`,
+set `deployment.public_url` on instance 1 and restart instance 1.
+
+### 5. Approve Instance 1 On Instance 2
+
+Instance 2 must trust instance 1 before it can send the reply back.
+
+```bash
+export I2_REQUEST_ID="$(
+  curl -sS "$I2_URL/api/admin/a2a/trust" \
+    -H "Authorization: Bearer $I2_TOKEN" \
+    | jq -r '.pairingRequests[] | select(.peerId == "inst-i1" and .status == "pending") | .requestId' \
+    | tail -n 1
+)"
+
+curl -sS -X POST "$I2_URL/api/admin/a2a/pairing/approve" \
+  -H "Authorization: Bearer $I2_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"requestId\":\"$I2_REQUEST_ID\",\"reason\":\"local A2A smoke test\"}" \
+  | jq
+```
+
+Confirm both sides trust each other:
+
+```bash
+curl -sS "$I1_URL/api/admin/a2a/trust" \
+  -H "Authorization: Bearer $I1_TOKEN" \
+  | jq '.peers[] | {peerId,status,agentCardUrl,deliveryUrl}'
+
+curl -sS "$I2_URL/api/admin/a2a/trust" \
+  -H "Authorization: Bearer $I2_TOKEN" \
+  | jq '.peers[] | {peerId,status,agentCardUrl,deliveryUrl}'
+```
+
+### 6. Send A Chat Message Across Instances
+
+Open instance 1's chat:
+
+```text
+http://127.0.0.1:9191/chat
+```
+
+Send:
+
+```text
+@main@local@inst-i2 Who are you?
+```
+
+Expected result:
+
+- the user message appears in the instance 1 chat
+- a compact delivery status appears while HybridClaw sends to instance 2
+- the status moves from sending to received to waiting
+- the status disappears when the remote reply is stored
+- the reply from `main@local@inst-i2` appears in the same instance 1 chat
+
+## Troubleshooting
+
+### The Admin API Says Unauthorized
+
+Use the token configured for that instance:
+
+```bash
+-H "Authorization: Bearer $I1_TOKEN"
+```
+
+If an instance has no `WEB_API_TOKEN` configured and you are using loopback
+browser access, the browser can authenticate with a local session cookie. Raw
+`curl` calls still need a bearer token when the gateway asks for one.
+
+### Pairing Trusts One Side But Replies Do Not Arrive
+
+Check the reverse trust direction. Instance 1 trusting instance 2 is enough for
+instance 1 to send. Instance 2 must also trust instance 1 to send a reply back.
+Approve the pending request on instance 2, or pair instance 2 back to instance
+1.
+
+### Peer Notification Fails
+
+Set `deployment.public_url` on the instance that starts pairing. For local
+same-machine tests, this can be the loopback base URL for that instance:
+
+```bash
+HYBRIDCLAW_DATA_DIR="$I1_DIR" hybridclaw config set deployment.public_url "$I1_URL"
+```
+
+For two machines, use a URL that the peer machine can actually reach.
+
+### The Agent ID Looks Wrong
+
+Use `agent-slug@user-slug@instance-id`, for example
+`main@local@inst-i2`. The middle component is not the transport; it is the
+owner or user routing namespace.
+
+### The Message Is Delivered But No Reply Appears
+
+Open the receiving instance's A2A inbox at `/admin/a2a-inbox` and check the
+gateway logs. The receiving instance must have an available target agent, and
+the reply can only be sent when reverse trust is present.

--- a/docs/content/navigation.json
+++ b/docs/content/navigation.json
@@ -131,6 +131,10 @@
           "path": "guides/remote-access.md"
         },
         {
+          "title": "A2A Peer Pairing",
+          "path": "guides/a2a-peer-pairing.md"
+        },
+        {
           "title": "Office Dependencies",
           "path": "guides/office-dependencies.md"
         },

--- a/src/a2a/a2a-inbound.ts
+++ b/src/a2a/a2a-inbound.ts
@@ -1,7 +1,7 @@
 import { X509Certificate } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
-import { getAgentById, listAgents } from '../agents/agent-registry.js';
+import { getAgentById } from '../agents/agent-registry.js';
 import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
 import { getRuntimeConfig } from '../config/runtime-config.js';
 import { GatewayRequestError } from '../errors/gateway-request-error.js';
@@ -13,7 +13,6 @@ import {
 import {
   AgentIdentityValidationError,
   parseAgentIdentity,
-  resolveLocalInstanceId,
 } from '../identity/agent-id.js';
 import { logger } from '../logger.js';
 import { decodeA2AJsonRpcRequest, type JsonRpcId } from './a2a-json-rpc.js';
@@ -35,7 +34,7 @@ import {
   summarizeA2AEnvelopeForAudit,
   validateA2AEnvelope,
 } from './envelope.js';
-import { resolveA2AAgentId } from './identity.js';
+import { isLocalA2AAgentId, resolveLocalA2AAgentId } from './identity.js';
 import { acceptA2AInboundEnvelope } from './inbound-pipeline.js';
 import { getA2AEnvelope } from './store.js';
 import {
@@ -97,11 +96,6 @@ class A2AMissingTrustedPeerError extends A2ADelegationTokenError {
     this.name = 'A2AMissingTrustedPeerError';
   }
 }
-
-let localCanonicalRecipientCache: {
-  key: string;
-  canonicalAgentIds: Set<string>;
-} | null = null;
 
 function readHeader(
   headers: IncomingMessage['headers'],
@@ -178,34 +172,11 @@ function resolveInboundAudience(req: IncomingMessage, url: URL): string {
   return normalizeAudience(new URL(url.pathname, origin));
 }
 
-function localCanonicalRecipientCacheKey(agents = listAgents()): string {
-  return agents.map((agent) => `${agent.id}\0${agent.owner || ''}`).join('\n');
-}
-
-function localCanonicalRecipientIds(): Set<string> {
-  const agents = listAgents();
-  const key = localCanonicalRecipientCacheKey(agents);
-  if (localCanonicalRecipientCache?.key === key) {
-    return localCanonicalRecipientCache.canonicalAgentIds;
-  }
-
-  const canonicalAgentIds = new Set<string>();
-  for (const agent of agents) {
-    try {
-      canonicalAgentIds.add(resolveA2AAgentId(agent.id));
-    } catch {
-      // Agent registry validation owns surfacing malformed local records.
-    }
-  }
-  localCanonicalRecipientCache = { key, canonicalAgentIds };
-  return canonicalAgentIds;
-}
-
 function localRecipientResolves(recipientAgentId: string): boolean {
   if (!recipientAgentId.includes('@')) {
     return Boolean(getAgentById(recipientAgentId));
   }
-  return localCanonicalRecipientIds().has(recipientAgentId.toLowerCase());
+  return resolveLocalA2AAgentId(recipientAgentId) !== null;
 }
 
 function parseJsonRpcPayload(rawBody: string): unknown {
@@ -302,7 +273,7 @@ function assertCanonicalLocalRecipient(envelope: A2AEnvelope): void {
     'recipient_agent_id',
     envelope.recipient_agent_id,
   );
-  if (recipient.instanceId !== resolveLocalInstanceId()) {
+  if (!isLocalA2AAgentId(recipient.id)) {
     throw new A2AEnvelopeValidationError([
       'recipient_agent_id instance-id does not match this instance',
     ]);

--- a/src/a2a/a2a-inbox-dispatcher.ts
+++ b/src/a2a/a2a-inbox-dispatcher.ts
@@ -1,12 +1,6 @@
-import {
-  listAgents,
-  resolveAgentEscalationTarget,
-} from '../agents/agent-registry.js';
+import { resolveAgentEscalationTarget } from '../agents/agent-registry.js';
 import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
-import {
-  parseAgentIdentity,
-  resolveLocalInstanceId,
-} from '../identity/agent-id.js';
+import { parseAgentIdentity } from '../identity/agent-id.js';
 import { logger } from '../logger.js';
 import { buildSessionKey } from '../session/session-key.js';
 import type { AddressEnvelope } from '../types/container.js';
@@ -22,7 +16,7 @@ import {
   createA2AEnvelope,
   summarizeA2AEnvelopeForAudit,
 } from './envelope.js';
-import { resolveA2AAgentId } from './identity.js';
+import { isLocalA2AAgentId, resolveLocalA2AAgentId } from './identity.js';
 import { normalizePositiveInteger } from './utils.js';
 
 export const A2A_INBOX_DISPATCH_CONCURRENCY = 2;
@@ -157,28 +151,20 @@ function dueAtOrBefore(item: A2AInboxDispatchItem, now: Date): boolean {
 function resolveLocalRecipientAgentId(
   envelope: A2AEnvelope,
 ): { agentId: string } | { reason: string } {
-  let recipient: ReturnType<typeof parseAgentIdentity>;
   try {
-    recipient = parseAgentIdentity(envelope.recipient_agent_id);
+    parseAgentIdentity(envelope.recipient_agent_id);
   } catch (error) {
     return { reason: errorMessage(error) };
   }
-  if (recipient.instanceId !== resolveLocalInstanceId()) {
+  const agentId = resolveLocalA2AAgentId(envelope.recipient_agent_id);
+  if (agentId) return { agentId };
+
+  if (!isLocalA2AAgentId(envelope.recipient_agent_id)) {
     return {
       reason: 'recipient_agent_id instance-id does not match this instance',
     };
   }
 
-  for (const agent of listAgents()) {
-    try {
-      if (resolveA2AAgentId(agent.id) === envelope.recipient_agent_id) {
-        return { agentId: agent.id };
-      }
-    } catch {
-      // Ignore malformed local agent records here; registry validation surfaces
-      // those separately.
-    }
-  }
   return { reason: 'recipient_agent_id does not resolve to a local agent' };
 }
 

--- a/src/a2a/identity-resolver.ts
+++ b/src/a2a/identity-resolver.ts
@@ -1,7 +1,6 @@
 import { listAgents } from '../agents/agent-registry.js';
 import { getRuntimeConfig } from '../config/runtime-config.js';
 import { getGatewayAdminTunnelStatus } from '../gateway/gateway-tunnel-service.js';
-import { resolveLocalInstanceId } from '../identity/agent-id.js';
 import {
   DnsIdentityResolverBackend,
   IdentityNotFoundError,
@@ -12,7 +11,7 @@ import {
   normalizeIdentityUrl,
   parseCanonicalIdentity,
 } from '../identity/resolver.js';
-import { resolveA2AAgentId } from './identity.js';
+import { isLocalA2AAgentId, resolveA2AAgentId } from './identity.js';
 import { registerA2AIdentityResolverInvalidator } from './identity-resolver-invalidation.js';
 import {
   A2APeerUntrustedError,
@@ -58,7 +57,6 @@ class LocalDeploymentA2AIdentityResolverBackend
   private localCanonicalAgentIds(): Set<string> {
     const agents = listAgents();
     const key = [
-      resolveLocalInstanceId(),
       ...agents.map(
         (agent) =>
           `${agent.id}\0${agent.canonicalId || ''}\0${agent.owner || ''}\0${agent.ownerUserId || ''}`,
@@ -85,7 +83,7 @@ class LocalDeploymentA2AIdentityResolverBackend
   async lookup(canonicalId: string): Promise<IdentityResolution | null> {
     const parsed = parseCanonicalIdentity(canonicalId);
     if (parsed.kind !== 'agent') return null;
-    if (parsed.parsed.instanceId !== resolveLocalInstanceId()) return null;
+    if (!isLocalA2AAgentId(parsed.id)) return null;
     if (!this.localCanonicalAgentIds().has(parsed.id)) return null;
 
     return {

--- a/src/a2a/identity.ts
+++ b/src/a2a/identity.ts
@@ -76,6 +76,42 @@ export function resolveA2AAgentId(agentId: string): string {
   }).canonicalId;
 }
 
+export function resolveLocalA2AAgentId(agentId: string): string | null {
+  const normalized = agentId.trim();
+  const kind = classifyA2AAgentId(normalized);
+  if (kind === 'local') {
+    try {
+      return findLocalAgent(normalized).id;
+    } catch {
+      return null;
+    }
+  }
+  if (kind !== 'canonical') return null;
+
+  const canonicalAgentId = parseAgentIdentity(normalized).id;
+  for (const agent of listAgents()) {
+    try {
+      if (resolveA2AAgentId(agent.id) === canonicalAgentId) {
+        return agent.id;
+      }
+    } catch {
+      // Agent registry validation owns surfacing malformed local records.
+    }
+  }
+  return null;
+}
+
+export function isLocalA2AAgentId(agentId: string): boolean {
+  const normalized = agentId.trim();
+  const kind = classifyA2AAgentId(normalized);
+  if (kind === 'local') return resolveLocalA2AAgentId(normalized) !== null;
+  if (kind !== 'canonical') return false;
+
+  const parsed = parseAgentIdentity(normalized);
+  if (resolveLocalA2AAgentId(parsed.id)) return true;
+  return parsed.instanceId === resolveLocalInstanceId();
+}
+
 export function resolveA2AEnvelopeAgentIds(envelope: unknown): A2AEnvelope {
   const normalizedEnvelope = validateA2AEnvelope(envelope);
   const senderAgentId = resolveA2AAgentId(normalizedEnvelope.sender_agent_id);

--- a/src/a2a/runtime.ts
+++ b/src/a2a/runtime.ts
@@ -1,7 +1,3 @@
-import {
-  parseAgentIdentity,
-  resolveLocalInstanceId,
-} from '../identity/agent-id.js';
 import { IDENTITY_DISCOVERY_ZONE_ENV } from '../identity/resolver.js';
 import { logger } from '../logger.js';
 import type { EscalationTarget } from '../types/execution.js';
@@ -14,7 +10,7 @@ import {
   validateA2AEnvelope,
 } from './envelope.js';
 import { attachA2AHandoffContext } from './handoff-context.js';
-import { resolveA2AEnvelopeAgentIds } from './identity.js';
+import { isLocalA2AAgentId, resolveA2AEnvelopeAgentIds } from './identity.js';
 import { normalizePeerDescriptor } from './peer-descriptor.js';
 import {
   type A2AThreadSummary,
@@ -181,8 +177,7 @@ export function sendMessage(
     return deliveryConfirmation('pending', normalizedEnvelope);
   }
 
-  const recipient = parseAgentIdentity(normalizedEnvelope.recipient_agent_id);
-  if (recipient.instanceId !== resolveLocalInstanceId()) {
+  if (!isLocalA2AAgentId(normalizedEnvelope.recipient_agent_id)) {
     warnIfIdentityDiscoveryDisabled(normalizedEnvelope.recipient_agent_id);
     enqueueUnresolvedA2AEnvelope(
       normalizedEnvelope,

--- a/src/a2a/webhook-inbound.ts
+++ b/src/a2a/webhook-inbound.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
-import { getAgentById, listAgents } from '../agents/agent-registry.js';
+import { getAgentById } from '../agents/agent-registry.js';
 import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
 import { GatewayRequestError } from '../errors/gateway-request-error.js';
 import { readRequestBody, sendJson } from '../gateway/gateway-http-utils.js';
@@ -13,7 +13,7 @@ import {
   summarizeA2AEnvelopeForAudit,
   validateA2AEnvelope,
 } from './envelope.js';
-import { resolveA2AAgentId } from './identity.js';
+import { resolveLocalA2AAgentId } from './identity.js';
 import { acceptA2AInboundEnvelope } from './inbound-pipeline.js';
 import {
   A2A_TRUST_LEDGER_DEFAULT_WEBHOOK_RATE_LIMIT_PER_MINUTE,
@@ -66,11 +66,6 @@ interface RateLimitBucket {
 }
 
 const rateLimitBuckets = new Map<string, RateLimitBucket>();
-let localCanonicalRecipientCache: {
-  key: string;
-  canonicalAgentIds: Set<string>;
-} | null = null;
-
 export function resetA2AWebhookInboundRateLimitsForTests(): void {
   rateLimitBuckets.clear();
 }
@@ -196,36 +191,11 @@ function resolveInboundSecret(params: {
   return secret;
 }
 
-function localCanonicalRecipientCacheKey(): string {
-  return listAgents()
-    .map((agent) => `${agent.id}\0${agent.owner || ''}`)
-    .join('\n');
-}
-
-function localCanonicalRecipientIds(): Set<string> {
-  const key = localCanonicalRecipientCacheKey();
-  if (localCanonicalRecipientCache?.key === key) {
-    return localCanonicalRecipientCache.canonicalAgentIds;
-  }
-
-  const canonicalAgentIds = new Set<string>();
-  for (const agent of listAgents()) {
-    try {
-      canonicalAgentIds.add(resolveA2AAgentId(agent.id));
-    } catch {
-      // Ignore malformed local agent records here; agent registry validation
-      // owns surfacing those errors on config mutation.
-    }
-  }
-  localCanonicalRecipientCache = { key, canonicalAgentIds };
-  return canonicalAgentIds;
-}
-
 function localRecipientResolves(recipientAgentId: string): boolean {
   if (!recipientAgentId.includes('@')) {
     return Boolean(getAgentById(recipientAgentId));
   }
-  return localCanonicalRecipientIds().has(recipientAgentId.toLowerCase());
+  return resolveLocalA2AAgentId(recipientAgentId) !== null;
 }
 
 function resolveLocalRecipientWorkspacePath(recipientAgentId: string): string {
@@ -237,17 +207,8 @@ function resolveLocalRecipientWorkspacePath(recipientAgentId: string): string {
     ]);
   }
 
-  const normalizedRecipient = recipientAgentId.toLowerCase();
-  for (const agent of listAgents()) {
-    try {
-      if (resolveA2AAgentId(agent.id) === normalizedRecipient) {
-        return agentWorkspaceDir(agent.id);
-      }
-    } catch {
-      // Malformed local agent records are ignored here; registry mutation
-      // validation owns surfacing those errors.
-    }
-  }
+  const localAgentId = resolveLocalA2AAgentId(recipientAgentId);
+  if (localAgentId) return agentWorkspaceDir(localAgentId);
   throw new A2AEnvelopeValidationError([
     'recipient_agent_id does not resolve to a local agent',
   ]);

--- a/src/gateway/a2a-inbox-dispatch.ts
+++ b/src/gateway/a2a-inbox-dispatch.ts
@@ -2,11 +2,62 @@ import type {
   A2AInboxDispatchHandler,
   A2AInboxDispatchHandlerResult,
 } from '../a2a/a2a-inbox-dispatcher.js';
+import { logger } from '../logger.js';
+import { memoryService } from '../memory/memory-service.js';
 import { handleGatewayMessage } from './gateway-chat-service.js';
+
+function storeA2AReplyInOriginThread(
+  invocation: Parameters<A2AInboxDispatchHandler>[0],
+): A2AInboxDispatchHandlerResult | null {
+  const envelope = invocation.envelope;
+  if (envelope.intent !== 'chat' || !envelope.parent_message_id) return null;
+
+  const targetSession = memoryService.getSessionById(envelope.thread_id);
+  if (!targetSession) {
+    return {
+      status: 'error',
+      error: `A2A reply target session not found: ${envelope.thread_id}`,
+    };
+  }
+
+  const content = envelope.content.trim();
+  if (!content) {
+    return {
+      status: 'success',
+      result: null,
+    };
+  }
+
+  const messageId = memoryService.storeMessage({
+    sessionId: targetSession.id,
+    userId: envelope.sender_agent_id,
+    username: envelope.sender_agent_id,
+    role: 'assistant',
+    content,
+    agentId: envelope.sender_agent_id,
+  });
+  logger.info(
+    {
+      messageId,
+      sessionId: targetSession.id,
+      a2aMessageId: envelope.id,
+      parentMessageId: envelope.parent_message_id,
+      senderAgentId: envelope.sender_agent_id,
+    },
+    'Stored A2A reply in origin chat thread',
+  );
+  return {
+    status: 'success',
+    result: null,
+  };
+}
 
 export const dispatchA2AInboxItemToGateway: A2AInboxDispatchHandler = async (
   invocation,
 ): Promise<A2AInboxDispatchHandlerResult> => {
+  const storedReply = storeA2AReplyInOriginThread(invocation);
+  if (storedReply) return storedReply;
+
   const result = await handleGatewayMessage({
     sessionId: invocation.sessionId,
     guildId: null,

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -899,13 +899,29 @@ async function handleGatewayMessageInner(
 
     const delivery =
       confirmation.delivered === true ? 'Delivered' : 'Queued for delivery';
+    const resultText = [
+      `${delivery} to \`${confirmation.recipient_agent_id}\`.`,
+      `Message: \`${confirmation.message_id}\``,
+      `Thread: \`${confirmation.thread_id}\``,
+    ].join('\n');
+    const userMessageId = memoryService.storeMessage({
+      sessionId: req.sessionId,
+      userId: req.userId,
+      username: req.username,
+      role: 'user',
+      content: req.content,
+    });
+    const assistantMessageId = memoryService.storeMessage({
+      sessionId: req.sessionId,
+      userId: 'assistant',
+      username: null,
+      role: 'assistant',
+      content: resultText,
+      agentId: senderAgentId,
+    });
     return attachSessionIdentity({
       status: 'success',
-      result: [
-        `${delivery} to \`${confirmation.recipient_agent_id}\`.`,
-        `Message: \`${confirmation.message_id}\``,
-        `Thread: \`${confirmation.thread_id}\``,
-      ].join('\n'),
+      result: resultText,
       toolsUsed: [],
       messageRole: 'command',
       addressEnvelope: addressed.envelope,
@@ -915,6 +931,8 @@ async function handleGatewayMessageInner(
         recipientAgentId: confirmation.recipient_agent_id,
         status: confirmation.delivered === true ? 'delivered' : 'pending',
       },
+      userMessageId,
+      assistantMessageId,
     });
   }
   if (addressed.kind === 'agent') {

--- a/tests/a2a-inbox-dispatcher.test.ts
+++ b/tests/a2a-inbox-dispatcher.test.ts
@@ -126,6 +126,45 @@ describe('A2A inbox dispatch processor', () => {
     ).toHaveLength(1);
   });
 
+  test('dispatches registered canonical recipients when runtime instance id differs', async () => {
+    const { dispatchStore, dispatcher } = await loadDispatchModules();
+    const runtimeConfig = await import('../src/config/runtime-config.ts');
+    runtimeConfig.updateRuntimeConfig((draft) => {
+      draft.agents.list = [
+        {
+          id: 'main',
+          canonicalId: 'main@team@agent-card-instance',
+          owner: 'team',
+          role: 'lead',
+        },
+      ];
+    });
+    dispatchStore.enqueueA2AInboxDispatch(
+      a2aEnvelope('msg-dispatch-pinned-canonical', {
+        recipient_agent_id: 'main@team@agent-card-instance',
+      }),
+    );
+
+    const dispatch = vi.fn(async () => ({ status: 'success' as const }));
+    await expect(
+      dispatcher.processA2AInboxDispatchQueue({ dispatch }),
+    ).resolves.toMatchObject({
+      processed: 1,
+      dispatched: 1,
+      failed: 0,
+    });
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch.mock.calls[0]?.[0]).toMatchObject({
+      agentId: 'main',
+      userId: 'remote@team@peer-instance',
+      addressEnvelope: {
+        to: 'main',
+        from: 'remote@team@peer-instance',
+      },
+    });
+  });
+
   test('does not redispatch an already processed envelope', async () => {
     const { dispatchStore, dispatcher } = await loadDispatchModules();
     const envelope = a2aEnvelope('msg-dispatch-idempotent');

--- a/tests/a2a-runtime.integration.test.ts
+++ b/tests/a2a-runtime.integration.test.ts
@@ -171,6 +171,53 @@ describe('A2A runtime API', () => {
     });
   });
 
+  test('delivers to a registered canonical local recipient even when the runtime instance id differs', async () => {
+    process.env.HYBRIDCLAW_INSTANCE_ID = 'runtime-state';
+    const { initDatabase } = await import('../src/memory/db.ts');
+    const runtimeConfig = await import('../src/config/runtime-config.ts');
+    const runtime = await import('../src/a2a/runtime.ts');
+
+    initDatabase({ quiet: true });
+    runtimeConfig.updateRuntimeConfig((draft) => {
+      draft.agents.list = [
+        {
+          id: 'main',
+          canonicalId: 'main@team@agent-card-instance',
+          owner: 'team',
+          role: 'lead',
+        },
+      ];
+    });
+
+    const confirmation = runtime.sendMessage(
+      {
+        id: 'msg-canonical-local-recipient',
+        sender_agent_id: 'remote@team@peer-instance',
+        recipient_agent_id: 'main@team@agent-card-instance',
+        thread_id: 'thread-canonical-local-recipient',
+        intent: 'chat',
+        content: 'Store this locally.',
+        created_at: '2026-05-01T10:00:00.000Z',
+      },
+      {
+        auditRole: 'receiver',
+      },
+    );
+
+    expect(confirmation).toMatchObject({
+      delivered: true,
+      message_id: 'msg-canonical-local-recipient',
+      recipient_agent_id: 'main@team@agent-card-instance',
+    });
+    expect(runtime.inbox('main')).toMatchObject([
+      {
+        id: 'msg-canonical-local-recipient',
+        sender_agent_id: 'remote@team@peer-instance',
+        recipient_agent_id: 'main@team@agent-card-instance',
+      },
+    ]);
+  });
+
   test('writes A2A message events to the hash-chain audit wire log', async () => {
     const { initDatabase } = await import('../src/memory/db.ts');
     const audit = await import('../src/audit/audit-trail.ts');

--- a/tests/gateway-a2a-inbox-dispatch.test.ts
+++ b/tests/gateway-a2a-inbox-dispatch.test.ts
@@ -1,0 +1,192 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+const { sendA2AMessageMock } = vi.hoisted(() => ({
+  sendA2AMessageMock: vi.fn(),
+}));
+
+vi.mock('../src/a2a/runtime.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/a2a/runtime.ts')>();
+  return {
+    ...actual,
+    sendMessage: sendA2AMessageMock,
+  };
+});
+
+const ORIGINAL_DATA_DIR = process.env.HYBRIDCLAW_DATA_DIR;
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_INSTANCE_ID = process.env.HYBRIDCLAW_INSTANCE_ID;
+const ORIGINAL_CONFIG_WATCHER = process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+
+let tmpDir: string;
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-gateway-a2a-dispatch-'));
+  process.env.HYBRIDCLAW_DATA_DIR = tmpDir;
+  process.env.HOME = tmpDir;
+  process.env.HYBRIDCLAW_INSTANCE_ID = 'inst-i1';
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+  vi.resetModules();
+});
+
+afterEach(() => {
+  sendA2AMessageMock.mockReset();
+  restoreEnvVar('HYBRIDCLAW_DATA_DIR', ORIGINAL_DATA_DIR);
+  restoreEnvVar('HOME', ORIGINAL_HOME);
+  restoreEnvVar('HYBRIDCLAW_INSTANCE_ID', ORIGINAL_INSTANCE_ID);
+  restoreEnvVar(
+    'HYBRIDCLAW_DISABLE_CONFIG_WATCHER',
+    ORIGINAL_CONFIG_WATCHER,
+  );
+  vi.resetModules();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test('persists outbound A2A chat sends in the web session history', async () => {
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const { handleGatewayMessage } = await import(
+    '../src/gateway/gateway-chat-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  sendA2AMessageMock.mockReturnValue({
+    delivered: true,
+    message_id: 'outbound-to-i2',
+    thread_id: 'web-thread-a2a-send',
+    recipient_agent_id: 'main@local@inst-i2',
+  });
+
+  const result = await handleGatewayMessage({
+    sessionId: 'web-thread-a2a-send',
+    guildId: null,
+    channelId: 'web',
+    userId: 'web-user',
+    username: 'web',
+    content: '@main@local@inst-i2 Who are you?',
+  });
+
+  expect(result).toMatchObject({
+    status: 'success',
+    result:
+      'Delivered to `main@local@inst-i2`.\n' +
+      'Message: `outbound-to-i2`\n' +
+      'Thread: `web-thread-a2a-send`',
+    messageRole: 'command',
+    userMessageId: expect.any(Number),
+    assistantMessageId: expect.any(Number),
+    a2aDelivery: {
+      messageId: 'outbound-to-i2',
+      threadId: 'web-thread-a2a-send',
+      recipientAgentId: 'main@local@inst-i2',
+      status: 'delivered',
+    },
+  });
+  expect(sendA2AMessageMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      recipient_agent_id: 'main@local@inst-i2',
+      thread_id: 'web-thread-a2a-send',
+      intent: 'chat',
+      content: 'Who are you?',
+    }),
+    expect.objectContaining({
+      actor: 'web-user',
+      sessionId: 'web-thread-a2a-send',
+    }),
+  );
+
+  const history = memoryService.getConversationHistory(
+    'web-thread-a2a-send',
+    10,
+  );
+  expect(history).toEqual([
+    expect.objectContaining({
+      role: 'assistant',
+      content:
+        'Delivered to `main@local@inst-i2`.\n' +
+        'Message: `outbound-to-i2`\n' +
+        'Thread: `web-thread-a2a-send`',
+      agent_id: 'main',
+    }),
+    expect.objectContaining({
+      role: 'user',
+      user_id: 'web-user',
+      username: 'web',
+      content: '@main@local@inst-i2 Who are you?',
+    }),
+  ]);
+});
+
+test('stores A2A parent replies in the originating chat session', async () => {
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const { createA2AEnvelope } = await import('../src/a2a/envelope.ts');
+  const { enqueueA2AInboxDispatch } = await import(
+    '../src/a2a/a2a-inbox-dispatch-store.ts'
+  );
+  const { dispatchA2AInboxItemToGateway } = await import(
+    '../src/gateway/a2a-inbox-dispatch.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const originSession = memoryService.getOrCreateSession(
+    'web-thread-a2a',
+    null,
+    'web',
+    'main',
+  );
+  const envelope = createA2AEnvelope({
+    id: 'reply-from-i2',
+    sender_agent_id: 'main@local@inst-i2',
+    recipient_agent_id: 'main@local@inst-i1',
+    thread_id: originSession.id,
+    parent_message_id: 'outbound-to-i2',
+    intent: 'chat',
+    content: 'I am I2.',
+  });
+  const item = enqueueA2AInboxDispatch(envelope);
+
+  await expect(
+    dispatchA2AInboxItemToGateway({
+      item,
+      envelope,
+      agentId: 'main',
+      sessionId: 'a2a-dispatch-session',
+      channelId: 'a2a',
+      userId: envelope.sender_agent_id,
+      username: envelope.sender_agent_id,
+      source: 'a2a.dispatch',
+      content: 'synthetic dispatch prompt should not be persisted',
+      addressEnvelope: {
+        to: 'main',
+        from: envelope.sender_agent_id,
+      },
+    }),
+  ).resolves.toEqual({
+    status: 'success',
+    result: null,
+  });
+
+  expect(memoryService.getSessionById('a2a-dispatch-session')).toBeUndefined();
+  expect(memoryService.getSessionById(originSession.id)?.message_count).toBe(1);
+  expect(memoryService.getConversationHistory(originSession.id, 10)).toEqual([
+    expect.objectContaining({
+      role: 'assistant',
+      user_id: 'main@local@inst-i2',
+      username: 'main@local@inst-i2',
+      agent_id: 'main@local@inst-i2',
+      content: 'I am I2.',
+    }),
+  ]);
+});


### PR DESCRIPTION
## Summary

- Treat registered canonical A2A agent IDs as local recipients even when the generic runtime instance-id file differs from the A2A Agent Card/keypair identity.
- Reuse that local-recipient resolution across A2A runtime delivery, inbound validation, inbox dispatch, webhook inbound, and local identity resolution.
- Fix the chat page race where a late initial history load could wipe the optimistic sent message/A2A delivery chip, and improve the delivered-chip text contrast.

## Root Cause

A local gateway restart without `HYBRIDCLAW_INSTANCE_ID` could allocate a new generic instance id while the A2A keypair and Agent Card continued advertising the previously pinned instance id. Incoming messages addressed to the advertised canonical agent, for example `main@local@inst-i2`, were then treated as remote and queued into outbound delivery instead of entering the local inbox-dispatch queue.

## Validation

- `npm run format`
- `npm run lint`
- `./node_modules/.bin/vitest run tests/a2a-runtime.integration.test.ts tests/a2a-inbox-dispatcher.test.ts tests/a2a-inbound.test.ts tests/a2a-webhook-inbound.test.ts`
- `../node_modules/.bin/vitest run --config vitest.config.ts src/routes/chat/use-chat-stream.test.ts` from `console/`
- `./node_modules/.bin/tsc --noEmit`
- `../node_modules/.bin/tsc --noEmit` from `console/`
- `git diff --check`