### PR TITLE
fix: avoid duplicate HybridAI stream content

### DIFF
--- a/container/src/providers/hybridai.ts
+++ b/container/src/providers/hybridai.ts
@@ -315,16 +315,14 @@ export async function callHybridAIProviderStream(
     if (choice.message) {
       const message = choice.message;
       if (typeof message.role === 'string' && message.role) role = message.role;
-      if (typeof message.content === 'string') {
+      if (typeof message.content === 'string' && message.content) {
         const nextContent = message.content;
-        const messageDelta = nextContent
-          ? nextContent.startsWith(textContent)
-            ? nextContent.slice(textContent.length)
-            : nextContent
-          : '';
+        usedMessageContent = true;
+        const messageDelta = nextContent.startsWith(textContent)
+          ? nextContent.slice(textContent.length)
+          : nextContent;
+        textContent = nextContent;
         if (messageDelta) {
-          textContent = nextContent;
-          usedMessageContent = true;
           args.onTextDelta(messageDelta);
         }
       }

--- a/tests/container.hybridai-provider.test.ts
+++ b/tests/container.hybridai-provider.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { callHybridAIProviderStream } from '../container/src/providers/hybridai.js';
+import type { NormalizedStreamCallArgs } from '../container/src/providers/shared.js';
+import type { ChatCompletionResponse } from '../container/src/types.js';
 
 function makeEventStreamResponse(chunks: string[]): Response {
   const encoder = new TextEncoder();
@@ -17,12 +19,213 @@ function makeEventStreamResponse(chunks: string[]): Response {
   });
 }
 
+const baseStreamArgs = {
+  provider: 'hybridai',
+  baseUrl: 'https://api.hybridai.one',
+  apiKey: 'test-key',
+  model: 'hybridai/gpt-5-nano',
+  chatbotId: '',
+  enableRag: false,
+  requestHeaders: undefined,
+  messages: [{ role: 'user', content: 'hello' }],
+  tools: [],
+  maxTokens: 128,
+  isLocal: false,
+  contextWindow: 1_000_000,
+  thinkingFormat: undefined,
+} satisfies Omit<NormalizedStreamCallArgs, 'onTextDelta'>;
+
+type StreamPayload = Record<string, unknown> | '[DONE]';
+
+async function streamPayloads(payloads: StreamPayload[]): Promise<{
+  textDeltas: string[];
+  result: ChatCompletionResponse;
+}> {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      makeEventStreamResponse(
+        payloads.map(
+          (payload) =>
+            `data: ${payload === '[DONE]' ? payload : JSON.stringify(payload)}\n\n`,
+        ),
+      ),
+    ),
+  );
+
+  const textDeltas: string[] = [];
+  const result = await callHybridAIProviderStream({
+    ...baseStreamArgs,
+    onTextDelta: (delta) => textDeltas.push(delta),
+  });
+  return { textDeltas, result };
+}
+
+function expectStreamText(
+  streamed: {
+    textDeltas: string[];
+    result: ChatCompletionResponse;
+  },
+  expectedDeltas: string[],
+  expectedContent: string,
+): void {
+  expect(streamed.textDeltas).toEqual(expectedDeltas);
+  expect(streamed.textDeltas.join('')).toBe(expectedContent);
+  expect(streamed.result.choices[0]?.message.content).toBe(expectedContent);
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
 describe('HybridAI container provider', () => {
+  test('keeps delta-only streams unchanged, including repeated text', async () => {
+    const streamed = await streamPayloads([
+      { choices: [{ delta: { content: 'Ja' } }] },
+      { choices: [{ delta: { content: 'Ja' }, finish_reason: 'stop' }] },
+      '[DONE]',
+    ]);
+
+    expectStreamText(streamed, ['Ja', 'Ja'], 'JaJa');
+  });
+
+  test('emits only new suffixes from cumulative message snapshots', async () => {
+    const streamed = await streamPayloads([
+      {
+        choices: [
+          { message: { content: 'Alles' }, delta: { content: 'Alles' } },
+        ],
+      },
+      {
+        choices: [
+          {
+            message: { content: 'Alles klar' },
+            delta: { content: ' klar' },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            message: { content: 'Alles klar!' },
+            delta: { content: '!' },
+            finish_reason: 'stop',
+          },
+        ],
+      },
+      '[DONE]',
+    ]);
+
+    expectStreamText(streamed, ['Alles', ' klar', '!'], 'Alles klar!');
+  });
+
+  test('does not duplicate a final message snapshot and delta', async () => {
+    const streamed = await streamPayloads([
+      { choices: [{ delta: { content: 'Alles klar' } }] },
+      {
+        choices: [
+          {
+            message: { content: 'Alles klar' },
+            delta: { content: 'Alles klar' },
+            finish_reason: 'stop',
+          },
+        ],
+      },
+      '[DONE]',
+    ]);
+
+    expectStreamText(streamed, ['Alles klar'], 'Alles klar');
+  });
+
+  test('does not let empty message content suppress a valid delta', async () => {
+    const streamed = await streamPayloads([
+      {
+        choices: [
+          {
+            message: { content: '' },
+            delta: { content: 'Alles klar' },
+            finish_reason: 'stop',
+          },
+        ],
+      },
+      '[DONE]',
+    ]);
+
+    expectStreamText(streamed, ['Alles klar'], 'Alles klar');
+  });
+
+  test('preserves tool calls before a final text response without duplication', async () => {
+    const streamed = await streamPayloads([
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_1',
+                  type: 'function',
+                  function: {
+                    name: 'complete_onboarding',
+                    arguments: '{"confirmed":',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  function: { arguments: 'true}' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      { choices: [{ delta: { content: 'Alles klar' } }] },
+      {
+        usage: {
+          prompt_tokens: 12,
+          completion_tokens: 2,
+          total_tokens: 14,
+        },
+        choices: [
+          {
+            message: { content: 'Alles klar' },
+            delta: { content: 'Alles klar' },
+            finish_reason: 'stop',
+          },
+        ],
+      },
+      '[DONE]',
+    ]);
+
+    expectStreamText(streamed, ['Alles klar'], 'Alles klar');
+    expect(streamed.result.choices[0]?.message.tool_calls).toEqual([
+      {
+        id: 'call_1',
+        type: 'function',
+        function: {
+          name: 'complete_onboarding',
+          arguments: '{"confirmed":true}',
+        },
+      },
+    ]);
+    expect(streamed.result.usage).toEqual({
+      prompt_tokens: 12,
+      completion_tokens: 2,
+      total_tokens: 14,
+    });
+  });
+
   test('streams structured reasoning separately from visible content', async () => {
     let requestBody: Record<string, unknown> | undefined;
     vi.stubGlobal(
@@ -43,21 +246,10 @@ describe('HybridAI container provider', () => {
     const textDeltas: string[] = [];
     const thinkingDeltas: string[] = [];
     const result = await callHybridAIProviderStream({
-      provider: 'hybridai',
-      baseUrl: 'https://api.hybridai.one',
-      apiKey: 'test-key',
+      ...baseStreamArgs,
       model: 'hybridai/anthropic/claude-sonnet-5',
-      chatbotId: '',
-      enableRag: false,
-      requestHeaders: undefined,
-      messages: [{ role: 'user', content: 'hello' }],
-      tools: [],
       onTextDelta: (delta) => textDeltas.push(delta),
       onThinkingDelta: (delta) => thinkingDeltas.push(delta),
-      maxTokens: 128,
-      isLocal: false,
-      contextWindow: 1_000_000,
-      thinkingFormat: undefined,
     });
 
     expect(thinkingDeltas).toEqual(['Plan', ' carefully']);


### PR DESCRIPTION
## Summary

- prefer non-empty `choice.message.content` over `choice.delta.content` within the same HybridAI SSE payload
- emit only the new suffix for cumulative message snapshots while preserving delta-only streams and valid deltas paired with empty messages
- add regression coverage for cumulative snapshots, the onboarding duplication case, tool calls, reasoning, usage, and streamed/final content consistency

## Root cause

The stream accumulator marked message content as consumed only when a message snapshot produced a non-empty suffix. When a final cumulative snapshot exactly matched the text already accumulated from earlier deltas, the marker remained false and the identical delta from the same payload was appended again.

## Impact

HybridAI onboarding responses and the resulting assistant message now contain the final text exactly once. Delta-only streams and legitimate repeated model output remain unchanged. No frontend changes are required.

## Validation

- `vitest`: 17 targeted HybridAI provider/router tests passed
- `npm --prefix container run lint`
- `npm run build`
- `npm run format`
- `npm run lint`