### PR TITLE
fix(console): correct Google connector OAuth flow (Desktop-loopback locally, Web remotely)

### DIFF
--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -1518,6 +1518,7 @@ export interface AdminConnector {
 export interface AdminConnectorsResponse {
   connectors: AdminConnector[];
   secretsPath: string;
+  oauthRedirectUri: string | null;
 }
 
 export interface AdminConnectorOAuthStartResponse {

--- a/console/src/routes/connectors.module.css
+++ b/console/src/routes/connectors.module.css
@@ -190,6 +190,34 @@
   font-size: 0.84rem;
 }
 
+.oauthSetup {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-muted);
+}
+
+.oauthSetup p {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+
+.redirectUri {
+  display: block;
+  overflow-wrap: anywhere;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--panel-bg);
+  border: 1px solid var(--line);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.82rem;
+  color: var(--foreground);
+}
+
 @media (max-width: 1180px) {
   .connectorGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/console/src/routes/connectors.test.tsx
+++ b/console/src/routes/connectors.test.tsx
@@ -290,6 +290,26 @@ describe('ConnectorsPage', () => {
     ).toBeTruthy();
   });
 
+  it('shows the Desktop app client guidance when the gateway is local', async () => {
+    const local = makeConnectorsResponse();
+    local.oauthRedirectUri = null;
+    fetchConnectorsMock.mockResolvedValue(local);
+
+    renderWithProviders(<ConnectorsPage />);
+
+    const connectButtons = await screen.findAllByRole('button', {
+      name: 'Connect',
+    });
+    fireEvent.click(connectButtons[1]);
+
+    expect(await screen.findByText('Connect Google Workspace')).toBeTruthy();
+    expect(screen.getByText('Desktop app')).toBeTruthy();
+    expect(screen.queryByText('Web application')).toBeNull();
+    expect(
+      screen.queryByText(/\/api\/connectors\/oauth\/callback/u),
+    ).toBeNull();
+  });
+
   it('opens HybridAI login and saves the pasted API key', async () => {
     const connected = makeConnectorsResponse();
     connected.connectors[0] = {

--- a/console/src/routes/connectors.test.tsx
+++ b/console/src/routes/connectors.test.tsx
@@ -27,6 +27,7 @@ vi.mock('../auth', () => ({
 function makeConnectorsResponse(): AdminConnectorsResponse {
   return {
     secretsPath: '/tmp/credentials.json',
+    oauthRedirectUri: 'https://console.example/api/connectors/oauth/callback',
     connectors: [
       {
         id: 'hybridai',
@@ -272,6 +273,21 @@ describe('ConnectorsPage', () => {
     expect(screen.queryByLabelText('Scopes')).toBeNull();
 
     openSpy.mockRestore();
+  });
+
+  it('shows the Web application client requirement and redirect URI in the Google dialog', async () => {
+    renderWithProviders(<ConnectorsPage />);
+
+    const connectButtons = await screen.findAllByRole('button', {
+      name: 'Connect',
+    });
+    fireEvent.click(connectButtons[1]);
+
+    expect(await screen.findByText('Connect Google Workspace')).toBeTruthy();
+    expect(screen.getByText('Web application')).toBeTruthy();
+    expect(
+      screen.getByText('https://console.example/api/connectors/oauth/callback'),
+    ).toBeTruthy();
   });
 
   it('opens HybridAI login and saves the pasted API key', async () => {

--- a/console/src/routes/connectors.tsx
+++ b/console/src/routes/connectors.tsx
@@ -272,11 +272,7 @@ export function ConnectorsPage() {
   const connectors = connectorsQuery.data?.connectors || [];
   const oauthTarget =
     connectors.find((connector) => connector.id === oauthTargetId) || null;
-  const oauthRedirectUri =
-    connectorsQuery.data?.oauthRedirectUri ||
-    (typeof window !== 'undefined'
-      ? `${window.location.origin}/api/connectors/oauth/callback`
-      : null);
+  const oauthRedirectUri = connectorsQuery.data?.oauthRedirectUri ?? null;
   const googleNeedsAccount =
     oauthTargetId === 'google' && !oauthDraft.account.trim();
   const googleNeedsClientId =

--- a/console/src/routes/connectors.tsx
+++ b/console/src/routes/connectors.tsx
@@ -550,15 +550,25 @@ export function ConnectorsPage() {
           </DialogHeader>
 
           <div className={styles.dialogForm}>
-            {oauthTargetId === 'google' && oauthRedirectUri ? (
-              <div className={styles.oauthSetup}>
-                <p>
-                  In Google Cloud Console, create an OAuth client of type{' '}
-                  <strong>Web application</strong> — not Desktop app — and add
-                  this exact authorized redirect URI:
-                </p>
-                <code className={styles.redirectUri}>{oauthRedirectUri}</code>
-              </div>
+            {oauthTargetId === 'google' ? (
+              oauthRedirectUri ? (
+                <div className={styles.oauthSetup}>
+                  <p>
+                    In Google Cloud Console, create an OAuth client of type{' '}
+                    <strong>Web application</strong> — not Desktop app — and add
+                    this exact authorized redirect URI:
+                  </p>
+                  <code className={styles.redirectUri}>{oauthRedirectUri}</code>
+                </div>
+              ) : (
+                <div className={styles.oauthSetup}>
+                  <p>
+                    In Google Cloud Console, create an OAuth client of type{' '}
+                    <strong>Desktop app</strong>. Authorization completes on
+                    this machine, so no redirect URI needs to be registered.
+                  </p>
+                </div>
+              )
             ) : null}
 
             <Field>

--- a/console/src/routes/connectors.tsx
+++ b/console/src/routes/connectors.tsx
@@ -272,6 +272,11 @@ export function ConnectorsPage() {
   const connectors = connectorsQuery.data?.connectors || [];
   const oauthTarget =
     connectors.find((connector) => connector.id === oauthTargetId) || null;
+  const oauthRedirectUri =
+    connectorsQuery.data?.oauthRedirectUri ||
+    (typeof window !== 'undefined'
+      ? `${window.location.origin}/api/connectors/oauth/callback`
+      : null);
   const googleNeedsAccount =
     oauthTargetId === 'google' && !oauthDraft.account.trim();
   const googleNeedsClientId =
@@ -549,6 +554,17 @@ export function ConnectorsPage() {
           </DialogHeader>
 
           <div className={styles.dialogForm}>
+            {oauthTargetId === 'google' && oauthRedirectUri ? (
+              <div className={styles.oauthSetup}>
+                <p>
+                  In Google Cloud Console, create an OAuth client of type{' '}
+                  <strong>Web application</strong> — not Desktop app — and add
+                  this exact authorized redirect URI:
+                </p>
+                <code className={styles.redirectUri}>{oauthRedirectUri}</code>
+              </div>
+            ) : null}
+
             <Field>
               <FieldLabel>Google account</FieldLabel>
               <Input

--- a/src/auth/google-auth.ts
+++ b/src/auth/google-auth.ts
@@ -190,17 +190,47 @@ export async function exchangeGoogleAuthorizationCode(input: {
   return { refreshToken: payload.refresh_token.trim() };
 }
 
-async function waitForAuthorizationCode(input: {
+export interface GoogleLoopbackAuthorization {
+  authorizationUrl: string;
+  redirectUri: string;
+  waitForCode: Promise<{ code: string; redirectUri: string }>;
+  close(): void;
+}
+
+// Start a loopback OAuth listener and return the authorization URL immediately,
+// with `waitForCode` resolving once Google redirects back to 127.0.0.1. Google
+// accepts any loopback redirect for a Desktop client without registering a
+// redirect URI, so both the CLI login and the local-gateway console flow use
+// this path.
+export function startGoogleLoopbackAuthorization(input: {
   clientId: string;
   scopes: string[];
   redirectPort?: number;
   timeoutMs?: number;
-}): Promise<{ code: string; redirectUri: string }> {
+}): Promise<GoogleLoopbackAuthorization> {
   const state = makeState();
   const timeoutMs = input.timeoutMs || DEFAULT_CALLBACK_TIMEOUT_MS;
 
-  return await new Promise((resolve, reject) => {
-    let settled = false;
+  return new Promise((resolveStart, rejectStart) => {
+    let codeSettled = false;
+    let resolveCode: (value: { code: string; redirectUri: string }) => void =
+      () => {};
+    let rejectCode: (error: unknown) => void = () => {};
+    const waitForCode = new Promise<{ code: string; redirectUri: string }>(
+      (resolve, reject) => {
+        resolveCode = resolve;
+        rejectCode = reject;
+      },
+    );
+
+    function settleCode(outcome: () => void): void {
+      if (codeSettled) return;
+      codeSettled = true;
+      clearTimeout(timer);
+      server.close();
+      outcome();
+    }
+
     const server = http.createServer((req, res) => {
       try {
         const requestUrl = new URL(req.url || '/', `http://${LOOPBACK_HOST}`);
@@ -214,21 +244,34 @@ async function waitForAuthorizationCode(input: {
         if (returnedState !== state) {
           res.writeHead(400, { 'Content-Type': 'text/plain' });
           res.end('Invalid OAuth state. Return to HybridClaw and retry.');
-          throw new Error('Google OAuth callback state did not match.');
+          settleCode(() =>
+            rejectCode(new Error('Google OAuth callback state did not match.')),
+          );
+          return;
         }
 
         const error = requestUrl.searchParams.get('error');
         if (error) {
           res.writeHead(400, { 'Content-Type': 'text/plain' });
           res.end('Google authorization was rejected.');
-          throw new Error(`Google OAuth authorization failed: ${error}`);
+          settleCode(() =>
+            rejectCode(
+              new Error(`Google OAuth authorization failed: ${error}`),
+            ),
+          );
+          return;
         }
 
         const code = requestUrl.searchParams.get('code') || '';
         if (!code) {
           res.writeHead(400, { 'Content-Type': 'text/plain' });
           res.end('Missing OAuth authorization code.');
-          throw new Error('Google OAuth callback did not include a code.');
+          settleCode(() =>
+            rejectCode(
+              new Error('Google OAuth callback did not include a code.'),
+            ),
+          );
+          return;
         }
 
         const address = server.address();
@@ -238,47 +281,58 @@ async function waitForAuthorizationCode(input: {
         res.end(
           'Google authorization complete. You can close this browser tab.',
         );
-        settled = true;
-        server.close();
-        resolve({
-          code,
-          redirectUri,
-        });
+        settleCode(() => resolveCode({ code, redirectUri }));
       } catch (error) {
-        settled = true;
-        server.close();
-        reject(error);
+        settleCode(() => rejectCode(error));
       }
     });
 
     server.once('error', (error) => {
-      if (settled) return;
-      settled = true;
-      reject(error);
+      rejectStart(error);
+      settleCode(() => rejectCode(error));
     });
+
+    const timer = setTimeout(() => {
+      settleCode(() =>
+        rejectCode(new Error('Timed out waiting for Google OAuth callback.')),
+      );
+    }, timeoutMs);
+    timer.unref();
 
     server.listen(input.redirectPort || 0, LOOPBACK_HOST, () => {
       const address = server.address();
       const port = typeof address === 'object' && address ? address.port : 0;
       const redirectUri = `http://${LOOPBACK_HOST}:${port}/oauth2/callback`;
-      const authorizeUrl = buildGoogleAuthorizeUrl({
+      const authorizationUrl = buildGoogleAuthorizeUrl({
         clientId: input.clientId,
         redirectUri,
         state,
         scopes: input.scopes,
       });
-      console.log('Open this Google authorization URL in your browser:');
-      console.log(authorizeUrl);
-      console.log(`Waiting for OAuth callback on ${redirectUri} ...`);
+      resolveStart({
+        authorizationUrl,
+        redirectUri,
+        waitForCode,
+        close: () =>
+          settleCode(() =>
+            rejectCode(new Error('Google OAuth authorization canceled.')),
+          ),
+      });
     });
-
-    setTimeout(() => {
-      if (settled) return;
-      settled = true;
-      server.close();
-      reject(new Error('Timed out waiting for Google OAuth callback.'));
-    }, timeoutMs).unref();
   });
+}
+
+async function waitForAuthorizationCode(input: {
+  clientId: string;
+  scopes: string[];
+  redirectPort?: number;
+  timeoutMs?: number;
+}): Promise<{ code: string; redirectUri: string }> {
+  const authorization = await startGoogleLoopbackAuthorization(input);
+  console.log('Open this Google authorization URL in your browser:');
+  console.log(authorization.authorizationUrl);
+  console.log(`Waiting for OAuth callback on ${authorization.redirectUri} ...`);
+  return authorization.waitForCode;
 }
 
 export async function loginGoogle(

--- a/src/gateway/gateway-admin-connectors.ts
+++ b/src/gateway/gateway-admin-connectors.ts
@@ -13,6 +13,7 @@ import {
   loginGoogle,
   mintGoogleAccessToken,
   parseGoogleScopes,
+  startGoogleLoopbackAuthorization,
 } from '../auth/google-auth.js';
 import {
   clearHybridAICredentials,
@@ -33,6 +34,7 @@ import {
   updateRuntimeConfig,
 } from '../config/runtime-config.js';
 import { GatewayRequestError } from '../errors/gateway-request-error.js';
+import { logger } from '../logger.js';
 import {
   readStoredRuntimeSecret,
   runtimeSecretsPath,
@@ -197,6 +199,38 @@ function resolveOAuthRedirectUriOrNull(requestBaseUrl?: string): string | null {
     .replace(/\/+$/g, '');
   if (!baseUrl) return null;
   return `${baseUrl}/api/connectors/oauth/callback`;
+}
+
+// The console is served from the same host as the gateway, so a loopback origin
+// means the user's browser can reach the gateway's ephemeral 127.0.0.1 OAuth
+// listener. That lets Google's Desktop-client loopback flow work with no
+// registered redirect URI. A non-loopback origin (LAN, tunnel, public URL)
+// cannot use loopback and must register the gateway-origin callback on a Web
+// OAuth client instead.
+function isLoopbackConnectorOrigin(requestBaseUrl?: string): boolean {
+  const raw = String(requestBaseUrl || '').trim();
+  if (!raw) return false;
+  let host: string;
+  try {
+    host = new URL(raw).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return (
+    host === 'localhost' ||
+    host === '127.0.0.1' ||
+    host === '::1' ||
+    host === '[::1]' ||
+    host.endsWith('.localhost')
+  );
+}
+
+// Redirect URI the console must register on a Web OAuth client. Null when the
+// gateway is local (the loopback Desktop flow needs no registration) or the
+// origin is unknown.
+function connectorOAuthRedirectUri(requestBaseUrl?: string): string | null {
+  if (isLoopbackConnectorOrigin(requestBaseUrl)) return null;
+  return resolveOAuthRedirectUriOrNull(requestBaseUrl);
 }
 
 function resolveOAuthRedirectUri(requestBaseUrl?: string): string {
@@ -713,7 +747,7 @@ export function getGatewayAdminConnectors(
       buildMicrosoft365Connector(),
     ],
     secretsPath: runtimeSecretsPath(),
-    oauthRedirectUri: resolveOAuthRedirectUriOrNull(requestBaseUrl),
+    oauthRedirectUri: connectorOAuthRedirectUri(requestBaseUrl),
   };
 }
 
@@ -729,7 +763,7 @@ export async function getGatewayAdminConnectorsWithPlatformState(
       buildMicrosoft365Connector(platformStatuses.get('microsoft365')),
     ],
     secretsPath: runtimeSecretsPath(),
-    oauthRedirectUri: resolveOAuthRedirectUriOrNull(requestBaseUrl),
+    oauthRedirectUri: connectorOAuthRedirectUri(requestBaseUrl),
   };
 }
 
@@ -748,20 +782,25 @@ export function saveGatewayAdminHybridAIConnectorApiKey(
   return getGatewayAdminConnectors(requestBaseUrl);
 }
 
-function resolveGoogleOAuthFlow(input: {
-  body: ConnectorOAuthStartInput;
-  redirectUri: string;
-}): PendingConnectorOAuthFlow {
+interface GoogleOAuthCredentials {
+  account: string;
+  clientId: string;
+  clientSecret: string;
+  scopes: string[];
+}
+
+function resolveGoogleOAuthCredentials(
+  body: ConnectorOAuthStartInput,
+): GoogleOAuthCredentials {
   const current = getGoogleAuthStatus();
-  const account = trimString(input.body.account) || current.account;
+  const account = trimString(body.account) || current.account;
   const clientId =
-    trimString(input.body.clientId) ||
-    readSecretOrEnv(GOOGLE_OAUTH_CLIENT_ID_SECRET);
+    trimString(body.clientId) || readSecretOrEnv(GOOGLE_OAUTH_CLIENT_ID_SECRET);
   const clientSecret =
-    trimString(input.body.clientSecret) ||
+    trimString(body.clientSecret) ||
     readSecretOrEnv(GOOGLE_OAUTH_CLIENT_SECRET_SECRET);
   const scopes = parseGoogleScopes(
-    trimString(input.body.scopes) ||
+    trimString(body.scopes) ||
       readSecretOrEnv(GOOGLE_OAUTH_SCOPES_SECRET) ||
       DEFAULT_GOOGLE_OAUTH_SCOPES.join(' '),
   );
@@ -776,13 +815,62 @@ function resolveGoogleOAuthFlow(input: {
     );
   }
 
+  return { account, clientId, clientSecret, scopes };
+}
+
+function resolveGoogleOAuthFlow(input: {
+  body: ConnectorOAuthStartInput;
+  redirectUri: string;
+}): PendingConnectorOAuthFlow {
   return {
-    account,
-    clientId,
-    clientSecret,
-    scopes,
+    ...resolveGoogleOAuthCredentials(input.body),
     redirectUri: input.redirectUri,
     createdAt: Date.now(),
+  };
+}
+
+// Local gateways use Google's Desktop-client loopback flow: the gateway opens
+// an ephemeral 127.0.0.1 listener, returns the authorization URL for the
+// console to open, and completes the login in the background once the browser
+// (same host) redirects back. No redirect URI needs to be registered.
+async function startGoogleConnectorLoopbackOAuth(
+  body: ConnectorOAuthStartInput,
+): Promise<GatewayAdminConnectorOAuthStartResult> {
+  const credentials = resolveGoogleOAuthCredentials(body);
+  const authorization = await startGoogleLoopbackAuthorization({
+    clientId: credentials.clientId,
+    scopes: credentials.scopes,
+  });
+
+  void authorization.waitForCode
+    .then(async ({ code, redirectUri }) => {
+      const exchanged = await exchangeGoogleAuthorizationCode({
+        clientId: credentials.clientId,
+        clientSecret: credentials.clientSecret,
+        code,
+        redirectUri,
+      });
+      await loginGoogle({
+        account: credentials.account,
+        clientId: credentials.clientId,
+        clientSecret: credentials.clientSecret,
+        refreshToken: exchanged.refreshToken,
+        scopes: credentials.scopes,
+      });
+      ensureGoogleWorkspaceRoutes();
+    })
+    .catch((error) => {
+      logger.warn(
+        { err: error },
+        'Google Workspace connector loopback authorization did not complete',
+      );
+    });
+
+  return {
+    provider: 'google',
+    state: '',
+    expiresAt: Date.now() + PENDING_CONNECTOR_OAUTH_TTL_MS,
+    authorizationUrl: authorization.authorizationUrl,
   };
 }
 
@@ -803,6 +891,10 @@ export async function startGatewayAdminConnectorOAuth(input: {
       provider,
       requestBaseUrl: input.requestBaseUrl,
     });
+  }
+
+  if (isLoopbackConnectorOrigin(input.requestBaseUrl)) {
+    return startGoogleConnectorLoopbackOAuth(input.body);
   }
 
   const redirectUri = resolveOAuthRedirectUri(input.requestBaseUrl);

--- a/src/gateway/gateway-admin-connectors.ts
+++ b/src/gateway/gateway-admin-connectors.ts
@@ -83,6 +83,7 @@ export interface GatewayAdminConnector {
 export interface GatewayAdminConnectorsResponse {
   connectors: GatewayAdminConnector[];
   secretsPath: string;
+  oauthRedirectUri: string | null;
 }
 
 export interface GatewayAdminConnectorTestResult {
@@ -190,17 +191,23 @@ function parseConnectorId(value: unknown): GatewayAdminConnectorId {
   );
 }
 
-function resolveOAuthRedirectUri(requestBaseUrl?: string): string {
+function resolveOAuthRedirectUriOrNull(requestBaseUrl?: string): string | null {
   const baseUrl = String(requestBaseUrl || '')
     .trim()
     .replace(/\/+$/g, '');
-  if (!baseUrl) {
+  if (!baseUrl) return null;
+  return `${baseUrl}/api/connectors/oauth/callback`;
+}
+
+function resolveOAuthRedirectUri(requestBaseUrl?: string): string {
+  const redirectUri = resolveOAuthRedirectUriOrNull(requestBaseUrl);
+  if (!redirectUri) {
     throw new GatewayRequestError(
       400,
       'Cannot determine the gateway base URL for the OAuth redirect.',
     );
   }
-  return `${baseUrl}/api/connectors/oauth/callback`;
+  return redirectUri;
 }
 
 function resolveConnectorReturnUrl(requestBaseUrl?: string): string {
@@ -695,7 +702,9 @@ async function startHybridAIPlatformConnectorOAuth(input: {
   };
 }
 
-export function getGatewayAdminConnectors(): GatewayAdminConnectorsResponse {
+export function getGatewayAdminConnectors(
+  requestBaseUrl?: string,
+): GatewayAdminConnectorsResponse {
   return {
     connectors: [
       buildHybridAIConnector(),
@@ -704,10 +713,13 @@ export function getGatewayAdminConnectors(): GatewayAdminConnectorsResponse {
       buildMicrosoft365Connector(),
     ],
     secretsPath: runtimeSecretsPath(),
+    oauthRedirectUri: resolveOAuthRedirectUriOrNull(requestBaseUrl),
   };
 }
 
-export async function getGatewayAdminConnectorsWithPlatformState(): Promise<GatewayAdminConnectorsResponse> {
+export async function getGatewayAdminConnectorsWithPlatformState(
+  requestBaseUrl?: string,
+): Promise<GatewayAdminConnectorsResponse> {
   const platformStatuses = await readHybridAIPlatformConnectorStatuses();
   return {
     connectors: [
@@ -717,19 +729,23 @@ export async function getGatewayAdminConnectorsWithPlatformState(): Promise<Gate
       buildMicrosoft365Connector(platformStatuses.get('microsoft365')),
     ],
     secretsPath: runtimeSecretsPath(),
+    oauthRedirectUri: resolveOAuthRedirectUriOrNull(requestBaseUrl),
   };
 }
 
-export function saveGatewayAdminHybridAIConnectorApiKey(input: {
-  apiKey?: unknown;
-}): GatewayAdminConnectorsResponse {
+export function saveGatewayAdminHybridAIConnectorApiKey(
+  input: {
+    apiKey?: unknown;
+  },
+  requestBaseUrl?: string,
+): GatewayAdminConnectorsResponse {
   const apiKey = trimString(input.apiKey);
   if (!apiKey) {
     throw new GatewayRequestError(400, 'HybridAI API key is required.');
   }
   saveNamedRuntimeSecrets({ HYBRIDAI_API_KEY: apiKey });
   refreshRuntimeSecretsFromEnv();
-  return getGatewayAdminConnectors();
+  return getGatewayAdminConnectors(requestBaseUrl);
 }
 
 function resolveGoogleOAuthFlow(input: {
@@ -839,9 +855,12 @@ export async function completeGatewayAdminConnectorOAuthCallback(input: {
   return { provider: 'google', name: 'Google Workspace' };
 }
 
-export function logoutGatewayAdminConnector(input: {
-  provider?: unknown;
-}): GatewayAdminConnectorsResponse {
+export function logoutGatewayAdminConnector(
+  input: {
+    provider?: unknown;
+  },
+  requestBaseUrl?: string,
+): GatewayAdminConnectorsResponse {
   const provider = parseConnectorId(input.provider);
   if (provider === 'hybridai') {
     clearHybridAICredentials();
@@ -853,5 +872,5 @@ export function logoutGatewayAdminConnector(input: {
   } else if (provider === 'google') {
     clearGoogleAuth();
   }
-  return getGatewayAdminConnectors();
+  return getGatewayAdminConnectors(requestBaseUrl);
 }

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -6009,7 +6009,13 @@ async function handleApiAdminConnectors(
 ): Promise<void> {
   const pathname = url.pathname;
   if (pathname === '/api/admin/connectors' && req.method === 'GET') {
-    sendJson(res, 200, await getGatewayAdminConnectorsWithPlatformState());
+    sendJson(
+      res,
+      200,
+      await getGatewayAdminConnectorsWithPlatformState(
+        resolveRequestOrigin(req),
+      ),
+    );
     return;
   }
 
@@ -6018,7 +6024,11 @@ async function handleApiAdminConnectors(
     req.method === 'PUT'
   ) {
     const body = (await readJsonBody(req)) as { apiKey?: unknown };
-    sendJson(res, 200, saveGatewayAdminHybridAIConnectorApiKey(body));
+    sendJson(
+      res,
+      200,
+      saveGatewayAdminHybridAIConnectorApiKey(body, resolveRequestOrigin(req)),
+    );
     return;
   }
 
@@ -6040,7 +6050,11 @@ async function handleApiAdminConnectors(
 
   if (pathname === '/api/admin/connectors/logout' && req.method === 'POST') {
     const body = (await readJsonBody(req)) as { provider?: unknown };
-    sendJson(res, 200, logoutGatewayAdminConnector(body));
+    sendJson(
+      res,
+      200,
+      logoutGatewayAdminConnector(body, resolveRequestOrigin(req)),
+    );
     return;
   }
 

--- a/tests/gateway-admin-connectors.test.ts
+++ b/tests/gateway-admin-connectors.test.ts
@@ -419,6 +419,34 @@ describe('gateway admin connectors', () => {
     ).rejects.toThrow('Google account email is required.');
   });
 
+  test('exposes the console-origin OAuth redirect URI for Web client setup', async () => {
+    const { connectors } = await importFreshConnectors();
+
+    const listed = await connectors.getGatewayAdminConnectorsWithPlatformState(
+      'http://console.example',
+    );
+    expect(listed.oauthRedirectUri).toBe(
+      'http://console.example/api/connectors/oauth/callback',
+    );
+    expect(connectors.getGatewayAdminConnectors().oauthRedirectUri).toBeNull();
+
+    const started = await connectors.startGatewayAdminConnectorOAuth({
+      requestBaseUrl: 'http://console.example',
+      body: {
+        provider: 'google',
+        account: 'user@example.com',
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+      },
+    });
+    const redirectUri = new URL(started.authorizationUrl).searchParams.get(
+      'redirect_uri',
+    );
+    expect(redirectUri).toBe(
+      'http://console.example/api/connectors/oauth/callback',
+    );
+  });
+
   test('rejects connector OAuth callbacks with unknown state', async () => {
     const { connectors } = await importFreshConnectors();
 

--- a/tests/gateway-admin-connectors.test.ts
+++ b/tests/gateway-admin-connectors.test.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -40,6 +41,9 @@ async function importFreshConnectors(options?: {
   process.env.HYBRIDCLAW_MASTER_KEY = 'a'.repeat(64);
 
   const runtimeConfig = {
+    ops: {
+      logLevel: 'info',
+    },
     tools: {
       httpRequest: {
         authRules: options?.authRules ? [...options.authRules] : [],
@@ -419,7 +423,7 @@ describe('gateway admin connectors', () => {
     ).rejects.toThrow('Google account email is required.');
   });
 
-  test('exposes the console-origin OAuth redirect URI for Web client setup', async () => {
+  test('exposes the console-origin OAuth redirect URI for a remote Web client', async () => {
     const { connectors } = await importFreshConnectors();
 
     const listed = await connectors.getGatewayAdminConnectorsWithPlatformState(
@@ -445,6 +449,73 @@ describe('gateway admin connectors', () => {
     expect(redirectUri).toBe(
       'http://console.example/api/connectors/oauth/callback',
     );
+  });
+
+  test('omits the redirect URI for a local gateway (loopback Desktop flow)', async () => {
+    const { connectors } = await importFreshConnectors();
+
+    const localhost =
+      await connectors.getGatewayAdminConnectorsWithPlatformState(
+        'http://localhost:5000',
+      );
+    expect(localhost.oauthRedirectUri).toBeNull();
+
+    const loopbackIp =
+      await connectors.getGatewayAdminConnectorsWithPlatformState(
+        'http://127.0.0.1:5000',
+      );
+    expect(loopbackIp.oauthRedirectUri).toBeNull();
+  });
+
+  test('completes the Google loopback flow for a local gateway', async () => {
+    const { connectors, runtimeSecrets } = await importFreshConnectors();
+    const fetchMock = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ refresh_token: 'refresh-abc' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const started = await connectors.startGatewayAdminConnectorOAuth({
+      requestBaseUrl: 'http://localhost:5000',
+      body: {
+        provider: 'google',
+        account: 'user@example.com',
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+      },
+    });
+
+    const authUrl = new URL(started.authorizationUrl);
+    const redirectUri = authUrl.searchParams.get('redirect_uri') || '';
+    expect(redirectUri).toMatch(
+      /^http:\/\/127\.0\.0\.1:\d+\/oauth2\/callback$/,
+    );
+
+    // Simulate Google redirecting the browser back to the loopback listener.
+    const callback = new URL(redirectUri);
+    callback.searchParams.set('state', authUrl.searchParams.get('state') || '');
+    callback.searchParams.set('code', 'auth-code');
+    await new Promise<void>((resolve, reject) => {
+      http
+        .get(callback.toString(), (res) => {
+          res.resume();
+          res.on('end', resolve);
+        })
+        .on('error', reject);
+    });
+
+    await vi.waitFor(() => {
+      const google = connectors
+        .getGatewayAdminConnectors()
+        .connectors.find((entry) => entry.id === 'google');
+      expect(google?.state).toBe('connected');
+    });
+    expect(
+      runtimeSecrets.readStoredRuntimeSecret('GOOGLE_OAUTH_REFRESH_TOKEN'),
+    ).toBe('refresh-abc');
   });
 
   test('rejects connector OAuth callbacks with unknown state', async () => {

--- a/tests/google-auth.test.ts
+++ b/tests/google-auth.test.ts
@@ -104,6 +104,31 @@ test('Google Workspace runtime env exposes minted OAuth tokens for gog and gws',
   expect(fetchMock).toHaveBeenCalledTimes(1);
 });
 
+test('loopback authorization uses a 127.0.0.1 redirect that needs no registration', async () => {
+  const homeDir = makeTempHome();
+  const { startGoogleLoopbackAuthorization } =
+    await importFreshGoogleAuth(homeDir);
+
+  const authorization = await startGoogleLoopbackAuthorization({
+    clientId: 'desktop-client-id',
+    scopes: ['https://www.googleapis.com/auth/calendar'],
+    timeoutMs: 1_000,
+  });
+  try {
+    const url = new URL(authorization.authorizationUrl);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      'https://accounts.google.com/o/oauth2/v2/auth',
+    );
+    expect(url.searchParams.get('client_id')).toBe('desktop-client-id');
+    const redirect = url.searchParams.get('redirect_uri') || '';
+    expect(redirect).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/oauth2\/callback$/);
+    expect(redirect).toBe(authorization.redirectUri);
+  } finally {
+    authorization.close();
+    await expect(authorization.waitForCode).rejects.toThrow();
+  }
+});
+
 test('Google Workspace runtime env recovery hint explains invalid_grant reauthorization', async () => {
   const homeDir = makeTempHome();
   const { getGoogleWorkspaceRuntimeEnvRecoveryHint } =


### PR DESCRIPTION
## Problem

A user hit `Fehler 400: redirect_uri_mismatch` connecting Google Workspace from the console after following the docs and creating a **Desktop app** OAuth client.

The console Connect flow authorized against `<console-origin>/api/connectors/oauth/callback`. A Desktop client has no redirect-URI allowlist, so Google rejects that redirect. The CLI (`hybridclaw auth login google`) never hit this because it uses Google's Desktop-client **loopback** redirect (`http://127.0.0.1:<port>`), which needs no registration — but the console had diverged onto a gateway-origin callback that requires a Web client.

## Fix

Make the console flow match the CLI where it can, and only require a Web client where it must:

- **Local gateway** (console served from `localhost`/`127.0.0.1`, including the desktop app and local self-hosted): authorize through the **Desktop-client loopback** flow. The gateway starts an ephemeral 127.0.0.1 listener, hands the console the authorization URL to open, and completes the login in the background once the browser (same host) redirects back; the existing poll then sees the connector connected. No redirect URI to register, and it sidesteps Google's https/public-domain restriction on Web-client redirects.
- **Remote gateway** (LAN, tunnel, public URL): keep the **Web-client** path with the gateway-origin callback, and surface the exact redirect URI (server-authoritative, since `resolveRequestOrigin` may use a configured public/tunnel URL) plus the required client type in the dialog.

The dialog now shows Desktop-app vs Web-application guidance based on which flow applies (`oauthRedirectUri` is null for the loopback flow). The CLI's loopback listener is refactored into a reusable `startGoogleLoopbackAuthorization` primitive shared by both paths.

## Tests

- `tests/google-auth.test.ts`: the loopback primitive returns a 127.0.0.1 redirect and a cancelable wait.
- `tests/gateway-admin-connectors.test.ts`: loopback origin omits the redirect URI; remote origin exposes it and uses it in the authorize URL; end-to-end loopback flow drives a real callback and marks Google connected.
- `console/src/routes/connectors.test.tsx`: dialog shows Web+redirect-URI for a remote origin and Desktop-app guidance (no redirect URI) for a local one.

All CI green; full `gateway-http-server` + `gateway-admin-connectors` + `google-auth` suites pass locally.

Docs companion: #1332.

## Follow-up (not in this PR)

Best possible UX is a **HybridAI-managed** Google connector (like GitHub/MS365 — zero Google Cloud Console), but that's gated on Google app verification for sensitive scopes. Worth a roadmap item.