### PR TITLE
fix: remove Anthropic streaming duration cap

### DIFF
--- a/container/src/providers/anthropic.ts
+++ b/container/src/providers/anthropic.ts
@@ -839,7 +839,6 @@ export async function callAnthropicProviderStream(
       method: 'POST',
       headers: buildHeaders({ ...args, stream: true }),
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(ANTHROPIC_INFERENCE_TIMEOUT_MS),
     },
   );
 

--- a/tests/container.anthropic-provider.test.ts
+++ b/tests/container.anthropic-provider.test.ts
@@ -145,11 +145,11 @@ describe('Anthropic container provider', () => {
     expect(result.usage?.cache_creation_input_tokens).toBe(1200);
   });
 
-  test('sets an inference timeout signal on streaming API requests', async () => {
+  test('does not impose a total-duration timeout on streaming API requests', async () => {
     const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
     const fetchMock = vi.fn(
       async (_input: RequestInfo | URL, init?: RequestInit) => {
-        expect(init?.signal).toBeInstanceOf(AbortSignal);
+        expect(init?.signal).toBeUndefined();
         return makeEventStreamResponse([
           'event: message_start\n',
           'data: {"type":"message_start","message":{"id":"msg_stream","model":"claude-sonnet-4-6","usage":{"input_tokens":4,"output_tokens":0}}}\n\n',
@@ -171,7 +171,7 @@ describe('Anthropic container provider', () => {
       onActivity: () => undefined,
     });
 
-    expect(timeoutSpy).toHaveBeenCalledWith(300_000);
+    expect(timeoutSpy).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(deltas).toEqual(['streamed']);
     expect(result.choices[0]?.message.content).toBe('streamed');


### PR DESCRIPTION
## Summary

- remove the five-minute total-duration abort signal from direct Anthropic streaming requests
- retain the existing 90-second per-read idle timeout for stalled streams
- keep the five-minute cap for non-streaming Anthropic requests
- add regression coverage ensuring streaming fetches receive no total-duration signal

## Root cause

`AbortSignal.timeout(300_000)` remained active while the streaming response body was consumed. Long Claude generations could therefore be aborted after five minutes despite continuing to emit data. The abort was classified as transient and retried, multiplying the delay without allowing the generation to finish.

## Impact

Long-running Anthropic streams can now complete as long as they continue producing data. Truly stalled streams still fail through the existing idle timeout and remain eligible for retry.

## Validation

- `npx vitest run --configLoader runner tests/container.anthropic-provider.test.ts`
- `npm --prefix container run lint`
- `npm run build`
- `npm run format`
- `npm run lint`
- `git diff --check`