### PR TITLE
fix: serialize concurrent session turns

### DIFF
--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -697,6 +697,10 @@ const gatewaySessionQueue = new KeyedSerialQueue();
 export async function handleGatewayMessage(
   req: GatewayChatRequest,
 ): Promise<GatewayChatResult> {
+  const source = req.source?.trim() || 'gateway.chat';
+  if (source !== 'fullauto') {
+    preemptRunningFullAutoTurn(req.sessionId, source);
+  }
   return gatewaySessionQueue.run(req.sessionId, () =>
     withSpan(
       'hybridclaw.gateway.handle_message',
@@ -975,7 +979,6 @@ async function handleGatewayMessageInner(
     });
   }
   if (source !== 'fullauto') {
-    preemptRunningFullAutoTurn(req.sessionId, source);
     clearScheduledFullAutoContinuation(req.sessionId);
     if (isFullAutoEnabled(session)) {
       noteFullAutoSupervisedIntervention({

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -93,6 +93,7 @@ import { buildMediaGenerationUsageEvents } from '../usage/media-generation-usage
 import { resolveUsageCostUsdAfterMetadataRefresh } from '../usage/model-cost.js';
 import { enqueueTokenUsage } from '../usage/token-usage-buffer.js';
 import { parseJsonObject } from '../utils/json-object.js';
+import { KeyedSerialQueue } from '../utils/keyed-serial-queue.js';
 import {
   ensureBootstrapFiles,
   resolveStartupBootstrapFile,
@@ -691,18 +692,22 @@ function buildA2AChatThreadId(session: {
   return session.main_session_key || session.session_key || session.id;
 }
 
+const gatewaySessionQueue = new KeyedSerialQueue();
+
 export async function handleGatewayMessage(
   req: GatewayChatRequest,
 ): Promise<GatewayChatResult> {
-  return withSpan(
-    'hybridclaw.gateway.handle_message',
-    {
-      'hybridclaw.session_id': req.sessionId,
-      'hybridclaw.agent_id': req.agentId || '',
-      'hybridclaw.channel_id': req.channelId || '',
-      'hybridclaw.model': req.model || '',
-    },
-    async () => handleGatewayMessageInner(req),
+  return gatewaySessionQueue.run(req.sessionId, () =>
+    withSpan(
+      'hybridclaw.gateway.handle_message',
+      {
+        'hybridclaw.session_id': req.sessionId,
+        'hybridclaw.agent_id': req.agentId || '',
+        'hybridclaw.channel_id': req.channelId || '',
+        'hybridclaw.model': req.model || '',
+      },
+      async () => handleGatewayMessageInner(req),
+    ),
   );
 }
 

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -79,6 +79,7 @@ import {
 } from '../types/execution.js';
 import type { ScheduledTaskInput } from '../types/scheduler.js';
 import type { AdditionalMount } from '../types/security.js';
+import { KeyedSerialQueue } from '../utils/keyed-serial-queue.js';
 import { ensureWorkspaceNodeModulesLink } from '../workspace.js';
 import {
   CONTAINER_BEHAVIOR_ANOMALY_TRAJECTORY_STORE_DIR,
@@ -173,6 +174,7 @@ interface ContainerPathAliasMount {
 }
 
 const pool = new Map<string, PoolEntry>();
+const containerSessionQueue = new KeyedSerialQueue();
 const warmPool = new WarmProcessPool<PoolEntry>(
   normalizeWarmProcessPoolRuntimeConfig(CONTAINER_WARM_POOL),
 );
@@ -994,14 +996,16 @@ function getOrSpawnContainer(
 export async function runContainer(
   params: ExecutorRequest,
 ): Promise<ContainerOutput> {
-  return withSpan(
-    'hybridclaw.container.execute',
-    {
-      'hybridclaw.session_id': params.sessionId,
-      'hybridclaw.agent_id': params.agentId || '',
-      'hybridclaw.model': params.model || '',
-    },
-    async () => runContainerInner(params),
+  return containerSessionQueue.run(params.sessionId, () =>
+    withSpan(
+      'hybridclaw.container.execute',
+      {
+        'hybridclaw.session_id': params.sessionId,
+        'hybridclaw.agent_id': params.agentId || '',
+        'hybridclaw.model': params.model || '',
+      },
+      async () => runContainerInner(params),
+    ),
   );
 }
 

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -64,6 +64,7 @@ import {
   type ToolProgressEvent,
 } from '../types/execution.js';
 import type { ScheduledTaskInput } from '../types/scheduler.js';
+import { KeyedSerialQueue } from '../utils/keyed-serial-queue.js';
 import { ensureBehaviorAnomalyTrajectoryStoreDir } from './behavior-anomaly-runtime.js';
 import {
   collectConfiguredDiscordChannelIds,
@@ -214,6 +215,7 @@ interface PoolEntry extends WarmRunnerEntry {
 }
 
 const pool = new Map<string, PoolEntry>();
+const hostSessionQueue = new KeyedSerialQueue();
 const warmPool = new WarmProcessPool<PoolEntry>(
   normalizeWarmProcessPoolRuntimeConfig(CONTAINER_WARM_POOL),
 );
@@ -852,14 +854,16 @@ export function stopSessionHostProcess(sessionId: string): boolean {
 export async function runHostProcess(
   params: ExecutorRequest,
 ): Promise<ContainerOutput> {
-  return withSpan(
-    'hybridclaw.host.execute',
-    {
-      'hybridclaw.session_id': params.sessionId,
-      'hybridclaw.agent_id': params.agentId || '',
-      'hybridclaw.model': params.model || '',
-    },
-    async () => runHostProcessInner(params),
+  return hostSessionQueue.run(params.sessionId, () =>
+    withSpan(
+      'hybridclaw.host.execute',
+      {
+        'hybridclaw.session_id': params.sessionId,
+        'hybridclaw.agent_id': params.agentId || '',
+        'hybridclaw.model': params.model || '',
+      },
+      async () => runHostProcessInner(params),
+    ),
   );
 }
 

--- a/src/utils/keyed-serial-queue.ts
+++ b/src/utils/keyed-serial-queue.ts
@@ -1,0 +1,22 @@
+export class KeyedSerialQueue {
+  private readonly tails = new Map<string, Promise<void>>();
+
+  async run<T>(key: string, task: () => Promise<T>): Promise<T> {
+    const previous = this.tails.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.tails.set(key, current);
+
+    await previous;
+    try {
+      return await task();
+    } finally {
+      release();
+      if (this.tails.get(key) === current) {
+        this.tails.delete(key);
+      }
+    }
+  }
+}

--- a/tests/keyed-serial-queue.test.ts
+++ b/tests/keyed-serial-queue.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest';
+import { KeyedSerialQueue } from '../src/utils/keyed-serial-queue.js';
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('KeyedSerialQueue', () => {
+  test('serializes tasks with the same key in arrival order', async () => {
+    const queue = new KeyedSerialQueue();
+    const firstGate = deferred();
+    const events: string[] = [];
+
+    const first = queue.run('shared-session', async () => {
+      events.push('first:start');
+      await firstGate.promise;
+      events.push('first:end');
+    });
+    const second = queue.run('shared-session', async () => {
+      events.push('second:start');
+      events.push('second:end');
+    });
+
+    await Promise.resolve();
+    expect(events).toEqual(['first:start']);
+    firstGate.resolve();
+    await Promise.all([first, second]);
+    expect(events).toEqual([
+      'first:start',
+      'first:end',
+      'second:start',
+      'second:end',
+    ]);
+  });
+
+  test('allows different keys to run concurrently', async () => {
+    const queue = new KeyedSerialQueue();
+    const gate = deferred();
+    const events: string[] = [];
+
+    const first = queue.run('session-a', async () => {
+      events.push('a');
+      await gate.promise;
+    });
+    const second = queue.run('session-b', async () => {
+      events.push('b');
+      await gate.promise;
+    });
+
+    await Promise.resolve();
+    expect(events).toEqual(['a', 'b']);
+    gate.resolve();
+    await Promise.all([first, second]);
+  });
+
+  test('releases the next task when the current task rejects', async () => {
+    const queue = new KeyedSerialQueue();
+    const events: string[] = [];
+
+    const first = queue.run('shared-session', async () => {
+      events.push('first');
+      throw new Error('failed turn');
+    });
+    const second = queue.run('shared-session', async () => {
+      events.push('second');
+      return 'completed';
+    });
+
+    await expect(first).rejects.toThrow('failed turn');
+    await expect(second).resolves.toBe('completed');
+    expect(events).toEqual(['first', 'second']);
+  });
+});


### PR DESCRIPTION
## Summary

- serialize complete gateway turns by session ID
- independently serialize host and container executor calls by execution session ID
- keep different sessions concurrent while preserving FIFO ordering within one session
- add focused coverage for ordering, cross-session concurrency, and failure release

## Root cause

Concurrent turns for one session shared a single runner pool entry and IPC directory. A later turn could delete the output file being polled by the earlier turn, replace its streaming callbacks, or abort the shared process. Channel-level concurrency made this reachable for Slack, Discord, and group chats.

## Impact

Each session now has one active gateway turn and one active executor call at a time. This prevents responses and stream events from crossing chats and avoids false output timeouts caused by another turn cleaning the shared IPC state. Unrelated sessions still execute concurrently.

## Risk notes

This changes scheduling only. It does not alter IPC formats, process-pool keys, channel concurrency limits, approval behavior, or abort APIs. Queue entries release in `finally`, including when a turn rejects.

## Validation

- `npm run lint` (root, console, and desktop typechecks)
- `vitest run tests/keyed-serial-queue.test.ts` — 3 passed
- host/container runner regression suites — 32 passed, 1 environment-sensitive agent-browser path test excluded because the temporary dependency symlink changes its expected binary path
- `git diff --check`
