### PR TITLE
fix: preserve tool exchanges during in-loop compaction

### DIFF
--- a/container/src/in-loop-compaction.ts
+++ b/container/src/in-loop-compaction.ts
@@ -38,6 +38,55 @@ function countLeadingSystemMessages(history: ChatMessage[]): number {
   return count;
 }
 
+function findSafeToolExchangeBoundaries(body: ChatMessage[]): boolean[] {
+  const safe = Array.from({ length: body.length + 1 }, () => true);
+
+  for (let index = 0; index < body.length; index += 1) {
+    const message = body[index];
+    if (
+      message?.role !== 'assistant' ||
+      !Array.isArray(message.tool_calls) ||
+      message.tool_calls.length === 0
+    ) {
+      continue;
+    }
+
+    let resultEnd = index + 1;
+    while (body[resultEnd]?.role === 'tool') {
+      resultEnd += 1;
+    }
+
+    // The assistant tool-call message and all immediately following results
+    // form one protocol-level exchange. A compaction boundary inside it would
+    // leave either unanswered tool calls or orphaned tool results.
+    const firstUnsafeBoundary = index + 1;
+    const lastUnsafeBoundary = Math.max(firstUnsafeBoundary, resultEnd - 1);
+    for (
+      let boundary = firstUnsafeBoundary;
+      boundary <= lastUnsafeBoundary;
+      boundary += 1
+    ) {
+      safe[boundary] = false;
+    }
+  }
+
+  return safe;
+}
+
+function findSafeBoundaryAtOrAfter(safe: boolean[], target: number): number {
+  for (let boundary = target; boundary < safe.length; boundary += 1) {
+    if (safe[boundary]) return boundary;
+  }
+  return safe.length - 1;
+}
+
+function findSafeBoundaryAtOrBefore(safe: boolean[], target: number): number {
+  for (let boundary = target; boundary >= 0; boundary -= 1) {
+    if (safe[boundary]) return boundary;
+  }
+  return 0;
+}
+
 function normalizeSummary(summary: string, maxChars: number): string {
   let normalized = summary.trim();
   if (normalized.startsWith('```')) {
@@ -84,6 +133,7 @@ function buildCompactionRegion(history: ChatMessage[]): {
     PROTECT_TAIL_MESSAGES,
     Math.max(0, body.length - headCount),
   );
+  const safeBoundaries = findSafeToolExchangeBoundaries(body);
   if (headCount + tailCount >= body.length) {
     // If the default protected slices would consume the whole body, fall back
     // to a smaller 2+4 split so the compaction region still has something to
@@ -92,8 +142,23 @@ function buildCompactionRegion(history: ChatMessage[]): {
     tailCount = Math.min(4, Math.max(1, body.length - headCount - 1));
   }
 
-  const middleStart = headCount;
-  const middleEnd = Math.max(middleStart, body.length - tailCount);
+  let middleStart = findSafeBoundaryAtOrAfter(safeBoundaries, headCount);
+  let middleEnd = findSafeBoundaryAtOrBefore(
+    safeBoundaries,
+    body.length - tailCount,
+  );
+  if (middleStart >= middleEnd) {
+    headCount = Math.min(2, Math.max(0, body.length - 1));
+    tailCount = Math.min(4, Math.max(1, body.length - headCount - 1));
+    middleStart = findSafeBoundaryAtOrAfter(safeBoundaries, headCount);
+    middleEnd = findSafeBoundaryAtOrBefore(
+      safeBoundaries,
+      body.length - tailCount,
+    );
+  }
+  if (middleStart >= middleEnd) {
+    return { prefix: history.slice(), middle: [], suffix: [] };
+  }
   return {
     prefix: [...systemPrefix, ...body.slice(0, middleStart)],
     middle: body.slice(middleStart, middleEnd),

--- a/tests/in-loop-compaction.test.ts
+++ b/tests/in-loop-compaction.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, test } from 'vitest';
 
 import { compactInLoop } from '../container/src/in-loop-compaction.js';
-import type { ChatMessage } from '../container/src/types.js';
+import type { ChatMessage, ToolCall } from '../container/src/types.js';
+
+function toolCall(id: string): ToolCall {
+  return {
+    id,
+    type: 'function',
+    function: { name: 'test_tool', arguments: '{}' },
+  };
+}
 
 function buildHistory(): ChatMessage[] {
   return [
@@ -9,11 +17,19 @@ function buildHistory(): ChatMessage[] {
     { role: 'user', content: 'User 1' },
     { role: 'assistant', content: 'Assistant 1' },
     { role: 'user', content: 'User 2' },
-    { role: 'assistant', content: 'Assistant 2' },
+    {
+      role: 'assistant',
+      content: 'Assistant 2',
+      tool_calls: [toolCall('call_1')],
+    },
     { role: 'tool', content: 'Tool 1', tool_call_id: 'call_1' },
     { role: 'assistant', content: 'Assistant 3' },
     { role: 'user', content: 'User 3' },
-    { role: 'assistant', content: 'Assistant 4' },
+    {
+      role: 'assistant',
+      content: 'Assistant 4',
+      tool_calls: [toolCall('call_2')],
+    },
     { role: 'tool', content: 'Tool 2', tool_call_id: 'call_2' },
     { role: 'assistant', content: 'Assistant 5' },
     { role: 'user', content: 'User 4' },
@@ -44,6 +60,53 @@ describe('compactInLoop', () => {
         String(message.content).includes('[In-loop compaction summary]'),
       ),
     ).toBe(true);
+  });
+
+  test('does not leave protected prefix tool calls unanswered', async () => {
+    const history = buildHistory();
+    const result = await compactInLoop({
+      history,
+      summarize: async () => 'Summary',
+    });
+
+    const summaryIndex = result.history.findIndex((message) =>
+      String(message.content).startsWith('[In-loop compaction summary]'),
+    );
+    expect(result.history[summaryIndex - 1]).toEqual(history[5]);
+    expect(result.history[summaryIndex - 1]?.role).toBe('tool');
+  });
+
+  test('keeps parallel tool calls with every result when adjusting the protected tail', async () => {
+    const calls = [toolCall('call_a'), toolCall('call_b')];
+    const history: ChatMessage[] = [
+      { role: 'system', content: 'System prompt' },
+      { role: 'user', content: 'User 1' },
+      { role: 'assistant', content: 'Assistant 1' },
+      { role: 'user', content: 'User 2' },
+      { role: 'assistant', content: 'Assistant 2' },
+      { role: 'user', content: 'User 3' },
+      { role: 'assistant', content: null, tool_calls: calls },
+      { role: 'tool', content: 'Tool A', tool_call_id: 'call_a' },
+      { role: 'tool', content: 'Tool B', tool_call_id: 'call_b' },
+      { role: 'assistant', content: 'Assistant 3' },
+      { role: 'user', content: 'User 4' },
+      { role: 'assistant', content: 'Assistant 4' },
+      { role: 'user', content: 'User 5' },
+      { role: 'assistant', content: 'Assistant 5' },
+      { role: 'user', content: 'User 6' },
+    ];
+
+    const result = await compactInLoop({
+      history,
+      summarize: async () => 'Summary',
+    });
+
+    const summaryIndex = result.history.findIndex((message) =>
+      String(message.content).startsWith('[In-loop compaction summary]'),
+    );
+    expect(result.history.slice(summaryIndex + 1, summaryIndex + 4)).toEqual(
+      history.slice(6, 9),
+    );
   });
 
   test('falls back to a heuristic summary when the summarizer fails', async () => {


### PR DESCRIPTION
## Summary

- treat assistant tool calls and their consecutive tool results as an atomic exchange when choosing in-loop compaction boundaries
- move protected head and tail cuts to safe protocol boundaries
- add regression coverage for unanswered prefix tool calls and orphaned parallel tool results

## Root cause

In-loop compaction selected its protected head and tail purely by message count. A cut could therefore land between an assistant `tool_calls` message and one or more following `tool` results. OpenAI-compatible and Anthropic APIs reject those malformed histories with a non-retryable 400, causing context rescue to fail exactly when a long session needed compaction.

## Impact

Long-running tool-heavy sessions can compact and retry without breaking provider-required tool call/result pairing. If no safe middle region remains, compaction leaves history unchanged instead of creating an invalid sequence.

## Validation

- `vitest run tests/in-loop-compaction.test.ts` (5 passed)
- `npm --prefix container run lint`
- `npm run lint`
- `npm run build`
- Biome check and `git diff --check`