### PR TITLE
fix: hot-reload Teams credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Microsoft Teams credential hot reload**: Setting or rotating
+  `MSTEAMS_APP_PASSWORD` through the admin secret store refreshes the running
+  gateway immediately, initializes Teams handlers that were waiting for
+  credentials, and rebuilds the Bot Framework adapter without requiring a
+  container restart.
+
 ## [0.28.1](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.1) - 2026-07-10
 
 ### Added

--- a/docs/content/channels/msteams.md
+++ b/docs/content/channels/msteams.md
@@ -56,6 +56,10 @@ Check what HybridClaw saved:
 hybridclaw auth status msteams
 ```
 
+On a running gateway, setting or rotating `MSTEAMS_APP_PASSWORD` from
+`/admin/secrets` refreshes the Teams credential and Bot Framework adapter in
+process. A container restart is not required.
+
 By default, Teams DMs and group channels start in `allowlist` mode. That means
 the bot will not answer anyone until you explicitly allow AAD object IDs in
 config or open a specific team/channel policy for testing.

--- a/docs/msteams.md
+++ b/docs/msteams.md
@@ -46,6 +46,10 @@ Check what HybridClaw saved:
 hybridclaw auth status msteams
 ```
 
+On a running gateway, setting or rotating `MSTEAMS_APP_PASSWORD` from
+`/admin/secrets` refreshes the Teams credential and Bot Framework adapter in
+process. A container restart is not required.
+
 By default, Teams DMs and group channels start in `allowlist` mode. That means
 the bot will not answer anyone until you explicitly allow AAD object IDs in
 config or open a specific team/channel policy for testing.

