### PR TITLE
Expose delegated job results via OpenAI API

### DIFF
--- a/docs/content/reference/commands.md
+++ b/docs/content/reference/commands.md
@@ -223,6 +223,20 @@ curl http://127.0.0.1:9090/v1/chat/completions \
 - requests must include `Authorization: Bearer <WEB_API_TOKEN>` or
   `Authorization: Bearer <GATEWAY_API_TOKEN>`; loopback address alone does not
   authenticate API requests
+- delegated chat completions return an acknowledgement and include
+  `hybridclaw.delegation` with `{ "id": "<completion-id>", "status": "queued" }`;
+  non-streaming responses also set `X-HybridClaw-Delegation-Id`
+- delegated streaming completions carry the same `hybridclaw.delegation`
+  object on the final stop chunk
+- poll `GET /v1/chat/completions/{completion-id}` to retrieve delegated job
+  state; responses include top-level `status` with one of `queued`,
+  `in_progress`, `completed`, `failed`, or `cancelled`
+- while a delegated job is queued or running, retrieval returns the original
+  acknowledgement with `finish_reason: null`; when completed, it returns the
+  synthesized final answer with `finish_reason: "stop"`; failed jobs include a
+  top-level OpenAI-shaped `error`
+- polling intervals around 1-5 seconds are appropriate for delegated jobs,
+  which may wait behind the delegation concurrency limit before running
 - these endpoints are intended for local tooling and eval harnesses rather than
   public exposure
 

--- a/src/agent/delegation-manager.ts
+++ b/src/agent/delegation-manager.ts
@@ -35,13 +35,14 @@ function pump(): void {
   }
 }
 
