### PR TITLE
fix: route Anthropic and Ollama client tools correctly

### DIFF
--- a/src/gateway/openai-compatible-model.ts
+++ b/src/gateway/openai-compatible-model.ts
@@ -209,6 +209,27 @@ function buildOpenAICompatRequestBody(
   return body;
 }
 
+function buildChatCompletionsUrl(
+  runtime: ResolvedModelRuntimeCredentials,
+): string {
+  const baseUrl = normalizeBaseUrl(runtime.baseUrl);
+  if (
+    runtime.provider === 'anthropic' ||
+    isOpenAICompatProviderId(runtime.provider)
+  ) {
+    return `${baseUrl}/chat/completions`;
+  }
+  return `${baseUrl}/v1/chat/completions`;
+}
+
+function buildChatCompletionsRequestBody(
+  params: OpenAICompatibleModelCallParams,
+): Record<string, unknown> {
+  return params.runtime.provider === 'hybridai'
+    ? buildHybridAIRequestBody(params)
+    : buildOpenAICompatRequestBody(params);
+}
+
 function convertMessageToResponsesInput(
   message: ChatMessage,
 ): Array<Record<string, unknown>> {
@@ -371,12 +392,8 @@ export async function callOpenAICompatibleModel(
     return adaptCodexResponse(await response.json(), params.model);
   }
 
-  const url = isOpenAICompatProviderId(params.runtime.provider)
-    ? `${normalizeBaseUrl(params.runtime.baseUrl)}/chat/completions`
-    : `${normalizeBaseUrl(params.runtime.baseUrl)}/v1/chat/completions`;
-  const body = isOpenAICompatProviderId(params.runtime.provider)
-    ? buildOpenAICompatRequestBody(params)
-    : buildHybridAIRequestBody(params);
+  const url = buildChatCompletionsUrl(params.runtime);
+  const body = buildChatCompletionsRequestBody(params);
   const response = await fetch(url, {
     method: 'POST',
     headers: buildHeaders({
@@ -496,12 +513,8 @@ export async function callOpenAICompatibleModelStream(
         };
   }
 
-  const url = isOpenAICompatProviderId(params.runtime.provider)
-    ? `${normalizeBaseUrl(params.runtime.baseUrl)}/chat/completions`
-    : `${normalizeBaseUrl(params.runtime.baseUrl)}/v1/chat/completions`;
-  const body = isOpenAICompatProviderId(params.runtime.provider)
-    ? buildOpenAICompatRequestBody(params)
-    : buildHybridAIRequestBody(params);
+  const url = buildChatCompletionsUrl(params.runtime);
+  const body = buildChatCompletionsRequestBody(params);
   const response = await fetch(url, {
     method: 'POST',
     headers: buildHeaders({

--- a/tests/openai-compatible-model.test.ts
+++ b/tests/openai-compatible-model.test.ts
@@ -200,6 +200,75 @@ test('openai-compatible HybridAI Gemma calls use native tools', async () => {
   expect(result.choices[0]?.message.content).toBe('ok');
 });
 
+test.each([
+  {
+    provider: 'anthropic' as const,
+    baseUrl: 'https://api.anthropic.com/v1',
+    model: 'anthropic/claude-sonnet-4-6',
+    upstreamModel: 'claude-sonnet-4-6',
+    expectedUrl: 'https://api.anthropic.com/v1/chat/completions',
+  },
+  {
+    provider: 'ollama' as const,
+    baseUrl: 'http://127.0.0.1:11434',
+    model: 'ollama/qwen3:8b',
+    upstreamModel: 'qwen3:8b',
+    expectedUrl: 'http://127.0.0.1:11434/v1/chat/completions',
+  },
+])(
+  'openai-compatible $provider calls use the provider URL and stripped model with tools',
+  async ({ provider, baseUrl, model, upstreamModel, expectedUrl }) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        expect(input).toBe(expectedUrl);
+        const body = JSON.parse(String(init?.body || '{}')) as Record<
+          string,
+          unknown
+        >;
+        expect(body.model).toBe(upstreamModel);
+        expect(body.tools).toEqual(tools);
+        expect(body.tool_choice).toBe('auto');
+        expect(body.chatbot_id).toBeUndefined();
+        expect(body.enable_rag).toBeUndefined();
+        return new Response(
+          JSON.stringify({
+            id: 'resp_1',
+            model: upstreamModel,
+            choices: [
+              {
+                message: { role: 'assistant', content: 'ok' },
+                finish_reason: 'stop',
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }),
+    );
+
+    const result = await callOpenAICompatibleModel({
+      runtime: {
+        provider,
+        apiKey: provider === 'anthropic' ? 'anthropic-key' : '',
+        baseUrl,
+        chatbotId: '',
+        enableRag: false,
+        requestHeaders: {},
+        agentId: 'main',
+        isLocal: provider === 'ollama',
+        contextWindow: 32_768,
+        thinkingFormat: undefined,
+      },
+      model,
+      messages: [{ role: 'user', content: 'run pwd' }],
+      tools,
+    });
+
+    expect(result.choices[0]?.message.content).toBe('ok');
+  },
+);
+
 test('openai-compatible remote calls omit empty tools', async () => {
   vi.stubGlobal(
     'fetch',
@@ -525,3 +594,67 @@ test('openai-compatible vLLM Gemma streams use native tools', async () => {
   expect(result.choices[0]?.message.content).toBe('ok');
   expect(fetchMock).toHaveBeenCalledTimes(1);
 });
+
+test.each([
+  {
+    provider: 'anthropic' as const,
+    baseUrl: 'https://api.anthropic.com/v1',
+    model: 'anthropic/claude-sonnet-4-6',
+    upstreamModel: 'claude-sonnet-4-6',
+    expectedUrl: 'https://api.anthropic.com/v1/chat/completions',
+  },
+  {
+    provider: 'ollama' as const,
+    baseUrl: 'http://127.0.0.1:11434',
+    model: 'ollama/qwen3:8b',
+    upstreamModel: 'qwen3:8b',
+    expectedUrl: 'http://127.0.0.1:11434/v1/chat/completions',
+  },
+])(
+  'openai-compatible $provider streams use the provider URL and stripped model with tools',
+  async ({ provider, baseUrl, model, upstreamModel, expectedUrl }) => {
+    const deltas: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        expect(input).toBe(expectedUrl);
+        const body = JSON.parse(String(init?.body || '{}')) as Record<
+          string,
+          unknown
+        >;
+        expect(body.model).toBe(upstreamModel);
+        expect(body.tools).toEqual(tools);
+        expect(body.tool_choice).toBe('auto');
+        expect(body.chatbot_id).toBeUndefined();
+        expect(body.enable_rag).toBeUndefined();
+        expect(body.stream).toBe(true);
+        return makeEventStreamResponse([
+          `data: {"id":"resp_1","model":"${upstreamModel}","choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}\n\n`,
+          'data: [DONE]\n\n',
+        ]);
+      }),
+    );
+
+    const result = await callOpenAICompatibleModelStream({
+      runtime: {
+        provider,
+        apiKey: provider === 'anthropic' ? 'anthropic-key' : '',
+        baseUrl,
+        chatbotId: '',
+        enableRag: false,
+        requestHeaders: {},
+        agentId: 'main',
+        isLocal: provider === 'ollama',
+        contextWindow: 32_768,
+        thinkingFormat: undefined,
+      },
+      model,
+      messages: [{ role: 'user', content: 'run pwd' }],
+      tools,
+      onTextDelta: (delta) => deltas.push(delta),
+    });
+
+    expect(deltas).toEqual(['ok']);
+    expect(result.choices[0]?.message.content).toBe('ok');
+  },
+);


### PR DESCRIPTION
## Summary

- route Anthropic client-tool requests to its existing `/v1/chat/completions` endpoint without duplicating `/v1`
- keep Ollama client-tool requests on `/v1/chat/completions` while stripping the `ollama/` model prefix
- reserve the HybridAI request body for HybridAI and use the OpenAI-compatible tool body for other runtime providers
- cover Anthropic and Ollama in both streaming and non-streaming modes

## Root cause

The client-tools path selected both its URL and request body through the `OPENAI_COMPAT_PROVIDER_IDS` allowlist. Anthropic and Ollama are intentionally absent from that general provider list, so both fell into the HybridAI branch. Anthropic received a duplicated `/v1/v1` path and HybridAI-shaped body; Ollama received an unstripped provider-prefixed model name.

## Impact

OpenAI-compatible `/v1/chat/completions` requests with tools now work for `anthropic/*` and `ollama/*` models in streaming and non-streaming modes.

## Validation

- `./node_modules/.bin/vitest run tests/openai-compatible-model.test.ts` (13 tests passed)
- `npm run typecheck`
- `npm run lint`
- `npm run format` (completed with pre-existing suggested warnings only)
- `git diff --check`