### PR TITLE
fix: clean up default provider health

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -425,7 +425,7 @@
   "local": {
     "backends": {
       "ollama": {
-        "enabled": true,
+        "enabled": false,
         "baseUrl": "http://127.0.0.1:11434"
       },
       "lmstudio": {

--- a/docs/content/developer-guide/runtime.md
+++ b/docs/content/developer-guide/runtime.md
@@ -379,6 +379,9 @@ HybridClaw can route agent turns to locally running LLM servers instead of
 - **llama.cpp** — default base URL `http://127.0.0.1:8081/v1`
 - **vLLM** — default base URL `http://127.0.0.1:8000/v1`
 
+Local backends are disabled by default and are probed only after an operator
+enables them.
+
 Enable and configure a backend with:
 
 ```bash

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -455,7 +455,7 @@ export let XIAOMI_ENABLED = false;
 export let XIAOMI_BASE_URL = 'https://api.xiaomimimo.com/v1';
 export let KILO_ENABLED = false;
 export let KILO_BASE_URL = 'https://api.kilo.ai/api/gateway';
-export let LOCAL_OLLAMA_ENABLED = true;
+export let LOCAL_OLLAMA_ENABLED = false;
 export let LOCAL_OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
 export let LOCAL_OLLAMA_MODEL_BEHAVIOR:
   | RuntimeConfig['local']['backends']['ollama']['modelBehavior']

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -1860,7 +1860,7 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   local: {
     backends: {
       ollama: {
-        enabled: true,
+        enabled: false,
         baseUrl: 'http://127.0.0.1:11434',
       },
       lmstudio: {

--- a/src/gateway/provider-status.ts
+++ b/src/gateway/provider-status.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+
 import {
   getAnthropicAuthStatus,
   isAnthropicAuthReadyForMethod,
@@ -30,9 +32,18 @@ export function buildGatewayProviderHealth(params: {
     anthropicStatus,
     runtimeConfig.anthropic.method,
   );
+  const codexConfigured =
+    params.codex.authenticated ||
+    fs.existsSync(params.codex.path) ||
+    runtimeConfig.hybridai.defaultModel
+      .trim()
+      .toLowerCase()
+      .startsWith('openai-codex/');
   const providerHealth: NonNullable<GatewayStatus['providerHealth']> = {
     hybridai: params.hybridaiHealth,
-    codex: {
+  };
+  if (codexConfigured) {
+    providerHealth.codex = {
       kind: 'remote',
       reachable: params.codex.authenticated && !params.codex.reloginRequired,
       ...(params.codex.authenticated && !params.codex.reloginRequired
@@ -50,8 +61,8 @@ export function buildGatewayProviderHealth(params: {
           : params.codex.reloginRequired
             ? 'Login required'
             : 'Not authenticated',
-    },
-  };
+    };
+  }
   if (runtimeConfig.anthropic.enabled || anthropicStatus.authenticated) {
     providerHealth.anthropic = {
       kind: 'remote',

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -297,6 +297,54 @@ test('getGatewayStatus uses cached HybridAI health when probe rejects', async ()
   });
 });
 
+test('getGatewayStatus omits Codex health when Codex was never configured', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  writeRuntimeConfig(homeDir);
+  vi.resetModules();
+  mockHealthProbes({ hybridaiReachable: true });
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { getGatewayStatus } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  initDatabase({ quiet: true });
+
+  const status = await getGatewayStatus({ refreshProviderHealth: false });
+
+  expect(status.codex).toMatchObject({
+    authenticated: false,
+    reloginRequired: true,
+  });
+  expect(status.providerHealth?.codex).toBeUndefined();
+});
+
+test('getGatewayStatus keeps Codex login health when Codex is selected', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  writeRuntimeConfig(homeDir, (config) => {
+    config.hybridai.defaultModel = 'openai-codex/gpt-5.4';
+  });
+  vi.resetModules();
+  mockHealthProbes({ hybridaiReachable: true });
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { getGatewayStatus } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  initDatabase({ quiet: true });
+
+  const status = await getGatewayStatus({ refreshProviderHealth: false });
+
+  expect(status.providerHealth?.codex).toMatchObject({
+    kind: 'remote',
+    reachable: false,
+    error: 'Login required',
+    loginRequired: true,
+    detail: 'Login required',
+  });
+});
+
 test('getGatewayStatus includes Codex auth state', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;

--- a/tests/runtime-config.migration-logging.test.ts
+++ b/tests/runtime-config.migration-logging.test.ts
@@ -118,6 +118,36 @@ afterEach(() => {
 });
 
 describe('runtime config migration logging', () => {
+  it('seeds fresh instances with Ollama disabled', async () => {
+    const homeDir = makeTempHome();
+
+    const runtimeConfig = await importFreshRuntimeConfig(homeDir);
+    const stored = JSON.parse(
+      fs.readFileSync(
+        path.join(homeDir, '.hybridclaw', 'config.json'),
+        'utf-8',
+      ),
+    ) as RuntimeConfig;
+
+    expect(runtimeConfig.getRuntimeConfig().local.backends.ollama.enabled).toBe(
+      false,
+    );
+    expect(stored.local.backends.ollama.enabled).toBe(false);
+  });
+
+  it('preserves explicitly enabled Ollama backends', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir, (config) => {
+      config.local.backends.ollama.enabled = true;
+    });
+
+    const runtimeConfig = await importFreshRuntimeConfig(homeDir);
+
+    expect(runtimeConfig.getRuntimeConfig().local.backends.ollama.enabled).toBe(
+      true,
+    );
+  });
+
   it('does not log normalization on repeated startup once the file is canonical', async () => {
     const homeDir = makeTempHome();
     writeRuntimeConfig(homeDir);


### PR DESCRIPTION
## Summary

- omit Codex from backend health when it has never been authenticated, configured, or selected
- keep the actionable Codex login warning when Codex is the selected provider
- disable Ollama in freshly seeded runtime configs while preserving explicit existing enablement
- update the example config, runtime documentation, and boundary/migration coverage

## Root cause

The gateway always emitted a Codex health entry, even when no Codex credentials or configuration existed. Fresh configs also enabled the localhost Ollama backend, so cloud instances displayed an unavailable local backend that operators had never opted into.

## Risk

The change is limited to provider-health presentation and the default used when creating a new runtime config. Existing explicit Ollama settings are preserved. No authentication, authorization, sandbox, or network boundary is weakened.

## Validation

- `npm run format` (passes; reports 27 existing unsafe-fix suggestions)
- `npm run typecheck`
- `npm run lint`
- targeted Vitest coverage: 97 tests passed across `gateway-status` and `runtime-config.migration-logging`
- full unit suite: 5,306 tests passed; three unrelated local failures were observed (an existing gateway-admin mock import TDZ, a host-runner dependency-path fixture mismatch, and one plugin singleton timeout that passed on focused rerun)