### PR TITLE
fix(console): unblock inline PDF previews in Chrome

### DIFF
--- a/console/src/routes/chat/message-block.test.tsx
+++ b/console/src/routes/chat/message-block.test.tsx
@@ -412,7 +412,9 @@ describe('MessageBlock artifacts', () => {
 
     const preview = await screen.findByTitle('report.pdf preview');
     expect(preview.getAttribute('src')).toBe('blob:artifact');
-    expect(preview.getAttribute('sandbox')).toBe('');
+    // Chrome blocks its PDF viewer inside sandboxed frames, so the preview
+    // iframe must not carry a sandbox attribute.
+    expect(preview.hasAttribute('sandbox')).toBe(false);
     expect(fetchArtifactBlobMock).toHaveBeenCalledWith(
       'test-token',
       '/tmp/report.pdf',
@@ -420,6 +422,37 @@ describe('MessageBlock artifacts', () => {
     expect(
       container.querySelector('[src*="token="], [href*="token="]'),
     ).toBeNull();
+  });
+
+  it('pins filename-detected PDF previews to application/pdf', async () => {
+    fetchArtifactBlobMock.mockResolvedValue(
+      new Blob(['<script>alert(1)</script>'], { type: 'text/html' }),
+    );
+
+    render(
+      <MessageBlock
+        message={makeMessage([
+          {
+            path: '/tmp/report.pdf',
+            filename: 'report.pdf',
+          },
+        ])}
+        token="test-token"
+        isStreaming={false}
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={vi.fn()}
+        approvalBusy={false}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
+
+    await screen.findByTitle('report.pdf preview');
+    const [previewBlob] = vi.mocked(URL.createObjectURL).mock.calls[0] ?? [];
+    expect(previewBlob).toBeInstanceOf(Blob);
+    expect((previewBlob as Blob).type).toBe('application/pdf');
   });
 
   it('renders video previews from authenticated blob URLs', async () => {

--- a/console/src/routes/chat/message-block.tsx
+++ b/console/src/routes/chat/message-block.tsx
@@ -227,6 +227,10 @@ function ArtifactCard(props: { artifact: ChatArtifact; token: string }) {
     /\.pdf$/i.test(artifact.filename ?? '') ||
     /\.pdf$/i.test(artifact.path ?? '');
   const canPreview = isImage || isVideo || isPdf;
+  // PDFs can be detected by filename alone; force the blob type so the
+  // unsandboxed preview iframe can only ever render as a PDF, never as HTML
+  // served with a mislabeled Content-Type.
+  const previewMimeType = isPdf ? 'application/pdf' : mimeType;
 
   useEffect(() => {
     const previousUrl = previewUrlRef.current;
@@ -240,7 +244,9 @@ function ArtifactCard(props: { artifact: ChatArtifact; token: string }) {
     void fetchArtifactBlob(token, artifact.path)
       .then((blob) => {
         if (cancelled) return;
-        const objectUrl = URL.createObjectURL(buildPreviewBlob(blob, mimeType));
+        const objectUrl = URL.createObjectURL(
+          buildPreviewBlob(blob, previewMimeType),
+        );
         previewUrlRef.current = objectUrl;
         setPreviewUrl(objectUrl);
       })
@@ -254,7 +260,7 @@ function ArtifactCard(props: { artifact: ChatArtifact; token: string }) {
       previewUrlRef.current = null;
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
-  }, [artifact.path, canPreview, mimeType, token]);
+  }, [artifact.path, canPreview, previewMimeType, token]);
 
   const downloadLabel = downloading ? 'Downloading…' : 'Download';
   const handleDownload = async () => {
@@ -315,11 +321,10 @@ function ArtifactCard(props: { artifact: ChatArtifact; token: string }) {
       ) : null}
       {isPdf && previewUrl ? (
         <div className={cx(css.artifactPreview, css.artifactPdfPreview)}>
-          <iframe
-            src={previewUrl}
-            title={`${artifactName} preview`}
-            sandbox=""
-          />
+          {/* No sandbox: Chrome refuses to run its PDF viewer inside a
+              sandboxed frame ("This page has been blocked by Chrome").
+              Safe because previewMimeType pins the blob to application/pdf. */}
+          <iframe src={previewUrl} title={`${artifactName} preview`} />
         </div>
       ) : null}
       {isVideo && previewUrl ? (


### PR DESCRIPTION
## Problem

Inline PDF previews in the chat artifact card render as **"This page has been blocked by Chrome"** instead of the document.

The preview iframe was rendered with `sandbox=""` (all restrictions). Chrome refuses to run its built-in PDF viewer inside a sandboxed frame — the viewer is treated like a plugin, and no sandbox token re-enables it — so every PDF preview was blocked. The blob itself was fine; only rendering failed.

## Fix

- Drop the `sandbox` attribute from the PDF preview iframe (`message-block.tsx`).
- Pin the preview blob's type to `application/pdf` whenever the artifact is treated as a PDF. `isPdf` can be true from the filename alone while `artifact.mimeType` is empty, in which case `buildPreviewBlob` previously kept the server's Content-Type. Since `blob:` URLs are same-origin with the console, an unsandboxed frame must never be able to render artifact bytes as HTML — forcing the type closes that off; Chrome will render the frame as a PDF or not at all.

## Security notes (artifact PDFs are agent-generated, i.e. untrusted)

- PDF-embedded JavaScript in Chrome's viewer runs in an isolated viewer process with no DOM/cookie/origin access to the embedding page.
- The mislabeled-Content-Type → same-origin HTML vector is closed by the blob type pin (covered by a new test that feeds `text/html` bytes through a filename-detected PDF).
- Residual exposure is "PDFium parser bug", which the one-click Download button already exposes users to.

Known limitation (pre-existing): Chrome on Android and iOS Safari don't render PDFs inline in iframes regardless; a PDF.js viewer in a scripts-only sandboxed frame is the eventual answer if mobile inline preview becomes a requirement.

## Testing

- `vitest run src/routes/chat/message-block.test.tsx` — 32 tests pass (updated the sandbox-attribute assertion, added the type-pinning test).
- `biome check` clean on both changed files. Console `lint` failures are pre-existing missing local deps (`highlight.js`, `@xterm`) unrelated to this change.