### PR TITLE
fix: restore live model response streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Model response streaming**: Provider text deltas reach clients as they
+  arrive instead of being buffered until the final response. HybridClaw keeps
+  classified Ralph drafts buffered, avoids replaying final text after a live
+  stream, and does not retry a failed model call after visible partial output.
+
 ## [0.28.1](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.1) - 2026-07-10
 
 ### Added

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -26,10 +26,12 @@ import { waitForInput, writeHealthOutput, writeOutput } from './ipc.js';
 import { McpClientManager } from './mcp/client-manager.js';
 import { McpConfigWatcher } from './mcp/config-watcher.js';
 import {
+  canReplayModelRequestAfterStreamError,
   formatModelErrorForLog,
   isRetryableModelError,
   shouldDowngradeStreamToNonStreaming,
 } from './model-retry.js';
+import { createModelTextDeltaForwarder } from './model-text-deltas.js';
 import {
   injectNativeAudioContent,
   injectNativeVisionContent,
@@ -767,6 +769,7 @@ async function callHybridAIWithRetry(params: {
   history: ChatMessage[];
   tools: ToolDefinition[];
   onTextDelta?: (delta: string) => void;
+  textDeltasVisible?: boolean;
   onThinkingDelta?: (delta: string) => void;
   onActivity?: () => void;
   maxTokens?: number;
@@ -789,6 +792,7 @@ async function callHybridAIWithRetry(params: {
     history,
     tools,
     onTextDelta,
+    textDeltasVisible = false,
     onThinkingDelta,
     onActivity,
     maxTokens,
@@ -805,11 +809,13 @@ async function callHybridAIWithRetry(params: {
     attempt += 1;
     const attemptStartedAt = Date.now();
     let firstTextDeltaMs: number | null = null;
+    let receivedTextDelta = false;
     const wrappedOnTextDelta = onTextDelta
       ? (delta: string) => {
           if (delta && firstTextDeltaMs == null) {
             firstTextDeltaMs = Date.now() - attemptStartedAt;
           }
+          if (delta) receivedTextDelta = true;
           onTextDelta(delta);
         }
       : undefined;
@@ -848,7 +854,15 @@ async function callHybridAIWithRetry(params: {
             provider,
             streamErr,
           );
-          if (!fallbackEligible) throw streamErr;
+          if (
+            !fallbackEligible ||
+            !canReplayModelRequestAfterStreamError({
+              receivedTextDelta,
+              textDeltasVisible,
+            })
+          ) {
+            throw streamErr;
+          }
           response = await callRoutedModel({
             provider,
             providerMethod,
@@ -908,6 +922,10 @@ async function callHybridAIWithRetry(params: {
       const retryable =
         RETRY_ENABLED &&
         isRetryableModelError(err) &&
+        canReplayModelRequestAfterStreamError({
+          receivedTextDelta,
+          textDeltasVisible,
+        }) &&
         attempt < RETRY_MAX_ATTEMPTS;
       await emitRuntimeEvent({
         event: retryable ? 'model_retry' : 'model_error',
@@ -1323,11 +1341,13 @@ async function processRequest(
     tokenUsage.estimatedPromptTokens += estimatedPromptTokensForCall;
 
     let response: Awaited<ReturnType<typeof callHybridAIWithRetry>>;
-    // Provider chunks are suppressed until this turn is classified as final.
-    const suppressTextDelta = (_delta: string): void => {};
-    const emitFinalTextDelta = (text: string | null): void => {
-      if (streamTextDeltas && text) emitStreamDelta(text);
-    };
+    // Ralph drafts need end-of-turn classification. Ordinary turns can stream
+    // live; tool preambles are moved into the gateway's activity trace.
+    const textDeltaForwarder = createModelTextDeltaForwarder({
+      enabled: streamTextDeltas,
+      forwardLive: !ralphEnabled,
+      emit: emitStreamDelta,
+    });
     try {
       response = await callHybridAIWithRetry({
         sessionId,
@@ -1341,7 +1361,10 @@ async function processRequest(
         requestHeaders,
         history,
         tools,
-        onTextDelta: streamTextDeltas ? suppressTextDelta : undefined,
+        onTextDelta: streamTextDeltas
+          ? textDeltaForwarder.onProviderDelta
+          : undefined,
+        textDeltasVisible: streamTextDeltas && !ralphEnabled,
         onThinkingDelta: streamTextDeltas
           ? (delta) => emitStreamThinkingDelta(delta)
           : undefined,
@@ -1524,7 +1547,7 @@ async function processRequest(
             startedAtMs: processStartedAt,
           });
           latestFinalAssistantText = assistantSegment.text;
-          emitFinalTextDelta(latestFinalAssistantText);
+          textDeltaForwarder.emitFinalFallback(latestFinalAssistantText);
           const completed: ContainerOutput = {
             status: 'success',
             result: latestFinalAssistantText,
@@ -1602,7 +1625,7 @@ async function processRequest(
       }
 
       latestFinalAssistantText = assistantSegment.text;
-      emitFinalTextDelta(latestFinalAssistantText);
+      textDeltaForwarder.emitFinalFallback(latestFinalAssistantText);
       const completed: ContainerOutput = {
         status: 'success',
         result: latestFinalAssistantText,

--- a/container/src/model-retry.ts
+++ b/container/src/model-retry.ts
@@ -168,6 +168,15 @@ export function shouldDowngradeStreamToNonStreaming(
   return shouldFallbackFromStreamError(error);
 }
 
+export function canReplayModelRequestAfterStreamError(params: {
+  receivedTextDelta: boolean;
+  textDeltasVisible: boolean;
+}): boolean {
+  // Reissuing a request after partial text reached the client duplicates the
+  // visible prefix when the next attempt starts from the beginning.
+  return !params.receivedTextDelta || !params.textDeltasVisible;
+}
+
 export function isRetryableModelError(error: unknown): boolean {
   if (error instanceof ProviderRequestError) {
     return error.status === 429 || (error.status >= 500 && error.status <= 504);

--- a/container/src/model-text-deltas.ts
+++ b/container/src/model-text-deltas.ts
@@ -1,0 +1,27 @@
+export function createModelTextDeltaForwarder(params: {
+  enabled: boolean;
+  forwardLive: boolean;
+  emit: (delta: string) => void;
+}): {
+  onProviderDelta: (delta: string) => void;
+  emitFinalFallback: (text: string | null) => void;
+} {
+  let forwardedText = false;
+
+  const forward = (text: string | null): void => {
+    if (!params.enabled || !text) return;
+    forwardedText = true;
+    params.emit(text);
+  };
+
+  return {
+    onProviderDelta(delta: string): void {
+      if (!params.forwardLive) return;
+      forward(delta);
+    },
+    emitFinalFallback(text: string | null): void {
+      if (forwardedText) return;
+      forward(text);
+    },
+  };
+}

--- a/tests/container.model-text-deltas.test.ts
+++ b/tests/container.model-text-deltas.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { createModelTextDeltaForwarder } from '../container/src/model-text-deltas.js';
+
+describe('container model text delta forwarding', () => {
+  test('forwards provider deltas immediately without replaying the final text', () => {
+    const emit = vi.fn();
+    const stream = createModelTextDeltaForwarder({
+      enabled: true,
+      forwardLive: true,
+      emit,
+    });
+
+    stream.onProviderDelta('Hello');
+    expect(emit).toHaveBeenCalledWith('Hello');
+
+    stream.onProviderDelta(' world');
+    stream.emitFinalFallback('Hello world');
+
+    expect(emit.mock.calls).toEqual([['Hello'], [' world']]);
+  });
+
+  test('emits the final response when the provider produced no text deltas', () => {
+    const emit = vi.fn();
+    const stream = createModelTextDeltaForwarder({
+      enabled: true,
+      forwardLive: true,
+      emit,
+    });
+
+    stream.onProviderDelta('');
+    stream.emitFinalFallback('Fallback response');
+
+    expect(emit).toHaveBeenCalledOnce();
+    expect(emit).toHaveBeenCalledWith('Fallback response');
+  });
+
+  test('keeps Ralph drafts buffered and emits only the classified final text', () => {
+    const emit = vi.fn();
+    const stream = createModelTextDeltaForwarder({
+      enabled: true,
+      forwardLive: false,
+      emit,
+    });
+
+    stream.onProviderDelta('Draft <choice>STOP</choice>');
+    expect(emit).not.toHaveBeenCalled();
+
+    stream.emitFinalFallback('Draft');
+    expect(emit).toHaveBeenCalledWith('Draft');
+  });
+
+  test('does not emit when text streaming is disabled', () => {
+    const emit = vi.fn();
+    const stream = createModelTextDeltaForwarder({
+      enabled: false,
+      forwardLive: true,
+      emit,
+    });
+
+    stream.onProviderDelta('Hello');
+    stream.emitFinalFallback('Hello');
+
+    expect(emit).not.toHaveBeenCalled();
+  });
+});

--- a/tests/hybridai-retry.test.ts
+++ b/tests/hybridai-retry.test.ts
@@ -1,11 +1,38 @@
 import { describe, expect, test } from 'vitest';
 import {
+  canReplayModelRequestAfterStreamError,
   formatModelErrorForLog,
   isRetryableModelError,
   shouldDowngradeStreamToNonStreaming,
   shouldFallbackFromStreamError,
 } from '../container/src/model-retry.js';
 import { ProviderRequestError } from '../container/src/providers/shared.js';
+
+describe('canReplayModelRequestAfterStreamError', () => {
+  test('blocks fallback and retries after visible partial output', () => {
+    expect(
+      canReplayModelRequestAfterStreamError({
+        receivedTextDelta: true,
+        textDeltasVisible: true,
+      }),
+    ).toBe(false);
+  });
+
+  test('allows replay before output or when deltas remain buffered', () => {
+    expect(
+      canReplayModelRequestAfterStreamError({
+        receivedTextDelta: false,
+        textDeltasVisible: true,
+      }),
+    ).toBe(true);
+    expect(
+      canReplayModelRequestAfterStreamError({
+        receivedTextDelta: true,
+        textDeltasVisible: false,
+      }),
+    ).toBe(true);
+  });
+});
 
 describe('shouldFallbackFromStreamError', () => {
   test('allows fallback for 500 stream errors', () => {


### PR DESCRIPTION
## Summary

- forward ordinary provider text deltas to clients as they arrive
- retain classified buffering for Ralph/full-auto drafts and emit final text only as a fallback
- prevent stream downgrade or model-call retries after visible partial output, avoiding duplicated prefixes
- add focused regression coverage and an Unreleased changelog entry

## Root cause

The container loop passed a no-op text callback to streaming providers so it could classify a turn before exposing it. The provider consumed HybridAI SSE deltas correctly, but HybridClaw discarded every delta and emitted the completed answer as one final chunk.

## Impact

HybridAI and other standard streaming providers now produce incremental client updates again. Tool-call preambles continue through the existing gateway activity-trace flow, while Ralph drafts stay hidden until classified.

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run lint`
- container lint
- 47 focused provider, retry, Ralph, and streaming tests
- host-runner and container-runner IPC streaming boundary tests
- gateway draft/tool streaming test