### PR TITLE
fix: preserve auxiliary max token caps

### DIFF
--- a/container/src/providers/auxiliary.ts
+++ b/container/src/providers/auxiliary.ts
@@ -167,10 +167,7 @@ export async function callAuxiliaryModel(
       model: context.model,
       discoveredMaxTokens: context.maxTokens,
     });
-    const maxTokens =
-      providerMaxTokens == null
-        ? undefined
-        : (normalizeMaxTokens(params.maxTokens) ?? providerMaxTokens);
+    const maxTokens = normalizeMaxTokens(params.maxTokens) ?? providerMaxTokens;
     const response = await callRoutedModel({
       provider: context.provider,
       providerMethod: context.providerMethod,

--- a/src/providers/auxiliary.ts
+++ b/src/providers/auxiliary.ts
@@ -308,10 +308,7 @@ function buildResolvedContext(params: {
     chatbotId: params.chatbotId.trim(),
     enableRag: params.enableRag,
     requestHeaders: params.requestHeaders ? { ...params.requestHeaders } : {},
-    maxTokens:
-      providerMaxTokens == null
-        ? undefined
-        : (normalizeMaxTokens(params.maxTokens) ?? providerMaxTokens),
+    maxTokens: normalizeMaxTokens(params.maxTokens) ?? providerMaxTokens,
   };
   validateContext(params.task, context);
   return context;

--- a/tests/container.auxiliary-router.test.ts
+++ b/tests/container.auxiliary-router.test.ts
@@ -209,7 +209,7 @@ describe('container auxiliary router', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  test('omits max_tokens for non-Anthropic OpenRouter fallback text calls', async () => {
+  test('passes max_tokens for non-Anthropic OpenRouter fallback text calls', async () => {
     const fetchMock = vi.fn(
       async (input: RequestInfo | URL, init?: RequestInit) => {
         expect(input).toBe('https://openrouter.ai/api/v1/chat/completions');
@@ -217,7 +217,7 @@ describe('container auxiliary router', () => {
           string,
           unknown
         >;
-        expect(body.max_tokens).toBeUndefined();
+        expect(body.max_tokens).toBe(222);
         return new Response(
           JSON.stringify({
             id: 'resp_aux_text',

--- a/tests/providers.auxiliary.test.ts
+++ b/tests/providers.auxiliary.test.ts
@@ -192,7 +192,7 @@ test('host auxiliary caller uses the configured compression task model', async (
       expect(body).toMatchObject({
         model: 'qwen/qwen2.5-instruct',
       });
-      expect(body.max_tokens).toBeUndefined();
+      expect(body.max_tokens).toBe(321);
       return new Response(
         JSON.stringify({
           choices: [
@@ -238,7 +238,7 @@ test('host auxiliary caller uses the configured compression task model', async (
       model: 'lmstudio/qwen/qwen2.5-instruct',
       messages: 2,
       tools: 0,
-      maxTokens: undefined,
+      maxTokens: 321,
     }),
     '[aux-model] call start',
   );
@@ -283,7 +283,7 @@ test('host auxiliary caller falls back to resolved runtime credentials', async (
       expect(body).toMatchObject({
         model: 'mistral-small',
       });
-      expect(body.max_tokens).toBeUndefined();
+      expect(body.max_tokens).toBe(222);
       return new Response(
         JSON.stringify({
           choices: [


### PR DESCRIPTION
## Summary

- preserve explicit auxiliary-model `maxTokens` caps for non-Anthropic providers in both host and container routing
- retain provider-derived token limits as the fallback when callers do not provide a cap
- update host and container tests to cover non-Anthropic token propagation

## Root cause

The existing ternary returned `undefined` whenever `resolveProviderRequestMaxTokens` did not produce a provider-specific limit. For non-Claude models that discarded explicit caller caps, making memory consolidation, compaction summarization, and `auxiliaryModels.*.maxTokens` limits ineffective.

## Impact

Explicit token caps are now forwarded to every supported auxiliary text provider while Anthropic-specific discovered limits remain the fallback.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm --prefix container run lint`
- `./node_modules/.bin/vitest run tests/providers.auxiliary.test.ts tests/container.auxiliary-task-tools.test.ts tests/container.auxiliary-router.test.ts` (38 tests passed)
- `npm run format`
- `git diff --check`