--- a/src/channels/msteams/runtime.ts
+++ b/src/channels/msteams/runtime.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import {
   type Request as BotFrameworkRequest,
@@ -99,7 +98,11 @@ export type CommandHandler = (
 let adapter: CloudAdapter | null = null;
 let messageHandler: MessageHandler | null = null;
 let commandHandler: CommandHandler | null = null;
-let adapterSignature = '';
+let adapterCredentials: {
+  appId: string;
+  password: string;
+  tenantId: string;
+} | null = null;
 const MAX_WEBHOOK_BYTES = 1_000_000;
 const ACTIVE_MSTEAMS_SESSIONS = new Map<string, ActiveMSTeamsSession>();
 
@@ -470,11 +473,17 @@ export async function sendToActiveMSTeamsSession(params: {
 }
 
 function buildAdapter(): CloudAdapter {
-  const passwordFingerprint = createHash('sha256')
-    .update(MSTEAMS_APP_PASSWORD)
-    .digest('hex');
-  const signature = `${MSTEAMS_APP_ID}:${MSTEAMS_TENANT_ID}:${passwordFingerprint}`;
-  if (adapter && adapterSignature === signature) {
+  const credentials = {
+    appId: MSTEAMS_APP_ID,
+    password: MSTEAMS_APP_PASSWORD,
+    tenantId: MSTEAMS_TENANT_ID,
+  };
+  if (
+    adapter &&
+    adapterCredentials?.appId === credentials.appId &&
+    adapterCredentials.password === credentials.password &&
+    adapterCredentials.tenantId === credentials.tenantId
+  ) {
     return adapter;
   }
 
@@ -493,7 +502,7 @@ function buildAdapter(): CloudAdapter {
   );
 
   adapter = new CloudAdapter(auth);
-  adapterSignature = signature;
+  adapterCredentials = credentials;
   adapter.onTurnError = async (turnContext, error) => {
     logger.error({ error }, 'Teams turn failed');
     try {

--- a/src/channels/msteams/runtime.ts
+++ b/src/channels/msteams/runtime.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import {
   type Request as BotFrameworkRequest,
@@ -469,9 +470,10 @@ export async function sendToActiveMSTeamsSession(params: {
 }
 
 function buildAdapter(): CloudAdapter {
-  const signature = `${MSTEAMS_APP_ID}:${MSTEAMS_TENANT_ID}:${Boolean(
-    MSTEAMS_APP_PASSWORD,
-  )}`;
+  const passwordFingerprint = createHash('sha256')
+    .update(MSTEAMS_APP_PASSWORD)
+    .digest('hex');
+  const signature = `${MSTEAMS_APP_ID}:${MSTEAMS_TENANT_ID}:${passwordFingerprint}`;
   if (adapter && adapterSignature === signature) {
     return adapter;
   }

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -4561,15 +4561,13 @@ async function handleApiAdminSecretOverwrite(
     });
     throw error;
   }
-  sendJson(
-    res,
-    200,
-    overwriteGatewayAdminSecret({
-      name,
-      value: readAdminSecretBodyValue(body),
-      audit,
-    }),
-  );
+  const result = overwriteGatewayAdminSecret({
+    name,
+    value: readAdminSecretBodyValue(body),
+    audit,
+  });
+  refreshRuntimeSecretsFromEnv();
+  sendJson(res, 200, result);
 }
 
 async function handleApiAdminSecretUnset(
@@ -4590,7 +4588,9 @@ async function handleApiAdminSecretUnset(
     return;
   }
 
-  sendJson(res, 200, unsetGatewayAdminSecret({ name, audit }));
+  const result = unsetGatewayAdminSecret({ name, audit });
+  refreshRuntimeSecretsFromEnv();
+  sendJson(res, 200, result);
 }
 
 function recordUnauthenticatedAdminSecretMutation(

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -1628,12 +1628,6 @@ async function startMSTeamsIntegration(): Promise<boolean> {
     logger.info('Microsoft Teams integration disabled');
     return false;
   }
-  if (!hasCredentials) {
-    logger.info(
-      'Microsoft Teams integration disabled: msteams.appId config or MSTEAMS_APP_PASSWORD runtime secret is missing',
-    );
-    return false;
-  }
   if (teamsConfig.webhook.port !== getConfigSnapshot().ops.healthPort) {
     logger.info(
       {
@@ -1825,6 +1819,12 @@ async function startMSTeamsIntegration(): Promise<boolean> {
       }
     },
   );
+  if (!hasCredentials) {
+    logger.info(
+      'Microsoft Teams integration disabled: msteams.appId config or MSTEAMS_APP_PASSWORD runtime secret is missing',
+    );
+    return false;
+  }
   logger.info(
     {
       webhookPath: teamsConfig.webhook.path,
@@ -2856,6 +2856,23 @@ async function refreshEmailIntegrationForConfigChange(
     );
   });
   await startEmailIntegration();
+}
+
+async function refreshMSTeamsIntegrationForConfigChange(
+  next: ReturnType<typeof getConfigSnapshot>,
+  prev: ReturnType<typeof getConfigSnapshot>,
+): Promise<void> {
+  if (shouldSkipChannelConfigRefresh(next, prev)) return;
+  if (JSON.stringify(next.msteams) === JSON.stringify(prev.msteams)) return;
+
+  logger.info(
+    {
+      enabled: next.msteams.enabled,
+      webhookPath: next.msteams.webhook.path,
+    },
+    'Config changed, refreshing Microsoft Teams integration',
+  );
+  await startMSTeamsIntegration();
 }
 
 async function refreshTelegramIntegrationForConfigChange(
@@ -3898,6 +3915,12 @@ async function main(): Promise<void> {
       logger.warn(
         { error },
         'Email integration restart failed after config change',
+      );
+    });
+    void refreshMSTeamsIntegrationForConfigChange(next, prev).catch((error) => {
+      logger.warn(
+        { error },
+        'Microsoft Teams integration refresh failed after config change',
       );
     });
     void refreshTelegramIntegrationForConfigChange(next, prev).catch(

--- a/tests/configured-models.test.ts
+++ b/tests/configured-models.test.ts
@@ -92,6 +92,42 @@ describe('env var overrides', () => {
     const config = await importFreshConfig(homeDir);
     expect(config.HYBRIDAI_CHATBOT_ID).toBe('from-config');
   });
+
+  it('hot-reloads the configured default chatbot when the env override is unset', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir, (config) => {
+      config.hybridai.defaultChatbotId = 'before-reload';
+    });
+    delete process.env.HYBRIDAI_CHATBOT_ID;
+    const config = await importFreshConfig(homeDir);
+    const { updateRuntimeConfig } = await import(
+      '../src/config/runtime-config.ts'
+    );
+
+    updateRuntimeConfig((draft) => {
+      draft.hybridai.defaultChatbotId = 'after-reload';
+    });
+
+    expect(config.HYBRIDAI_CHATBOT_ID).toBe('after-reload');
+  });
+
+  it('keeps the env chatbot override when the runtime config changes', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir, (config) => {
+      config.hybridai.defaultChatbotId = 'before-reload';
+    });
+    process.env.HYBRIDAI_CHATBOT_ID = 'from-env';
+    const config = await importFreshConfig(homeDir);
+    const { updateRuntimeConfig } = await import(
+      '../src/config/runtime-config.ts'
+    );
+
+    updateRuntimeConfig((draft) => {
+      draft.hybridai.defaultChatbotId = 'after-reload';
+    });
+
+    expect(config.HYBRIDAI_CHATBOT_ID).toBe('from-env');
+  });
 });
 
 describe('configured model catalog', () => {

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -8096,6 +8096,7 @@ describe('gateway HTTP server', () => {
         sourceIp: '127.0.0.1',
       },
     });
+    expect(state.refreshRuntimeSecretsFromEnv).toHaveBeenCalledTimes(1);
     expect(res.statusCode).toBe(200);
   });
 
@@ -8203,6 +8204,7 @@ describe('gateway HTTP server', () => {
         sourceIp: '127.0.0.1',
       },
     });
+    expect(state.refreshRuntimeSecretsFromEnv).toHaveBeenCalledTimes(1);
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toEqual({
       secret: {
@@ -8228,6 +8230,7 @@ describe('gateway HTTP server', () => {
 
     expect(state.getGatewayAdminSecrets).not.toHaveBeenCalled();
     expect(state.overwriteGatewayAdminSecret).not.toHaveBeenCalled();
+    expect(state.refreshRuntimeSecretsFromEnv).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(405);
     expect(res.body).not.toContain('SET_SECRET');
     expect(res.body).not.toContain('OTHER_SECRET');
@@ -8254,6 +8257,7 @@ describe('gateway HTTP server', () => {
     await settle();
 
     expect(state.overwriteGatewayAdminSecret).not.toHaveBeenCalled();
+    expect(state.refreshRuntimeSecretsFromEnv).not.toHaveBeenCalled();
     expect(state.recordGatewayAdminSecretMutationFailure).toHaveBeenCalledWith({
       type: 'secret.overwritten',
       name: 'SET_SECRET',

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -1697,6 +1697,44 @@ describe('gateway bootstrap', () => {
     expect(state.teamsCommandHandler).toBeNull();
   });
 
+  test('registers Teams handlers before credentials are configured', async () => {
+    const state = await importFreshGatewayMain({
+      msteamsEnabled: true,
+      hasMSTeamsCredentials: false,
+    });
+
+    expect(state.initMSTeams).toHaveBeenCalledTimes(1);
+    expect(state.teamsMessageHandler).toEqual(expect.any(Function));
+    expect(state.teamsCommandHandler).toEqual(expect.any(Function));
+    expect(state.loggerInfo).toHaveBeenCalledWith(
+      'Microsoft Teams integration disabled: msteams.appId config or MSTEAMS_APP_PASSWORD runtime secret is missing',
+    );
+  });
+
+  test('initializes Teams when it is enabled after gateway startup', async () => {
+    const state = await importFreshGatewayMain({
+      msteamsEnabled: false,
+      hasMSTeamsCredentials: true,
+    });
+    const previous = structuredClone(state.currentConfig);
+    state.currentConfig.msteams.enabled = true;
+
+    state.configChangeListener?.(state.currentConfig, previous);
+    await settle();
+
+    expect(state.initMSTeams).toHaveBeenCalledTimes(1);
+    expect(state.teamsMessageHandler).toEqual(expect.any(Function));
+    expect(state.teamsCommandHandler).toEqual(expect.any(Function));
+    expectInfoLog(
+      state,
+      'Config changed, refreshing Microsoft Teams integration',
+      {
+        enabled: true,
+        webhookPath: '/api/msteams/messages',
+      },
+    );
+  });
+
   test('formats command replies based on gateway command result kind', async () => {
     const state = await importFreshGatewayMain();
     const reply = vi.fn(async () => {});

--- a/tests/msteams.runtime.test.ts
+++ b/tests/msteams.runtime.test.ts
@@ -25,6 +25,7 @@ const loggerErrorMock = vi.fn();
 const loggerInfoMock = vi.fn();
 const loggerWarnMock = vi.fn();
 const cloudAdapters: Array<{ onTurnError?: unknown }> = [];
+let msteamsAppPassword = 'teams-secret';
 
 function makeRequest(body: unknown): IncomingMessage {
   return Object.assign(
@@ -140,7 +141,9 @@ async function importRuntime() {
     APP_VERSION: '0.7.1',
     DATA_DIR: '/tmp/hybridclaw-test-data',
     MSTEAMS_APP_ID: 'teams-app-id',
-    MSTEAMS_APP_PASSWORD: 'teams-secret',
+    get MSTEAMS_APP_PASSWORD() {
+      return msteamsAppPassword;
+    },
     MSTEAMS_ENABLED: true,
     MSTEAMS_TENANT_ID: 'teams-tenant-id',
   }));
@@ -237,11 +240,36 @@ afterEach(() => {
   loggerInfoMock.mockReset();
   loggerWarnMock.mockReset();
   cloudAdapters.length = 0;
+  msteamsAppPassword = 'teams-secret';
   vi.restoreAllMocks();
   vi.resetModules();
 });
 
 describe('Microsoft Teams runtime webhook adapter', () => {
+  test('rebuilds the adapter after the app password rotates', async () => {
+    processMock.mockResolvedValue(undefined);
+
+    const runtime = await importRuntime();
+    await runtime.handleMSTeamsWebhook(
+      makeRequest({ type: 'message', text: 'First' }),
+      makeResponse(),
+    );
+
+    msteamsAppPassword = 'rotated-teams-secret';
+    await runtime.handleMSTeamsWebhook(
+      makeRequest({ type: 'message', text: 'Second' }),
+      makeResponse(),
+    );
+
+    expect(cloudAdapters).toHaveLength(2);
+    expect(credentialsFactoryMock).toHaveBeenLastCalledWith({
+      MicrosoftAppId: 'teams-app-id',
+      MicrosoftAppPassword: 'rotated-teams-secret',
+      MicrosoftAppTenantId: 'teams-tenant-id',
+      MicrosoftAppType: 'SingleTenant',
+    });
+  });
+
   test('parses the raw request body and adapts the Node response for botbuilder', async () => {
     processMock.mockResolvedValue(undefined);
 


### PR DESCRIPTION
## Summary

- refresh runtime secret exports immediately after authorized admin secret overwrite/unset operations
- register Microsoft Teams message and command handlers even when credentials are not available yet
- reconcile Teams when its runtime configuration changes
- rebuild the Bot Framework adapter when the app password rotates
- document the no-container-restart behavior
- verify that the configured default HybridAI chatbot hot-reloads while explicit environment overrides remain authoritative

## Root cause

When the gateway started without `MSTEAMS_APP_PASSWORD`, `startMSTeamsIntegration()` returned before calling `initMSTeams()`. Adding the secret later refreshed credentials but left the Teams message and command handlers unset, so authenticated webhooks failed with `Teams runtime was not initialized with handlers.`

The adapter cache also keyed only on whether a password existed, so rotating one non-empty password to another did not invalidate the existing Bot Framework adapter.

## Impact

Operators can enable Teams and set or rotate `MSTEAMS_APP_PASSWORD` from `/admin/secrets` without restarting or reprovisioning the container. The next Teams request uses the refreshed credential and adapter.

Runtime changes to `hybridai.defaultChatbotId` already update the effective default in process. An explicit `HYBRIDAI_CHATBOT_ID` environment variable continues to take precedence.

## Security and failure boundaries

- secret values remain write-only and are not returned or logged
- denied, unauthenticated, malformed, and unsupported secret mutations do not refresh runtime credentials
- adapter invalidation compares the current in-memory credential snapshot directly and never hashes, serializes, or logs the password
- disabling Teams continues to reject webhook processing through the existing runtime readiness check

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run format`
- `npx biome check src/channels/msteams/runtime.ts tests/configured-models.test.ts`
- `npx vitest run tests/msteams.runtime.test.ts tests/configured-models.test.ts tests/gateway-main.test.ts tests/gateway-http-server.test.ts` — 457 passed

The earlier full `npm run test:unit` run reached 5,315 tests with 5,306 passing and 9 unrelated existing/environment failures in Cloudflare tunnel timing, Codex CLI capability detection, GBrain/plugin timeouts, container dependency-path expectations, and circular-initialization tests. None touch the changed Teams, runtime-config, or admin-secret paths.