### PR TITLE
feat: add model routing tier substrate

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,5 @@
 {
-  "version": 34,
+  "version": 35,
   "security": {
     "trustModelAccepted": false,
     "trustModelAcceptedAt": "",
@@ -583,6 +583,10 @@
     }
   },
   "routing": {
+    "enabled": false,
+    "tiers": [],
+    "defaultStart": "",
+    "escalationStickyTurns": 3,
     "concierge": {
       "enabled": false,
       "model": "gemini-3-flash",

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -1021,6 +1021,7 @@ export interface ChatModel {
 }
 
 export interface AdminModelCatalogEntry extends ChatModel {
+  zone: 'local' | 'hai' | 'region' | 'cloud';
   discovered: boolean;
   maxTokens: number | null;
   pricingUsdPerToken: {

--- a/console/src/routes/models.test.tsx
+++ b/console/src/routes/models.test.tsx
@@ -9,6 +9,7 @@ const saveModelsMock = vi.fn();
 const useAuthMock = vi.fn();
 
 const modelMetadataDefaults = {
+  zone: 'cloud' as const,
   pricingUsdPerToken: { input: null, output: null },
   capabilities: {
     vision: true,

--- a/console/src/routes/output-guard.test.tsx
+++ b/console/src/routes/output-guard.test.tsx
@@ -124,6 +124,7 @@ beforeEach(() => {
       {
         id: 'hybridai/default-chat',
         provider: 'hybridai',
+        zone: 'cloud',
         backend: null,
         contextWindow: 128000,
         isReasoning: false,
@@ -146,6 +147,7 @@ beforeEach(() => {
       {
         id: 'openrouter/openai/gpt-5-mini',
         provider: 'openrouter',
+        zone: 'cloud',
         backend: null,
         contextWindow: 128000,
         isReasoning: false,

--- a/docs/content/developer-guide/runtime.md
+++ b/docs/content/developer-guide/runtime.md
@@ -396,6 +396,9 @@ Runtime details:
 - Additional same-type endpoints are stored in `local.endpoints[]`; endpoint
   names become model prefixes such as
   `haigpu2/mistralai/Mistral-7B-Instruct-v0.3`.
+- Named endpoints carry a fail-closed privacy `zone` and can provide
+  `pricing.inputEurPerMillion` / `pricing.outputEurPerMillion` for usage
+  accounting. Missing zones resolve to `cloud`; missing prices stay unknown.
 - Local models are prefixed with the backend name (e.g. `lmstudio/qwen/qwen3.5-9b`,
   `ollama/llama3`).
 - Special model behavior is explicit in `modelBehavior`, for example

--- a/docs/content/extensibility/agent-packages.md
+++ b/docs/content/extensibility/agent-packages.md
@@ -251,7 +251,7 @@ interface ClawManifest {
   };
 
   agent?: {
-    model?: string | { primary: string; fallbacks?: string[] };
+    model?: string | { primary: string };
     enableRag?: boolean;
   };
 

--- a/docs/content/guides/local-providers.md
+++ b/docs/content/guides/local-providers.md
@@ -51,7 +51,11 @@ Then select or route models by endpoint name:
 ```
 
 Named endpoints are stored in `local.endpoints[]` with `name`, `type`,
-`enabled`, `baseUrl`, optional `apiKey`, and optional `modelBehavior`. Use
+`enabled`, `baseUrl`, optional `apiKey`, optional `modelBehavior`, a privacy
+`zone`, and optional `pricing.inputEurPerMillion` and
+`pricing.outputEurPerMillion`. An omitted or invalid zone defaults to `cloud`
+so routing cannot silently widen the data boundary; omitted pricing is shown
+as unknown rather than zero. Use
 `modelBehavior.thinkingFormat: "qwen"` for Qwen thinking markup handling. API
 keys provided through the CLI are stored in the encrypted runtime secret store
 and referenced from config.

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -127,9 +127,19 @@ saved revision history directly.
   `hybridclaw config set hybridai.maxTokens <n>`
 - `local.endpoints[]` for additional named local model endpoints. Each entry
   has `name`, `type` (`ollama`, `lmstudio`, `llamacpp`, or `vllm`), `enabled`,
-  `baseUrl`, optional `apiKey`, and optional `modelBehavior`; named models use
+  `baseUrl`, optional `apiKey`, optional `modelBehavior`, a privacy `zone`
+  (`local`, `hai`, `region`, or `cloud`), and optional EUR-per-million token
+  prices under `pricing.inputEurPerMillion` and
+  `pricing.outputEurPerMillion`; omitted or invalid zones fail closed to
+  `cloud`, and omitted prices are reported as unknown. Named models use
   `<name>/<model-id>`, for example `haigpu2/mistralai/Mistral-7B-Instruct-v0.3`.
   `modelBehavior` currently supports `thinkingFormat: "qwen"`.
+- `routing.enabled`, ordered `routing.tiers[]`, `routing.defaultStart`, and
+  `routing.escalationStickyTurns` define the model-routing ladder. Each tier
+  has a unique `name` and an ordered, non-empty `models` list. Remote model
+  references must exist in the configured provider catalogs; named local
+  endpoint references use `<endpoint>/<model-id>`. Phase 1 validates and
+  exposes this substrate without changing live turn selection.
 - `codex.baseUrl`, `codex.turnRuntime`, and `codex.models` for first-class
   Codex provider behavior. `codex.turnRuntime` accepts `hybridclaw` for the
   standard HybridClaw tool loop or `app-server` for the native Codex app-server

--- a/docs/content/reference/model-selection.md
+++ b/docs/content/reference/model-selection.md
@@ -83,10 +83,12 @@ Examples:
 
 `/model info` also reports configured auxiliary model routes and known model
 metadata when HybridClaw can resolve it: context window, maximum output tokens,
-capability flags, pricing per 1M tokens, and source references. Local models
-and Codex subscription-backed models are shown as zero-cost in local usage
-summaries; remote-provider pricing is shown only when the provider catalog
-exposes usable pricing metadata.
+capability flags, privacy zone, pricing per 1M tokens, and source references.
+Named local endpoints use their configured EUR-per-million token pricing;
+unpriced local models are shown with unknown pricing. Codex
+subscription-backed models remain zero-cost in local usage summaries, and
+remote-provider pricing is shown only when the provider catalog exposes usable
+pricing metadata.
 
 The admin Models page combines the same metadata with daily and monthly usage
 rollups, so operators can sort by context window or monthly usage and compare

--- a/src/agents/agent-config-command.ts
+++ b/src/agents/agent-config-command.ts
@@ -114,17 +114,7 @@ function normalizeModelConfig(value: unknown): AgentModelConfig | undefined {
 
   const primary = normalizeOptionalString(value.primary);
   if (!primary) return undefined;
-  const seen = new Set<string>([primary]);
-  const fallbacks = Array.isArray(value.fallbacks)
-    ? value.fallbacks
-        .map(normalizeOptionalString)
-        .filter((entry): entry is string => {
-          if (!entry || seen.has(entry)) return false;
-          seen.add(entry);
-          return true;
-        })
-    : [];
-  return fallbacks.length > 0 ? { primary, fallbacks } : { primary };
+  return { primary };
 }
 
 function parseAgentConfigJson(rawJson: string): AgentConfigJsonPayload {

--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -98,12 +98,7 @@ function cloneModelConfig(
 ): AgentModelConfig | undefined {
   if (!value) return undefined;
   if (typeof value === 'string') return value;
-  return {
-    primary: value.primary,
-    ...(Array.isArray(value.fallbacks) && value.fallbacks.length > 0
-      ? { fallbacks: [...value.fallbacks] }
-      : {}),
-  };
+  return { primary: value.primary };
 }
 
 function normalizeModelConfig(value: unknown): AgentModelConfig | undefined {
@@ -117,20 +112,7 @@ function normalizeModelConfig(value: unknown): AgentModelConfig | undefined {
 
   const primary = normalizeString((value as { primary?: unknown }).primary);
   if (!primary) return undefined;
-  const rawFallbacks: unknown[] = Array.isArray(
-    (value as { fallbacks?: unknown }).fallbacks,
-  )
-    ? ((value as { fallbacks?: unknown[] }).fallbacks ?? [])
-    : [];
-  const seen = new Set<string>([primary]);
-  const fallbacks = rawFallbacks
-    .map((entry) => normalizeString(entry))
-    .filter((entry) => {
-      if (!entry || seen.has(entry)) return false;
-      seen.add(entry);
-      return true;
-    });
-  return fallbacks.length > 0 ? { primary, fallbacks } : { primary };
+  return { primary };
 }
 
 function normalizeDefaults(value: unknown): AgentDefaultsConfig {
@@ -262,7 +244,7 @@ function fingerprintStringArray(values: string[] | undefined): string {
 function fingerprintModel(model: AgentModelConfig | undefined): string {
   if (!model) return '';
   if (typeof model === 'string') return `s:${fingerprintString(model)}`;
-  return `o:${fingerprintString(model.primary)}:${fingerprintStringArray(model.fallbacks)}`;
+  return `o:${fingerprintString(model.primary)}`;
 }
 
 function fingerprintCv(cv: AgentConfig['cv']): string {

--- a/src/agents/agent-runtime-config.ts
+++ b/src/agents/agent-runtime-config.ts
@@ -23,7 +23,7 @@ function sameStringArray(a?: string[], b?: string[]): boolean {
 function sameModelConfig(a?: AgentModelConfig, b?: AgentModelConfig): boolean {
   if (a === b) return true;
   if (typeof a === 'string' || typeof b === 'string' || !a || !b) return false;
-  return a.primary === b.primary && sameStringArray(a.fallbacks, b.fallbacks);
+  return a.primary === b.primary;
 }
 
 function sameAgentConfig(a: AgentConfig | undefined, b: AgentConfig): boolean {

--- a/src/agents/agent-types.ts
+++ b/src/agents/agent-types.ts
@@ -22,7 +22,6 @@ export type AgentModelConfig =
   | string
   | {
       primary: string;
-      fallbacks?: string[];
     };
 
 export interface AgentCv {

--- a/src/agents/claw-manifest.ts
+++ b/src/agents/claw-manifest.ts
@@ -91,10 +91,7 @@ function normalizeModelConfig(value: unknown): AgentModelConfig | undefined {
 
   const primary = normalizeString(value.primary);
   if (!primary) return undefined;
-  const fallbacks = normalizeStringArray(value.fallbacks).filter(
-    (entry) => entry !== primary,
-  );
-  return fallbacks.length > 0 ? { primary, fallbacks } : { primary };
+  return { primary };
 }
 
 function normalizePresentation(value: unknown): ClawPresentation | undefined {

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -74,9 +74,15 @@ import { CODEX_DEFAULT_BASE_URL } from '../providers/codex-constants.js';
 import type {
   LocalBackendType,
   LocalEndpointConfig,
+  LocalEndpointPricingConfig,
   LocalModelBehavior,
   LocalProviderConfig,
 } from '../providers/local-types.js';
+import {
+  type ModelRoutingConfig,
+  type ModelRoutingTier,
+  normalizeModelRoutingZone,
+} from '../providers/model-routing.js';
 import {
   isLocalBackendType,
   isRuntimeProviderId,
@@ -144,7 +150,7 @@ import {
 import { DEFAULT_RUNTIME_HOME_DIR } from './runtime-paths.js';
 
 export const CONFIG_FILE_NAME = 'config.json';
-export const CONFIG_VERSION = 34;
+export const CONFIG_VERSION = 35;
 export const SECURITY_POLICY_VERSION = '2026-02-28';
 export const DEFAULT_HYBRIDAI_MODEL = 'gpt-5.4-mini';
 export const DEFAULT_HYBRIDAI_ONBOARDING_MODEL = '';
@@ -499,6 +505,10 @@ export interface RuntimeRoutingConciergeConfig {
     balanced: string;
     noHurry: string;
   };
+}
+
+export interface RuntimeRoutingConfig extends ModelRoutingConfig {
+  concierge: RuntimeRoutingConciergeConfig;
 }
 
 export interface RuntimeDiscordHumanDelayConfig {
@@ -1219,9 +1229,7 @@ export interface RuntimeConfig {
   media: {
     audio: RuntimeMediaAudioConfig;
   };
-  routing: {
-    concierge: RuntimeRoutingConciergeConfig;
-  };
+  routing: RuntimeRoutingConfig;
   heartbeat: {
     enabled: boolean;
     intervalMs: number;
@@ -2005,6 +2013,10 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
     },
   },
   routing: {
+    enabled: false,
+    tiers: [],
+    defaultStart: '',
+    escalationStickyTurns: 3,
     concierge: {
       enabled: false,
       model: 'gemini-3-flash',
@@ -2808,12 +2820,7 @@ function cloneAgentModelConfig(
 ): AgentModelConfig | undefined {
   if (!value) return undefined;
   if (typeof value === 'string') return value;
-  return {
-    primary: value.primary,
-    ...(Array.isArray(value.fallbacks) && value.fallbacks.length > 0
-      ? { fallbacks: [...value.fallbacks] }
-      : {}),
-  };
+  return { primary: value.primary };
 }
 
 function normalizeAgentModelConfig(
@@ -2828,10 +2835,7 @@ function normalizeAgentModelConfig(
 
   const primary = normalizeString(value.primary, '', { allowEmpty: true });
   if (!primary) return cloneAgentModelConfig(fallback);
-  const fallbacks = normalizeStringArray(value.fallbacks, []).filter(
-    (candidate) => candidate !== primary,
-  );
-  return fallbacks.length > 0 ? { primary, fallbacks } : { primary };
+  return { primary };
 }
 
 function normalizeAgentDefaultsConfig(
@@ -5176,6 +5180,43 @@ function normalizeModelBehaviorConfig(
   return Object.keys(behavior).length > 0 ? behavior : undefined;
 }
 
+function normalizeLocalEndpointEuroPrice(
+  value: unknown,
+  path: string,
+): number | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${path} must be a finite non-negative number.`);
+  }
+  return value;
+}
+
+function normalizeLocalEndpointPricing(
+  value: unknown,
+  endpointName: string,
+): LocalEndpointPricingConfig | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) {
+    throw new Error(
+      `local.endpoints.${endpointName}.pricing must be an object.`,
+    );
+  }
+  const pricing: LocalEndpointPricingConfig = {
+    inputEurPerMillion: normalizeLocalEndpointEuroPrice(
+      value.inputEurPerMillion,
+      `local.endpoints.${endpointName}.pricing.inputEurPerMillion`,
+    ),
+    outputEurPerMillion: normalizeLocalEndpointEuroPrice(
+      value.outputEurPerMillion,
+      `local.endpoints.${endpointName}.pricing.outputEurPerMillion`,
+    ),
+  };
+  return pricing.inputEurPerMillion == null &&
+    pricing.outputEurPerMillion == null
+    ? undefined
+    : pricing;
+}
+
 function normalizeLocalEndpointConfigs(value: unknown): LocalEndpointConfig[] {
   if (!Array.isArray(value)) return [];
   const endpoints: LocalEndpointConfig[] = [];
@@ -5199,6 +5240,7 @@ function normalizeLocalEndpointConfigs(value: unknown): LocalEndpointConfig[] {
       path: `local.endpoints.${name}.apiKey`,
       required: isSecretRefInput(raw.apiKey) && enabled,
     });
+    const pricing = normalizeLocalEndpointPricing(raw.pricing, name);
     endpoints.push({
       name,
       type,
@@ -5206,6 +5248,8 @@ function normalizeLocalEndpointConfigs(value: unknown): LocalEndpointConfig[] {
       baseUrl: normalizeBaseUrl(raw.baseUrl, fallbackBaseUrl),
       apiKey: normalizeString(resolvedApiKey, '', { allowEmpty: true }),
       modelBehavior: normalizeModelBehaviorConfig(raw.modelBehavior),
+      zone: normalizeModelRoutingZone(raw.zone),
+      ...(pricing ? { pricing } : {}),
     });
   }
   return endpoints;
@@ -6676,6 +6720,132 @@ function normalizeRoutingConciergeConfig(
   };
 }
 
+interface RoutingModelReferenceCatalog {
+  models: Set<string>;
+  dynamicPrefixes: Set<string>;
+}
+
+function buildRoutingModelReferenceCatalog(params: {
+  hybridaiModels: string[];
+  hybridaiDefaultModel: string;
+  hybridaiOnboardingModel: string;
+  remoteModels: string[][];
+  localEndpoints: LocalEndpointConfig[];
+}): RoutingModelReferenceCatalog {
+  const models = new Set<string>();
+  for (const model of [
+    ...params.hybridaiModels,
+    params.hybridaiDefaultModel,
+    params.hybridaiOnboardingModel,
+  ]) {
+    const normalized = model.trim();
+    if (!normalized) continue;
+    models.add(normalized);
+    models.add(
+      normalized.toLowerCase().startsWith('hybridai/')
+        ? normalized
+        : `hybridai/${normalized}`,
+    );
+  }
+  for (const model of params.remoteModels.flat()) {
+    const normalized = model.trim();
+    if (normalized) models.add(normalized);
+  }
+  return {
+    models,
+    dynamicPrefixes: new Set([
+      'ollama',
+      'lmstudio',
+      'llamacpp',
+      'vllm',
+      ...params.localEndpoints.map((endpoint) => endpoint.name),
+    ]),
+  };
+}
+
+function isKnownRoutingModelReference(
+  model: string,
+  catalog: RoutingModelReferenceCatalog,
+): boolean {
+  if (catalog.models.has(model)) return true;
+  const slashIndex = model.indexOf('/');
+  return (
+    slashIndex > 0 &&
+    slashIndex < model.length - 1 &&
+    catalog.dynamicPrefixes.has(model.slice(0, slashIndex))
+  );
+}
+
+function normalizeModelRoutingConfig(
+  value: unknown,
+  fallback: ModelRoutingConfig,
+  catalog: RoutingModelReferenceCatalog,
+): ModelRoutingConfig {
+  const raw = isRecord(value) ? value : {};
+  const enabled = normalizeBoolean(raw.enabled, fallback.enabled);
+  const rawTiers = raw.tiers === undefined ? fallback.tiers : raw.tiers;
+  if (!Array.isArray(rawTiers)) {
+    throw new Error('routing.tiers must be an array.');
+  }
+
+  const seenTierNames = new Set<string>();
+  const tiers: ModelRoutingTier[] = rawTiers.map((entry, index) => {
+    if (!isRecord(entry)) {
+      throw new Error(`routing.tiers[${index}] must be an object.`);
+    }
+    const name = normalizeString(entry.name, '', { allowEmpty: false });
+    if (!name) {
+      throw new Error(`routing.tiers[${index}].name is required.`);
+    }
+    const nameKey = name.toLowerCase();
+    if (seenTierNames.has(nameKey)) {
+      throw new Error(`Duplicate routing tier name: ${name}.`);
+    }
+    seenTierNames.add(nameKey);
+    if (!Array.isArray(entry.models) || entry.models.length === 0) {
+      throw new Error(`routing.tiers[${index}].models must not be empty.`);
+    }
+    const models = normalizeOptionalTrimmedUniqueStringArray(entry.models);
+    if (!models || models.length !== entry.models.length) {
+      throw new Error(
+        `routing.tiers[${index}].models must contain unique non-empty model references.`,
+      );
+    }
+    for (const model of models) {
+      if (!isKnownRoutingModelReference(model, catalog)) {
+        throw new Error(
+          `routing.tiers[${index}] references unknown model \`${model}\`.`,
+        );
+      }
+    }
+    return { name, models };
+  });
+
+  if (enabled && tiers.length === 0) {
+    throw new Error('routing.tiers must not be empty when routing is enabled.');
+  }
+  const defaultStart = normalizeString(
+    raw.defaultStart,
+    tiers[0]?.name ?? fallback.defaultStart,
+    { allowEmpty: tiers.length === 0 },
+  );
+  if (tiers.length > 0 && !tiers.some((tier) => tier.name === defaultStart)) {
+    throw new Error(
+      `routing.defaultStart references unknown routing tier \`${defaultStart}\`.`,
+    );
+  }
+  return {
+    enabled,
+    tiers,
+    defaultStart,
+    escalationStickyTurns: normalizeInteger(
+      raw.escalationStickyTurns,
+      fallback.escalationStickyTurns,
+      { min: 0, max: 100 },
+    ),
+  };
+}
+
 function normalizeTavilySearchDepth(
   value: unknown,
   fallback: 'basic' | 'advanced',
@@ -7018,6 +7188,16 @@ function normalizeRuntimeConfig(
     DEFAULT_RUNTIME_CONFIG.hybridai.defaultChatbotId,
     { allowEmpty: true },
   );
+  const hybridDefaultModel = normalizeString(
+    rawHybridAi.defaultModel,
+    DEFAULT_RUNTIME_CONFIG.hybridai.defaultModel,
+    { allowEmpty: false },
+  );
+  const hybridOnboardingModel = normalizeString(
+    rawHybridAi.onboardingModel,
+    DEFAULT_RUNTIME_CONFIG.hybridai.onboardingModel,
+    { allowEmpty: true },
+  );
   const normalizedDbPath = normalizeDbPath(rawOps.dbPath, defaultOps.dbPath);
 
   const threshold = normalizeInteger(
@@ -7101,6 +7281,35 @@ function normalizeRuntimeConfig(
   const kiloModelList = normalizeStringArray(
     rawKilo.models,
     DEFAULT_RUNTIME_CONFIG.kilo.models,
+  );
+  const localEndpointConfigs = normalizeLocalEndpointConfigs(
+    rawLocal.endpoints,
+  );
+  const modelRouting = normalizeModelRoutingConfig(
+    rawRouting,
+    DEFAULT_RUNTIME_CONFIG.routing,
+    buildRoutingModelReferenceCatalog({
+      hybridaiModels: modelList,
+      hybridaiDefaultModel: hybridDefaultModel,
+      hybridaiOnboardingModel: hybridOnboardingModel,
+      remoteModels: [
+        codexModelList,
+        anthropicModelList,
+        openRouterModelList,
+        mistralModelList,
+        huggingFaceModelList,
+        geminiModelList,
+        deepSeekModelList,
+        xaiModelList,
+        zaiModelList,
+        kimiModelList,
+        miniMaxModelList,
+        dashScopeModelList,
+        xiaomiModelList,
+        kiloModelList,
+      ],
+      localEndpoints: localEndpointConfigs,
+    }),
   );
   const normalizedCommandUserId = normalizeString(
     rawDiscord.commandUserId,
@@ -7518,16 +7727,8 @@ function normalizeRuntimeConfig(
     }),
     hybridai: {
       baseUrl: hybridBaseUrl,
-      defaultModel: normalizeString(
-        rawHybridAi.defaultModel,
-        DEFAULT_RUNTIME_CONFIG.hybridai.defaultModel,
-        { allowEmpty: false },
-      ),
-      onboardingModel: normalizeString(
-        rawHybridAi.onboardingModel,
-        DEFAULT_RUNTIME_CONFIG.hybridai.onboardingModel,
-        { allowEmpty: true },
-      ),
+      defaultModel: hybridDefaultModel,
+      onboardingModel: hybridOnboardingModel,
       defaultChatbotId: hybridDefaultChatbotId,
       maxTokens: normalizeInteger(
         rawHybridAi.maxTokens,
@@ -7751,7 +7952,7 @@ function normalizeRuntimeConfig(
           ),
         },
       },
-      endpoints: normalizeLocalEndpointConfigs(rawLocal.endpoints),
+      endpoints: localEndpointConfigs,
       discovery: {
         enabled: normalizeBoolean(
           rawLocalDiscovery.enabled,
@@ -8127,6 +8328,7 @@ function normalizeRuntimeConfig(
     },
     media: normalizeMediaConfig(rawMedia, DEFAULT_RUNTIME_CONFIG.media),
     routing: {
+      ...modelRouting,
       concierge: normalizeRoutingConciergeConfig(
         rawRouting.concierge,
         DEFAULT_RUNTIME_CONFIG.routing.concierge,

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -6982,6 +6982,7 @@ export async function getGatewayAdminModels(): Promise<GatewayAdminModelsRespons
         return {
           id: modelId,
           provider: providerKeyByModel.get(modelId) ?? 'hybridai',
+          zone: metadata.zone,
           discovered: Boolean(info),
           backend: info?.backend || null,
           contextWindow: metadata.contextWindow,

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -1354,6 +1354,7 @@ export type { GatewayModelProviderKey } from './model-provider-keys.js';
 export interface GatewayAdminModelCatalogEntry {
   id: string;
   provider: GatewayModelProviderKey;
+  zone: 'local' | 'hai' | 'region' | 'cloud';
   discovered: boolean;
   backend: 'ollama' | 'lmstudio' | 'llamacpp' | 'vllm' | null;
   contextWindow: number | null;

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -3468,18 +3468,7 @@ function serializeAgentModelConfig(
   }
   const primary = model.primary.trim();
   if (!primary) return null;
-  const fallbacks = Array.isArray(model.fallbacks)
-    ? Array.from(
-        new Set(
-          model.fallbacks
-            .map((fallback) => fallback.trim())
-            .filter((fallback) => fallback && fallback !== primary),
-        ),
-      )
-    : [];
-  return JSON.stringify(
-    fallbacks.length > 0 ? { primary, fallbacks } : { primary },
-  );
+  return JSON.stringify({ primary });
 }
 
 function parseAgentModelConfig(
@@ -3500,19 +3489,7 @@ function parseAgentModelConfig(
           ? (parsed as { primary: string }).primary.trim()
           : '';
       if (!primary) return undefined;
-      const fallbacks = Array.isArray(
-        (parsed as { fallbacks?: unknown }).fallbacks,
-      )
-        ? Array.from(
-            new Set(
-              ((parsed as { fallbacks?: unknown[] }).fallbacks ?? [])
-                .filter((entry): entry is string => typeof entry === 'string')
-                .map((entry) => entry.trim())
-                .filter((entry) => entry && entry !== primary),
-            ),
-          )
-        : [];
-      return fallbacks.length > 0 ? { primary, fallbacks } : { primary };
+      return { primary };
     }
   } catch {
     // Keep supporting legacy plain-string rows stored before JSON objects.

--- a/src/providers/hybridai-discovery.ts
+++ b/src/providers/hybridai-discovery.ts
@@ -9,6 +9,10 @@ import {
   stripHybridAIModelPrefix,
 } from './model-names.js';
 import {
+  type ModelRoutingZone,
+  normalizeModelRoutingZone,
+} from './model-routing.js';
+import {
   type DiscoveredModelPricingUsdPerToken,
   readDiscoveredModelPricingUsdPerToken,
 } from './pricing-discovery.js';
@@ -260,6 +264,7 @@ export interface HybridAIDiscoveryStore {
   getModelContextWindow: (model: string) => number | null;
   getModelMaxTokens: (model: string) => number | null;
   getModelVisionCapability: (model: string) => boolean | null;
+  getModelZone: (model: string) => ModelRoutingZone | null;
   getModelPricingUsdPerToken: (
     model: string,
   ) => { input: number | null; output: number | null } | null;
@@ -273,6 +278,8 @@ interface HybridAIDiscoveryState {
   maxTokensModelKeyLookup: HybridAIModelKeyLookup;
   visionCapabilityByModel: Map<string, boolean>;
   visionCapabilityModelKeyLookup: HybridAIModelKeyLookup;
+  zoneByModel: Map<string, ModelRoutingZone>;
+  zoneModelKeyLookup: HybridAIModelKeyLookup;
   pricingByModel: Map<string, DiscoveredModelPricingUsdPerToken>;
   pricingModelKeyLookup: HybridAIModelKeyLookup;
 }
@@ -285,6 +292,8 @@ const buildEmptyHybridAIDiscoveryState = (): HybridAIDiscoveryState => ({
   maxTokensModelKeyLookup: buildHybridAIModelKeyLookup([]),
   visionCapabilityByModel: new Map(),
   visionCapabilityModelKeyLookup: buildHybridAIModelKeyLookup([]),
+  zoneByModel: new Map(),
+  zoneModelKeyLookup: buildHybridAIModelKeyLookup([]),
   pricingByModel: new Map(),
   pricingModelKeyLookup: buildHybridAIModelKeyLookup([]),
 });
@@ -327,6 +336,7 @@ export function createHybridAIDiscoveryStore(): HybridAIDiscoveryStore {
     const contextWindows = new Map<string, number>();
     const maxTokens = new Map<string, number>();
     const visionCapabilities = new Map<string, boolean>();
+    const zones = new Map<string, ModelRoutingZone>();
     const pricingByModel = new Map<string, DiscoveredModelPricingUsdPerToken>();
 
     for (const entry of getDiscoveryEntries(payload)) {
@@ -352,6 +362,7 @@ export function createHybridAIDiscoveryStore(): HybridAIDiscoveryStore {
       if (visionCapability != null) {
         visionCapabilities.set(normalized, visionCapability);
       }
+      zones.set(normalized, normalizeModelRoutingZone(entry.zone));
       const pricing = readDiscoveredModelPricingUsdPerToken(entry);
       if (pricing) {
         pricingByModel.set(normalized, pricing);
@@ -371,6 +382,8 @@ export function createHybridAIDiscoveryStore(): HybridAIDiscoveryStore {
       visionCapabilityModelKeyLookup: buildHybridAIModelKeyLookup(
         visionCapabilities.keys(),
       ),
+      zoneByModel: zones,
+      zoneModelKeyLookup: buildHybridAIModelKeyLookup(zones.keys()),
       pricingByModel,
       pricingModelKeyLookup: buildHybridAIModelKeyLookup(pricingByModel.keys()),
     };
@@ -439,6 +452,15 @@ export function createHybridAIDiscoveryStore(): HybridAIDiscoveryStore {
       );
       return state.visionCapabilityByModel.get(normalized) ?? null;
     },
+    getModelZone: (model: string) => {
+      const state = discoveryStore.getState();
+      const normalized = resolveCachedHybridAIModelKey(
+        model,
+        state.zoneByModel,
+        state.zoneModelKeyLookup,
+      );
+      return state.zoneByModel.get(normalized) ?? null;
+    },
     getModelPricingUsdPerToken: (model: string) => {
       const state = discoveryStore.getState();
       const normalized = resolveCachedHybridAIModelKey(
@@ -483,6 +505,12 @@ export function getDiscoveredHybridAIModelVisionCapability(
   model: string,
 ): boolean | null {
   return defaultHybridAIDiscoveryStore.getModelVisionCapability(model);
+}
+
+export function getDiscoveredHybridAIModelZone(
+  model: string,
+): ModelRoutingZone | null {
+  return defaultHybridAIDiscoveryStore.getModelZone(model);
 }
 
 export function getDiscoveredHybridAIModelPricingUsdPerToken(

--- a/src/providers/local-discovery.ts
+++ b/src/providers/local-discovery.ts
@@ -28,15 +28,17 @@ import type {
   LocalModelInfo,
   LocalThinkingFormat,
 } from './local-types.js';
+import { MODEL_METADATA_USD_TO_EUR } from './model-metadata.js';
+import { normalizeModelRoutingZone } from './model-routing.js';
 import { LOCAL_BACKEND_IDS } from './provider-ids.js';
 import { isRecord, normalizeBaseUrl } from './utils.js';
 
 const DISCOVERY_ORDER: LocalBackendType[] = [...LOCAL_BACKEND_IDS];
-const ZERO_COST = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
+const UNKNOWN_COST = {
+  input: null,
+  output: null,
+  cacheRead: null,
+  cacheWrite: null,
 } as const;
 
 function hasEnabledLocalBackend(): boolean {
@@ -96,7 +98,8 @@ function createLocalModelInfo(
       : {}),
     ...(thinkingFormat ? { thinkingFormat } : {}),
     ...(modelBehavior ? { modelBehavior } : {}),
-    cost: ZERO_COST,
+    zone: normalizeModelRoutingZone(overrides?.zone ?? 'local'),
+    cost: overrides?.cost ?? UNKNOWN_COST,
     ...(typeof overrides?.sizeBytes === 'number'
       ? { sizeBytes: overrides.sizeBytes }
       : {}),
@@ -412,38 +415,71 @@ async function discoverLlamacppModels(
 async function discoverEndpointModels(
   endpoint: LocalEndpointConfig,
 ): Promise<LocalModelInfo[]> {
+  const endpointMetadata: Pick<LocalModelInfo, 'cost' | 'zone'> = {
+    zone: normalizeModelRoutingZone(endpoint.zone),
+    cost: {
+      input:
+        endpoint.pricing?.inputEurPerMillion == null
+          ? null
+          : (endpoint.pricing.inputEurPerMillion *
+              MODEL_METADATA_USD_TO_EUR.usdPerEur) /
+            1_000_000,
+      output:
+        endpoint.pricing?.outputEurPerMillion == null
+          ? null
+          : (endpoint.pricing.outputEurPerMillion *
+              MODEL_METADATA_USD_TO_EUR.usdPerEur) /
+            1_000_000,
+      cacheRead: null,
+      cacheWrite: null,
+    },
+  };
+  const applyEndpointMetadata = (models: LocalModelInfo[]) =>
+    models.map((model) => ({ ...model, ...endpointMetadata }));
   if (endpoint.type === 'ollama') {
     const models = await discoverOllamaModels(endpoint.baseUrl, {
       maxModels: LOCAL_DISCOVERY_MAX_MODELS,
       concurrency: LOCAL_DISCOVERY_CONCURRENCY,
     });
     return applyModelBehavior(
-      models.map((model) => ({ ...model, endpointName: endpoint.name })),
+      applyEndpointMetadata(
+        models.map((model) => ({ ...model, endpointName: endpoint.name })),
+      ),
       endpoint.modelBehavior,
     );
   }
   if (endpoint.type === 'lmstudio') {
     return applyModelBehavior(
-      await discoverLmStudioModels(
-        endpoint.baseUrl,
-        endpoint.name,
-        endpoint.apiKey,
+      applyEndpointMetadata(
+        await discoverLmStudioModels(
+          endpoint.baseUrl,
+          endpoint.name,
+          endpoint.apiKey,
+        ),
       ),
       endpoint.modelBehavior,
     );
   }
   if (endpoint.type === 'llamacpp') {
     return applyModelBehavior(
-      await discoverLlamacppModels(
-        endpoint.baseUrl,
-        endpoint.name,
-        endpoint.apiKey,
+      applyEndpointMetadata(
+        await discoverLlamacppModels(
+          endpoint.baseUrl,
+          endpoint.name,
+          endpoint.apiKey,
+        ),
       ),
       endpoint.modelBehavior,
     );
   }
   return applyModelBehavior(
-    await discoverVllmModels(endpoint.baseUrl, endpoint.apiKey, endpoint.name),
+    applyEndpointMetadata(
+      await discoverVllmModels(
+        endpoint.baseUrl,
+        endpoint.apiKey,
+        endpoint.name,
+      ),
+    ),
     endpoint.modelBehavior,
   );
 }

--- a/src/providers/local-types.ts
+++ b/src/providers/local-types.ts
@@ -2,6 +2,7 @@ import type {
   ModelBehavior,
   ModelThinkingFormat,
 } from '../types/model-behavior.js';
+import type { ModelRoutingZone } from './model-routing.js';
 import type { LocalBackendType } from './provider-ids.js';
 
 export type { LocalBackendType } from './provider-ids.js';
@@ -18,15 +19,21 @@ export interface LocalModelInfo {
   endpointName?: string;
   thinkingFormat?: LocalThinkingFormat;
   modelBehavior?: LocalModelBehavior;
+  zone: ModelRoutingZone;
   sizeBytes?: number;
   family?: string;
   parameterSize?: string;
   cost: {
-    input: 0;
-    output: 0;
-    cacheRead: 0;
-    cacheWrite: 0;
+    input: number | null;
+    output: number | null;
+    cacheRead: number | null;
+    cacheWrite: number | null;
   };
+}
+
+export interface LocalEndpointPricingConfig {
+  inputEurPerMillion: number | null;
+  outputEurPerMillion: number | null;
 }
 
 export interface LocalBackendConfig {
@@ -39,6 +46,8 @@ export interface LocalBackendConfig {
 export interface LocalEndpointConfig extends LocalBackendConfig {
   name: string;
   type: LocalBackendType;
+  zone?: ModelRoutingZone;
+  pricing?: LocalEndpointPricingConfig;
 }
 
 export interface LocalProviderConfig {

--- a/src/providers/model-catalog.ts
+++ b/src/providers/model-catalog.ts
@@ -30,6 +30,7 @@ import {
   getDiscoveredHybridAIModelNames,
   getDiscoveredHybridAIModelPricingUsdPerToken,
   getDiscoveredHybridAIModelVisionCapability,
+  getDiscoveredHybridAIModelZone,
 } from './hybridai-discovery.js';
 import { isStaticModelVisionCapable } from './hybridai-models.js';
 import {
@@ -38,7 +39,10 @@ import {
   getLocalModelInfo,
   resolveLocalModelContextWindow,
 } from './local-discovery.js';
-import { resolveLocalBackendFromEndpointModel } from './local-endpoints.js';
+import {
+  resolveLocalBackendFromEndpointModel,
+  resolveLocalEndpointForModel,
+} from './local-endpoints.js';
 import {
   discoverMistralModels,
   getDiscoveredMistralModelContextWindow,
@@ -49,6 +53,7 @@ import {
 } from './mistral-discovery.js';
 import { MISTRAL_MODEL_PREFIX } from './mistral-utils.js';
 import {
+  MODEL_METADATA_USD_TO_EUR,
   type ModelCapabilityFlags,
   resolveStaticModelCatalogMetadata,
   type StaticModelCatalogMetadata,
@@ -56,7 +61,12 @@ import {
 import {
   formatHybridAIModelForCatalog,
   formatModelForDisplay,
+  HYBRIDAI_MODEL_PREFIX,
 } from './model-names.js';
+import {
+  type ModelRoutingZone,
+  normalizeModelRoutingZone,
+} from './model-routing.js';
 import { OPENAI_CODEX_MODEL_PREFIX } from './openai.js';
 import {
   discoverOpenAICompatRemoteModels,
@@ -79,6 +89,7 @@ import { isRuntimeProviderId, type RuntimeProviderId } from './provider-ids.js';
 export type ModelCatalogProviderFilter = RuntimeProviderId | 'local';
 
 export interface ModelCatalogMetadata extends StaticModelCatalogMetadata {
+  zone: ModelRoutingZone;
   pricingUsdPerToken: {
     input: number | null;
     output: number | null;
@@ -533,7 +544,26 @@ function resolveKnownModelPricingUsdPerToken(
   model: string,
 ): ModelCatalogMetadata['pricingUsdPerToken'] {
   if (isLocalPrefixedModel(model)) {
-    return { input: 0, output: 0 };
+    const info = getLocalModelInfo(model);
+    if (info) {
+      return { input: info.cost.input, output: info.cost.output };
+    }
+    const endpointPricing =
+      resolveLocalEndpointForModel(model)?.endpoint.pricing;
+    return {
+      input:
+        endpointPricing?.inputEurPerMillion == null
+          ? null
+          : (endpointPricing.inputEurPerMillion *
+              MODEL_METADATA_USD_TO_EUR.usdPerEur) /
+            1_000_000,
+      output:
+        endpointPricing?.outputEurPerMillion == null
+          ? null
+          : (endpointPricing.outputEurPerMillion *
+              MODEL_METADATA_USD_TO_EUR.usdPerEur) /
+            1_000_000,
+    };
   }
   if (hasModelPrefix(model, OPENAI_CODEX_MODEL_PREFIX)) {
     return (
@@ -556,11 +586,30 @@ function resolveKnownModelPricingUsdPerToken(
   );
 }
 
+function resolveKnownModelZone(model: string): ModelRoutingZone {
+  if (isLocalPrefixedModel(model)) {
+    return normalizeModelRoutingZone(
+      getLocalModelInfo(model)?.zone ??
+        resolveLocalEndpointForModel(model)?.endpoint.zone ??
+        'local',
+    );
+  }
+  const normalized = model.trim().toLowerCase();
+  if (
+    normalized.startsWith(HYBRIDAI_MODEL_PREFIX) ||
+    !normalized.includes('/')
+  ) {
+    return normalizeModelRoutingZone(getDiscoveredHybridAIModelZone(model));
+  }
+  return 'cloud';
+}
+
 export function getModelCatalogMetadata(model: string): ModelCatalogMetadata {
   const staticMetadata = resolveStaticModelCatalogMetadata(model);
   const contextWindow = resolveKnownModelContextWindow(model, staticMetadata);
   const maxTokens = resolveKnownModelMaxTokens(model, staticMetadata);
   const pricingUsdPerToken = resolveKnownModelPricingUsdPerToken(model);
+  const zone = resolveKnownModelZone(model);
   const vision = isModelVisionCapable(model);
 
   return {
@@ -572,6 +621,7 @@ export function getModelCatalogMetadata(model: string): ModelCatalogMetadata {
       vision,
     contextWindow,
     maxTokens,
+    zone,
     pricingUsdPerToken,
     capabilities: {
       ...staticMetadata.capabilities,

--- a/src/providers/model-routing.ts
+++ b/src/providers/model-routing.ts
@@ -1,0 +1,181 @@
+export const MODEL_ROUTING_ZONES = ['local', 'hai', 'region', 'cloud'] as const;
+
+export type ModelRoutingZone = (typeof MODEL_ROUTING_ZONES)[number];
+
+export interface ModelRoutingTier {
+  name: string;
+  models: string[];
+}
+
+export interface ModelRoutingConfig {
+  enabled: boolean;
+  tiers: ModelRoutingTier[];
+  defaultStart: string;
+  escalationStickyTurns: number;
+}
+
+export interface ResolveLadderContext {
+  startTier?: string;
+  minimumTier?: string;
+  maximumTier?: string;
+  stickyTier?: string;
+  maximumZone?: ModelRoutingZone;
+  modelZones?: Readonly<Record<string, ModelRoutingZone | undefined>>;
+}
+
+export type LadderResolutionReason =
+  | 'disabled'
+  | 'default-start'
+  | 'configured-start'
+  | 'minimum-tier'
+  | 'sticky-tier'
+  | 'no-eligible-models';
+
+export interface ResolvedModelRoutingTier extends ModelRoutingTier {
+  sourceIndex: number;
+}
+
+export interface ResolvedLadder {
+  enabled: boolean;
+  tiers: ResolvedModelRoutingTier[];
+  startTier: string | null;
+  startIndex: number;
+  referenceModel: string | null;
+  reason: LadderResolutionReason;
+  exhausted: boolean;
+}
+
+const ZONE_INDEX = new Map<ModelRoutingZone, number>(
+  MODEL_ROUTING_ZONES.map((zone, index) => [zone, index]),
+);
+
+export function normalizeModelRoutingZone(value: unknown): ModelRoutingZone {
+  const normalized = String(value || '')
+    .trim()
+    .toLowerCase();
+  return MODEL_ROUTING_ZONES.includes(normalized as ModelRoutingZone)
+    ? (normalized as ModelRoutingZone)
+    : 'cloud';
+}
+
+export function modelRoutingZoneAllows(
+  maximumZone: ModelRoutingZone,
+  modelZone: ModelRoutingZone | undefined,
+): boolean {
+  return (
+    (ZONE_INDEX.get(normalizeModelRoutingZone(modelZone)) ??
+      MODEL_ROUTING_ZONES.length - 1) <=
+    (ZONE_INDEX.get(maximumZone) ?? MODEL_ROUTING_ZONES.length - 1)
+  );
+}
+
+function requireTierIndex(
+  tiers: ModelRoutingTier[],
+  tierName: string,
+  field: string,
+): number {
+  const index = tiers.findIndex((tier) => tier.name === tierName);
+  if (index < 0) {
+    throw new Error(
+      `${field} references unknown routing tier \`${tierName}\`.`,
+    );
+  }
+  return index;
+}
+
+export function resolveLadder(
+  config: ModelRoutingConfig,
+  context: ResolveLadderContext = {},
+): ResolvedLadder {
+  if (!config.enabled) {
+    return {
+      enabled: false,
+      tiers: [],
+      startTier: null,
+      startIndex: -1,
+      referenceModel: null,
+      reason: 'disabled',
+      exhausted: false,
+    };
+  }
+
+  if (config.tiers.length === 0) {
+    throw new Error('Enabled model routing requires at least one tier.');
+  }
+
+  let desiredIndex = requireTierIndex(
+    config.tiers,
+    context.startTier ?? config.defaultStart,
+    context.startTier ? 'startTier' : 'defaultStart',
+  );
+  let reason: LadderResolutionReason = context.startTier
+    ? 'configured-start'
+    : 'default-start';
+
+  if (context.minimumTier) {
+    const minimumIndex = requireTierIndex(
+      config.tiers,
+      context.minimumTier,
+      'minimumTier',
+    );
+    if (minimumIndex > desiredIndex) {
+      desiredIndex = minimumIndex;
+      reason = 'minimum-tier';
+    }
+  }
+
+  if (context.stickyTier) {
+    const stickyIndex = requireTierIndex(
+      config.tiers,
+      context.stickyTier,
+      'stickyTier',
+    );
+    if (stickyIndex > desiredIndex) {
+      desiredIndex = stickyIndex;
+      reason = 'sticky-tier';
+    }
+  }
+
+  const maximumIndex = context.maximumTier
+    ? requireTierIndex(config.tiers, context.maximumTier, 'maximumTier')
+    : config.tiers.length - 1;
+  const maximumZone = context.maximumZone ?? 'cloud';
+  const tiers = config.tiers
+    .map(
+      (tier, sourceIndex): ResolvedModelRoutingTier => ({
+        name: tier.name,
+        models: tier.models.filter((model) =>
+          modelRoutingZoneAllows(maximumZone, context.modelZones?.[model]),
+        ),
+        sourceIndex,
+      }),
+    )
+    .filter(
+      (tier) => tier.sourceIndex <= maximumIndex && tier.models.length > 0,
+    );
+
+  const startIndex = tiers.findIndex(
+    (tier) => tier.sourceIndex >= desiredIndex,
+  );
+  if (desiredIndex > maximumIndex || startIndex < 0) {
+    return {
+      enabled: true,
+      tiers,
+      startTier: null,
+      startIndex: -1,
+      referenceModel: tiers.at(-1)?.models[0] ?? null,
+      reason: 'no-eligible-models',
+      exhausted: true,
+    };
+  }
+
+  return {
+    enabled: true,
+    tiers,
+    startTier: tiers[startIndex]?.name ?? null,
+    startIndex,
+    referenceModel: tiers.at(-1)?.models[0] ?? null,
+    reason,
+    exhausted: false,
+  };
+}

--- a/src/usage/model-cost.ts
+++ b/src/usage/model-cost.ts
@@ -9,6 +9,19 @@ interface UsageTokenCounts {
   completionTokens?: unknown;
 }
 
+export interface RoutingCostAttempt {
+  model: string;
+  promptTokens: number;
+  completionTokens: number;
+  costUsd?: number;
+}
+
+export interface RoutingSavingsEstimate {
+  actualCostUsd: number;
+  counterfactualCostUsd: number;
+  savedUsd: number;
+}
+
 function readFiniteNonNegativeNumber(value: unknown): number | null {
   if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
     return null;
@@ -49,6 +62,42 @@ export function estimateModelUsageCostUsd(params: {
     params.promptTokens * (pricing.input ?? 0) +
     params.completionTokens * (pricing.output ?? 0)
   );
+}
+
+export function estimateRoutingSavingsUsd(params: {
+  referenceModel: string;
+  referenceUsage: {
+    promptTokens: number;
+    completionTokens: number;
+  };
+  attempts: RoutingCostAttempt[];
+}): RoutingSavingsEstimate | null {
+  const counterfactualCostUsd = estimateModelUsageCostUsd({
+    model: params.referenceModel,
+    promptTokens: params.referenceUsage.promptTokens,
+    completionTokens: params.referenceUsage.completionTokens,
+  });
+  if (counterfactualCostUsd == null) return null;
+
+  let actualCostUsd = 0;
+  for (const attempt of params.attempts) {
+    const explicitCost = readFiniteNonNegativeNumber(attempt.costUsd);
+    const attemptCost =
+      explicitCost ??
+      estimateModelUsageCostUsd({
+        model: attempt.model,
+        promptTokens: attempt.promptTokens,
+        completionTokens: attempt.completionTokens,
+      });
+    if (attemptCost == null) return null;
+    actualCostUsd += attemptCost;
+  }
+
+  return {
+    actualCostUsd,
+    counterfactualCostUsd,
+    savedUsd: counterfactualCostUsd - actualCostUsd,
+  };
 }
 
 export function resolveUsageCostUsd(params: {

--- a/src/usage/token-usage-buffer.ts
+++ b/src/usage/token-usage-buffer.ts
@@ -29,6 +29,7 @@ import {
   recordUsageEventBatch,
   resolveSessionIdCompat,
 } from '../memory/db.js';
+import type { ModelRoutingZone } from '../providers/model-routing.js';
 
 export interface TokenUsageEvent {
   sessionId: string;
@@ -39,6 +40,10 @@ export interface TokenUsageEvent {
   totalTokens?: number;
   toolCalls?: number;
   costUsd?: number;
+  routeTier?: string;
+  routeZone?: ModelRoutingZone;
+  routeReason?: string;
+  escalated?: boolean;
   /** ISO-8601 timestamp; auto-generated if omitted. */
   timestamp?: string;
   /** Optional run context to thread the batch audit event. */

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -66,7 +66,6 @@ test('resolveAgentForRequest prefers request, then session, then configured defa
         name: 'Research Agent',
         model: {
           primary: 'ollama/llama3.2',
-          fallbacks: ['gpt-5-mini'],
         },
         chatbotId: 'bot-research',
       },
@@ -88,7 +87,6 @@ test('resolveAgentForRequest prefers request, then session, then configured defa
         name: 'Research Agent',
         model: {
           primary: 'ollama/llama3.2',
-          fallbacks: ['gpt-5-mini'],
         },
         chatbotId: 'bot-research',
       },
@@ -100,7 +98,6 @@ test('resolveAgentForRequest prefers request, then session, then configured defa
   const researchAgent = resolveAgentConfig('research');
   expect(researchAgent.model).toEqual({
     primary: 'ollama/llama3.2',
-    fallbacks: ['gpt-5-mini'],
   });
   expect(resolveAgentModel(researchAgent)).toBe('ollama/llama3.2');
 

--- a/tests/local-cli.test.ts
+++ b/tests/local-cli.test.ts
@@ -1006,6 +1006,7 @@ test('local configure vllm with name stores a named endpoint secret ref', async 
     enabled: true,
     baseUrl: 'http://haigpu2:8000/v1',
     apiKey: 'gemma-secret-key',
+    zone: 'cloud',
   });
   expect(config.hybridai.defaultModel).toBe('gpt-5.4-mini');
   expect(rawEndpoint?.apiKey).toEqual({

--- a/tests/model-catalog.test.ts
+++ b/tests/model-catalog.test.ts
@@ -270,7 +270,10 @@ test('available model catalog merges the current default model with discovered l
   expect(
     catalog.getModelCatalogMetadata('lmstudio/qwen/qwen3.5-9b')
       .pricingUsdPerToken,
-  ).toEqual({ input: 0, output: 0 });
+  ).toEqual({ input: null, output: null });
+  expect(
+    catalog.getModelCatalogMetadata('lmstudio/qwen/qwen3.5-9b').zone,
+  ).toBe('local');
   expect(catalog.getAvailableModelList('hybridai')).toContain(
     'hybridai/gpt-4.1-mini',
   );
@@ -290,6 +293,11 @@ test('available model catalog includes named local endpoints in local and backen
         enabled: true,
         baseUrl: 'http://haigpu1:8000/v1',
         apiKey: '',
+        zone: 'hai',
+        pricing: {
+          inputEurPerMillion: 0.4,
+          outputEurPerMillion: 1.2,
+        },
       },
       {
         name: 'haigpu2',
@@ -297,6 +305,11 @@ test('available model catalog includes named local endpoints in local and backen
         enabled: true,
         baseUrl: 'http://haigpu2:8000/v1',
         apiKey: '',
+        zone: 'hai',
+        pricing: {
+          inputEurPerMillion: 0.5,
+          outputEurPerMillion: 1.5,
+        },
       },
     ];
   });
@@ -341,8 +354,36 @@ test('available model catalog includes named local endpoints in local and backen
   ).toMatchObject({
     known: true,
     contextWindow: 32_768,
-    pricingUsdPerToken: { input: 0, output: 0 },
+    zone: 'hai',
+    pricingUsdPerToken: {
+      input: (0.5 * 1.1712) / 1_000_000,
+      output: (1.5 * 1.1712) / 1_000_000,
+    },
   });
+  const { estimateModelUsageCostUsd } = await import(
+    '../src/usage/model-cost.js'
+  );
+  const localCostUsd = estimateModelUsageCostUsd({
+    model: 'haigpu2/google/gemma-4-e4b-it',
+    promptTokens: 1_000_000,
+    completionTokens: 200_000,
+  });
+  expect(localCostUsd).not.toBeNull();
+  expect((localCostUsd ?? 0) / 1.1712).toBeCloseTo(0.8, 8);
+  const usageDb = await import('../src/memory/db.js');
+  usageDb.initDatabase({
+    quiet: true,
+    dbPath: path.join(homeDir, '.hybridclaw', 'data', 'local-cost.db'),
+  });
+  usageDb.recordUsageEvent({
+    sessionId: 'session-haigpu2-cost',
+    agentId: 'main',
+    model: 'haigpu2/google/gemma-4-e4b-it',
+    inputTokens: 1_000_000,
+    outputTokens: 200_000,
+    costUsd: localCostUsd ?? 0,
+  });
+  expect(usageDb.monthlySpendEur('main')).toBeCloseTo(0.8, 8);
 });
 
 test('available model catalog prefixes HybridAI provider-family models', async () => {
@@ -365,6 +406,7 @@ test('available model catalog prefixes HybridAI provider-family models', async (
             {
               id: 'mistral-small',
               provider: 'mistral',
+              zone: 'region',
               context_length: 131_072,
               pricing: {
                 prompt: '0.000001',
@@ -398,6 +440,12 @@ test('available model catalog prefixes HybridAI provider-family models', async (
     catalog.getModelCatalogMetadata('hybridai/mistral/mistral-small')
       .pricingUsdPerToken,
   ).toEqual({ input: 0.000001, output: 0.000002 });
+  expect(
+    catalog.getModelCatalogMetadata('hybridai/mistral/mistral-small').zone,
+  ).toBe('region');
+  expect(catalog.getModelCatalogMetadata('mistral/mistral-small').zone).toBe(
+    'cloud',
+  );
 });
 
 test('model catalog selects the cheapest model matching capability flags', async () => {

--- a/tests/model-cost.test.ts
+++ b/tests/model-cost.test.ts
@@ -11,6 +11,7 @@ vi.mock('../src/providers/model-catalog.js', () => ({
 }));
 
 const {
+  estimateRoutingSavingsUsd,
   extractExplicitUsageCostUsd,
   resolveUsageCostUsd,
   resolveUsageCostUsdAfterMetadataRefresh,
@@ -114,4 +115,60 @@ test('resolveUsageCostUsdAfterMetadataRefresh skips refresh when explicit cost e
     }),
   ).resolves.toBe(0.25);
   expect(refreshModelCatalogMetadata).not.toHaveBeenCalled();
+});
+
+test('estimateRoutingSavingsUsd prices the same successful tokens at the reference model', () => {
+  getModelCatalogMetadata.mockImplementation((model: string) => ({
+    pricingUsdPerToken:
+      model === 'frontier/model'
+        ? { input: 10 / 1_000_000, output: 30 / 1_000_000 }
+        : { input: 1 / 1_000_000, output: 3 / 1_000_000 },
+  }));
+
+  expect(
+    estimateRoutingSavingsUsd({
+      referenceModel: 'frontier/model',
+      referenceUsage: {
+        promptTokens: 1_000_000,
+        completionTokens: 200_000,
+      },
+      attempts: [
+        {
+          model: 'small/model',
+          promptTokens: 1_000_000,
+          completionTokens: 200_000,
+        },
+      ],
+    }),
+  ).toEqual({
+    actualCostUsd: 1.6,
+    counterfactualCostUsd: 16,
+    savedUsd: 14.4,
+  });
+});
+
+test('estimateRoutingSavingsUsd includes escalation overhead and permits negative savings', () => {
+  mockPricing(1 / 1_000_000, 1 / 1_000_000);
+
+  const estimate = estimateRoutingSavingsUsd({
+    referenceModel: 'frontier/model',
+    referenceUsage: { promptTokens: 100, completionTokens: 100 },
+    attempts: [
+      {
+        model: 'small/model',
+        promptTokens: 100,
+        completionTokens: 0,
+        costUsd: 0.001,
+      },
+      {
+        model: 'frontier/model',
+        promptTokens: 100,
+        completionTokens: 100,
+        costUsd: 0.002,
+      },
+    ],
+  });
+  expect(estimate?.actualCostUsd).toBeCloseTo(0.003, 10);
+  expect(estimate?.counterfactualCostUsd).toBeCloseTo(0.0002, 10);
+  expect(estimate?.savedUsd).toBeCloseTo(-0.0028, 10);
 });

--- a/tests/model-routing-config.test.ts
+++ b/tests/model-routing-config.test.ts
@@ -1,0 +1,130 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_DISABLE_CONFIG_WATCHER =
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+
+let homeDir = '';
+
+beforeEach(() => {
+  homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-routing-config-'));
+  process.env.HOME = homeDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+  vi.resetModules();
+});
+
+afterEach(() => {
+  fs.rmSync(homeDir, { recursive: true, force: true });
+  vi.resetModules();
+  if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = ORIGINAL_HOME;
+  if (ORIGINAL_DISABLE_CONFIG_WATCHER === undefined) {
+    delete process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+  } else {
+    process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER =
+      ORIGINAL_DISABLE_CONFIG_WATCHER;
+  }
+});
+
+async function loadConfigModule() {
+  return import('../src/config/runtime-config.js');
+}
+
+describe('model routing runtime config', () => {
+  test('normalizes a valid ordered ladder and local endpoint metadata', async () => {
+    const configModule = await loadConfigModule();
+    const draft = configModule.getRuntimeConfig();
+    draft.local.endpoints = [
+      {
+        name: 'haigpu1',
+        type: 'vllm',
+        enabled: true,
+        baseUrl: 'http://haigpu1:8000/v1',
+        zone: 'hai',
+        pricing: {
+          inputEurPerMillion: 0.4,
+          outputEurPerMillion: 1.2,
+        },
+      },
+      {
+        name: 'unclassified',
+        type: 'vllm',
+        enabled: true,
+        baseUrl: 'http://unclassified:8000/v1',
+      },
+    ];
+    draft.routing = {
+      ...draft.routing,
+      enabled: true,
+      tiers: [
+        { name: 'small', models: ['haigpu1/qwen3.7-27b'] },
+        { name: 'frontier', models: ['hybridai/gpt-5'] },
+      ],
+      defaultStart: 'small',
+      escalationStickyTurns: 5,
+    };
+
+    const saved = configModule.saveRuntimeConfig(draft);
+
+    expect(saved.routing).toMatchObject({
+      enabled: true,
+      defaultStart: 'small',
+      escalationStickyTurns: 5,
+      tiers: [
+        { name: 'small', models: ['haigpu1/qwen3.7-27b'] },
+        { name: 'frontier', models: ['hybridai/gpt-5'] },
+      ],
+    });
+    expect(saved.local.endpoints[0]).toMatchObject({
+      zone: 'hai',
+      pricing: {
+        inputEurPerMillion: 0.4,
+        outputEurPerMillion: 1.2,
+      },
+    });
+    expect(saved.local.endpoints[1]?.zone).toBe('cloud');
+  });
+
+  test('rejects an enabled empty ladder', async () => {
+    const configModule = await loadConfigModule();
+    const draft = configModule.getRuntimeConfig();
+    draft.routing.enabled = true;
+    draft.routing.tiers = [];
+
+    expect(() => configModule.saveRuntimeConfig(draft)).toThrow(
+      'routing.tiers must not be empty',
+    );
+  });
+
+  test('rejects duplicate tier names', async () => {
+    const configModule = await loadConfigModule();
+    const draft = configModule.getRuntimeConfig();
+    draft.routing.enabled = true;
+    draft.routing.tiers = [
+      { name: 'same', models: ['hybridai/gpt-5-mini'] },
+      { name: 'SAME', models: ['hybridai/gpt-5'] },
+    ];
+    draft.routing.defaultStart = 'same';
+
+    expect(() => configModule.saveRuntimeConfig(draft)).toThrow(
+      'Duplicate routing tier name',
+    );
+  });
+
+  test('rejects unknown model references', async () => {
+    const configModule = await loadConfigModule();
+    const draft = configModule.getRuntimeConfig();
+    draft.routing.enabled = true;
+    draft.routing.tiers = [
+      { name: 'only', models: ['hybridai/not-in-the-catalog'] },
+    ];
+    draft.routing.defaultStart = 'only';
+
+    expect(() => configModule.saveRuntimeConfig(draft)).toThrow(
+      'references unknown model',
+    );
+  });
+});

--- a/tests/model-routing.test.ts
+++ b/tests/model-routing.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'vitest';
+import {
+  type ModelRoutingConfig,
+  normalizeModelRoutingZone,
+  resolveLadder,
+} from '../src/providers/model-routing.js';
+
+const config: ModelRoutingConfig = {
+  enabled: true,
+  tiers: [
+    { name: 'economy', models: ['edge/small'] },
+    {
+      name: 'general',
+      models: ['hai/medium', 'regional/medium'],
+    },
+    { name: 'advanced', models: ['cloud/frontier'] },
+  ],
+  defaultStart: 'general',
+  escalationStickyTurns: 3,
+};
+
+const modelZones = {
+  'edge/small': 'local',
+  'hai/medium': 'hai',
+  'regional/medium': 'region',
+  'cloud/frontier': 'cloud',
+} as const;
+
+describe('resolveLadder', () => {
+  test('returns no active ladder when routing is disabled', () => {
+    expect(resolveLadder({ ...config, enabled: false })).toEqual({
+      enabled: false,
+      tiers: [],
+      startTier: null,
+      startIndex: -1,
+      referenceModel: null,
+      reason: 'disabled',
+      exhausted: false,
+    });
+  });
+
+  test('uses the configured default and highest allowed primary as reference', () => {
+    const resolved = resolveLadder(config, { modelZones });
+
+    expect(resolved.startTier).toBe('general');
+    expect(resolved.startIndex).toBe(1);
+    expect(resolved.referenceModel).toBe('cloud/frontier');
+    expect(resolved.reason).toBe('default-start');
+    expect(resolved.exhausted).toBe(false);
+  });
+
+  test('applies start, capability floor, and sticky floors in ladder order', () => {
+    expect(
+      resolveLadder(config, { startTier: 'economy', modelZones }).startTier,
+    ).toBe('economy');
+    expect(
+      resolveLadder(config, {
+        startTier: 'economy',
+        minimumTier: 'general',
+        modelZones,
+      }),
+    ).toMatchObject({ startTier: 'general', reason: 'minimum-tier' });
+    expect(
+      resolveLadder(config, {
+        startTier: 'economy',
+        stickyTier: 'advanced',
+        modelZones,
+      }),
+    ).toMatchObject({ startTier: 'advanced', reason: 'sticky-tier' });
+  });
+
+  test('filters by sovereignty, skips empty rungs, and fails closed', () => {
+    const sovereign = resolveLadder(config, {
+      startTier: 'economy',
+      maximumZone: 'hai',
+      modelZones,
+    });
+    expect(sovereign.tiers.map((tier) => tier.name)).toEqual([
+      'economy',
+      'general',
+    ]);
+    expect(sovereign.tiers[1]?.models).toEqual(['hai/medium']);
+    expect(sovereign.referenceModel).toBe('hai/medium');
+
+    expect(
+      resolveLadder(config, {
+        startTier: 'advanced',
+        maximumZone: 'hai',
+        modelZones,
+      }),
+    ).toMatchObject({
+      startTier: null,
+      reason: 'no-eligible-models',
+      exhausted: true,
+    });
+  });
+
+  test('does not violate a floor when the maximum tier is lower', () => {
+    expect(
+      resolveLadder(config, {
+        minimumTier: 'advanced',
+        maximumTier: 'general',
+        modelZones,
+      }),
+    ).toMatchObject({
+      startTier: null,
+      reason: 'no-eligible-models',
+      exhausted: true,
+    });
+  });
+
+  test('throws for context tier names outside the configured ladder', () => {
+    expect(() =>
+      resolveLadder(config, { startTier: 'hardcoded-name', modelZones }),
+    ).toThrow('unknown routing tier');
+  });
+});
+
+test('unknown zones default to cloud', () => {
+  expect(normalizeModelRoutingZone(undefined)).toBe('cloud');
+  expect(normalizeModelRoutingZone('unclassified')).toBe('cloud');
+  expect(normalizeModelRoutingZone('HAI')).toBe('hai');
+});


### PR DESCRIPTION
## Summary

Implements Phase 1 (R1) of the model-routing design without changing live model-selection behavior.

- adds ordered routing tiers, default start tier, escalation stickiness, and fail-closed model zones
- adds a pure `resolveLadder(config, context)` helper
- supports real EUR/Mtoken pricing for named local endpoints and feeds it through the existing usage-cost ledger
- adds honest counterfactual routing savings that include escalation retries and permit negative savings
- adds route metadata fields to token usage events for Phase 2 wiring
- removes the unused `AgentModelConfig.fallbacks` schema
- updates model catalog, admin API types, examples, and documentation

## Impact

Routing remains disabled by default and this PR does not reroute live turns. Unclassified providers and endpoint zones resolve to `cloud`, preserving the sovereignty boundary. Unpriced local models remain usable but report unknown catalog pricing rather than being presented as free.

## Validation

- `npm run format`
- `npm run lint`
- 14 affected Vitest files: 305 tests passed on Node.js 22
- 2 affected console Vitest files: 6 tests passed
- `git diff --check`

A broad unit sweep was also attempted. The sandbox prevented tests from writing runtime SQLite/audit state under `~/.hybridclaw`, producing unrelated failures and timeout cascades; all affected targeted tests pass.

## Follow-up

The R1 live exit gate still requires deployed local-fleet traffic to confirm that the admin usage rollup records non-zero EUR values.