### PR TITLE
fix: prevent duplicate channel turn dispatch

### DIFF
--- a/src/channels/discord/inbound.ts
+++ b/src/channels/discord/inbound.ts
@@ -82,6 +82,13 @@ export function cleanIncomingContent(
   return normalizeNativeAgentAddressingText(text);
 }
 
+export function hasDiscordMessageContentChanged(
+  oldContent: string | null | undefined,
+  newContent: string | null | undefined,
+): boolean {
+  return oldContent !== newContent;
+}
+
 export function hasPrefixInvocation(
   content: string,
   botMentionRegex: RegExp | null,

--- a/src/channels/discord/runtime.ts
+++ b/src/channels/discord/runtime.ts
@@ -81,6 +81,7 @@ import {
   buildSessionIdFromContext as buildSessionIdFromContextInbound,
   cleanIncomingContent as cleanIncomingContentInbound,
   type DiscordGuildMessageMode,
+  hasDiscordMessageContentChanged,
   hasLooseBotMention as hasLooseBotMentionInbound,
   hasPrefixInvocation as hasPrefixInvocationInbound,
   hasSlashCommandInvocation as hasSlashCommandInvocationInbound,
@@ -2572,13 +2573,16 @@ export async function initDiscord(
     await queueConversationMessage(msg, content, behavior);
   });
 
-  client.on('messageUpdate', async (_oldMsg, nextMsg) => {
+  client.on('messageUpdate', async (oldMsg, nextMsg) => {
     if (DISCORD_COMMANDS_ONLY) return;
     const fetched = nextMsg.partial
       ? await nextMsg.fetch().catch(() => null)
       : nextMsg;
     if (!fetched) return;
     if (fetched.author?.bot) return;
+    if (!hasDiscordMessageContentChanged(oldMsg.content, fetched.content)) {
+      return;
+    }
 
     const updatedContent = cleanIncomingContent(fetched.content || '');
     const behavior = resolveChannelBehavior(fetched);

--- a/src/channels/slack/runtime.ts
+++ b/src/channels/slack/runtime.ts
@@ -50,6 +50,7 @@ import {
 const MAX_SEEN_EVENTS = 2_000;
 const MAX_ACTIVE_SLACK_SESSIONS = 2_000;
 const MAX_USER_DISPLAY_NAMES = 2_000;
+const SLACK_EVENT_MERGE_DELAY_MS = 25;
 const SLACK_STATUS_INDICATOR_DELAY_MS = 750;
 
 export type SlackReplyFn = (content: string) => Promise<void>;
@@ -153,6 +154,10 @@ let botUserId = '';
 const activeSlackSessions = new Map<string, ActiveSlackSession>();
 const activeThreadKeys = new Set<string>();
 const seenEventKeys = new Map<string, number>();
+const pendingEventsByKey = new Map<
+  string,
+  { event: SlackMessageEvent; processing: Promise<void> }
+>();
 const userDisplayNameCache = new Map<string, string>();
 
 function rememberSeenEvent(key: string): boolean {
@@ -170,6 +175,31 @@ function rememberSeenEvent(key: string): boolean {
     }
   }
   return false;
+}
+
+function mergeSlackEvents(
+  current: SlackMessageEvent,
+  incoming: SlackMessageEvent,
+): SlackMessageEvent {
+  const definedIncomingFields = Object.fromEntries(
+    Object.entries(incoming).filter(([, value]) => value !== undefined),
+  );
+  const currentFiles = Array.isArray(current.files) ? current.files : [];
+  const incomingFiles = Array.isArray(incoming.files) ? incoming.files : [];
+  return {
+    ...current,
+    ...definedIncomingFields,
+    ...(currentFiles.length > 0 && incomingFiles.length === 0
+      ? { files: current.files }
+      : {}),
+  };
+}
+
+function mayHaveAppMentionTwin(event: SlackMessageEvent): boolean {
+  return (
+    trimValue(event.type) === 'app_mention' ||
+    Boolean(botUserId && String(event.text || '').includes(`<@${botUserId}>`))
+  );
 }
 
 function rememberSlackDisplayName(userId: string, displayName: string): void {
@@ -699,10 +729,42 @@ async function handleIncomingSlackEvent(
   const event = rawEvent as SlackMessageEvent;
 
   const eventKey = `${trimValue(event.channel)}:${trimValue(event.ts)}`;
+  const pending = pendingEventsByKey.get(eventKey);
+  if (pending) {
+    pending.event = mergeSlackEvents(pending.event, event);
+    await pending.processing;
+    return;
+  }
   if (rememberSeenEvent(eventKey)) {
     return;
   }
 
+  if (mayHaveAppMentionTwin(event)) {
+    const pendingEvent = {
+      event,
+      processing: Promise.resolve(),
+    };
+    pendingEventsByKey.set(eventKey, pendingEvent);
+    pendingEvent.processing = new Promise<void>((resolve) => {
+      setTimeout(resolve, SLACK_EVENT_MERGE_DELAY_MS);
+    })
+      .then(() => processIncomingSlackEvent(pendingEvent.event, messageHandler))
+      .finally(() => {
+        if (pendingEventsByKey.get(eventKey) === pendingEvent) {
+          pendingEventsByKey.delete(eventKey);
+        }
+      });
+    await pendingEvent.processing;
+    return;
+  }
+
+  await processIncomingSlackEvent(event, messageHandler);
+}
+
+async function processIncomingSlackEvent(
+  event: SlackMessageEvent,
+  messageHandler: SlackMessageHandler,
+): Promise<void> {
   const inbound = await processInboundSlackEvent({
     event,
     botUserId: botUserId || null,

--- a/src/channels/whatsapp/inbound.ts
+++ b/src/channels/whatsapp/inbound.ts
@@ -92,6 +92,30 @@ function normalizeAllowEntry(value: string): string | null {
   return normalizePhoneNumber(trimmed) ?? jidToPhone(trimmed);
 }
 
+function isLidJid(value: string | null | undefined): boolean {
+  return /@(hosted\.)?lid$/i.test(String(value || '').trim());
+}
+
+function resolveInboundSenderJid(message: WAMessage): string {
+  const participant = (
+    message.key.participant ||
+    message.participant ||
+    ''
+  ).trim();
+  if (isLidJid(participant)) {
+    const participantAlt = message.key.participantAlt?.trim();
+    if (participantAlt) return participantAlt;
+  }
+
+  const chatJid = message.key.remoteJid?.trim() || '';
+  if (isLidJid(chatJid)) {
+    const senderAlt = message.key.remoteJidAlt?.trim();
+    if (senderAlt) return senderAlt;
+  }
+
+  return participant || chatJid;
+}
+
 function matchesAllowList(list: string[], senderPhone: string | null): boolean {
   if (list.includes('*')) return true;
   if (!senderPhone) return false;
@@ -310,12 +334,7 @@ export async function processInboundWhatsAppMessage(params: {
     return null;
   }
 
-  const senderJid = (
-    params.message.key.participant ||
-    params.message.participant ||
-    params.message.key.remoteJid ||
-    ''
-  ).trim();
+  const senderJid = resolveInboundSenderJid(params.message);
   if (!senderJid) return null;
 
   const access = evaluateWhatsAppAccessPolicy({

--- a/tests/discord.basic.test.ts
+++ b/tests/discord.basic.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from 'vitest';
 import { buildResponseText } from '../src/channels/discord/delivery.js';
 import {
   cleanIncomingContent,
+  hasDiscordMessageContentChanged,
   hasLooseBotMention,
   isAddressedToChannel,
   isAuthorizedCommandUser,
@@ -61,6 +62,19 @@ test('cleanIncomingContent maps native agent labels to @slug addressing', () => 
   expect(cleanIncomingContent('@"Research Agent" review this', null, '!claw')).toBe(
     '@Research-Agent review this',
   );
+});
+
+test('message updates ignore unchanged content from embed unfurls', () => {
+  expect(
+    hasDiscordMessageContentChanged(
+      'Read https://example.com',
+      'Read https://example.com',
+    ),
+  ).toBe(false);
+});
+
+test('message updates recognize user content edits', () => {
+  expect(hasDiscordMessageContentChanged('original', 'edited')).toBe(true);
 });
 
 test('isTrigger blocks non-command chatter when channel mode is off', () => {

--- a/tests/slack.runtime.test.ts
+++ b/tests/slack.runtime.test.ts
@@ -516,6 +516,62 @@ describe('slack runtime', () => {
     });
   });
 
+  test('merges duplicate message and app_mention events before dispatch', async () => {
+    vi.useFakeTimers();
+    const state = await importFreshSlackRuntime();
+    state.processInboundSlackEvent.mockImplementation(async ({ event }) => ({
+      sessionId: 'agent:main:channel:slack:chat:thread:peer:c1234567890:thread:1710000000.200000',
+      guildId: 'T0315EDR0',
+      channelId: 'slack:C1234567890:1710000000.200000',
+      userId: 'U1234567890',
+      content: 'hello',
+      media: [],
+      target: 'slack:C1234567890:1710000000.200000',
+      isDm: false,
+      threadTs: '1710000000.200000',
+      rawEvent: event,
+    }));
+    const messageHandler = vi.fn(async () => {});
+
+    await state.runtime.initSlack(messageHandler, async () => {});
+    const messageEventHandler = state.eventHandlers.get('message');
+    const mentionEventHandler = state.eventHandlers.get('app_mention');
+    const messageEvent = messageEventHandler?.({
+      event: {
+        type: 'message',
+        channel: 'C1234567890',
+        channel_type: 'channel',
+        ts: '1710000000.200000',
+        text: '<@U9999999999> hello',
+        files: [{ id: 'F1234567890' }],
+      },
+    });
+    const mentionEvent = mentionEventHandler?.({
+      event: {
+        type: 'app_mention',
+        channel: 'C1234567890',
+        ts: '1710000000.200000',
+        text: '<@U9999999999> hello',
+        team: 'T0315EDR0',
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+    await Promise.all([messageEvent, mentionEvent]);
+
+    expect(state.processInboundSlackEvent).toHaveBeenCalledTimes(1);
+    expect(state.processInboundSlackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          channel_type: 'channel',
+          team: 'T0315EDR0',
+          files: [{ id: 'F1234567890' }],
+        }),
+      }),
+    );
+    expect(messageHandler).toHaveBeenCalledTimes(1);
+  });
+
   test('routes native Slack slash commands through the command handler', async () => {
     const state = await importFreshSlackRuntime();
     const commandHandler = vi.fn(async (_1, _2, _3, _4, _5, args, reply) => {

--- a/tests/whatsapp.inbound.test.ts
+++ b/tests/whatsapp.inbound.test.ts
@@ -283,6 +283,70 @@ describe('whatsapp inbound policy filtering', () => {
     expect(result?.userId).toBe('+491703330161');
   });
 
+  test('uses the alternate sender identity for lid direct chats', async () => {
+    const result = await processInboundWhatsAppMessage({
+      message: {
+        key: {
+          id: 'msg-lid-dm-1',
+          fromMe: false,
+          remoteJid: '1061007917075@lid',
+          remoteJidAlt: '4915123456789@s.whatsapp.net',
+        },
+        message: {
+          conversation: 'hello from a lid chat',
+        },
+      },
+      sock: {
+        updateMediaMessage: async () => undefined,
+        logger: NOOP_WA_LOGGER,
+      },
+      config: {
+        ...BASE_WHATSAPP_CONFIG,
+        dmPolicy: 'allowlist',
+        allowFrom: ['+4915123456789'],
+      },
+      selfJids: ['4915999999999@s.whatsapp.net'],
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.senderJid).toBe('4915123456789@s.whatsapp.net');
+    expect(result?.userId).toBe('+4915123456789');
+    expect(result?.sessionId).toBe(
+      'agent:main:channel:whatsapp:chat:dm:peer:%2B4915123456789',
+    );
+  });
+
+  test('uses the alternate participant identity for lid group senders', async () => {
+    const result = await processInboundWhatsAppMessage({
+      message: {
+        key: {
+          id: 'msg-lid-group-1',
+          fromMe: false,
+          remoteJid: '120363401234567890@g.us',
+          participant: '1061007917075@lid',
+          participantAlt: '4915123456789@s.whatsapp.net',
+        },
+        message: {
+          conversation: 'hello from a lid participant',
+        },
+      },
+      sock: {
+        updateMediaMessage: async () => undefined,
+        logger: NOOP_WA_LOGGER,
+      },
+      config: {
+        ...BASE_WHATSAPP_CONFIG,
+        groupPolicy: 'allowlist',
+        groupAllowFrom: ['+4915123456789'],
+      },
+      selfJids: ['4915999999999@s.whatsapp.net'],
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.senderJid).toBe('4915123456789@s.whatsapp.net');
+    expect(result?.userId).toBe('+4915123456789');
+  });
+
   test('cleanupWhatsAppInboundMedia removes managed WhatsApp temp dirs only', async () => {
     const managedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-wa-'));
     const managedFile = path.join(managedDir, 'voice.ogg');


### PR DESCRIPTION
## Summary

- ignore Discord `messageUpdate` events when message content is unchanged, preventing embed unfurls from aborting and replaying in-flight turns
- coalesce Slack `message` and `app_mention` deliveries by channel/timestamp so their fields are merged before a single dispatch
- resolve WhatsApp phone-number identities from alternate sender/participant JIDs for LID-addressed chats
- add focused regressions for Discord unfurls and edits, Slack duplicate delivery, and WhatsApp direct/group LID senders

## Root cause

Discord treated every update as a user edit, Slack marked the first matching event as seen before the complementary event could contribute metadata, and WhatsApp only read primary participant fields even when Baileys supplied the phone identity in alternate JID fields.

These paths could respectively replay tool side effects, drop Slack event metadata, or route and authorize WhatsApp messages under LID identities instead of phone identities.

## Validation

- `npm run format`
- `npm run lint`
- `./node_modules/.bin/vitest run tests/discord.basic.test.ts tests/slack.runtime.test.ts tests/whatsapp.inbound.test.ts` — 61 tests passed
- broad unit run: 5,263/5,265 passed initially; the container dependency-related failure passed after `npm run setup`, while the unrelated `gateway-admin-tokens.test.ts` config/logger initialization-order failure remains reproducible standalone
