### PR TITLE
fix: keep onboarding autostart visible

### DIFF
--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -2037,6 +2037,7 @@ async function handleGatewayMessageInner(
       agentId,
       bootstrapFile: startupBootstrapFile,
       toolExecutions,
+      turnSucceeded: output.status === 'success',
     });
     if (hatchingCompletion) {
       logger.info(

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -8538,7 +8538,7 @@ function resolveBootstrapAutostartContext(params: {
   if (
     existingSession &&
     !params.allowExistingSessionMessages &&
-    (existingSession.message_count > 0 ||
+    (sessionHasUserMessages(existingSession.id) ||
       String(existingSession.session_summary || '').trim().length > 0)
   ) {
     return null;
@@ -8561,7 +8561,7 @@ function resolveBootstrapAutostartContext(params: {
   );
   if (
     !params.allowExistingSessionMessages &&
-    (session.message_count > 0 ||
+    (sessionHasUserMessages(session.id) ||
       String(session.session_summary || '').trim().length > 0)
   ) {
     return null;
@@ -9039,6 +9039,7 @@ export async function ensureGatewayBootstrapAutostart(params: {
       agentId: resolved.agentId,
       bootstrapFile,
       toolExecutions: output.toolExecutions || [],
+      turnSucceeded: output.status === 'success',
     });
     if (hatchingCompletion) {
       logger.info(
@@ -9516,7 +9517,20 @@ export async function getGatewayAgentList(): Promise<GatewayAgentListResponse> {
 
 function isProtectedNoUserChatCleanupSession(session: Session): boolean {
   const sessionKey = String(session.session_key || '').trim();
+  const agentId = String(session.agent_id || '').trim();
+  const bootstrapAutostartActive = Array.from(
+    activeBootstrapAutostartSessions,
+  ).some((lockKey) => lockKey.startsWith(`${session.id}:`));
+  const hasStoredConversation =
+    session.message_count > 0 ||
+    String(session.session_summary || '').trim().length > 0;
+  const awaitingBootstrapReply =
+    agentId.length > 0 &&
+    hasStoredConversation &&
+    resolveStartupBootstrapFile(agentId) === 'BOOTSTRAP.md';
   return (
+    bootstrapAutostartActive ||
+    awaitingBootstrapReply ||
     session.full_auto_enabled === 1 ||
     session.channel_id === 'scheduler' ||
     session.id.startsWith('scheduler:') ||

--- a/src/gateway/hatching-completion.ts
+++ b/src/gateway/hatching-completion.ts
@@ -413,6 +413,7 @@ export function recordBootstrapHatchingTurnResult(params: {
   agentId: string;
   bootstrapFile: 'BOOTSTRAP.md' | 'OPENING.md' | null;
   toolExecutions: ToolExecution[];
+  turnSucceeded: boolean;
   handledAt?: string;
 }): BootstrapHatchingTurnResult | null {
   if (params.bootstrapFile !== 'BOOTSTRAP.md') return null;
@@ -426,6 +427,14 @@ export function recordBootstrapHatchingTurnResult(params: {
     .map(readSuccessfulMessageSend)
     .find((candidate): candidate is MessageSend => Boolean(candidate));
   if (!send) {
+    if (!params.turnSucceeded) {
+      return {
+        completed: false,
+        updated: false,
+        reason: 'hatching turn failed before completion',
+        files,
+      };
+    }
     return {
       ...recordHatchingTurnWithoutMessage({
         agentId: params.agentId,

--- a/tests/gateway-service.bootstrap-autostart.test.ts
+++ b/tests/gateway-service.bootstrap-autostart.test.ts
@@ -265,6 +265,122 @@ test('ensureGatewayBootstrapAutostart stores prelude and bootstrap opener once p
   expect(getGatewayHistory(sessionId, 10).history).toHaveLength(2);
 });
 
+test('ensureGatewayBootstrapAutostart retries after a failed opener without consuming a hatching turn', async () => {
+  setupHome();
+
+  runAgentMock
+    .mockResolvedValueOnce({
+      status: 'error',
+      error: 'temporary provider failure',
+      toolsUsed: [],
+      toolExecutions: [],
+    })
+    .mockResolvedValueOnce({
+      status: 'success',
+      result: 'Recovered onboarding opener.',
+      toolsUsed: [],
+      toolExecutions: [],
+    });
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.ts');
+  const { ensureGatewayBootstrapAutostart, getGatewayHistory } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  const sessionId =
+    'agent:main:channel:web:chat:dm:peer:bootstrap-retry-after-error';
+  await ensureGatewayBootstrapAutostart({ sessionId });
+
+  expect(runAgentMock).toHaveBeenCalledTimes(1);
+  expect(getGatewayHistory(sessionId, 10).history).toEqual([
+    expect.objectContaining({
+      role: 'assistant',
+      content: DEFAULT_GATEWAY_AUXILIARY_PRELUDE,
+    }),
+  ]);
+  const statePath = path.join(
+    agentWorkspaceDir('main'),
+    '.hybridclaw',
+    'workspace-state.json',
+  );
+  expect(JSON.parse(fs.readFileSync(statePath, 'utf8'))).not.toHaveProperty(
+    'hatchingTurnsWithoutMessage',
+  );
+
+  await ensureGatewayBootstrapAutostart({ sessionId });
+
+  expect(runAgentMock).toHaveBeenCalledTimes(2);
+  expect(
+    getGatewayHistory(sessionId, 10).history.some(
+      (message) => message.content === 'Recovered onboarding opener.',
+    ),
+  ).toBe(true);
+  expect(JSON.parse(fs.readFileSync(statePath, 'utf8'))).toMatchObject({
+    hatchingTurnsWithoutMessage: 1,
+  });
+});
+
+test('cleanupGatewayNoUserChatSessions preserves bootstrap autostart before its prelude is stored', async () => {
+  setupHome();
+
+  let markAuxiliaryStarted: (() => void) | undefined;
+  const auxiliaryStarted = new Promise<void>((resolve) => {
+    markAuxiliaryStarted = resolve;
+  });
+  let resolveAuxiliary:
+    | ((value: {
+        provider: string;
+        model: string;
+        content: string;
+      }) => void)
+    | undefined;
+  callAuxiliaryModelMock.mockImplementationOnce(() => {
+    markAuxiliaryStarted?.();
+    return new Promise((resolve) => {
+      resolveAuxiliary = resolve;
+    });
+  });
+  runAgentMock.mockResolvedValue({
+    status: 'success',
+    result: 'Onboarding is ready.',
+    toolsUsed: [],
+    toolExecutions: [],
+  });
+
+  const { initDatabase, getSessionById } = await import('../src/memory/db.ts');
+  const {
+    cleanupGatewayNoUserChatSessions,
+    ensureGatewayBootstrapAutostart,
+  } = await import('../src/gateway/gateway-service.ts');
+
+  initDatabase({ quiet: true });
+
+  const sessionId =
+    'agent:main:channel:web:chat:dm:peer:bootstrap-cleanup-race';
+  const autostart = ensureGatewayBootstrapAutostart({ sessionId });
+  await auxiliaryStarted;
+
+  const cleanup = cleanupGatewayNoUserChatSessions({
+    channelId: 'web',
+    keepSessionId: 'different-session',
+  });
+
+  expect(cleanup.deletedSessionIds).not.toContain(sessionId);
+  expect(getSessionById(sessionId)).toBeTruthy();
+
+  resolveAuxiliary?.({
+    provider: 'hybridai',
+    model: 'auxiliary/test',
+    content: DEFAULT_GATEWAY_AUXILIARY_PRELUDE,
+  });
+  await autostart;
+
+  expect(runAgentMock).toHaveBeenCalledTimes(1);
+});
+
 test('ensureGatewayBootstrapAutostart records terminal hatching audit when a post-hatching hook throws', async () => {
   setupHome();
 

--- a/tests/gateway-service.chat-cleanup.test.ts
+++ b/tests/gateway-service.chat-cleanup.test.ts
@@ -6,7 +6,7 @@ const { setupHome } = setupGatewayTest({
   tempHomePrefix: 'hybridclaw-gateway-chat-cleanup-',
 });
 
-test('cleanupGatewayNoUserChatSessions deletes web sessions with no user messages', async () => {
+test('cleanupGatewayNoUserChatSessions preserves onboarding sessions awaiting a reply', async () => {
   setupHome();
 
   const { initDatabase, getOrCreateSession, getSessionById, storeMessage } =
@@ -14,8 +14,10 @@ test('cleanupGatewayNoUserChatSessions deletes web sessions with no user message
   const { cleanupGatewayNoUserChatSessions } = await import(
     '../src/gateway/gateway-service.ts'
   );
+  const { ensureBootstrapFiles } = await import('../src/workspace.ts');
 
   initDatabase({ quiet: true });
+  ensureBootstrapFiles('onboarding-agent');
 
   const keepSession = getOrCreateSession('cleanup-keep', null, 'web', 'main');
   const emptySession = getOrCreateSession('cleanup-empty', null, 'web', 'main');
@@ -26,6 +28,12 @@ test('cleanupGatewayNoUserChatSessions deletes web sessions with no user message
     'main',
   );
   const userSession = getOrCreateSession('cleanup-user', null, 'web', 'main');
+  const onboardingSession = getOrCreateSession(
+    'cleanup-onboarding',
+    null,
+    'web',
+    'onboarding-agent',
+  );
   const schedulerSession = getOrCreateSession(
     'cron:cleanup-daily',
     null,
@@ -40,6 +48,14 @@ test('cleanupGatewayNoUserChatSessions deletes web sessions with no user message
     'assistant',
     'Opening message',
     'main',
+  );
+  storeMessage(
+    onboardingSession.id,
+    'assistant',
+    null,
+    'assistant',
+    'What should I call you?',
+    'onboarding-agent',
   );
   storeMessage(userSession.id, 'web-user', 'User', 'user', 'Hello', 'main');
 
@@ -56,6 +72,7 @@ test('cleanupGatewayNoUserChatSessions deletes web sessions with no user message
   expect(getSessionById(assistantOnlySession.id)).toBeUndefined();
   expect(getSessionById(emptySession.id)).toBeUndefined();
   expect(getSessionById(keepSession.id)).toBeTruthy();
+  expect(getSessionById(onboardingSession.id)).toBeTruthy();
   expect(getSessionById(userSession.id)).toBeTruthy();
   expect(getSessionById(schedulerSession.id)).toBeTruthy();
 });

--- a/tests/gateway-service.context-references.test.ts
+++ b/tests/gateway-service.context-references.test.ts
@@ -771,6 +771,72 @@ test('handleGatewayMessage completes hatching when the agent deletes BOOTSTRAP.m
   );
 });
 
+test('handleGatewayMessage does not consume a hatching turn when the agent run fails', async () => {
+  setupHome();
+
+  runAgentMock
+    .mockResolvedValueOnce({
+      status: 'error',
+      error: 'temporary provider failure',
+      toolsUsed: [],
+      toolExecutions: [],
+    })
+    .mockResolvedValue({
+      status: 'success',
+      result: 'Still learning.',
+      toolsUsed: [],
+      toolExecutions: [],
+    });
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayMessage } = await import(
+    '../src/gateway/gateway-chat-service.ts'
+  );
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.ts');
+  const { ensureBootstrapFiles } = await import('../src/workspace.ts');
+
+  initDatabase({ quiet: true });
+  ensureBootstrapFiles('research');
+
+  const workspaceDir = agentWorkspaceDir('research');
+  const bootstrapPath = path.join(workspaceDir, 'BOOTSTRAP.md');
+  const statePath = path.join(
+    workspaceDir,
+    '.hybridclaw',
+    'workspace-state.json',
+  );
+  const sendTurn = (content: string) =>
+    handleGatewayMessage({
+      sessionId: 'session-onboarding-error-does-not-count',
+      guildId: null,
+      channelId: 'web',
+      userId: 'user-1',
+      username: 'user',
+      agentId: 'research',
+      content,
+      chatbotId: 'bot-1',
+    });
+
+  await sendTurn('Failed hatching turn.');
+
+  expect(fs.existsSync(bootstrapPath)).toBe(true);
+  expect(JSON.parse(fs.readFileSync(statePath, 'utf-8'))).not.toHaveProperty(
+    'hatchingTurnsWithoutMessage',
+  );
+
+  await sendTurn('First successful turn.');
+  await sendTurn('Second successful turn.');
+
+  expect(fs.existsSync(bootstrapPath)).toBe(true);
+  expect(JSON.parse(fs.readFileSync(statePath, 'utf-8'))).toMatchObject({
+    hatchingTurnsWithoutMessage: 2,
+  });
+
+  await sendTurn('Third successful turn.');
+
+  expect(fs.existsSync(bootstrapPath)).toBe(false);
+});
+
 test('handleGatewayMessage completes hatching after three turns without a message send', async () => {
   setupHome();
 


### PR DESCRIPTION
## Summary

- retry bootstrap autostart after an assistant-only prelude when the first model call fails
- prevent failed agent runs from consuming the three-turn hatching fallback
- preserve in-flight and reply-pending onboarding sessions during no-user chat cleanup
- add regression coverage for transient failures and cleanup races

## Root cause

Bootstrap retries were blocked by any stored message, including the quick assistant prelude. Failed model calls also advanced the no-message counter, while draft cleanup treated onboarding sessions with no user reply as disposable. Together these paths could suppress, abort, or delete onboarding before the user saw and completed it.

## Impact

Onboarding remains visible and recoverable across transient provider failures and chat cleanup, while existing user sessions, compacted sessions, and ordinary empty drafts retain their previous behavior.

## Validation

- `npx vitest run tests/gateway-service.bootstrap-autostart.test.ts tests/gateway-service.chat-cleanup.test.ts tests/gateway-service.context-references.test.ts` — 32 tests passed
- `npm run typecheck`
- `npm run lint`
- Biome check on changed source files
- `git diff --check`