### PR TITLE
fix: enforce chunk delivery limits

### DIFF
--- a/src/channels/discord-webhook/delivery.ts
+++ b/src/channels/discord-webhook/delivery.ts
@@ -8,6 +8,7 @@ import {
 } from './target.js';
 
 const DISCORD_WEBHOOK_CONTENT_LIMIT = 2_000;
+const DISCORD_WEBHOOK_CHUNK_MARGIN = 100;
 const DISCORD_WEBHOOK_RETRY_MAX_ATTEMPTS = 5;
 const DISCORD_WEBHOOK_RETRY_BASE_DELAY_MS = 500;
 const DISCORD_WEBHOOK_RETRY_MAX_DELAY_MS = 10_000;
@@ -83,7 +84,7 @@ function normalizeWebhookText(text: string): string {
 
 export function prepareDiscordWebhookTextChunks(text: string): string[] {
   const chunks = chunkMessage(normalizeWebhookText(text), {
-    maxChars: DISCORD_WEBHOOK_CONTENT_LIMIT,
+    maxChars: DISCORD_WEBHOOK_CONTENT_LIMIT - DISCORD_WEBHOOK_CHUNK_MARGIN,
     maxLines: 100,
   })
     .map((entry) => entry.trim())

--- a/src/channels/discord/delivery.ts
+++ b/src/channels/discord/delivery.ts
@@ -13,6 +13,7 @@ import type { MemoryCitation } from '../../types/memory.js';
 import { sleep } from '../../utils/sleep.js';
 import { getHumanDelayMs, type HumanDelayConfig } from './human-delay.js';
 import { type MentionLookup, rewriteUserMentions } from './mentions.js';
+import { logDiscordApiError } from './transport-errors.js';
 
 export { formatError, formatInfo } from '../../utils/text-format.js';
 
@@ -30,6 +31,8 @@ type ChunkedPayload = {
   files?: AttachmentBuilder[];
   components?: DiscordMessageComponents;
 };
+
+const DISCORD_CONTENT_LIMIT_WITH_MARGIN = 1_900;
 
 export function buildResponseText(
   text: string,
@@ -61,7 +64,10 @@ export function prepareChunkedPayloads(
     ? rewriteUserMentions(text, mentionLookup)
     : text;
   const chunks = chunkMessage(prepared, {
-    maxChars: Math.max(200, Math.min(2_000, DISCORD_TEXT_CHUNK_LIMIT)),
+    maxChars: Math.max(
+      200,
+      Math.min(DISCORD_CONTENT_LIMIT_WITH_MARGIN, DISCORD_TEXT_CHUNK_LIMIT),
+    ),
     maxLines: Math.max(4, Math.min(200, DISCORD_MAX_LINES_PER_MESSAGE)),
   }).filter((chunk) => chunk.trim().length > 0);
   const safeChunks = chunks.length > 0 ? chunks : ['(no content)'];
@@ -87,24 +93,47 @@ export async function sendChunkedReply(params: {
     params.components,
     params.mentionLookup,
   );
+  const channel = params.msg.channel as unknown as {
+    send: (next: {
+      content: string;
+      files?: AttachmentBuilder[];
+    }) => Promise<void>;
+  };
   for (let i = 0; i < payloads.length; i += 1) {
-    if (i === 0) {
-      await params.withRetry('reply', () => params.msg.reply(payloads[i]));
-    } else {
+    const payload = payloads[i];
+    if (i > 0) {
       const delayMs = getHumanDelayMs(params.humanDelay);
-      if (delayMs > 0) {
-        await sleep(delayMs);
+      if (delayMs > 0) await sleep(delayMs);
+    }
+
+    try {
+      if (i === 0) {
+        await params.withRetry('reply', () => params.msg.reply(payload));
+      } else {
+        await params.withRetry('send', () => channel.send(payload));
       }
-      await params.withRetry('send', () =>
-        (
-          params.msg.channel as unknown as {
-            send: (next: {
-              content: string;
-              files?: AttachmentBuilder[];
-            }) => Promise<void>;
-          }
-        ).send(payloads[i]),
-      );
+    } catch (error) {
+      logDiscordApiError({
+        error,
+        expectedAction: 'The remaining response chunks will still be sent.',
+        unexpectedMessage: 'Failed to send Discord response chunk',
+        metadata: { chunkIndex: i + 1, chunkCount: payloads.length },
+      });
+
+      if (payload.files?.length) {
+        try {
+          await params.withRetry('send-attachments', () =>
+            channel.send({ content: 'Attached files:', files: payload.files }),
+          );
+        } catch (attachmentError) {
+          logDiscordApiError({
+            error: attachmentError,
+            expectedAction: 'The response attachments were not delivered.',
+            unexpectedMessage: 'Failed to send Discord response attachments',
+            metadata: { chunkIndex: i + 1, chunkCount: payloads.length },
+          });
+        }
+      }
     }
   }
 }

--- a/src/channels/discord/stream.ts
+++ b/src/channels/discord/stream.ts
@@ -35,6 +35,7 @@ export interface DiscordStreamOptions {
 
 const DEFAULT_EDIT_INTERVAL_MS = 1_200;
 const DISCORD_STREAM_RETRY_LOG_MESSAGE = 'Discord request failed; retrying';
+const DISCORD_CONTENT_LIMIT_WITH_MARGIN = 1_900;
 
 function isRenderableChunk(chunk: string): boolean {
   return chunk.trim().length > 0;
@@ -49,8 +50,8 @@ export class DiscordStreamManager {
   private readonly onFirstMessage?: () => void;
   private readonly humanDelay?: HumanDelayConfig;
 
-  private readonly messages: DiscordEditMessage[] = [];
-  private sentChunks: string[] = [];
+  private readonly messages: Array<DiscordEditMessage | undefined> = [];
+  private sentChunks: Array<string | undefined> = [];
   private content = '';
   private lastEditAt = 0;
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -62,7 +63,10 @@ export class DiscordStreamManager {
     this.channel = sourceMessage.channel as unknown as DiscordSendChannel;
     this.maxChars = Math.max(
       200,
-      Math.min(2_000, options?.maxChars ?? DISCORD_TEXT_CHUNK_LIMIT),
+      Math.min(
+        DISCORD_CONTENT_LIMIT_WITH_MARGIN,
+        options?.maxChars ?? DISCORD_TEXT_CHUNK_LIMIT,
+      ),
     );
     this.maxLines = Math.max(
       4,
@@ -77,7 +81,7 @@ export class DiscordStreamManager {
   }
 
   hasSentMessages(): boolean {
-    return this.messages.length > 0;
+    return this.messages.some(Boolean);
   }
 
   append(delta: string): Promise<void> {
@@ -123,6 +127,7 @@ export class DiscordStreamManager {
     this.closed = true;
     return this.enqueue(async () => {
       for (const message of this.messages) {
+        if (!message) continue;
         try {
           await withDiscordRetry('delete', () => message.delete(), {
             logMessage: DISCORD_STREAM_RETRY_LOG_MESSAGE,
@@ -173,15 +178,7 @@ export class DiscordStreamManager {
 
     if (chunks.length === 0) {
       if (files && files.length > 0) {
-        const fallback = 'Attached files:';
-        const sent = await withDiscordRetry(
-          'reply',
-          () => this.sourceMessage.reply({ content: fallback, files }),
-          { logMessage: DISCORD_STREAM_RETRY_LOG_MESSAGE },
-        );
-        this.messages.push(sent as unknown as DiscordEditMessage);
-        this.sentChunks.push(fallback);
-        this.onFirstMessage?.();
+        await this.sendAttachmentFallback(files);
       }
       return;
     }
@@ -190,28 +187,33 @@ export class DiscordStreamManager {
       const chunk = chunks[i];
       const isLast = i === chunks.length - 1;
 
-      if (i >= this.messages.length) {
+      const message = this.messages[i];
+      if (!message) {
         if (i > 0) {
           const delayMs = getHumanDelayMs(this.humanDelay);
           if (delayMs > 0) {
             await sleep(delayMs);
           }
         }
-        const sent =
-          i === 0
-            ? await withDiscordRetry(
-                'reply',
-                () => this.sourceMessage.reply({ content: chunk }),
-                { logMessage: DISCORD_STREAM_RETRY_LOG_MESSAGE },
-              )
-            : await withDiscordRetry(
-                'send',
-                () => this.channel.send({ content: chunk }),
-                { logMessage: DISCORD_STREAM_RETRY_LOG_MESSAGE },
-              );
-        this.messages.push(sent as unknown as DiscordEditMessage);
-        this.sentChunks.push(chunk);
-        this.onFirstMessage?.();
+        try {
+          const sent =
+            i === 0
+              ? await withDiscordRetry(
+                  'reply',
+                  () => this.sourceMessage.reply({ content: chunk }),
+                  { logMessage: DISCORD_STREAM_RETRY_LOG_MESSAGE },
+                )
+              : await withDiscordRetry(
+                  'send',
+                  () => this.channel.send({ content: chunk }),
+                  { logMessage: DISCORD_STREAM_RETRY_LOG_MESSAGE },
+                );
+          this.messages[i] = sent as unknown as DiscordEditMessage;
+          this.sentChunks[i] = chunk;
+          this.onFirstMessage?.();
+        } catch (error) {
+          this.logChunkFailure(error, 'send', i, chunks.length);
+        }
         continue;
       }
 
@@ -223,20 +225,28 @@ export class DiscordStreamManager {
         continue;
       }
 
-      await withDiscordRetry(
-        'edit',
-        () => this.messages[i].edit({ content: chunk }),
-        { logMessage: DISCORD_STREAM_RETRY_LOG_MESSAGE },
-      );
-      this.sentChunks[i] = chunk;
-      this.lastEditAt = Date.now();
+      try {
+        await withDiscordRetry('edit', () => message.edit({ content: chunk }), {
+          logMessage: DISCORD_STREAM_RETRY_LOG_MESSAGE,
+        });
+        this.sentChunks[i] = chunk;
+        this.lastEditAt = Date.now();
+      } catch (error) {
+        this.logChunkFailure(error, 'edit', i, chunks.length);
+      }
     }
 
     if (this.messages.length > chunks.length) {
       for (let i = this.messages.length - 1; i >= chunks.length; i -= 1) {
-        await withDiscordRetry('delete', () => this.messages[i].delete(), {
-          logMessage: DISCORD_STREAM_RETRY_LOG_MESSAGE,
-        });
+        const message = this.messages[i];
+        if (!message) continue;
+        try {
+          await withDiscordRetry('delete', () => message.delete(), {
+            logMessage: DISCORD_STREAM_RETRY_LOG_MESSAGE,
+          });
+        } catch (error) {
+          this.logChunkFailure(error, 'delete', i, this.messages.length);
+        }
       }
       this.messages.splice(chunks.length);
       this.sentChunks = this.sentChunks.slice(0, chunks.length);
@@ -244,14 +254,64 @@ export class DiscordStreamManager {
 
     if (files && files.length > 0) {
       const lastIndex = chunks.length - 1;
-      await withDiscordRetry(
-        'edit',
-        () =>
-          this.messages[lastIndex].edit({ content: chunks[lastIndex], files }),
-        { logMessage: DISCORD_STREAM_RETRY_LOG_MESSAGE },
-      );
-      this.sentChunks[lastIndex] = chunks[lastIndex];
-      this.lastEditAt = Date.now();
+      const lastMessage = this.messages[lastIndex];
+      if (lastMessage) {
+        try {
+          await withDiscordRetry(
+            'edit',
+            () => lastMessage.edit({ content: chunks[lastIndex], files }),
+            { logMessage: DISCORD_STREAM_RETRY_LOG_MESSAGE },
+          );
+          this.sentChunks[lastIndex] = chunks[lastIndex];
+          this.lastEditAt = Date.now();
+          return;
+        } catch (error) {
+          this.logChunkFailure(error, 'attach files', lastIndex, chunks.length);
+        }
+      }
+      await this.sendAttachmentFallback(files);
+    }
+  }
+
+  private logChunkFailure(
+    error: unknown,
+    operation: string,
+    index: number,
+    chunkCount: number,
+  ): void {
+    logDiscordApiError({
+      error,
+      expectedAction: 'The remaining response chunks will still be processed.',
+      unexpectedMessage: `Failed to ${operation} Discord stream chunk`,
+      metadata: { chunkIndex: index + 1, chunkCount },
+    });
+  }
+
+  private async sendAttachmentFallback(
+    files: AttachmentBuilder[],
+  ): Promise<void> {
+    const fallback = 'Attached files:';
+    try {
+      const sent = this.hasSentMessages()
+        ? await withDiscordRetry(
+            'send',
+            () => this.channel.send({ content: fallback, files }),
+            { logMessage: DISCORD_STREAM_RETRY_LOG_MESSAGE },
+          )
+        : await withDiscordRetry(
+            'reply',
+            () => this.sourceMessage.reply({ content: fallback, files }),
+            { logMessage: DISCORD_STREAM_RETRY_LOG_MESSAGE },
+          );
+      this.messages.push(sent as unknown as DiscordEditMessage);
+      this.sentChunks.push(fallback);
+      this.onFirstMessage?.();
+    } catch (error) {
+      logDiscordApiError({
+        error,
+        expectedAction: 'The response attachments were not delivered.',
+        unexpectedMessage: 'Failed to send Discord stream attachments',
+      });
     }
   }
 }

--- a/src/channels/slack-webhook/delivery.ts
+++ b/src/channels/slack-webhook/delivery.ts
@@ -8,6 +8,7 @@ import {
 } from './target.js';
 
 const SLACK_WEBHOOK_BLOCK_TEXT_LIMIT = 3_000;
+const SLACK_WEBHOOK_CHUNK_MARGIN = 100;
 const SLACK_WEBHOOK_RETRY_MAX_ATTEMPTS = 5;
 const SLACK_WEBHOOK_RETRY_BASE_DELAY_MS = 500;
 const SLACK_WEBHOOK_RETRY_MAX_DELAY_MS = 10_000;
@@ -82,7 +83,7 @@ function normalizeWebhookText(text: string): string {
 
 export function prepareSlackWebhookTextBlocks(text: string): string[] {
   return chunkSlackText(normalizeWebhookText(text), {
-    maxChars: SLACK_WEBHOOK_BLOCK_TEXT_LIMIT,
+    maxChars: SLACK_WEBHOOK_BLOCK_TEXT_LIMIT - SLACK_WEBHOOK_CHUNK_MARGIN,
     maxLines: 100,
   });
 }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -288,7 +288,7 @@ export let DISCORD_GROUP_POLICY: RuntimeConfig['discord']['groupPolicy'] =
 export let DISCORD_SEND_POLICY: RuntimeConfig['discord']['sendPolicy'] = 'open';
 export let DISCORD_SEND_ALLOWED_CHANNEL_IDS: string[] = [];
 export let DISCORD_FREE_RESPONSE_CHANNELS: string[] = [];
-export let DISCORD_TEXT_CHUNK_LIMIT = 2_000;
+export let DISCORD_TEXT_CHUNK_LIMIT = 1_900;
 export let DISCORD_MAX_LINES_PER_MESSAGE = 17;
 export let DISCORD_HUMAN_DELAY: RuntimeConfig['discord']['humanDelay'] = {
   mode: 'natural',
@@ -834,7 +834,7 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
   DISCORD_FREE_RESPONSE_CHANNELS = [...config.discord.freeResponseChannels];
   DISCORD_TEXT_CHUNK_LIMIT = Math.max(
     200,
-    Math.min(2_000, config.discord.textChunkLimit),
+    Math.min(1_900, config.discord.textChunkLimit),
   );
   DISCORD_MAX_LINES_PER_MESSAGE = Math.max(
     4,

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -1555,7 +1555,7 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
     sendPolicy: 'open',
     sendAllowedChannelIds: [],
     freeResponseChannels: [],
-    textChunkLimit: 2_000,
+    textChunkLimit: 1_900,
     maxLinesPerMessage: 17,
     humanDelay: {
       mode: 'natural',

--- a/src/memory/chunk.ts
+++ b/src/memory/chunk.ts
@@ -1,3 +1,8 @@
+import {
+  sliceHeadAtCodePointBoundary,
+  sliceTailAtCodePointBoundary,
+} from '../session/token-efficiency.js';
+
 export interface ChunkMessageOptions {
   maxChars?: number;
   maxLines?: number;
@@ -5,6 +10,7 @@ export interface ChunkMessageOptions {
 
 const DEFAULT_MAX_CHARS = 1_900;
 const DEFAULT_MAX_LINES = 20;
+const FENCE_CLOSE_SUFFIX = '\n```';
 
 function isFenceLine(line: string): boolean {
   return line.trim().startsWith('```');
@@ -63,16 +69,23 @@ function splitLongLine(line: string, maxChars: number): string[] {
       splitAt = Math.min(maxChars, remaining.length);
     }
 
-    const head = remaining.slice(0, splitAt).trimEnd();
+    const safeSlice = sliceHeadAtCodePointBoundary(remaining, splitAt);
+    const head = safeSlice.trimEnd();
     if (!head) {
-      const fallback = remaining.slice(0, maxChars);
+      const fallback = sliceHeadAtCodePointBoundary(remaining, maxChars);
       pieces.push(fallback);
-      remaining = remaining.slice(maxChars);
+      remaining = sliceTailAtCodePointBoundary(
+        remaining,
+        remaining.length - fallback.length,
+      );
       continue;
     }
 
     pieces.push(head);
-    remaining = remaining.slice(splitAt).trimStart();
+    remaining = sliceTailAtCodePointBoundary(
+      remaining,
+      remaining.length - safeSlice.length,
+    ).trimStart();
   }
 
   if (remaining.length > 0) {
@@ -99,17 +112,24 @@ export function chunkMessage(
   let openFence = false;
   let fenceLanguage = '';
 
+  const getReopenedFence = (): string => {
+    const candidate = fenceLanguage ? `\`\`\`${fenceLanguage}` : '```';
+    return candidate.length + FENCE_CLOSE_SUFFIX.length < maxChars
+      ? candidate
+      : '```';
+  };
+
   const flush = (isFinal: boolean): void => {
     if (currentLines.length === 0) return;
 
     let chunk = currentLines.join('\n');
     if (openFence) {
-      chunk += '\n```';
+      chunk += FENCE_CLOSE_SUFFIX;
     }
     chunks.push(chunk);
 
     if (!isFinal && openFence) {
-      const reopenedFence = fenceLanguage ? `\`\`\`${fenceLanguage}` : '```';
+      const reopenedFence = getReopenedFence();
       currentLines = [reopenedFence];
       currentChars = reopenedFence.length;
     } else {
@@ -127,9 +147,12 @@ export function chunkMessage(
       currentLines.length === 0 ? line.length : line.length + 1;
     const nextChars = currentChars + addedChars;
     const nextLines = currentLines.length + 1;
+    const nextFenceOpen = isFenceLine(line) ? !openFence : openFence;
+    const charBudget =
+      maxChars - (nextFenceOpen ? FENCE_CLOSE_SUFFIX.length : 0);
     if (
       currentLines.length > 0 &&
-      (nextChars > maxChars || nextLines > maxLines)
+      (nextChars > charBudget || nextLines > maxLines)
     ) {
       flush(false);
     }
@@ -150,9 +173,22 @@ export function chunkMessage(
   };
 
   for (const rawLine of inputLines) {
-    const splitLines = splitLongLine(rawLine, maxChars);
-    for (const part of splitLines) {
+    const pendingLines = [rawLine];
+    while (pendingLines.length > 0) {
+      const line = pendingLines.shift() ?? '';
+      const fenceLine = isFenceLine(line);
+      const reopenedFenceChars = openFence ? getReopenedFence().length + 1 : 0;
+      const closingFenceChars =
+        openFence && fenceLine ? 0 : FENCE_CLOSE_SUFFIX.length;
+      const lineBudget = Math.max(
+        2,
+        maxChars -
+          reopenedFenceChars -
+          (openFence || fenceLine ? closingFenceChars : 0),
+      );
+      const [part, ...remainingParts] = splitLongLine(line, lineBudget);
       appendLine(part);
+      pendingLines.unshift(...remainingParts);
     }
   }
 

--- a/src/session/token-efficiency.ts
+++ b/src/session/token-efficiency.ts
@@ -19,7 +19,10 @@ function isLowSurrogate(code: number): boolean {
   return code >= 0xdc00 && code <= 0xdfff;
 }
 
-function sliceHeadAtCodePointBoundary(text: string, maxChars: number): string {
+export function sliceHeadAtCodePointBoundary(
+  text: string,
+  maxChars: number,
+): string {
   let end = Math.max(0, Math.min(Math.floor(maxChars), text.length));
   if (
     end > 0 &&
@@ -32,7 +35,10 @@ function sliceHeadAtCodePointBoundary(text: string, maxChars: number): string {
   return text.slice(0, end);
 }
 
-function sliceTailAtCodePointBoundary(text: string, maxChars: number): string {
+export function sliceTailAtCodePointBoundary(
+  text: string,
+  maxChars: number,
+): string {
   let start = Math.max(0, text.length - Math.max(0, Math.floor(maxChars)));
   if (
     start > 0 &&

--- a/tests/discord-delivery.test.ts
+++ b/tests/discord-delivery.test.ts
@@ -9,6 +9,7 @@ async function importFreshDelivery() {
   );
   const getHumanDelayMs = vi.fn(() => 0);
   const sleep = vi.fn(async () => {});
+  const logDiscordApiError = vi.fn();
 
   vi.doMock('../src/config/config.ts', () => ({
     DISCORD_MAX_LINES_PER_MESSAGE: 20,
@@ -26,6 +27,9 @@ async function importFreshDelivery() {
   vi.doMock('../src/channels/discord/mentions.js', () => ({
     rewriteUserMentions,
   }));
+  vi.doMock('../src/channels/discord/transport-errors.js', () => ({
+    logDiscordApiError,
+  }));
 
   const delivery = await import('../src/channels/discord/delivery.js');
   return {
@@ -34,6 +38,7 @@ async function importFreshDelivery() {
     rewriteUserMentions,
     getHumanDelayMs,
     sleep,
+    logDiscordApiError,
   };
 }
 
@@ -44,6 +49,7 @@ afterEach(() => {
   vi.doUnmock('../src/channels/discord/human-delay.js');
   vi.doUnmock('../src/utils/sleep.js');
   vi.doUnmock('../src/channels/discord/mentions.js');
+  vi.doUnmock('../src/channels/discord/transport-errors.js');
   vi.resetModules();
 });
 
@@ -99,6 +105,10 @@ describe('discord delivery', () => {
       { content: 'chunk-1', components },
       { content: 'chunk-2', files },
     ]);
+    expect(chunkMessage).toHaveBeenCalledWith(
+      'rewritten:@alice hello',
+      expect.objectContaining({ maxChars: 1_900 }),
+    );
   });
 
   test('falls back to a no-content payload when chunking yields nothing', async () => {
@@ -159,6 +169,67 @@ describe('discord delivery', () => {
     });
     expect(send).toHaveBeenCalledWith({ content: 'second chunk' });
     expect(sleep).toHaveBeenCalledWith(25);
+  });
+
+  test('continues after a failed chunk so later chunks and attachments are delivered', async () => {
+    const { delivery, chunkMessage, logDiscordApiError } =
+      await importFreshDelivery();
+    chunkMessage.mockReturnValue(['bad chunk', 'middle chunk', 'final chunk']);
+    const files = [{ name: 'report.txt' }] as unknown as [];
+
+    const reply = vi.fn(async () => {
+      throw new Error('bad chunk');
+    });
+    const send = vi.fn(async () => {});
+    const withRetry = async <T>(_label: string, fn: () => Promise<T>) => fn();
+
+    await delivery.sendChunkedReply({
+      msg: { reply, channel: { send } } as never,
+      text: 'ignored',
+      files,
+      withRetry,
+    });
+
+    expect(send).toHaveBeenNthCalledWith(1, { content: 'middle chunk' });
+    expect(send).toHaveBeenNthCalledWith(2, {
+      content: 'final chunk',
+      files,
+    });
+    expect(logDiscordApiError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        unexpectedMessage: 'Failed to send Discord response chunk',
+        metadata: { chunkIndex: 1, chunkCount: 3 },
+      }),
+    );
+  });
+
+  test('retries attachments separately when their final text chunk fails', async () => {
+    const { delivery, chunkMessage } = await importFreshDelivery();
+    chunkMessage.mockReturnValue(['first chunk', 'bad final chunk']);
+    const files = [{ name: 'report.txt' }] as unknown as [];
+
+    const reply = vi.fn(async () => {});
+    const send = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('bad final chunk'))
+      .mockResolvedValueOnce(undefined);
+    const withRetry = async <T>(_label: string, fn: () => Promise<T>) => fn();
+
+    await delivery.sendChunkedReply({
+      msg: { reply, channel: { send } } as never,
+      text: 'ignored',
+      files,
+      withRetry,
+    });
+
+    expect(send).toHaveBeenNthCalledWith(1, {
+      content: 'bad final chunk',
+      files,
+    });
+    expect(send).toHaveBeenNthCalledWith(2, {
+      content: 'Attached files:',
+      files,
+    });
   });
 
   test('sends chunked direct replies through DM open then DM sends', async () => {

--- a/tests/discord-stream.test.ts
+++ b/tests/discord-stream.test.ts
@@ -6,6 +6,7 @@ async function importFreshStream() {
   const chunkMessage = vi.fn<(text: string) => string[]>();
   const getHumanDelayMs = vi.fn(() => 0);
   const sleep = vi.fn(async () => {});
+  const logDiscordApiError = vi.fn();
   const logger = {
     warn: vi.fn(),
     debug: vi.fn(),
@@ -27,9 +28,19 @@ async function importFreshStream() {
   vi.doMock('../src/logger.ts', () => ({
     logger,
   }));
+  vi.doMock('../src/channels/discord/transport-errors.js', () => ({
+    logDiscordApiError,
+  }));
 
   const stream = await import('../src/channels/discord/stream.js');
-  return { stream, chunkMessage, getHumanDelayMs, sleep, logger };
+  return {
+    stream,
+    chunkMessage,
+    getHumanDelayMs,
+    sleep,
+    logger,
+    logDiscordApiError,
+  };
 }
 
 function makeSentMessage() {
@@ -46,6 +57,7 @@ afterEach(() => {
   vi.doUnmock('../src/channels/discord/human-delay.js');
   vi.doUnmock('../src/utils/sleep.js');
   vi.doUnmock('../src/logger.ts');
+  vi.doUnmock('../src/channels/discord/transport-errors.js');
   vi.resetModules();
 });
 
@@ -65,5 +77,40 @@ describe('DiscordStreamManager', () => {
 
     expect(reply).toHaveBeenCalledWith({ content: 'visible chunk' });
     expect(send).not.toHaveBeenCalled();
+    expect(chunkMessage).toHaveBeenCalledWith('ignored', {
+      maxChars: 1_900,
+      maxLines: 20,
+    });
+  });
+
+  test('continues streaming after one chunk fails and still attaches files', async () => {
+    const { stream, chunkMessage, logDiscordApiError } =
+      await importFreshStream();
+    chunkMessage.mockReturnValue(['bad chunk', 'final chunk']);
+    const files = [{ name: 'report.txt' }] as unknown as [];
+    const sentMessage = makeSentMessage();
+
+    const reply = vi.fn(async () => {
+      throw new Error('bad chunk');
+    });
+    const send = vi.fn(async () => sentMessage);
+    const manager = new stream.DiscordStreamManager({
+      reply,
+      channel: { send },
+    } as never);
+
+    await manager.finalize('ignored', files);
+
+    expect(send).toHaveBeenCalledWith({ content: 'final chunk' });
+    expect(sentMessage.edit).toHaveBeenCalledWith({
+      content: 'final chunk',
+      files,
+    });
+    expect(logDiscordApiError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        unexpectedMessage: 'Failed to send Discord stream chunk',
+        metadata: { chunkIndex: 1, chunkCount: 2 },
+      }),
+    );
   });
 });

--- a/tests/discord-webhook.test.ts
+++ b/tests/discord-webhook.test.ts
@@ -82,7 +82,7 @@ describe('Discord webhook channel', () => {
     }
   });
 
-  test('builds Discord webhook content chunks no longer than 2000 chars', async () => {
+  test('keeps Discord webhook chunks below the hard content limit', async () => {
     const { delivery } = await importFreshDiscordWebhook();
     const payloads = delivery.buildDiscordWebhookPayloads('a'.repeat(4_500), {
       defaultUsername: 'HybridClaw',
@@ -90,7 +90,7 @@ describe('Discord webhook channel', () => {
     });
 
     expect(payloads.length).toBeGreaterThan(1);
-    expect(payloads.every((payload) => payload.content.length <= 2_000)).toBe(
+    expect(payloads.every((payload) => payload.content.length <= 1_900)).toBe(
       true,
     );
     expect(payloads[0]).toMatchObject({

--- a/tests/local-cli.test.ts
+++ b/tests/local-cli.test.ts
@@ -1221,7 +1221,7 @@ test('channels whatsapp setup preserves an existing custom ack reaction', async 
           sendPolicy: 'open',
           sendAllowedChannelIds: [],
           freeResponseChannels: [],
-          textChunkLimit: 2000,
+          textChunkLimit: 1900,
           maxLinesPerMessage: 17,
           humanDelay: { mode: 'natural', minMs: 800, maxMs: 2500 },
           typingMode: 'thinking',

--- a/tests/memory-chunk.test.ts
+++ b/tests/memory-chunk.test.ts
@@ -54,6 +54,22 @@ describe('chunkMessage', () => {
     expect(chunks[1]).toContain('tail');
   });
 
+  test('does not split UTF-16 surrogate pairs at hard character boundaries', () => {
+    const text = `${'x'.repeat(199)}😀tail`;
+
+    const chunks = chunkMessage(text, { maxChars: 200 });
+
+    expect(chunks.join('')).toBe(text);
+    expect(
+      chunks.every((chunk) => {
+        const first = chunk.charCodeAt(0);
+        const last = chunk.charCodeAt(chunk.length - 1);
+        return !(first >= 0xdc00 && first <= 0xdfff) &&
+          !(last >= 0xd800 && last <= 0xdbff);
+      }),
+    ).toBe(true);
+  });
+
   test('splits on maxLines boundaries', () => {
     const text = Array.from(
       { length: 9 },
@@ -85,5 +101,20 @@ describe('chunkMessage', () => {
       '```ts\nconst a = 1;\nconst b = 2;\nconst c = 3;\n```',
       '```ts\nconst d = 4;\n```',
     ]);
+  });
+
+  test('reserves closing-fence headroom within the character limit', () => {
+    const chunks = chunkMessage(`\`\`\`ts\n${'x'.repeat(194)}`, {
+      maxChars: 200,
+    });
+    const longFenceChunks = chunkMessage(`\`\`\`${'x'.repeat(450)}`, {
+      maxChars: 200,
+    });
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toHaveLength(200);
+    expect(chunks.every((chunk) => chunk.length <= 200)).toBe(true);
+    expect(chunks.every((chunk) => chunk.endsWith('\n```'))).toBe(true);
+    expect(longFenceChunks.every((chunk) => chunk.length <= 200)).toBe(true);
   });
 });

--- a/tests/slack-webhook.test.ts
+++ b/tests/slack-webhook.test.ts
@@ -71,7 +71,7 @@ describe('Slack webhook channel', () => {
     }
   });
 
-  test('builds Block Kit section chunks no longer than 3000 chars', async () => {
+  test('keeps Block Kit section chunks below the hard text limit', async () => {
     const { delivery } = await importFreshSlackWebhook();
     const payload = delivery.buildSlackWebhookPayload('a'.repeat(6_500), {
       defaultUsername: 'HybridClaw',
@@ -83,7 +83,7 @@ describe('Slack webhook channel', () => {
     expect(payload.icon_emoji).toBe(':robot_face:');
     expect(payload.blocks.length).toBeGreaterThan(1);
     expect(
-      payload.blocks.every((block) => block.text.text.length <= 3_000),
+      payload.blocks.every((block) => block.text.text.length <= 2_900),
     ).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

- make `chunkMessage` reserve closing-fence headroom within `maxChars`
- reuse surrogate-safe slicing at hard split boundaries
- keep Discord and webhook chunks below platform hard limits
- isolate Discord chunk failures so later chunks and attachments are still delivered
- add boundary and delivery regression coverage

## Root cause

The shared chunker checked content length before appending a four-character closing fence, so fenced chunks could exceed `maxChars`. Discord and webhook callers also passed exact platform limits, leaving no transport margin. A rejected Discord chunk aborted the delivery loop, which dropped all later chunks and final attachments; streaming similarly stopped processing after a failed operation.

## Impact

Fenced responses remain within platform limits, UTF-16 surrogate pairs stay intact at seams, and a single rejected Discord chunk no longer prevents subsequent response content or attachments from being delivered.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run check` (passes with existing warnings)
- targeted Vitest suite: 85 tests passed
- broad unit suite: 5,261 tests passed; six unrelated host-runner/plugin tests failed because container runtime assets were unavailable and one singleton test timed out