### PR TITLE
fix: prevent WhatsApp self-chat reply loops

### DIFF
--- a/src/channels/whatsapp/runtime.ts
+++ b/src/channels/whatsapp/runtime.ts
@@ -131,13 +131,13 @@ export function createWhatsAppRuntime() {
   const sendTextToChat = async (jid: string, text: string): Promise<void> => {
     const manager = ensureConnectionManager();
     const socket = await manager.waitForSocket();
-    const refs = await sendChunkedWhatsAppText(
-      socket,
-      jid,
-      text,
-      manager.rememberSentMessage,
-    );
-    selfEchoCache?.remember(refs);
+    await sendChunkedWhatsAppText(socket, jid, text, async (sent) => {
+      selfEchoCache?.remember({
+        chatJid: sent?.key.remoteJid?.trim() || jid,
+        messageId: sent?.key.id?.trim() || null,
+      });
+      await manager.rememberSentMessage(sent);
+    });
   };
 
   const sendMediaToChat = async (

--- a/tests/whatsapp.runtime.test.ts
+++ b/tests/whatsapp.runtime.test.ts
@@ -349,6 +349,46 @@ test('ignores reflected self-chat messages sent by HybridClaw itself', async () 
   );
 });
 
+test('ignores each reflected self-chat chunk while later chunks are still sending', async () => {
+  vi.useFakeTimers();
+  const { processInboundWhatsAppMessage, runtime, socket, upsertHandlers } =
+    await importFreshRuntimeModule();
+  const messageHandler = vi.fn(async () => {});
+
+  await runtime.initWhatsApp(messageHandler);
+  const sendPromise = runtime.sendToWhatsAppChat(
+    '491703330161@s.whatsapp.net',
+    'a'.repeat(4_500),
+  );
+  await Promise.resolve();
+  await Promise.resolve();
+
+  expect(socket.sendMessage).toHaveBeenCalledTimes(1);
+  await upsertHandlers[0]?.({
+    type: 'notify',
+    messages: [
+      {
+        key: {
+          id: 'bot-1',
+          fromMe: true,
+          remoteJid: '491703330161@s.whatsapp.net',
+        },
+        message: {
+          conversation: 'a'.repeat(4_000),
+        },
+      },
+    ],
+  });
+  await Promise.resolve();
+
+  expect(processInboundWhatsAppMessage).not.toHaveBeenCalled();
+  expect(messageHandler).not.toHaveBeenCalled();
+
+  await vi.runAllTimersAsync();
+  await sendPromise;
+  expect(socket.sendMessage).toHaveBeenCalledTimes(2);
+});
+
 test('shows WhatsApp composing presence while processing an inbound turn', async () => {
   const { runtime, socket, upsertHandlers } = await importFreshRuntimeModule();
   let resolveTurn: (() => void) | null = null;


### PR DESCRIPTION
## Summary

- cache each outbound WhatsApp message reference immediately after its chunk sends
- preserve outbound message-store persistence for every chunk
- add a regression test for an own-message upsert arriving while later chunks are still pending

## Root cause

`selfEchoCache.remember(refs)` ran only after `sendChunkedWhatsAppText` completed every chunk. Baileys can emit the own-message upsert roughly 100 ms after each send, while HybridClaw waits 350 ms between chunks. In self-chat mode, those early reflected chunks therefore missed the cache and re-entered as inbound user messages.

## Impact

Multi-chunk replies in WhatsApp self-chat are now suppressed as echoes chunk by chunk, preventing HybridClaw from responding to its own output. Normal direct-message and group filtering is unchanged.

## Validation

- `npm run format`
- `npm run lint`
- `./node_modules/.bin/vitest run tests/whatsapp.runtime.test.ts` (15 passed)
- `git diff --check`