-export function enqueueDelegation(job: DelegationJob): void {
+export function enqueueDelegation(job: DelegationJob): boolean {
   if (!PROACTIVE_DELEGATION_ENABLED) {
     logger.info({ jobId: job.id }, 'Delegation skipped — disabled');
-    return;
+    return false;
   }
   queue.push(job);
   pump();
+  return true;
 }
 
 export function delegationQueueStatus(): { queued: number; active: number } {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -725,6 +725,8 @@ export let PROACTIVE_DELEGATION_MODEL = '';
 export let PROACTIVE_DELEGATION_MAX_CONCURRENT = 3;
 export let PROACTIVE_DELEGATION_MAX_DEPTH = 2;
 export let PROACTIVE_DELEGATION_MAX_PER_TURN = 3;
+export let DELEGATION_JOBS_RETENTION_DAYS = 7;
+export let DELEGATION_JOBS_MAX_ROWS = 1000;
 
 export let PROACTIVE_AUTO_RETRY_ENABLED = true;
 export let PROACTIVE_AUTO_RETRY_MAX_ATTEMPTS = 3;
@@ -1209,6 +1211,14 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
   PROACTIVE_DELEGATION_MAX_PER_TURN = Math.max(
     1,
     config.proactive.delegation.maxPerTurn,
+  );
+  DELEGATION_JOBS_RETENTION_DAYS = Math.max(
+    1,
+    config.proactive.delegation.jobsRetentionDays,
+  );
+  DELEGATION_JOBS_MAX_ROWS = Math.max(
+    1,
+    config.proactive.delegation.jobsMaxRows,
   );
 
   PROACTIVE_AUTO_RETRY_ENABLED = config.proactive.autoRetry.enabled;

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -1311,6 +1311,8 @@ export interface RuntimeConfig {
       maxConcurrent: number;
       maxDepth: number;
       maxPerTurn: number;
+      jobsRetentionDays: number;
+      jobsMaxRows: number;
     };
     autoRetry: {
       enabled: boolean;
@@ -2075,6 +2077,8 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
       maxConcurrent: 3,
       maxDepth: 2,
       maxPerTurn: 3,
+      jobsRetentionDays: 7,
+      jobsMaxRows: 1000,
     },
     autoRetry: {
       enabled: true,
@@ -8369,6 +8373,16 @@ function normalizeRuntimeConfig(
           rawDelegation.maxPerTurn,
           DEFAULT_RUNTIME_CONFIG.proactive.delegation.maxPerTurn,
           { min: 1, max: 8 },
+        ),
+        jobsRetentionDays: normalizeInteger(
+          rawDelegation.jobsRetentionDays,
+          DEFAULT_RUNTIME_CONFIG.proactive.delegation.jobsRetentionDays,
+          { min: 1, max: 365 },
+        ),
+        jobsMaxRows: normalizeInteger(
+          rawDelegation.jobsMaxRows,
+          DEFAULT_RUNTIME_CONFIG.proactive.delegation.jobsMaxRows,
+          { min: 1, max: 100_000 },
         ),
       },
       autoRetry: {

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -2189,25 +2189,29 @@ async function handleGatewayMessageInner(
       },
       allowSchedules: !isGoalContinuationSource(source),
     });
-    const delegationAcknowledgement =
+    const ackText =
       acceptedDelegations > 0
         ? `Started ${acceptedDelegations} delegate ${acceptedDelegations === 1 ? 'job' : 'jobs'}. I'll synthesize the final answer when they finish.`
         : null;
-    if (acceptedDelegationPlans.length > 0) {
-      enqueueDelegationBatchFromSideEffects({
-        plans: acceptedDelegationPlans,
-        parentSessionId: req.sessionId,
-        channelId: req.channelId,
-        chatbotId,
-        enableRag,
-        agentId,
-        parentModel: model,
-        onProactiveMessage: req.onProactiveMessage,
-        parentDepth,
-        parentPrompt: req.content,
-        parentResult: delegationAcknowledgement || '',
-      });
-    }
+    const delegationDescriptor =
+      acceptedDelegationPlans.length > 0
+        ? enqueueDelegationBatchFromSideEffects({
+            plans: acceptedDelegationPlans,
+            parentSessionId: req.sessionId,
+            channelId: req.channelId,
+            chatbotId,
+            enableRag,
+            agentId,
+            parentModel: model,
+            onProactiveMessage: req.onProactiveMessage,
+            parentDepth,
+            parentPrompt: req.content,
+            parentResult: ackText || '',
+            publicId: req.delegationPublicId,
+            ackText: ackText || '',
+          })
+        : null;
+    const delegationAcknowledgement = delegationDescriptor ? ackText : null;
 
     promoteWorkspaceSkills(workspacePath);
 
@@ -2488,6 +2492,14 @@ async function handleGatewayMessageInner(
       skillUsed: observedSkillName ?? undefined,
       agentId,
       addressEnvelope: req.addressEnvelope,
+      ...(delegationDescriptor
+        ? {
+            delegation: {
+              id: delegationDescriptor.publicId,
+              status: 'queued' as const,
+            },
+          }
+        : {}),
       model,
       provider,
       memoryCitations: output.memoryCitations,

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -369,6 +369,7 @@ import {
 import { consumeGatewayMediaUploadQuota } from './media-upload-quota.js';
 import {
   handleOpenAICompatibleChatCompletions,
+  handleOpenAICompatibleCompletionRetrieve,
   handleOpenAICompatibleModelList,
 } from './openai-compatible.js';
 import {
@@ -9097,6 +9098,13 @@ export function startGatewayHttpServer(): GatewayHttpServer {
         }
         if (pathname === '/v1/chat/completions' && method === 'POST') {
           await handleOpenAICompatibleChatCompletions(req, res);
+          return;
+        }
+        if (method === 'GET' && pathname.startsWith('/v1/chat/completions/')) {
+          const id = decodeURIComponent(
+            pathname.slice('/v1/chat/completions/'.length),
+          );
+          await handleOpenAICompatibleCompletionRetrieve(req, res, id, url);
           return;
         }
         sendJson(res, 404, {

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -243,12 +243,16 @@ import { NoCompactableMessagesError } from '../memory/compaction.js';
 import { runMemoryConsolidation } from '../memory/consolidation-runner.js';
 import {
   claimMemoryValue,
+  completeDelegationJob,
   countStructuredAuditEntries,
+  createDelegationJob,
   createFreshSessionInstance,
   deleteMemoryValue,
   deleteSessionData,
   enqueueProactiveMessage,
+  failDelegationJob,
   getAllSessions,
+  getDelegationJob,
   getFullAutoSessionCount,
   getMemoryValue,
   getQueuedProactiveMessageCount,
@@ -278,6 +282,7 @@ import {
   listUsageByModel,
   listUsageBySession,
   listUsageDailyBreakdown,
+  markDelegationJobInProgress,
   recordRequestLog,
   sessionHasUserMessages,
   setMemoryValue,
@@ -10535,6 +10540,27 @@ async function publishDelegationCompletion(params: {
     content: forLLM,
   });
 
+  const trimmedForUser = forUser.trim();
+  if (trimmedForUser && trimmedForUser !== forLLM.trim()) {
+    memoryService.storeMessage({
+      sessionId: parentSessionId,
+      userId: 'assistant',
+      username: null,
+      role: 'assistant',
+      content: trimmedForUser,
+      agentId,
+      artifacts: artifacts?.length ? artifacts : null,
+    });
+    appendSessionTranscript(agentId, {
+      sessionId: parentSessionId,
+      channelId,
+      role: 'assistant',
+      userId: 'assistant',
+      username: null,
+      content: trimmedForUser,
+    });
+  }
+
   if (publishForUser) {
     await publishDelegationLifecycleMessage({
       parentSessionId,
@@ -10560,8 +10586,10 @@ export function enqueueDelegationFromSideEffect(params: {
   parentDepth: number;
   parentPrompt?: string;
   parentResult?: string;
-}): void {
-  enqueueDelegationBatchFromSideEffects({
+  publicId?: string;
+  ackText?: string;
+}): { publicId: string } | null {
+  return enqueueDelegationBatchFromSideEffects({
     ...params,
     plans: [params.plan],
   });
@@ -10581,7 +10609,9 @@ export function enqueueDelegationBatchFromSideEffects(params: {
   parentDepth: number;
   parentPrompt?: string;
   parentResult?: string;
-}): void {
+  publicId?: string;
+  ackText?: string;
+}): { publicId: string } | null {
   const {
     plans,
     parentSessionId,
@@ -10594,16 +10624,18 @@ export function enqueueDelegationBatchFromSideEffects(params: {
     parentDepth,
     parentPrompt,
     parentResult,
+    publicId: requestedPublicId,
+    ackText,
   } = params;
   const activePlans = plans.filter((plan) => plan.tasks.length > 0);
-  if (activePlans.length === 0) return;
+  if (activePlans.length === 0) return null;
   const childDepth = parentDepth + 1;
   if (childDepth > PROACTIVE_DELEGATION_MAX_DEPTH) {
     logger.info(
       { parentSessionId, childDepth, maxDepth: PROACTIVE_DELEGATION_MAX_DEPTH },
       'Delegation skipped — depth limit reached',
     );
-    return;
+    return null;
   }
 
   const statusEntries: DelegationStatusEntry[] = [];
@@ -10633,215 +10665,272 @@ export function enqueueDelegationBatchFromSideEffects(params: {
           .join(', ') || undefined;
 
   const jobId = `${parentSessionId}:${Date.now()}:${randomUUID()}`;
-  enqueueDelegation({
+  const publicId =
+    requestedPublicId?.trim() ||
+    `dlg_${randomUUID().replace(/-/g, '').slice(0, 24)}`;
+  try {
+    createDelegationJob({
+      publicId,
+      internalId: jobId,
+      parentSessionId,
+      channelId,
+      agentId,
+      model: parentModel || null,
+      taskCount: statusEntries.length,
+      ackText: ackText || null,
+    });
+  } catch (err) {
+    logger.error(
+      {
+        err,
+        parentSessionId,
+        channelId,
+        publicId,
+        internalId: jobId,
+      },
+      'Failed to create delegation job row',
+    );
+    return null;
+  }
+
+  const accepted = enqueueDelegation({
     id: jobId,
     run: async () => {
+      if (getDelegationJob(publicId)?.status === 'cancelled') return;
+      markDelegationJobInProgress(publicId);
       const startedAt = Date.now();
       const entries: DelegationCompletionEntry[] = [];
-      await publishDelegationLifecycleMessage({
-        parentSessionId,
-        channelId,
-        text: formatDelegationStatus({
-          label: batchLabel,
-          entries: statusEntries,
-          parentModel,
-        }),
-        onProactiveMessage,
-      });
-
-      let statusPublishChain = Promise.resolve();
-      const publishStatus = (): Promise<void> => {
-        const text = formatDelegationStatus({
-          label: batchLabel,
-          entries: statusEntries,
-          parentModel,
-        });
-        statusPublishChain = statusPublishChain
-          .catch(() => undefined)
-          .then(() =>
-            publishDelegationLifecycleMessage({
-              parentSessionId,
-              channelId,
-              text,
-              onProactiveMessage,
-            }),
-          );
-        return statusPublishChain;
-      };
-      const runTask = async (params: {
-        plan: NormalizedDelegationPlan;
-        task: NormalizedDelegationTask;
-        index: number;
-        statusEntry: DelegationStatusEntry;
-        prompt?: string;
-      }): Promise<DelegationCompletionEntry> => {
-        const { plan, task, statusEntry, prompt } = params;
-        statusEntry.status = 'running';
-        await publishStatus();
-        const run = await runDelegationTaskWithRetry({
-          parentSessionId,
-          childDepth,
-          channelId,
-          chatbotId,
-          enableRag,
-          agentId,
-          mode: plan.mode,
-          task: prompt ? { ...task, prompt } : task,
-          onToolProgress: (event) => {
-            if (event.phase === 'finish') {
-              statusEntry.toolUses += 1;
-              statusEntry.lastTool = statusEntry.currentTool ?? event.toolName;
-              statusEntry.lastToolDetail = statusEntry.currentToolDetail;
-              statusEntry.currentTool = undefined;
-              statusEntry.currentToolDetail = undefined;
-              void publishStatus();
-              return;
-            }
-            statusEntry.currentTool = event.toolName;
-            statusEntry.currentToolDetail = formatDelegationToolDetail(event);
-            void publishStatus();
-          },
-        });
-        statusEntry.status = run.status;
-        statusEntry.currentTool = undefined;
-        statusEntry.currentToolDetail = undefined;
-        statusEntry.lastTool = undefined;
-        statusEntry.lastToolDetail = undefined;
-        statusEntry.toolUses = Math.max(
-          statusEntry.toolUses,
-          run.toolsUsed.length,
-        );
-        statusEntry.tokenCount = run.tokenCount;
-        await publishStatus();
-        return {
-          title: statusEntry.title,
-          run,
-        };
-      };
-
-      const runPlan = async (
-        plan: NormalizedDelegationPlan,
-        planIndex: number,
-      ): Promise<DelegationCompletionEntry[]> => {
-        const planStatusEntries = statusEntriesByPlan[planIndex] || [];
-        if (plan.mode === 'parallel') {
-          return Promise.all(
-            plan.tasks.map(async (task, index) =>
-              runTask({
-                plan,
-                task,
-                index,
-                statusEntry: planStatusEntries[index],
-              }),
-            ),
-          );
-        }
-
-        if (plan.mode === 'chain') {
-          const planEntries: DelegationCompletionEntry[] = [];
-          let previousResult = '';
-          for (let i = 0; i < plan.tasks.length; i++) {
-            const task = plan.tasks[i];
-            const entry = await runTask({
-              plan,
-              task,
-              index: i,
-              statusEntry: planStatusEntries[i],
-              prompt: interpolateChainPrompt(task.prompt, previousResult),
-            });
-            planEntries.push(entry);
-            if (entry.run.status !== 'completed') break;
-            previousResult = entry.run.result || '';
-          }
-          return planEntries;
-        }
-
-        const task = plan.tasks[0];
-        return [
-          await runTask({
-            plan,
-            task,
-            index: 0,
-            statusEntry: planStatusEntries[0],
-          }),
-        ];
-      };
-
-      const planEntries = await Promise.all(
-        activePlans.map(async (plan, planIndex) => runPlan(plan, planIndex)),
-      );
-      entries.push(...planEntries.flat());
-
-      if (entries.length === 0) {
-        logger.warn(
-          { parentSessionId, planCount: activePlans.length },
-          'Delegation produced no entries',
-        );
-        return;
-      }
-
-      const completion = formatDelegationCompletion({
-        mode:
-          activePlans.length === 1
-            ? activePlans[0]?.mode || 'single'
-            : 'parallel',
-        label: batchLabel,
-        entries,
-        totalDurationMs: Date.now() - startedAt,
-      });
-      let finalForUser: string | null = null;
-      let streamedFinal = false;
-      let synthesisStream: ReturnType<
-        typeof createDelegationSynthesisStream
-      > | null = null;
       try {
-        synthesisStream =
-          channelId === 'tui'
-            ? createDelegationSynthesisStream({
+        await publishDelegationLifecycleMessage({
+          parentSessionId,
+          channelId,
+          text: formatDelegationStatus({
+            label: batchLabel,
+            entries: statusEntries,
+            parentModel,
+          }),
+          onProactiveMessage,
+        });
+
+        let statusPublishChain = Promise.resolve();
+        const publishStatus = (): Promise<void> => {
+          const text = formatDelegationStatus({
+            label: batchLabel,
+            entries: statusEntries,
+            parentModel,
+          });
+          statusPublishChain = statusPublishChain
+            .catch(() => undefined)
+            .then(() =>
+              publishDelegationLifecycleMessage({
                 parentSessionId,
                 channelId,
-              })
-            : null;
-        finalForUser = await synthesizeDelegationFinal({
+                text,
+                onProactiveMessage,
+              }),
+            );
+          return statusPublishChain;
+        };
+        const runTask = async (params: {
+          plan: NormalizedDelegationPlan;
+          task: NormalizedDelegationTask;
+          index: number;
+          statusEntry: DelegationStatusEntry;
+          prompt?: string;
+        }): Promise<DelegationCompletionEntry> => {
+          const { plan, task, statusEntry, prompt } = params;
+          statusEntry.status = 'running';
+          await publishStatus();
+          const run = await runDelegationTaskWithRetry({
+            parentSessionId,
+            childDepth,
+            channelId,
+            chatbotId,
+            enableRag,
+            agentId,
+            mode: plan.mode,
+            task: prompt ? { ...task, prompt } : task,
+            onToolProgress: (event) => {
+              if (event.phase === 'finish') {
+                statusEntry.toolUses += 1;
+                statusEntry.lastTool =
+                  statusEntry.currentTool ?? event.toolName;
+                statusEntry.lastToolDetail = statusEntry.currentToolDetail;
+                statusEntry.currentTool = undefined;
+                statusEntry.currentToolDetail = undefined;
+                void publishStatus();
+                return;
+              }
+              statusEntry.currentTool = event.toolName;
+              statusEntry.currentToolDetail = formatDelegationToolDetail(event);
+              void publishStatus();
+            },
+          });
+          statusEntry.status = run.status;
+          statusEntry.currentTool = undefined;
+          statusEntry.currentToolDetail = undefined;
+          statusEntry.lastTool = undefined;
+          statusEntry.lastToolDetail = undefined;
+          statusEntry.toolUses = Math.max(
+            statusEntry.toolUses,
+            run.toolsUsed.length,
+          );
+          statusEntry.tokenCount = run.tokenCount;
+          await publishStatus();
+          return {
+            title: statusEntry.title,
+            run,
+          };
+        };
+
+        const runPlan = async (
+          plan: NormalizedDelegationPlan,
+          planIndex: number,
+        ): Promise<DelegationCompletionEntry[]> => {
+          const planStatusEntries = statusEntriesByPlan[planIndex] || [];
+          if (plan.mode === 'parallel') {
+            return Promise.all(
+              plan.tasks.map(async (task, index) =>
+                runTask({
+                  plan,
+                  task,
+                  index,
+                  statusEntry: planStatusEntries[index],
+                }),
+              ),
+            );
+          }
+
+          if (plan.mode === 'chain') {
+            const planEntries: DelegationCompletionEntry[] = [];
+            let previousResult = '';
+            for (let i = 0; i < plan.tasks.length; i++) {
+              const task = plan.tasks[i];
+              const entry = await runTask({
+                plan,
+                task,
+                index: i,
+                statusEntry: planStatusEntries[i],
+                prompt: interpolateChainPrompt(task.prompt, previousResult),
+              });
+              planEntries.push(entry);
+              if (entry.run.status !== 'completed') break;
+              previousResult = entry.run.result || '';
+            }
+            return planEntries;
+          }
+
+          const task = plan.tasks[0];
+          return [
+            await runTask({
+              plan,
+              task,
+              index: 0,
+              statusEntry: planStatusEntries[0],
+            }),
+          ];
+        };
+
+        const planEntries = await Promise.all(
+          activePlans.map(async (plan, planIndex) => runPlan(plan, planIndex)),
+        );
+        entries.push(...planEntries.flat());
+
+        if (entries.length === 0) {
+          logger.warn(
+            { parentSessionId, planCount: activePlans.length },
+            'Delegation produced no entries',
+          );
+          failDelegationJob(publicId, 'no_delegation_entries');
+          return;
+        }
+
+        const completion = formatDelegationCompletion({
+          mode:
+            activePlans.length === 1
+              ? activePlans[0]?.mode || 'single'
+              : 'parallel',
+          label: batchLabel,
+          entries,
+          totalDurationMs: Date.now() - startedAt,
+        });
+        let finalForUser: string | null = null;
+        let streamedFinal = false;
+        let synthesisStream: ReturnType<
+          typeof createDelegationSynthesisStream
+        > | null = null;
+        try {
+          synthesisStream =
+            channelId === 'tui'
+              ? createDelegationSynthesisStream({
+                  parentSessionId,
+                  channelId,
+                })
+              : null;
+          finalForUser = await synthesizeDelegationFinal({
+            parentSessionId,
+            channelId,
+            chatbotId,
+            enableRag,
+            agentId,
+            model: parentModel || HYBRIDAI_MODEL,
+            parentPrompt,
+            parentResult,
+            delegationResults: completion.forLLM,
+            onTextDelta: synthesisStream?.onTextDelta,
+          });
+          synthesisStream?.finish();
+          streamedFinal =
+            Boolean(finalForUser) &&
+            (synthesisStream?.started() === true ||
+              Boolean(synthesisStream?.text().trim()));
+          if (streamedFinal && synthesisStream) {
+            finalForUser = synthesisStream.text().trim() || finalForUser;
+          }
+        } catch (err) {
+          logger.warn(
+            { parentSessionId, channelId, err },
+            'Delegation final synthesis failed; using completion summary',
+          );
+        } finally {
+          synthesisStream?.finish();
+        }
+        const resultText = finalForUser || completion.forUser;
+        await publishDelegationCompletion({
           parentSessionId,
           channelId,
-          chatbotId,
-          enableRag,
           agentId,
-          model: parentModel || HYBRIDAI_MODEL,
-          parentPrompt,
-          parentResult,
-          delegationResults: completion.forLLM,
-          onTextDelta: synthesisStream?.onTextDelta,
+          forLLM: completion.forLLM,
+          forUser: resultText,
+          artifacts: completion.artifacts,
+          publishForUser: !streamedFinal,
+          onProactiveMessage,
         });
-        synthesisStream?.finish();
-        streamedFinal =
-          Boolean(finalForUser) &&
-          (synthesisStream?.started() === true ||
-            Boolean(synthesisStream?.text().trim()));
-        if (streamedFinal && synthesisStream) {
-          finalForUser = synthesisStream.text().trim() || finalForUser;
-        }
+        completeDelegationJob(publicId, {
+          resultText,
+          resultDigest: completion.forLLM,
+          artifacts: completion.artifacts,
+        });
       } catch (err) {
-        logger.warn(
-          { parentSessionId, channelId, err },
-          'Delegation final synthesis failed; using completion summary',
+        const message = err instanceof Error ? err.message : String(err);
+        failDelegationJob(publicId, message);
+        logger.error(
+          { err, parentSessionId, channelId, publicId, internalId: jobId },
+          'Delegation batch failed',
         );
       } finally {
-        synthesisStream?.finish();
+        const row = getDelegationJob(publicId);
+        if (row?.status === 'queued' || row?.status === 'in_progress') {
+          failDelegationJob(publicId, 'unknown_termination');
+        }
       }
-      await publishDelegationCompletion({
-        parentSessionId,
-        channelId,
-        agentId,
-        forLLM: completion.forLLM,
-        forUser: finalForUser || completion.forUser,
-        artifacts: completion.artifacts,
-        publishForUser: !streamedFinal,
-        onProactiveMessage,
-      });
     },
   });
+  if (!accepted) {
+    failDelegationJob(publicId, 'delegation_disabled');
+    return null;
+  }
+  return { publicId };
 }
 
 export async function prepareSessionAutoReset(params: {

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -107,6 +107,10 @@ export interface GatewayChatResult {
   agentId?: string;
   addressEnvelope?: GatewayAddressEnvelope;
   a2aDelivery?: GatewayA2ADeliveryDescriptor;
+  delegation?: {
+    id: string;
+    status: 'queued';
+  };
   assistantPresentation?: GatewayAssistantPresentation;
   model?: string;
   provider?: string;
@@ -239,6 +243,7 @@ export interface GatewayChatRequest {
   }) => void | Promise<void>;
   abortSignal?: AbortSignal;
   source?: string;
+  delegationPublicId?: string;
 }
 
 export interface GatewayMediaUploadResult {

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -148,6 +148,7 @@ import {
 import {
   deleteQueuedProactiveMessage,
   enqueueProactiveMessage,
+  failStaleDelegationJobs,
   getMostRecentSessionChannelId,
   getQueuedProactiveMessageCount,
   initDatabase,
@@ -3535,6 +3536,13 @@ async function main(): Promise<void> {
   logWarmProcessPoolStartup(getConfigSnapshot().container);
   validateGatewayPromptEnvDefaults();
   initDatabase();
+  const failedDelegationJobs = failStaleDelegationJobs('gateway_restart');
+  if (failedDelegationJobs > 0) {
+    logger.warn(
+      { count: failedDelegationJobs },
+      'Marked stale delegation jobs failed after gateway startup',
+    );
+  }
   migrateConfigSchedulerJobsToDatabase();
   listAgents();
   await initGatewayService();

--- a/src/gateway/openai-compatible-response.ts
+++ b/src/gateway/openai-compatible-response.ts
@@ -80,8 +80,9 @@ export function buildOpenAICompatibleCompletionResponse(params: {
   model: string;
   content: string | null;
   toolCalls?: ToolCall[];
-  finishReason?: string;
+  finishReason?: string | null;
   tokenUsage?: TokenUsageStats;
+  extensions?: Record<string, unknown>;
 }): Record<string, unknown> {
   return {
     id: params.completionId,
@@ -99,13 +100,15 @@ export function buildOpenAICompatibleCompletionResponse(params: {
             : {}),
         },
         finish_reason:
-          params.finishReason ||
-          (params.toolCalls && params.toolCalls.length > 0
-            ? 'tool_calls'
-            : 'stop'),
+          params.finishReason !== undefined
+            ? params.finishReason
+            : params.toolCalls && params.toolCalls.length > 0
+              ? 'tool_calls'
+              : 'stop',
       },
     ],
     usage: mapOpenAICompatibleUsage(params.tokenUsage),
+    ...(params.extensions || {}),
   };
 }
 
@@ -168,6 +171,7 @@ export function buildOpenAICompatibleStreamStopChunk(params: {
   created: number;
   model: string;
   finishReason?: string;
+  extensions?: Record<string, unknown>;
 }): Record<string, unknown> {
   return {
     id: params.completionId,
@@ -181,6 +185,7 @@ export function buildOpenAICompatibleStreamStopChunk(params: {
         finish_reason: params.finishReason || 'stop',
       },
     ],
+    ...(params.extensions || {}),
   };
 }
 

--- a/src/gateway/openai-compatible.ts
+++ b/src/gateway/openai-compatible.ts
@@ -12,6 +12,7 @@ import {
 } from '../evals/eval-profile.js';
 import { agentWorkspaceDir } from '../infra/ipc.js';
 import { logger } from '../logger.js';
+import { getDelegationJob } from '../memory/db.js';
 import { memoryService } from '../memory/memory-service.js';
 import { callAuxiliaryModel } from '../providers/auxiliary.js';
 import {
@@ -51,6 +52,7 @@ import {
   buildOpenAICompatibleStreamTextChunk,
   buildOpenAICompatibleStreamToolCallsChunk,
   buildOpenAICompatibleStreamUsageChunk,
+  sendOpenAICompatibleError,
   sendOpenAICompatibleStreamError,
   writeOpenAICompatibleStreamChunk,
 } from './openai-compatible-response.js';
@@ -296,6 +298,7 @@ function prepareOpenAICompatibleRequest(
 function buildGatewayChatRequest(params: {
   input: Awaited<ReturnType<typeof readOpenAICompatibleChatRequest>>;
   prepared: ReturnType<typeof prepareOpenAICompatibleRequest>;
+  completionId: string;
   executionSessionId?: string;
 }): GatewayChatRequest {
   const includeAgentId =
@@ -319,6 +322,7 @@ function buildGatewayChatRequest(params: {
     ...(params.input.media.length > 0 ? { media: params.input.media } : {}),
     ...(includeAgentId ? { agentId: params.prepared.requestAgentId } : {}),
     model: params.prepared.model,
+    delegationPublicId: params.completionId,
     ...(params.prepared.profile.ablateSystemPrompt
       ? { promptMode: 'none' as const }
       : {}),
@@ -452,6 +456,69 @@ export async function handleOpenAICompatibleModelList(
   res.end(JSON.stringify(payload, null, 2));
 }
 
+function openAICompatibleCreatedFromTimestamp(timestamp: string): number {
+  const normalized = timestamp.includes('T')
+    ? timestamp
+    : `${timestamp.replace(' ', 'T')}Z`;
+  const parsed = Date.parse(normalized);
+  return Number.isFinite(parsed)
+    ? Math.floor(parsed / 1000)
+    : Math.floor(Date.now() / 1000);
+}
+
+export async function handleOpenAICompatibleCompletionRetrieve(
+  _req: IncomingMessage,
+  res: ServerResponse,
+  completionId: string,
+  _url: URL,
+): Promise<void> {
+  const job = getDelegationJob(completionId);
+  if (!job) {
+    sendOpenAICompatibleError(
+      res,
+      404,
+      'No delegation job found for this completion id.',
+      {
+        type: 'invalid_request_error',
+        code: 'not_found',
+      },
+    );
+    return;
+  }
+
+  const isTerminalSuccess = job.status === 'completed';
+  const isPending = job.status === 'queued' || job.status === 'in_progress';
+  const payload = buildOpenAICompatibleCompletionResponse({
+    completionId: job.public_id,
+    created: openAICompatibleCreatedFromTimestamp(job.created_at),
+    model: job.model || HYBRIDAI_MODEL,
+    content: isPending
+      ? job.ack_text || ''
+      : isTerminalSuccess
+        ? job.result_text || ''
+        : null,
+    finishReason: isTerminalSuccess ? 'stop' : null,
+    extensions: {
+      status: job.status,
+      ...(job.status === 'failed'
+        ? {
+            error: {
+              message: job.error || 'delegation_failed',
+              type: 'server_error',
+            },
+          }
+        : {}),
+    },
+  });
+
+  res.writeHead(200, {
+    'X-HybridClaw-Session-Id': job.parent_session_id,
+    'X-HybridClaw-Delegation-Status': job.status,
+    'Content-Type': 'application/json; charset=utf-8',
+  });
+  res.end(JSON.stringify(payload, null, 2));
+}
+
 async function handleOpenAICompatibleNonStreamingChat(
   res: ServerResponse,
   chatRequest: GatewayChatRequest,
@@ -474,6 +541,9 @@ async function handleOpenAICompatibleNonStreamingChat(
           'X-HybridClaw-Execution-Session-Id': chatRequest.executionSessionId,
         }
       : {}),
+    ...(result.delegation
+      ? { 'X-HybridClaw-Delegation-Id': result.delegation.id }
+      : {}),
     'X-HybridClaw-Artifact-Count': String(result.artifacts?.length || 0),
   };
   const payload = buildOpenAICompatibleCompletionResponse({
@@ -482,6 +552,15 @@ async function handleOpenAICompatibleNonStreamingChat(
     model: responseModel,
     content: typeof result.result === 'string' ? result.result : '',
     tokenUsage: result.tokenUsage,
+    ...(result.delegation
+      ? {
+          extensions: {
+            hybridclaw: {
+              delegation: result.delegation,
+            },
+          },
+        }
+      : {}),
   });
   res.writeHead(200, {
     ...responseTraceHeaders,
@@ -674,6 +753,15 @@ async function handleOpenAICompatibleStreamingChat(
         completionId,
         created,
         model: responseModel,
+        ...(result.delegation
+          ? {
+              extensions: {
+                hybridclaw: {
+                  delegation: result.delegation,
+                },
+              },
+            }
+          : {}),
       }),
     );
 
@@ -878,6 +966,7 @@ export async function handleOpenAICompatibleChatCompletions(
       const chatRequest = buildGatewayChatRequest({
         input,
         prepared,
+        completionId,
         executionSessionId: executionSession?.sessionId,
       });
       if (input.wantsStream) {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -23,7 +23,11 @@ import {
 } from '../agents/team-structure.js';
 import { agentTeamStructureAssetPath } from '../agents/team-structure-revisions.js';
 import type { WireRecord } from '../audit/audit-trail.js';
-import { DB_PATH } from '../config/config.js';
+import {
+  DB_PATH,
+  DELEGATION_JOBS_MAX_ROWS,
+  DELEGATION_JOBS_RETENTION_DAYS,
+} from '../config/config.js';
 import {
   getRuntimeConfig,
   type RuntimeSchedulerJob,
@@ -167,7 +171,7 @@ let databaseInitialized = false;
 let usageEventBatchInsertStatement: Database.Statement | null = null;
 const usageRecordSubscribers = new Set<UsageRecordSubscriber>();
 
-export const DATABASE_SCHEMA_VERSION = 49;
+export const DATABASE_SCHEMA_VERSION = 50;
 const AGENT_CANONICAL_ID_COLLISION_LIMIT = 20;
 const DEFAULT_LOCAL_OWNER_USER_ID = formatLocalOwnerUserId('');
 const STRUCTURED_AUDIT_SESSION_LIMIT = 10_000;
@@ -267,6 +271,32 @@ interface ResponseRatingRow {
   skill_name: string | null;
   created_at: string;
   updated_at: string;
+}
+
+export type DelegationJobStatus =
+  | 'queued'
+  | 'in_progress'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+export interface DelegationJobRow {
+  public_id: string;
+  internal_id: string;
+  parent_session_id: string;
+  channel_id: string;
+  agent_id: string;
+  model: string | null;
+  status: DelegationJobStatus;
+  task_count: number;
+  ack_text: string | null;
+  result_text: string | null;
+  result_digest: string | null;
+  artifacts_json: string | null;
+  error: string | null;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
 }
 
 export interface ResponseRatingTarget {
@@ -780,6 +810,33 @@ function recordMigration(
     .run(version, description);
 }
 
+function createDelegationJobsSchema(database: Database.Database): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS delegation_jobs (
+      public_id TEXT PRIMARY KEY,
+      internal_id TEXT NOT NULL,
+      parent_session_id TEXT NOT NULL,
+      channel_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      model TEXT,
+      status TEXT NOT NULL CHECK (status IN ('queued','in_progress','completed','failed','cancelled')),
+      task_count INTEGER NOT NULL DEFAULT 0,
+      ack_text TEXT,
+      result_text TEXT,
+      result_digest TEXT,
+      artifacts_json TEXT,
+      error TEXT,
+      created_at TEXT DEFAULT (datetime('now')),
+      started_at TEXT,
+      completed_at TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_delegation_jobs_status
+      ON delegation_jobs(status);
+    CREATE INDEX IF NOT EXISTS idx_delegation_jobs_created
+      ON delegation_jobs(created_at);
+  `);
+}
+
 function migrateV1(database: Database.Database): void {
   database.exec(`
     CREATE TABLE IF NOT EXISTS sessions (
@@ -944,6 +1001,7 @@ function migrateV1(database: Database.Database): void {
       description TEXT
     );
   `);
+  createDelegationJobsSchema(database);
   createResponseRatingsSchema(database);
   recordMigration(database, 1, 'Initial schema');
 }
@@ -3196,6 +3254,11 @@ function migrateV49(database: Database.Database): void {
   recordMigration(database, 49, 'Persist scoped API token registry');
 }
 
+function migrateV50(database: Database.Database): void {
+  createDelegationJobsSchema(database);
+  recordMigration(database, 50, 'Persist delegated job status and results');
+}
+
 function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -3317,6 +3380,7 @@ function runMigrations(
   }
   if (currentVersion < 48) migrateV48(database, opts);
   if (currentVersion < 49) migrateV49(database);
+  if (currentVersion < 50) migrateV50(database);
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);
   if (!quiet && currentVersion < DATABASE_SCHEMA_VERSION) {
@@ -11308,6 +11372,196 @@ export function deleteObservabilityIngestToken(tokenKey: string): void {
   db.prepare('DELETE FROM observability_ingest_tokens WHERE token_key = ?').run(
     normalized,
   );
+}
+
+const TERMINAL_DELEGATION_JOB_STATUSES = [
+  'completed',
+  'failed',
+  'cancelled',
+] as const;
+
+function normalizeDelegationJobId(publicId: string): string {
+  return String(publicId || '').trim();
+}
+
+export function pruneDelegationJobs(params?: {
+  retentionDays?: number;
+  maxRows?: number;
+}): void {
+  const retentionDays = Math.max(
+    1,
+    Math.floor(params?.retentionDays ?? DELEGATION_JOBS_RETENTION_DAYS),
+  );
+  const maxRows = Math.max(
+    1,
+    Math.floor(params?.maxRows ?? DELEGATION_JOBS_MAX_ROWS),
+  );
+  const terminalPlaceholders = TERMINAL_DELEGATION_JOB_STATUSES.map(
+    () => '?',
+  ).join(', ');
+
+  db.prepare(
+    `DELETE FROM delegation_jobs
+     WHERE status IN (${terminalPlaceholders})
+       AND created_at < datetime('now', ?)`,
+  ).run(...TERMINAL_DELEGATION_JOB_STATUSES, `-${retentionDays} days`);
+
+  db.prepare(
+    `DELETE FROM delegation_jobs
+     WHERE status IN (${terminalPlaceholders})
+       AND public_id NOT IN (
+         SELECT public_id
+         FROM delegation_jobs
+         WHERE status IN (${terminalPlaceholders})
+         ORDER BY created_at DESC, public_id DESC
+         LIMIT ?
+       )`,
+  ).run(
+    ...TERMINAL_DELEGATION_JOB_STATUSES,
+    ...TERMINAL_DELEGATION_JOB_STATUSES,
+    maxRows,
+  );
+}
+
+export function createDelegationJob(row: {
+  publicId: string;
+  internalId: string;
+  parentSessionId: string;
+  channelId: string;
+  agentId: string;
+  model?: string | null;
+  taskCount: number;
+  ackText?: string | null;
+}): void {
+  const publicId = normalizeDelegationJobId(row.publicId);
+  const internalId = String(row.internalId || '').trim();
+  const parentSessionId = String(row.parentSessionId || '').trim();
+  const channelId = String(row.channelId || '').trim();
+  const agentId = String(row.agentId || '').trim();
+  if (!publicId || !internalId || !parentSessionId || !channelId || !agentId) {
+    throw new Error(
+      'Delegation job requires public, internal, session, channel, and agent ids.',
+    );
+  }
+
+  db.prepare(
+    `INSERT INTO delegation_jobs (
+       public_id,
+       internal_id,
+       parent_session_id,
+       channel_id,
+       agent_id,
+       model,
+       status,
+       task_count,
+       ack_text
+     ) VALUES (?, ?, ?, ?, ?, ?, 'queued', ?, ?)`,
+  ).run(
+    publicId,
+    internalId,
+    parentSessionId,
+    channelId,
+    agentId,
+    row.model?.trim() || null,
+    Math.max(0, Math.floor(row.taskCount || 0)),
+    row.ackText?.trim() || null,
+  );
+  pruneDelegationJobs();
+}
+
+export function markDelegationJobInProgress(publicId: string): void {
+  const normalized = normalizeDelegationJobId(publicId);
+  if (!normalized) return;
+  db.prepare(
+    `UPDATE delegation_jobs
+     SET status = 'in_progress',
+         started_at = COALESCE(started_at, datetime('now'))
+     WHERE public_id = ?
+       AND status = 'queued'`,
+  ).run(normalized);
+}
+
+export function completeDelegationJob(
+  publicId: string,
+  result: {
+    resultText?: string | null;
+    resultDigest?: string | null;
+    artifacts?: ArtifactMetadata[] | null;
+  },
+): void {
+  const normalized = normalizeDelegationJobId(publicId);
+  if (!normalized) return;
+  db.prepare(
+    `UPDATE delegation_jobs
+     SET status = 'completed',
+         result_text = ?,
+         result_digest = ?,
+         artifacts_json = ?,
+         error = NULL,
+         completed_at = datetime('now')
+     WHERE public_id = ?
+       AND status IN ('queued', 'in_progress')`,
+  ).run(
+    result.resultText?.trim() || null,
+    result.resultDigest?.trim() || null,
+    serializeMessageArtifacts(result.artifacts),
+    normalized,
+  );
+}
+
+export function failDelegationJob(publicId: string, error: string): void {
+  const normalized = normalizeDelegationJobId(publicId);
+  if (!normalized) return;
+  const normalizedError = String(error || '').trim() || 'delegation_failed';
+  db.prepare(
+    `UPDATE delegation_jobs
+     SET status = 'failed',
+         error = ?,
+         completed_at = datetime('now')
+     WHERE public_id = ?
+       AND status IN ('queued', 'in_progress')`,
+  ).run(normalizedError, normalized);
+}
+
+export function cancelDelegationJob(publicId: string): boolean {
+  const normalized = normalizeDelegationJobId(publicId);
+  if (!normalized) return false;
+  const result = db
+    .prepare(
+      `UPDATE delegation_jobs
+       SET status = 'cancelled',
+           completed_at = datetime('now')
+       WHERE public_id = ?
+         AND status = 'queued'`,
+    )
+    .run(normalized);
+  return result.changes > 0;
+}
+
+export function getDelegationJob(publicId: string): DelegationJobRow | null {
+  const normalized = normalizeDelegationJobId(publicId);
+  if (!normalized) return null;
+  return (
+    queryOne<DelegationJobRow, [string]>(
+      db,
+      'SELECT * FROM delegation_jobs WHERE public_id = ?',
+      normalized,
+    ) || null
+  );
+}
+
+export function failStaleDelegationJobs(error: string): number {
+  const normalizedError = String(error || '').trim() || 'gateway_restart';
+  const result = db
+    .prepare(
+      `UPDATE delegation_jobs
+       SET status = 'failed',
+           error = ?,
+           completed_at = datetime('now')
+       WHERE status IN ('queued', 'in_progress')`,
+    )
+    .run(normalizedError);
+  return result.changes;
 }
 
 export interface QueuedProactiveMessage {

--- a/tests/delegation-jobs-store.test.ts
+++ b/tests/delegation-jobs-store.test.ts
@@ -1,0 +1,169 @@
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
+
+const makeTempHome = useTempDir('hybridclaw-delegation-jobs-');
+const ORIGINAL_HOME = process.env.HOME;
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+useCleanMocks({
+  resetModules: true,
+  cleanup: () => {
+    restoreEnvVar('HOME', ORIGINAL_HOME);
+  },
+});
+
+async function importFreshDb(homeDir: string) {
+  process.env.HOME = homeDir;
+  const db = await import('../src/memory/db.js');
+  db.initDatabase({
+    quiet: true,
+    dbPath: path.join(homeDir, 'hybridclaw.db'),
+  });
+  return db;
+}
+
+test('delegation job accessors track lifecycle and artifacts', async () => {
+  const db = await importFreshDb(makeTempHome());
+
+  db.createDelegationJob({
+    publicId: 'chatcmpl_lifecycle',
+    internalId: 'parent:1:internal',
+    parentSessionId: 'parent-session',
+    channelId: 'openai',
+    agentId: 'main',
+    model: 'gpt-5',
+    taskCount: 2,
+    ackText: 'Started 2 delegate jobs.',
+  });
+  expect(db.getDelegationJob('chatcmpl_lifecycle')).toMatchObject({
+    public_id: 'chatcmpl_lifecycle',
+    status: 'queued',
+    task_count: 2,
+    ack_text: 'Started 2 delegate jobs.',
+  });
+
+  db.markDelegationJobInProgress('chatcmpl_lifecycle');
+  expect(db.getDelegationJob('chatcmpl_lifecycle')).toMatchObject({
+    status: 'in_progress',
+    started_at: expect.any(String),
+  });
+
+  db.completeDelegationJob('chatcmpl_lifecycle', {
+    resultText: 'Final synthesized answer.',
+    resultDigest: 'Internal digest.',
+    artifacts: [
+      {
+        path: '/tmp/report.md',
+        filename: 'report.md',
+        mimeType: 'text/markdown',
+      },
+    ],
+  });
+  const completed = db.getDelegationJob('chatcmpl_lifecycle');
+  expect(completed).toMatchObject({
+    status: 'completed',
+    result_text: 'Final synthesized answer.',
+    result_digest: 'Internal digest.',
+    error: null,
+    completed_at: expect.any(String),
+  });
+  expect(JSON.parse(completed?.artifacts_json || '[]')).toEqual([
+    {
+      path: '/tmp/report.md',
+      filename: 'report.md',
+      mimeType: 'text/markdown',
+    },
+  ]);
+});
+
+test('delegation job cancellation and stale failure only affect active rows', async () => {
+  const db = await importFreshDb(makeTempHome());
+
+  db.createDelegationJob({
+    publicId: 'chatcmpl_cancel',
+    internalId: 'parent:cancel',
+    parentSessionId: 'parent-session',
+    channelId: 'openai',
+    agentId: 'main',
+    taskCount: 1,
+  });
+  expect(db.cancelDelegationJob('chatcmpl_cancel')).toBe(true);
+  expect(db.getDelegationJob('chatcmpl_cancel')?.status).toBe('cancelled');
+
+  db.createDelegationJob({
+    publicId: 'chatcmpl_running',
+    internalId: 'parent:running',
+    parentSessionId: 'parent-session',
+    channelId: 'openai',
+    agentId: 'main',
+    taskCount: 1,
+  });
+  db.markDelegationJobInProgress('chatcmpl_running');
+  expect(db.cancelDelegationJob('chatcmpl_running')).toBe(false);
+  expect(db.getDelegationJob('chatcmpl_running')?.status).toBe('in_progress');
+
+  db.createDelegationJob({
+    publicId: 'chatcmpl_queued',
+    internalId: 'parent:queued',
+    parentSessionId: 'parent-session',
+    channelId: 'openai',
+    agentId: 'main',
+    taskCount: 1,
+  });
+  expect(db.failStaleDelegationJobs('gateway_restart')).toBe(2);
+  expect(db.getDelegationJob('chatcmpl_cancel')?.status).toBe('cancelled');
+  expect(db.getDelegationJob('chatcmpl_running')).toMatchObject({
+    status: 'failed',
+    error: 'gateway_restart',
+  });
+  expect(db.getDelegationJob('chatcmpl_queued')).toMatchObject({
+    status: 'failed',
+    error: 'gateway_restart',
+  });
+});
+
+test('delegation job pruning removes old terminal rows and preserves active rows', async () => {
+  const db = await importFreshDb(makeTempHome());
+
+  for (const id of ['old_completed', 'new_completed', 'active_queued']) {
+    db.createDelegationJob({
+      publicId: `chatcmpl_${id}`,
+      internalId: `parent:${id}`,
+      parentSessionId: 'parent-session',
+      channelId: 'openai',
+      agentId: 'main',
+      taskCount: 1,
+    });
+  }
+  db.completeDelegationJob('chatcmpl_old_completed', {
+    resultText: 'old',
+    resultDigest: 'old digest',
+  });
+  db.completeDelegationJob('chatcmpl_new_completed', {
+    resultText: 'new',
+    resultDigest: 'new digest',
+  });
+  db.withMemoryDatabase((database) => {
+    database
+      .prepare(
+        "UPDATE delegation_jobs SET created_at = datetime('now', '-10 days') WHERE public_id = ?",
+      )
+      .run('chatcmpl_old_completed');
+  });
+
+  db.pruneDelegationJobs({ retentionDays: 7, maxRows: 1 });
+  expect(db.getDelegationJob('chatcmpl_old_completed')).toBeNull();
+  expect(db.getDelegationJob('chatcmpl_new_completed')?.status).toBe(
+    'completed',
+  );
+  expect(db.getDelegationJob('chatcmpl_active_queued')?.status).toBe('queued');
+});

--- a/tests/gateway-delegation-proactive.test.ts
+++ b/tests/gateway-delegation-proactive.test.ts
@@ -139,7 +139,15 @@ test('delegation batch queues status updates and a synthesized final answer for 
             durationMs: 20,
           },
         ],
-        artifacts: [],
+        artifacts: content.includes('furukama')
+          ? [
+              {
+                path: '/tmp/furukama-report.md',
+                filename: 'furukama-report.md',
+                mimeType: 'text/markdown',
+              },
+            ]
+          : [],
       };
     },
   );
@@ -181,7 +189,7 @@ test('delegation batch queues status updates and a synthesized final answer for 
   expect(furukamaPlan?.tasks[0]?.model).toBe('llamacpp/liquidai/lfm');
   expect(hybridaiPlan?.tasks[0]?.model).toBe('llamacpp/liquidai/lfm');
 
-  enqueueDelegationBatchFromSideEffects({
+  const descriptor = enqueueDelegationBatchFromSideEffects({
     plans: [furukamaPlan!, hybridaiPlan!],
     parentSessionId: 'parent-session',
     channelId: 'tui',
@@ -193,6 +201,7 @@ test('delegation batch queues status updates and a synthesized final answer for 
     parentPrompt: 'Summarize furukama.com and hybridai.one.',
     parentResult: 'I will synthesize after delegates return.',
   });
+  expect(descriptor?.publicId).toMatch(/^dlg_[a-f0-9]{24}$/);
 
   await vi.waitFor(() => {
     const messages = listQueuedProactiveMessages(100).filter(
@@ -357,7 +366,61 @@ test('delegation batch queues status updates and a synthesized final answer for 
     messages_json: string | null;
     tool_executions_json: string | null;
   }>;
+  const parentRows = inspect
+    .prepare(
+      `SELECT content, artifacts_json
+       FROM messages
+       WHERE session_id = ?
+         AND role = 'assistant'
+       ORDER BY id ASC`,
+    )
+    .all('parent-session') as Array<{
+    content: string;
+    artifacts_json: string | null;
+  }>;
+  const jobRows = inspect
+    .prepare(
+      `SELECT public_id, status, result_text, result_digest, artifacts_json
+       FROM delegation_jobs
+       WHERE parent_session_id = ?
+       ORDER BY created_at ASC`,
+    )
+    .all('parent-session') as Array<{
+    public_id: string;
+    status: string;
+    result_text: string | null;
+    result_digest: string | null;
+    artifacts_json: string | null;
+  }>;
   inspect.close();
+
+  expect(parentRows).toHaveLength(2);
+  expect(parentRows[0]?.content).toContain('[Delegate:');
+  expect(parentRows[0]?.content).toContain('completed');
+  expect(parentRows[0]?.content).toContain('furukama child summary');
+  expect(parentRows[1]?.content).toBe('final synthesized comparison');
+  expect(JSON.parse(parentRows[1]?.artifacts_json || '[]')).toEqual([
+    {
+      path: '/tmp/furukama-report.md',
+      filename: 'furukama-report.md',
+      mimeType: 'text/markdown',
+    },
+  ]);
+
+  expect(jobRows).toHaveLength(1);
+  expect(jobRows[0]).toMatchObject({
+    public_id: descriptor?.publicId,
+    status: 'completed',
+    result_text: 'final synthesized comparison',
+  });
+  expect(jobRows[0]?.result_digest).toContain('furukama child summary');
+  expect(JSON.parse(jobRows[0]?.artifacts_json || '[]')).toEqual([
+    {
+      path: '/tmp/furukama-report.md',
+      filename: 'furukama-report.md',
+      mimeType: 'text/markdown',
+    },
+  ]);
 
   expect(childRows).toHaveLength(2);
   for (const row of childRows) {
@@ -468,6 +531,56 @@ test('delegation prefers configured delegate model over echoed parent-model over
       model: 'llamacpp/unsloth/LFM2.5-1.2B-Instruct-GGUF',
     },
   ]);
+});
+
+test('delegation disabled returns no descriptor and fails the durable job row', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+
+  const { enqueueDelegationBatchFromSideEffects, normalizeDelegationEffect } =
+    await import('../src/gateway/gateway-service.ts');
+  const { getDelegationJob, initDatabase } = await import(
+    '../src/memory/db.ts'
+  );
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  initDatabase({
+    quiet: true,
+    dbPath: path.join(homeDir, 'hybridclaw.db'),
+  });
+  updateRuntimeConfig((draft) => {
+    draft.proactive.delegation.enabled = false;
+  });
+
+  const plan = normalizeDelegationEffect(
+    {
+      mode: 'single',
+      label: 'disabled-delegation',
+      prompt: 'Research the disabled path.',
+    },
+    'orchestrator-model',
+  ).plan;
+  const descriptor = enqueueDelegationBatchFromSideEffects({
+    plans: [plan!],
+    parentSessionId: 'disabled-parent-session',
+    channelId: 'openai',
+    chatbotId: 'test-bot',
+    enableRag: false,
+    agentId: 'test-agent',
+    parentModel: 'orchestrator-model',
+    parentDepth: 0,
+    publicId: 'chatcmpl_disabled',
+    ackText:
+      "Started 1 delegate job. I'll synthesize the final answer when they finish.",
+  });
+
+  expect(descriptor).toBeNull();
+  expect(runAgentMock).not.toHaveBeenCalled();
+  expect(getDelegationJob('chatcmpl_disabled')).toMatchObject({
+    status: 'failed',
+    error: 'delegation_disabled',
+  });
 });
 
 test('delegation status tracks duplicate task titles independently', async () => {

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -13,6 +13,7 @@ const OPENAI_SESSION_ID_RE =
   /^agent:[^:]+:channel:openai:chat:dm:peer:[a-f0-9]{16}$/;
 const OPENAI_EXECUTION_SESSION_ID_RE =
   /^agent:[^:]+:channel:openai:chat:dm:peer:(?:[a-f0-9]{16}|exec-[a-f0-9]{24})$/;
+const OPENAI_COMPLETION_ID_RE = /^chatcmpl_[a-f0-9]{32}$/;
 const DEFAULT_TEST_GATEWAY_API_TOKEN = 'gateway-token';
 
 const ORIGINAL_HOME = process.env.HOME;
@@ -2106,6 +2107,7 @@ async function importFreshHealth(options?: {
   const claimQueuedProactiveMessages = vi.fn(() => [
     { id: 1, text: 'queued message' },
   ]);
+  const getDelegationJob = vi.fn((_publicId: string) => null as unknown);
   const consumeGatewayMediaUploadQuota = vi.fn((params: { bytes: number }) => ({
     allowed: true,
     remainingBytes: Number.POSITIVE_INFINITY,
@@ -2254,6 +2256,7 @@ async function importFreshHealth(options?: {
   }));
   vi.doMock('../src/memory/db.js', () => ({
     claimQueuedProactiveMessages,
+    getDelegationJob,
     getSessionById,
     resetSessionIfExpired: vi.fn(() => null),
     setMessageActivityTrace,
@@ -2608,6 +2611,7 @@ async function importFreshHealth(options?: {
     runMessageToolAction,
     normalizeDiscordToolAction,
     claimQueuedProactiveMessages,
+    getDelegationJob,
     consumeGatewayMediaUploadQuota,
     listLoadedPluginCommands,
   };
@@ -3004,7 +3008,7 @@ describe('gateway HTTP server', () => {
   });
 
   test('allows unsafe local web-session API requests with a matching origin', async () => {
-    const state = await importFreshHealth();
+    const state = await importFreshHealth({ deploymentPublicUrl: '' });
     const cookie = issueLocalWebSessionCookie(state);
     const req = makeRequest({
       method: 'POST',
@@ -3106,6 +3110,7 @@ describe('gateway HTTP server', () => {
     const authSecret = 'api-session-mutation-auth-secret';
     const state = await importFreshHealth({
       authSecret,
+      deploymentPublicUrl: '',
       webApiToken: 'web-token',
     });
     const req = makeRequest({
@@ -3136,6 +3141,7 @@ describe('gateway HTTP server', () => {
     const authSecret = 'api-session-forwarded-origin-auth-secret';
     const state = await importFreshHealth({
       authSecret,
+      deploymentPublicUrl: '',
       webApiToken: 'web-token',
     });
     const req = makeRequest({
@@ -3746,6 +3752,7 @@ describe('gateway HTTP server', () => {
         },
       ],
       model: 'gpt-5',
+      delegationPublicId: expect.stringMatching(OPENAI_COMPLETION_ID_RE),
       source: 'gateway.chat.openai-compatible',
     });
     expect(state.stopSessionExecution).not.toHaveBeenCalled();
@@ -3767,6 +3774,46 @@ describe('gateway HTTP server', () => {
       completion_tokens: 7,
       total_tokens: 19,
     });
+    expect(payload.hybridclaw).toBeUndefined();
+    expect(res.getHeader('x-hybridclaw-delegation-id')).toBeUndefined();
+  });
+
+  test('adds delegation metadata to non-streaming OpenAI chat completions when a job is created', async () => {
+    const state = await importFreshHealth();
+    state.handleGatewayMessage.mockImplementationOnce(
+      async (request: { delegationPublicId?: string }) => ({
+        status: 'success' as const,
+        result:
+          "Started 2 delegate jobs. I'll synthesize the final answer when they finish.",
+        toolsUsed: [],
+        delegation: {
+          id: request.delegationPublicId || 'chatcmpl_missing',
+          status: 'queued' as const,
+        },
+      }),
+    );
+    const req = makeRequest({
+      method: 'POST',
+      url: '/v1/chat/completions',
+      body: {
+        model: 'gpt-5',
+        messages: [{ role: 'user', content: 'Research this deeply.' }],
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    const payload = JSON.parse(res.body);
+    expect(payload.id).toMatch(OPENAI_COMPLETION_ID_RE);
+    expect(payload.hybridclaw).toEqual({
+      delegation: {
+        id: payload.id,
+        status: 'queued',
+      },
+    });
+    expect(res.getHeader('x-hybridclaw-delegation-id')).toBe(payload.id);
   });
 
   test('reuses the OpenAI executor session across repeated requests in the same conversation seed', async () => {
@@ -3907,6 +3954,7 @@ describe('gateway HTTP server', () => {
       agentId: 'charly',
       model: 'gpt-5',
       promptMode: 'none',
+      delegationPublicId: expect.stringMatching(OPENAI_COMPLETION_ID_RE),
       source: 'gateway.chat.openai-compatible',
     });
 
@@ -3994,6 +4042,7 @@ describe('gateway HTTP server', () => {
       agentId: 'charly',
       model: 'gpt-5',
       promptMode: 'none',
+      delegationPublicId: expect.stringMatching(OPENAI_COMPLETION_ID_RE),
       source: 'gateway.chat.openai-compatible',
     });
 
@@ -4066,6 +4115,7 @@ describe('gateway HTTP server', () => {
       agentId: expect.stringMatching(/^eval-[a-f0-9]{16}$/),
       model: 'gpt-5',
       omitPromptParts: ['bootstrap', 'soul'],
+      delegationPublicId: expect.stringMatching(OPENAI_COMPLETION_ID_RE),
       source: 'gateway.chat.openai-compatible',
       executionSessionId: expect.stringMatching(OPENAI_EXECUTION_SESSION_ID_RE),
     });
@@ -4137,6 +4187,174 @@ describe('gateway HTTP server', () => {
       '"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}',
     );
     expect(res.body).toContain('data: [DONE]');
+  });
+
+  test('adds delegation metadata to the OpenAI streaming stop chunk when a job is created', async () => {
+    const state = await importFreshHealth();
+    state.handleGatewayMessage.mockImplementationOnce(
+      async (request: { delegationPublicId?: string }) => ({
+        status: 'success' as const,
+        result:
+          "Started 1 delegate job. I'll synthesize the final answer when they finish.",
+        toolsUsed: [],
+        delegation: {
+          id: request.delegationPublicId || 'chatcmpl_missing',
+          status: 'queued' as const,
+        },
+      }),
+    );
+    const req = makeRequest({
+      method: 'POST',
+      url: '/v1/chat/completions',
+      body: {
+        model: 'gpt-5',
+        stream: true,
+        messages: [{ role: 'user', content: 'Research this deeply.' }],
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    const chunks = res.body
+      .split('\n\n')
+      .filter((chunk) => chunk.startsWith('data: {'))
+      .map((chunk) => JSON.parse(chunk.slice('data: '.length)));
+    const stopChunk = chunks.find(
+      (chunk) => chunk.choices?.[0]?.finish_reason === 'stop',
+    );
+    expect(stopChunk?.id).toMatch(OPENAI_COMPLETION_ID_RE);
+    expect(stopChunk?.hybridclaw).toEqual({
+      delegation: {
+        id: stopChunk.id,
+        status: 'queued',
+      },
+    });
+  });
+
+  test('retrieves OpenAI-compatible delegation jobs by completion id', async () => {
+    const state = await importFreshHealth();
+    const cases = [
+      {
+        status: 'queued',
+        content:
+          "Started 1 delegate job. I'll synthesize the final answer when they finish.",
+        finishReason: null,
+      },
+      {
+        status: 'in_progress',
+        content:
+          "Started 1 delegate job. I'll synthesize the final answer when they finish.",
+        finishReason: null,
+      },
+      {
+        status: 'completed',
+        content: 'Synthesized final answer.',
+        finishReason: 'stop',
+      },
+      {
+        status: 'failed',
+        content: null,
+        finishReason: null,
+        error: {
+          message: 'gateway_restart',
+          type: 'server_error',
+        },
+      },
+      {
+        status: 'cancelled',
+        content: null,
+        finishReason: null,
+      },
+    ] as const;
+
+    for (const item of cases) {
+      const id = `chatcmpl_${item.status}`;
+      state.getDelegationJob.mockReturnValueOnce({
+        public_id: id,
+        internal_id: `internal-${item.status}`,
+        parent_session_id: 'agent:main:channel:openai:chat:dm:peer:abc123',
+        channel_id: 'openai',
+        agent_id: 'main',
+        model: 'gpt-5',
+        status: item.status,
+        task_count: 1,
+        ack_text:
+          "Started 1 delegate job. I'll synthesize the final answer when they finish.",
+        result_text:
+          item.status === 'completed' ? 'Synthesized final answer.' : null,
+        result_digest: item.status === 'completed' ? 'Digest.' : null,
+        artifacts_json: null,
+        error: item.status === 'failed' ? 'gateway_restart' : null,
+        created_at: '2026-07-08 12:34:56',
+        started_at:
+          item.status === 'queued' ? null : '2026-07-08 12:35:00',
+        completed_at:
+          item.status === 'queued' || item.status === 'in_progress'
+            ? null
+            : '2026-07-08 12:36:00',
+      });
+      const req = makeRequest({
+        method: 'GET',
+        url: `/v1/chat/completions/${encodeURIComponent(id)}`,
+      });
+      const res = makeResponse();
+
+      state.handler(req as never, res as never);
+      await waitForResponse(res, (next) => next.writableEnded);
+
+      const payload = JSON.parse(res.body);
+      expect(res.statusCode).toBe(200);
+      expect(payload).toMatchObject({
+        id,
+        object: 'chat.completion',
+        model: 'gpt-5',
+        status: item.status,
+      });
+      expect(payload.choices[0]).toEqual({
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: item.content,
+        },
+        finish_reason: item.finishReason,
+      });
+      if (item.error) {
+        expect(payload.error).toEqual(item.error);
+      } else {
+        expect(payload.error).toBeUndefined();
+      }
+      expect(res.getHeader('x-hybridclaw-session-id')).toBe(
+        'agent:main:channel:openai:chat:dm:peer:abc123',
+      );
+      expect(res.getHeader('x-hybridclaw-delegation-status')).toBe(
+        item.status,
+      );
+    }
+  });
+
+  test('returns OpenAI error shape for unknown delegation completion ids', async () => {
+    const state = await importFreshHealth();
+    state.getDelegationJob.mockReturnValueOnce(null);
+    const req = makeRequest({
+      method: 'GET',
+      url: '/v1/chat/completions/chatcmpl_missing',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({
+      error: {
+        message: 'No delegation job found for this completion id.',
+        type: 'invalid_request_error',
+        param: null,
+        code: 'not_found',
+      },
+    });
   });
 
   test('rejects OpenAI chat completions requests where n is not 1', async () => {
@@ -8755,7 +8973,7 @@ describe('gateway HTTP server', () => {
   });
 
   test('allows terminal websocket upgrades with local web-session cookie and matching origin', async () => {
-    const state = await importFreshHealth();
+    const state = await importFreshHealth({ deploymentPublicUrl: '' });
     const cookie = issueLocalWebSessionCookie(state);
     const socket = {
       write: vi.fn(),

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -251,6 +251,7 @@ function createGatewayMainTestState(options?: {
     initGatewayService: vi.fn(
       options?.initGatewayServiceImpl || (async () => {}),
     ),
+    failStaleDelegationJobs: vi.fn(() => 0),
     listAgents: vi.fn(() => []),
     stopGatewayPlugins: vi.fn(async () => {}),
     listQueuedProactiveMessages: vi.fn(() => []),
@@ -600,6 +601,7 @@ async function importFreshGatewayMain(options?: {
   vi.doMock('../src/memory/db.js', () => ({
     deleteQueuedProactiveMessage: vi.fn(),
     enqueueProactiveMessage: vi.fn(() => ({ dropped: 0, queued: 1 })),
+    failStaleDelegationJobs: state.failStaleDelegationJobs,
     getMostRecentSessionChannelId: vi.fn(
       () => state.currentMostRecentSessionChannelId,
     ),


### PR DESCRIPTION
## Summary

- Persist delegated final `forUser` answers to parent session history with artifacts.
- Add durable `delegation_jobs` storage, lifecycle transitions, pruning, and gateway restart recovery.
- Surface delegation ids on OpenAI-compatible create responses and add `GET /v1/chat/completions/{id}` retrieval for job status and final synthesized answers.
- Document the polling contract and add focused coverage for job storage, delegation lifecycle, OpenAI create/retrieve behavior, and gateway startup mocks.

## Why

Delegated OpenAI-compatible requests previously returned an acknowledgement while the synthesized final answer ran detached in the background. The answer was not durably stored in a retrievable API-facing location, so SDK clients could not reliably correlate or poll for the result.

## Validation

- `npm run lint`
- `npx vitest run --configLoader runner --project unit tests/delegation-jobs-store.test.ts tests/gateway-delegation-proactive.test.ts tests/gateway-http-server.test.ts tests/gateway-main.test.ts`
- `git diff --check`

`npm run check` exits 0; it reports unrelated existing optional-chain warnings elsewhere in the repo.