### PR TITLE
chore: consolidate merge-artifact comment in buildUpdateCommand

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -327,17 +327,13 @@ function buildUpdateCommand(
       return { bin: 'bun', args, display: `bun ${args.join(' ')}` };
     }
     default: {
-      // `--no-fund`/`--no-audit`/`--loglevel=error` are npm-specific and trim
-      // the funding/audit/deprecation noise from the self-update output while
-      // keeping real errors visible. They are intentionally not added to the
-      // pnpm/yarn/bun branches, which don't support these flags and don't emit
-      // that output.
       // `--omit=dev` keeps the published workspace shrinkwrap's development
-      // tree out of the global install. `--no-fund`/`--no-audit` are npm-specific
-      // and trim the funding/audit noise from the self-update output. These are
-      // intentionally not added to the pnpm/yarn/bun branches, which don't
-      // support the same flags or emit that output. Deprecation warnings are
-      // left visible on purpose (see SECURITY.md and the npm supply-chain notes).
+      // tree out of the global install. `--no-fund`/`--no-audit`/
+      // `--loglevel=error` are npm-specific and trim the funding/audit/
+      // deprecation noise from the self-update output while keeping real
+      // errors visible. These flags are intentionally not added to the
+      // pnpm/yarn/bun branches, which don't support them and don't emit that
+      // output.
       const args = [
         'install',
         '-g',


### PR DESCRIPTION
## Summary
The `--omit=dev` flag itself already landed on main via 200ac785 and shipped in v0.28.1, so this PR only cleans up what the #1314 merge left behind: two overlapping comment blocks on the npm self-update command, the older of which still claimed deprecation warnings are left visible — no longer true since `--loglevel=error` suppresses them.

Consolidates both into one accurate comment. No behavior change.

## Test plan
- Comment-only change; `npm test` update suite already covers the flag list (`tests/update.test.ts`).