### PR TITLE
docs(auth): distinguish Desktop vs Web Google OAuth client flows

### DIFF
--- a/docs/content/getting-started/authentication.md
+++ b/docs/content/getting-started/authentication.md
@@ -226,19 +226,24 @@ Use an OAuth desktop client, not an API key. A service account can work for
 some Google APIs, but it is a different setup and is not what
 `google-oauth` routes use.
 
-> ⚠️ **Desktop app is for the CLI login only.**
-> `hybridclaw auth login google` runs a temporary loopback server and
-> authorizes against a `http://127.0.0.1:<port>/oauth2/callback` redirect,
-> which a **Desktop app** client accepts without registering any redirect URI.
+> ⚠️ **Which OAuth client type do I need?** It depends on how you authorize.
 >
-> If you instead connect Google Workspace from the **admin console**
-> Connectors page (the **Connect** button), Google authorizes against
-> `<your-console-origin>/api/connectors/oauth/callback`. A Desktop client has
-> no redirect URI allowlist and Google rejects that redirect with
-> `redirect_uri_mismatch` (`Fehler 400: redirect_uri_mismatch`). For the
-> console flow, create a **Web application** OAuth client instead and add that
-> exact callback URL under **Authorized redirect URIs**. The connector dialog
-> shows the URL to register.
+> - **CLI (`hybridclaw auth login google`) or the admin console opened
+>   locally** (`localhost` / `127.0.0.1`, including the desktop app): use a
+>   **Desktop app** client. Authorization completes over a loopback redirect
+>   (`http://127.0.0.1:<port>/oauth2/callback`) that Google accepts without
+>   registering any redirect URI.
+> - **Admin console reached over a network origin** (LAN address, tunnel, or
+>   public URL): the loopback redirect can't reach the gateway, so Google
+>   authorizes against `<your-console-origin>/api/connectors/oauth/callback`
+>   instead. A Desktop client has no redirect URI allowlist and Google rejects
+>   that with `redirect_uri_mismatch` (`Fehler 400: redirect_uri_mismatch`).
+>   Create a **Web application** client and add that exact callback URL under
+>   **Authorized redirect URIs**. Google only accepts https public origins (or
+>   `localhost`) there, so the gateway needs a real public URL or tunnel.
+>
+> The Connect dialog shows which client type applies and, for the Web case,
+> the exact redirect URI to register.
 
 ### 2. Authorize The Required Scopes
 

--- a/docs/content/getting-started/authentication.md
+++ b/docs/content/getting-started/authentication.md
@@ -226,15 +226,15 @@ Use an OAuth desktop client, not an API key. A service account can work for
 some Google APIs, but it is a different setup and is not what
 `google-oauth` routes use.
 
-> ⚠️ **Desktop app is for the CLI login only.** `hybridclaw auth login
-> google` runs a temporary loopback server and authorizes against a
-> `http://127.0.0.1:<port>/oauth2/callback` redirect, which a **Desktop app**
-> client accepts without registering any redirect URI.
+> ⚠️ **Desktop app is for the CLI login only.**
+> `hybridclaw auth login google` runs a temporary loopback server and
+> authorizes against a `http://127.0.0.1:<port>/oauth2/callback` redirect,
+> which a **Desktop app** client accepts without registering any redirect URI.
 >
 > If you instead connect Google Workspace from the **admin console**
 > Connectors page (the **Connect** button), Google authorizes against
 > `<your-console-origin>/api/connectors/oauth/callback`. A Desktop client has
-> no redirect-URI allowlist and Google rejects that redirect with
+> no redirect URI allowlist and Google rejects that redirect with
 > `redirect_uri_mismatch` (`Fehler 400: redirect_uri_mismatch`). For the
 > console flow, create a **Web application** OAuth client instead and add that
 > exact callback URL under **Authorized redirect URIs**. The connector dialog

--- a/docs/content/getting-started/authentication.md
+++ b/docs/content/getting-started/authentication.md
@@ -226,6 +226,20 @@ Use an OAuth desktop client, not an API key. A service account can work for
 some Google APIs, but it is a different setup and is not what
 `google-oauth` routes use.
 
+> ⚠️ **Desktop app is for the CLI login only.** `hybridclaw auth login
+> google` runs a temporary loopback server and authorizes against a
+> `http://127.0.0.1:<port>/oauth2/callback` redirect, which a **Desktop app**
+> client accepts without registering any redirect URI.
+>
+> If you instead connect Google Workspace from the **admin console**
+> Connectors page (the **Connect** button), Google authorizes against
+> `<your-console-origin>/api/connectors/oauth/callback`. A Desktop client has
+> no redirect-URI allowlist and Google rejects that redirect with
+> `redirect_uri_mismatch` (`Fehler 400: redirect_uri_mismatch`). For the
+> console flow, create a **Web application** OAuth client instead and add that
+> exact callback URL under **Authorized redirect URIs**. The connector dialog
+> shows the URL to register.
+
 ### 2. Authorize The Required Scopes
 
 Run `auth login google` with the scopes needed by the APIs you will call. For


### PR DESCRIPTION
## Problem

The Google OAuth docs only described a **Desktop app** client, correct for the CLI loopback login but not for every console path. Users following them for the admin console **Connect** flow could hit `redirect_uri_mismatch`.

## Fix

Rewrite the callout to pick the client type by **how you authorize**, matching the behavior in #1331:

- **CLI, or the console opened locally** (`localhost`/`127.0.0.1`, incl. the desktop app): **Desktop app** client — loopback redirect, nothing to register.
- **Console over a network origin** (LAN/tunnel/public URL): **Web application** client with `<console-origin>/api/connectors/oauth/callback` registered. Notes Google's https/public-origin requirement for Web-client redirects.

The Connect dialog shows which type applies and, for the Web case, the redirect URI to register.

Code companion: #1331.