### PR TITLE
fix: link trace turns to stored assistant messages

### DIFF
--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -3900,6 +3900,7 @@ export function recordSuccessfulTurn(opts: {
       type: 'turn.end',
       turnIndex: opts.turnIndex,
       finishReason: 'completed',
+      assistantMessageId: storedTurn.assistantMessageId,
     },
   });
   recordAuditEvent({
@@ -9005,6 +9006,7 @@ export async function ensureGatewayBootstrapAutostart(params: {
           type: 'turn.end',
           turnIndex,
           finishReason: 'completed',
+          assistantMessageId,
         },
       });
       recordAuditEvent({
@@ -9183,6 +9185,7 @@ export async function ensureGatewayBootstrapAutostart(params: {
         type: 'turn.end',
         turnIndex,
         finishReason: 'completed',
+        assistantMessageId,
       },
     });
     recordAuditEvent({

--- a/src/session/session-trace-export.ts
+++ b/src/session/session-trace-export.ts
@@ -25,7 +25,6 @@ import { isRecord } from '../utils/type-guards.js';
 import {
   type AuditTurnTraceSelector,
   buildAuditTurnTraceRecords,
-  countCompletedTurnsBefore,
   selectAuditTurnGroups,
   type AuditTurnGroup as TurnGroup,
 } from './session-turn-trace.js';
@@ -89,6 +88,8 @@ const TRACE_EXPORT_BASE_LIMITATIONS = Object.freeze([
 ]);
 const TRACE_EXPORT_FALLBACK_LIMITATION =
   'Structured turn audit was unavailable, so steps were reconstructed directly from stored session messages.';
+const TRACE_EXPORT_ASSISTANT_MESSAGE_ID_LIMITATION =
+  'One or more completed audit turns referenced an assistant message ID that could not be resolved to an assistant message in the exported session; their agent content was left empty.';
 const TRACE_DEPENDENCY_MANIFEST_FILES = [
   'package.json',
   'requirements.txt',
@@ -106,10 +107,16 @@ interface TurnRowSummary {
   agentStart: StructuredAuditEntry | null;
   usageRow: StructuredAuditEntry | null;
   turnEnd: StructuredAuditEntry | null;
+  onboardingAssistantMessage: StructuredAuditEntry | null;
   errorRow: StructuredAuditEntry | null;
   toolCallRows: StructuredAuditEntry[];
   toolResultRows: StructuredAuditEntry[];
 }
+
+type AssistantMessageReference =
+  | { status: 'absent' }
+  | { status: 'invalid' }
+  | { status: 'valid'; id: number };
 
 interface TraceProjectContext {
   workspaceRoot: string;
@@ -825,6 +832,7 @@ function summarizeTurnRows(rows: StructuredAuditEntry[]): TurnRowSummary {
     agentStart: null,
     usageRow: null,
     turnEnd: null,
+    onboardingAssistantMessage: null,
     errorRow: null,
     toolCallRows: [],
     toolResultRows: [],
@@ -839,6 +847,9 @@ function summarizeTurnRows(rows: StructuredAuditEntry[]): TurnRowSummary {
         break;
       case 'turn.end':
         summary.turnEnd ??= row;
+        break;
+      case 'onboarding.assistant_message':
+        summary.onboardingAssistantMessage ??= row;
         break;
       case 'error':
         summary.errorRow ??= row;
@@ -993,23 +1004,80 @@ function readTurnFinishReason(summary: TurnRowSummary): string | null {
   return turnEndPayload ? readString(turnEndPayload, 'finishReason') : null;
 }
 
+function readAssistantMessageReference(
+  payload: Record<string, unknown>,
+): AssistantMessageReference {
+  if (!Object.hasOwn(payload, 'assistantMessageId')) {
+    return { status: 'absent' };
+  }
+  const id = payload.assistantMessageId;
+  return typeof id === 'number' && Number.isSafeInteger(id) && id > 0
+    ? { status: 'valid', id }
+    : { status: 'invalid' };
+}
+
+function readTurnAssistantMessageReference(
+  summary: TurnRowSummary,
+): AssistantMessageReference {
+  const turnEndPayload = summary.turnEnd
+    ? parseJsonObject(summary.turnEnd.payload)
+    : null;
+  if (turnEndPayload) {
+    const reference = readAssistantMessageReference(turnEndPayload);
+    if (reference.status !== 'absent') return reference;
+  }
+
+  const onboardingPayload = summary.onboardingAssistantMessage
+    ? parseJsonObject(summary.onboardingAssistantMessage.payload)
+    : null;
+  return onboardingPayload
+    ? readAssistantMessageReference(onboardingPayload)
+    : { status: 'absent' };
+}
+
 function resolveTurnAgentContent(
   summary: TurnRowSummary,
   finishReason: string | null,
   assistantMessages: StoredMessage[],
+  assistantIndexById: Map<number, number>,
   assistantIndex: number,
 ): {
   content: string;
   nextAssistantIndex: number;
   completed: boolean;
   errored: boolean;
+  unresolvedAssistantMessageReference: boolean;
 } {
   if (finishReason === 'completed') {
+    const reference = readTurnAssistantMessageReference(summary);
+    if (reference.status !== 'absent') {
+      const referencedIndex =
+        reference.status === 'valid'
+          ? assistantIndexById.get(reference.id)
+          : undefined;
+      if (referencedIndex == null) {
+        return {
+          content: '',
+          nextAssistantIndex: assistantIndex,
+          completed: true,
+          errored: false,
+          unresolvedAssistantMessageReference: true,
+        };
+      }
+      return {
+        content: assistantMessages[referencedIndex]?.content || '',
+        nextAssistantIndex: Math.max(assistantIndex, referencedIndex + 1),
+        completed: true,
+        errored: false,
+        unresolvedAssistantMessageReference: false,
+      };
+    }
     return {
       content: assistantMessages[assistantIndex]?.content || '',
       nextAssistantIndex: assistantIndex + 1,
       completed: true,
       errored: false,
+      unresolvedAssistantMessageReference: false,
     };
   }
 
@@ -1021,7 +1089,33 @@ function resolveTurnAgentContent(
     nextAssistantIndex: assistantIndex,
     completed: false,
     errored: true,
+    unresolvedAssistantMessageReference: false,
   };
+}
+
+function findAssistantIndexBeforeTurn(params: {
+  allTurns: TurnGroup[];
+  selectedTurns: TurnGroup[];
+  assistantMessages: StoredMessage[];
+  assistantIndexById: Map<number, number>;
+}): number {
+  const firstSelectedSeq = params.selectedTurns[0]?.turnStart.seq;
+  if (firstSelectedSeq == null) return 0;
+
+  let assistantIndex = 0;
+  for (const turn of params.allTurns) {
+    if (turn.turnStart.seq >= firstSelectedSeq) break;
+    const summary = summarizeTurnRows(turn.rows);
+    const resolved = resolveTurnAgentContent(
+      summary,
+      readTurnFinishReason(summary),
+      params.assistantMessages,
+      params.assistantIndexById,
+      assistantIndex,
+    );
+    assistantIndex = resolved.nextAssistantIndex;
+  }
+  return assistantIndex;
 }
 
 function readTurnStepTimestamp(
@@ -1062,10 +1156,11 @@ function buildPromptPrefixTraceEntries(params: {
 
 function buildTraceSteps(params: {
   turns: TurnGroup[];
+  allTurns?: TurnGroup[];
+  sessionId: string;
   messages: StoredMessage[];
   fallbackModel: string;
   systemPromptHashByRunId: Map<string, string>;
-  assistantStartIndex?: number;
   preferResultPreview?: boolean;
 }): {
   steps: Array<Record<string, unknown>>;
@@ -1074,17 +1169,31 @@ function buildTraceSteps(params: {
   errorTurns: number;
   cacheReadTokens: number;
   cacheWriteTokens: number;
+  unresolvedAssistantMessageReferences: number;
 } {
   const assistantMessages = params.messages.filter(
-    (message) => message.role === 'assistant',
+    (message) =>
+      message.session_id === params.sessionId && message.role === 'assistant',
   );
+  const assistantIndexById = new Map<number, number>();
+  assistantMessages.forEach((message, index) => {
+    if (Number.isSafeInteger(message.id) && message.id > 0) {
+      assistantIndexById.set(message.id, index);
+    }
+  });
   const steps: Array<Record<string, unknown>> = [];
-  let assistantIndex = params.assistantStartIndex || 0;
+  let assistantIndex = findAssistantIndexBeforeTurn({
+    allTurns: params.allTurns || params.turns,
+    selectedTurns: params.turns,
+    assistantMessages,
+    assistantIndexById,
+  });
   let stepIndex = 0;
   let completedTurns = 0;
   let errorTurns = 0;
   let cacheReadTokens = 0;
   let cacheWriteTokens = 0;
+  let unresolvedAssistantMessageReferences = 0;
   const agentStepIndexByRunId = new Map<string, number>();
 
   for (const turn of params.turns) {
@@ -1130,11 +1239,15 @@ function buildTraceSteps(params: {
       summary,
       finishReason,
       assistantMessages,
+      assistantIndexById,
       assistantIndex,
     );
     assistantIndex = resolvedContent.nextAssistantIndex;
     if (resolvedContent.completed) completedTurns += 1;
     if (resolvedContent.errored) errorTurns += 1;
+    if (resolvedContent.unresolvedAssistantMessageReference) {
+      unresolvedAssistantMessageReferences += 1;
+    }
 
     agentStepIndexByRunId.set(turn.runId, stepIndex);
     steps.push({
@@ -1175,6 +1288,7 @@ function buildTraceSteps(params: {
     errorTurns,
     cacheReadTokens,
     cacheWriteTokens,
+    unresolvedAssistantMessageReferences,
   };
 }
 
@@ -1430,9 +1544,6 @@ export async function exportSessionTraceAtifJsonl(params: {
     }
     const allTurns = selection.allTurns;
     const turns = params.selector ? selection.selectedTurns : allTurns;
-    const assistantStartIndex = params.selector
-      ? countCompletedTurnsBefore(allTurns, turns)
-      : 0;
     const fallbackModel = params.session.model || '';
     const { systemPrompts, systemPromptHashByRunId } =
       buildTraceSystemPrompts(turns);
@@ -1440,10 +1551,11 @@ export async function exportSessionTraceAtifJsonl(params: {
       turns.length > 0
         ? buildTraceSteps({
             turns,
+            allTurns,
+            sessionId,
             messages: params.messages,
             fallbackModel,
             systemPromptHashByRunId,
-            assistantStartIndex,
             preferResultPreview: Boolean(params.selector),
           })
         : {
@@ -1453,6 +1565,7 @@ export async function exportSessionTraceAtifJsonl(params: {
             errorTurns: 0,
             cacheReadTokens: 0,
             cacheWriteTokens: 0,
+            unresolvedAssistantMessageReferences: 0,
           };
     const steps = traceData.steps;
     const exportedSystemPrompts = systemPrompts;
@@ -1495,10 +1608,13 @@ export async function exportSessionTraceAtifJsonl(params: {
       workspaceRoot: projectContext.workspaceRoot,
       repoRoot: projectContext.repoRoot,
     });
-    const limitations =
+    const limitations: string[] =
       turns.length === 0
         ? [...TRACE_EXPORT_BASE_LIMITATIONS, TRACE_EXPORT_FALLBACK_LIMITATION]
         : [...TRACE_EXPORT_BASE_LIMITATIONS];
+    if (traceData.unresolvedAssistantMessageReferences > 0) {
+      limitations.push(TRACE_EXPORT_ASSISTANT_MESSAGE_ID_LIMITATION);
+    }
     const committedOutcome = detectCommittedOutcomeFromSteps(steps);
     const focusedTurnTrace = params.selector
       ? buildAuditTurnTraceRecords({

--- a/tests/gateway-service.audit.test.ts
+++ b/tests/gateway-service.audit.test.ts
@@ -1069,6 +1069,55 @@ test('handleGatewayMessage skips request logs when request logging is disabled',
   expect(rowCount.count).toBe(0);
 });
 
+test('handleGatewayMessage records the stored assistant message id on successful turn end', async () => {
+  setupHome();
+
+  runAgentMock.mockResolvedValue({
+    status: 'success',
+    result: 'Stored assistant response.',
+    toolsUsed: [],
+    toolExecutions: [],
+  });
+
+  const {
+    getRecentMessages,
+    getRecentStructuredAuditForSession,
+    initDatabase,
+  } = await import('../src/memory/db.ts');
+  const { handleGatewayMessage } = await import(
+    '../src/gateway/gateway-chat-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const sessionId = 'session-turn-assistant-message-id';
+  const result = await handleGatewayMessage({
+    sessionId,
+    guildId: null,
+    channelId: 'web',
+    userId: 'user-1',
+    username: 'alice',
+    content: 'Store this turn',
+    model: 'test-model',
+    chatbotId: 'bot-1',
+  });
+
+  expect(result.status).toBe('success');
+  const assistantMessage = getRecentMessages(sessionId).find(
+    (message) => message.role === 'assistant',
+  );
+  expect(assistantMessage).toBeTruthy();
+  expect(result.assistantMessageId).toBe(assistantMessage?.id);
+
+  const turnEnd = getRecentStructuredAuditForSession(sessionId, 20).find(
+    (row) => row.event_type === 'turn.end',
+  );
+  expect(JSON.parse(turnEnd?.payload || '{}')).toMatchObject({
+    type: 'turn.end',
+    finishReason: 'completed',
+    assistantMessageId: assistantMessage?.id,
+  });
+});
+
 test('handleGatewayMessage warns once and disables request logs for invalid env values', async () => {
   setupHome({ HYBRIDCLAW_LOG_REQUESTS: 'true' });
 

--- a/tests/gateway-service.bootstrap-autostart.test.ts
+++ b/tests/gateway-service.bootstrap-autostart.test.ts
@@ -228,13 +228,18 @@ test('ensureGatewayBootstrapAutostart stores prelude and bootstrap opener once p
   const assistantMessageEvent = auditRows.find(
     (row) => row.event_type === 'onboarding.assistant_message',
   );
+  const turnEndEvent = auditRows.find(
+    (row) => row.event_type === 'turn.end',
+  );
   expect(quickMessageEvent).toBeTruthy();
   expect(assistantMessageEvent).toBeTruthy();
+  expect(turnEndEvent).toBeTruthy();
   expect(JSON.parse(String(quickMessageEvent?.payload || '{}'))).toMatchObject({
     type: 'onboarding.quick_message',
     workspaceAgentId: 'main',
     source: 'gateway.bootstrap',
     bootstrapFile: 'BOOTSTRAP.md',
+    assistantMessageId: history[0]?.id,
     messageRole: 'assistant',
     messageChars: DEFAULT_GATEWAY_AUXILIARY_PRELUDE.length,
   });
@@ -245,9 +250,15 @@ test('ensureGatewayBootstrapAutostart stores prelude and bootstrap opener once p
     workspaceAgentId: 'main',
     source: 'gateway.bootstrap',
     bootstrapFile: 'BOOTSTRAP.md',
+    assistantMessageId: history[1]?.id,
     messageRole: 'assistant',
     messageChars: 'Hello. I am ready to get you oriented.'.length,
     toolCallCount: 0,
+  });
+  expect(JSON.parse(String(turnEndEvent?.payload || '{}'))).toMatchObject({
+    type: 'turn.end',
+    finishReason: 'completed',
+    assistantMessageId: history[1]?.id,
   });
   expect(pluginManagerMock.notifySessionStart).toHaveBeenCalledTimes(1);
   expect(pluginManagerMock.notifyBeforeAgentStart).toHaveBeenCalledTimes(1);

--- a/tests/session-trace-export.test.ts
+++ b/tests/session-trace-export.test.ts
@@ -36,7 +36,7 @@ test('exports an opentraces/ATIF-compatible JSONL trace from stored session data
   );
   updateSessionModel(session.id, 'gpt-5-nano');
   storeMessage(session.id, 'user-1', 'alice', 'user', 'Fix the parser test');
-  storeMessage(
+  const assistantMessageId = storeMessage(
     session.id,
     'assistant',
     null,
@@ -104,6 +104,7 @@ test('exports an opentraces/ATIF-compatible JSONL trace from stored session data
       type: 'turn.end',
       turnIndex: 1,
       finishReason: 'completed',
+      assistantMessageId,
     },
   });
   recordAuditEvent({
@@ -149,7 +150,7 @@ test('exports an opentraces/ATIF-compatible JSONL trace from stored session data
         created_at: new Date().toISOString(),
       },
       {
-        id: 2,
+        id: assistantMessageId,
         session_id: session.id,
         user_id: 'assistant',
         username: null,
@@ -282,6 +283,278 @@ test('exports an opentraces/ATIF-compatible JSONL trace from stored session data
       error: null,
     },
   ]);
+});
+
+test('trace export resolves assistant messages by stable id and preserves legacy fallback ordering', async () => {
+  setupHome();
+
+  const {
+    getOrCreateSession,
+    getSessionById,
+    getSessionUsageTotals,
+    getStructuredAuditForSession,
+    initDatabase,
+  } = await import('../src/memory/db.ts');
+  const { emitToolExecutionAuditEvents, recordAuditEvent } = await import(
+    '../src/audit/audit-events.ts'
+  );
+  const { exportSessionTraceAtifJsonl } = await import(
+    '../src/session/session-trace-export.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const session = getOrCreateSession(
+    'session-trace-message-ids',
+    null,
+    'channel-trace-message-ids',
+  );
+  const timestamp = new Date().toISOString();
+  const messages = [
+    {
+      id: 1,
+      session_id: session.id,
+      user_id: 'assistant',
+      username: null,
+      role: 'assistant',
+      content: 'Bootstrap prelude.',
+      created_at: timestamp,
+    },
+    {
+      id: 2,
+      session_id: session.id,
+      user_id: 'assistant',
+      username: null,
+      role: 'assistant',
+      content: 'Actual onboarding greeting.',
+      created_at: timestamp,
+    },
+    {
+      id: 3,
+      session_id: session.id,
+      user_id: 'user-1',
+      username: 'alice',
+      role: 'user',
+      content: 'Finish onboarding',
+      created_at: timestamp,
+    },
+    {
+      id: 4,
+      session_id: session.id,
+      user_id: 'assistant',
+      username: null,
+      role: 'assistant',
+      content: 'Interleaved proactive message.',
+      created_at: timestamp,
+    },
+    {
+      id: 5,
+      session_id: session.id,
+      user_id: 'assistant',
+      username: null,
+      role: 'assistant',
+      content: 'Die echte deutsche Abschlussantwort.',
+      created_at: timestamp,
+    },
+    {
+      id: 6,
+      session_id: session.id,
+      user_id: 'user-1',
+      username: 'alice',
+      role: 'user',
+      content: 'Legacy prompt',
+      created_at: timestamp,
+    },
+    {
+      id: 7,
+      session_id: session.id,
+      user_id: 'assistant',
+      username: null,
+      role: 'assistant',
+      content: 'Legacy positional response.',
+      created_at: timestamp,
+    },
+    {
+      id: 8,
+      session_id: session.id,
+      user_id: 'user-1',
+      username: 'alice',
+      role: 'user',
+      content: 'This is not an assistant message.',
+      created_at: timestamp,
+    },
+    {
+      id: 9,
+      session_id: session.id,
+      user_id: 'assistant',
+      username: null,
+      role: 'assistant',
+      content: 'Must not be substituted for a missing reference.',
+      created_at: timestamp,
+    },
+  ];
+
+  recordAuditEvent({
+    sessionId: session.id,
+    runId: 'turn_message_id_onboarding',
+    event: {
+      type: 'turn.start',
+      turnIndex: 1,
+      userInput: 'Start onboarding',
+      source: 'gateway.bootstrap',
+    },
+  });
+  recordAuditEvent({
+    sessionId: session.id,
+    runId: 'turn_message_id_onboarding',
+    event: {
+      type: 'onboarding.assistant_message',
+      assistantMessageId: 2,
+      messageRole: 'assistant',
+    },
+  });
+  recordAuditEvent({
+    sessionId: session.id,
+    runId: 'turn_message_id_onboarding',
+    event: {
+      type: 'turn.end',
+      turnIndex: 1,
+      finishReason: 'completed',
+    },
+  });
+
+  recordAuditEvent({
+    sessionId: session.id,
+    runId: 'turn_message_id_normal',
+    event: {
+      type: 'turn.start',
+      turnIndex: 2,
+      userInput: 'Finish onboarding',
+      source: 'gateway.chat',
+    },
+  });
+  emitToolExecutionAuditEvents({
+    sessionId: session.id,
+    runId: 'turn_message_id_normal',
+    toolExecutions: [
+      {
+        name: 'message.send',
+        arguments: JSON.stringify({ channel: 'email', content: 'Willkommen' }),
+        result: 'Message sent.',
+        durationMs: 12,
+        isError: false,
+      },
+    ],
+  });
+  recordAuditEvent({
+    sessionId: session.id,
+    runId: 'turn_message_id_normal',
+    event: {
+      type: 'turn.end',
+      turnIndex: 2,
+      finishReason: 'completed',
+      assistantMessageId: 5,
+    },
+  });
+
+  recordAuditEvent({
+    sessionId: session.id,
+    runId: 'turn_message_id_legacy',
+    event: {
+      type: 'turn.start',
+      turnIndex: 3,
+      userInput: 'Legacy prompt',
+      source: 'gateway.chat',
+    },
+  });
+  recordAuditEvent({
+    sessionId: session.id,
+    runId: 'turn_message_id_legacy',
+    event: {
+      type: 'turn.end',
+      turnIndex: 3,
+      finishReason: 'completed',
+    },
+  });
+
+  for (const [runId, turnIndex, assistantMessageId] of [
+    ['turn_message_id_missing', 4, 999],
+    ['turn_message_id_wrong_role', 5, 8],
+    ['turn_message_id_non_positive', 6, 0],
+    ['turn_message_id_unsafe', 7, Number.MAX_SAFE_INTEGER + 1],
+  ] as const) {
+    recordAuditEvent({
+      sessionId: session.id,
+      runId,
+      event: {
+        type: 'turn.start',
+        turnIndex,
+        userInput: `Unresolvable reference ${assistantMessageId}`,
+        source: 'gateway.chat',
+      },
+    });
+    recordAuditEvent({
+      sessionId: session.id,
+      runId,
+      event: {
+        type: 'turn.end',
+        turnIndex,
+        finishReason: 'completed',
+        assistantMessageId,
+      },
+    });
+  }
+
+  const refreshedSession = getSessionById(session.id);
+  if (!refreshedSession) {
+    throw new Error('Expected refreshed session to exist');
+  }
+  const exported = await exportSessionTraceAtifJsonl({
+    agentId: refreshedSession.agent_id,
+    session: refreshedSession,
+    messages,
+    auditEntries: getStructuredAuditForSession(session.id),
+    usageTotals: getSessionUsageTotals(session.id),
+  });
+
+  expect(exported).not.toBeNull();
+  const raw = fs.readFileSync(exported?.path || '', 'utf-8').trim();
+  const record = JSON.parse(raw) as Record<string, unknown>;
+  const agentSteps = (record.steps as Array<Record<string, unknown>>).filter(
+    (step) => step.role === 'agent',
+  );
+  expect(agentSteps.map((step) => step.content || '')).toEqual([
+    'Actual onboarding greeting.',
+    'Die echte deutsche Abschlussantwort.',
+    'Legacy positional response.',
+    '',
+    '',
+    '',
+    '',
+  ]);
+  expect(agentSteps[1]?.tool_calls).toEqual([
+    expect.objectContaining({ tool_name: 'message.send' }),
+  ]);
+  expect(agentSteps[1]?.observations).toEqual([
+    expect.objectContaining({ content: 'Message sent.' }),
+  ]);
+  expect(JSON.stringify(agentSteps)).not.toContain('Bootstrap prelude.');
+  expect(JSON.stringify(agentSteps)).not.toContain(
+    'Interleaved proactive message.',
+  );
+  expect(JSON.stringify(agentSteps)).not.toContain(
+    'Must not be substituted for a missing reference.',
+  );
+  expect(record.metadata).toMatchObject({
+    hybridclaw: {
+      stored_message_count: messages.length,
+      audit_event_count: expect.any(Number),
+    },
+  });
+  const limitations = (record.metadata as { limitations: string[] })
+    .limitations;
+  expect(limitations).toContain(
+    'One or more completed audit turns referenced an assistant message ID that could not be resolved to an assistant message in the exported session; their agent content was left empty.',
+  );
 });
 
 test('trace export keeps consecutive buildConversationContext system prompts byte-identical', async () => {
@@ -862,9 +1135,22 @@ test('gateway export trace command writes a focused turn trace', async () => {
     'channel-trace-turn-command',
   );
   storeMessage(session.id, 'user-1', 'alice', 'user', 'Prompt 1');
-  storeMessage(session.id, 'assistant', null, 'assistant', 'Assistant 1');
+  const assistantMessageId1 = storeMessage(
+    session.id,
+    'assistant',
+    null,
+    'assistant',
+    'Assistant 1',
+  );
   storeMessage(session.id, 'user-1', 'alice', 'user', 'Prompt 2');
   storeMessage(
+    session.id,
+    'assistant',
+    null,
+    'assistant',
+    'Interleaved proactive assistant message',
+  );
+  const assistantMessageId2 = storeMessage(
     session.id,
     'assistant',
     null,
@@ -908,6 +1194,8 @@ test('gateway export trace command writes a focused turn trace', async () => {
         type: 'turn.end',
         turnIndex: index,
         finishReason: 'completed',
+        assistantMessageId:
+          index === 1 ? assistantMessageId1 : assistantMessageId2,
       },
     });
   }
@@ -982,6 +1270,19 @@ test('gateway export trace command writes a focused turn trace', async () => {
     throw new Error(`Unexpected result kind: ${runResult.kind}`);
   }
   expect(runResult.text).toContain('Runs: turn_trace_focus_2');
+  const runFileLine = runResult.text
+    .split('\n')
+    .find((line) => line.startsWith('File: '));
+  const runRaw = fs
+    .readFileSync(runFileLine?.slice('File: '.length) || '', 'utf-8')
+    .trim();
+  const runRecord = JSON.parse(runRaw) as Record<string, unknown>;
+  const runSteps = runRecord.steps as Array<Record<string, unknown>>;
+  expect(runSteps).toHaveLength(2);
+  expect(String(runSteps[1]?.content)).toContain('Assistant 2');
+  expect(JSON.stringify(runSteps)).not.toContain(
+    'Interleaved proactive assistant message',
+  );
 });
 
 test('trace export adds a fallback limitation when structured turn audit is unavailable', async () => {


### PR DESCRIPTION
## Summary

- record the persisted assistant message ID on successful `turn.end` audit events for normal chat, bootstrap autostart, and opening completion paths
- resolve exported trace agent content by stable message ID, with the existing onboarding audit event as a compatibility fallback
- preserve positional resolution only for legacy audit turns without a stable ID and advance its cursor after ID-based matches
- keep focused `--turn` and `--run` exports aligned with the same resolution rules

## Root cause

Trace export previously paired completed audit turns with assistant messages by position. Bootstrap preludes, proactive assistant messages, and other additional assistant entries shifted that position, so a turn could receive the wrong stored response and tool calls could be shown beside unrelated content.

## Security and compatibility

- IDs are resolved only against the messages already supplied for the exported session
- references must be positive safe integers and target an `assistant` message
- unresolved, invalid, wrong-role, or foreign IDs leave agent content empty and add an export limitation instead of silently substituting another message
- existing audits remain readable through onboarding and positional fallbacks
- no database migration or ATIF schema-version bump

## Validation

- `npx vitest run tests/container.hybridai-provider.test.ts`
- `npx vitest run tests/session-trace-export.test.ts`
- `npx vitest run tests/gateway-service.bootstrap-autostart.test.ts`
- `npx vitest run tests/gateway-service.audit.test.ts`
- `npm --prefix container run lint`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
