### PR TITLE
chore: release v0.28.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,13 +375,19 @@ When the user says "bump release":
    - `container/package-lock.json` and `container/npm-shrinkwrap.json` (root
      `version` and `packages[""]`)
    - any user-facing version text (for example `src/tui.ts` banner)
-3. Move `CHANGELOG.md` release notes from `Unreleased` to the new version
+3. Review the generated lockfile diff. Even a version-only release changes the
+   lockfile bytes, so update the matching SHA-256 entries in
+   `scripts/dependency-policy-baseline.json` after confirming that no dependency
+   versions or lifecycle scripts changed. Run `npm run deps:policy` before the
+   release commit; the pre-commit override does not approve stale baseline
+   hashes in CI.
+4. Move `CHANGELOG.md` release notes from `Unreleased` to the new version
    heading (or create one).
-4. Update `README.md` "latest tag" link/text if present.
-5. Commit with `chore: release vX.Y.Z`.
-6. Create an annotated git tag `vX.Y.Z`.
-7. Push the commit and tag.
-8. Create or publish a GitHub Release entry for the tag using the same curated
+5. Update `README.md` "latest tag" link/text if present.
+6. Commit with `chore: release vX.Y.Z`.
+7. Create an annotated git tag `vX.Y.Z`.
+8. Push the commit and tag.
+9. Create or publish a GitHub Release entry for the tag using the same curated
    format as `v0.9.2`:
    - title: `HybridClaw vX.Y.Z`
    - `Release Date:` line with the calendar date

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,74 @@
 
 ## Unreleased
 
+## [0.28.2](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.2) - 2026-07-17
+
+### Added
+
+- **A2A local mode**: Operators can enable an A2A-only deployment posture from
+  `/admin/a2a-trust`. Loopback and authenticated admin management remain
+  available, Agent Card and A2A delivery routes stay reachable, and external
+  chat, OpenAI-compatible APIs, webhooks, channel runtimes, and channel delivery
+  are disabled.
+- **Dedicated tunnel administration**: Public tunnel configuration and status
+  now live on a focused admin surface with provider selection, URL validation,
+  save/start/stop/reconnect controls, health details, and actionable errors.
+
+### Changed
+
+- **Google Workspace console OAuth**: Local consoles, including the desktop
+  app, use Google's Desktop-client loopback flow without a registered redirect
+  URI. Consoles opened through LAN, tunnel, or public origins use the Web-client
+  flow and show the exact server-computed callback URI that must be registered.
+- **Provider health defaults**: Local model backends, including Ollama, are
+  disabled and unprobed until an operator enables them. Gateway health omits
+  unused Codex warnings while retaining status when Codex is configured,
+  selected, or authenticated.
+- **Trace-to-message attribution**: Turn completion and onboarding audit events
+  carry the stored assistant message id, and ATIF trace exports resolve that
+  exact response for full or selected turn ranges. Missing references are
+  reported as export limitations instead of shifting later responses onto the
+  wrong turn.
+- **Architecture design documentation**: Internal docs define the configurable
+  model-tier ladder, deterministic escalation, privacy zones, quality/speed
+  target, auditable savings metric, five testable delivery phases, and the
+  companion HybridRouter SFT/PEFT roadmap. A separate SSO and per-user identity
+  design specifies trusted-proxy and generic OIDC front doors, IdP group-to-role
+  mapping, per-user sessions, per-agent ACLs, security boundaries, and phased
+  delivery.
+
 ### Fixed
 
 - **Microsoft Teams credential hot reload**: Setting or rotating
   `MSTEAMS_APP_PASSWORD` through the admin secret store refreshes the running
   gateway immediately, initializes Teams handlers that were waiting for
   credentials, and rebuilds the Bot Framework adapter without requiring a
-  container restart.
+  container restart. Adapter refresh detection no longer derives password
+  hashes.
 - **Model response streaming**: Provider text deltas reach clients as they
   arrive instead of being buffered until the final response. HybridClaw keeps
   classified Ralph drafts buffered, avoids replaying final text after a live
-  stream, and does not retry a failed model call after visible partial output.
+  stream, does not retry a failed model call after visible partial output, and
+  accepts both cumulative and delta-style HybridAI chunks without duplicating
+  content.
+- **Concurrent session turns**: Gateway, host, and container execution serialize
+  requests per session while allowing different sessions to run concurrently.
+  Interactive input preempts an active full-auto turn before waiting on the
+  session queue, preventing overlapping history writes or delayed intervention.
+- **In-loop compaction tool exchanges**: Compaction boundaries keep assistant
+  tool calls together with all immediately following tool results, including
+  parallel calls, so providers never receive unanswered calls or orphaned
+  results.
+- **Anthropic and Ollama client tools**: Direct Anthropic and Ollama requests use
+  their correct OpenAI-compatible request bodies, model ids, and completion
+  URLs when client tools are present. Direct Anthropic streams are no longer
+  terminated by a fixed total-duration cap.
+- **WhatsApp self-chat echo prevention**: Outbound message ids are registered
+  with the echo guard as soon as each chunk is sent, before slower persistence
+  work can let a reflected message start another agent turn.
+- **Inline PDF previews**: Artifact PDFs render in Chrome without the sandboxed
+  iframe block while the preview blob is pinned to `application/pdf` so
+  mislabeled content cannot become same-origin HTML.
 
 ## [0.28.1](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.1) - 2026-07-10
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ rails instead of fragile free-form prompting.
 HybridClaw also treats agents as networked coworkers. Local agents, hosted
 HybridAI proxy agents, and trusted peer HybridClaw instances can address one
 another, exchange A2A envelopes, and route work through approval-aware
-channels.
+channels. An A2A local mode keeps peer delivery and authenticated administration
+reachable while disabling other external gateway and channel surfaces.
 
 First-run onboarding is built around hatching: a new agent asks about the
 user's work, records useful context, keeps setup links visible in chat, and can
@@ -60,7 +61,7 @@ HybridClaw on HybridAI Cloud in a few minutes at
 | A first run that becomes useful quickly | Guided hatching with setup links, tailored first-job suggestions, optional onboarding-specific model routing, welcome-email handoff, and structured audit events |
 | Business workflows that survive real use | Production skill helpers with fixtures, eval scenarios, targeted tests, approval tiers, and a `Qwen/Qwen3.6-27B-FP8` validation baseline |
 | Generated work artifacts you can reuse | An Apps gallery for self-contained HTML apps, dashboards, documents, games, tools, live connector-backed views, sharing links, and Teams tabs |
-| Multi-agent workflows across installations | Local agents, hosted proxy agents, A2A trust, explicit addressing, inbound envelopes, reply-back delivery, and admin-visible peer pairing |
+| Multi-agent workflows across installations | Local agents, hosted proxy agents, A2A trust, explicit addressing, inbound envelopes, reply-back delivery, admin-visible peer pairing, and an A2A-only deployment mode |
 | Credentials the model cannot read | Encrypted runtime secrets, SecretRef-backed execution paths, and scoped gateway API tokens that keep raw keys and passwords out of prompts and tool results |
 | Assistants that can act, not just chat | A gateway, web chat, Apps gallery, TUI, admin console, scheduler, tools, and OpenAI-compatible API behind one local service |
 | Control over sensitive work | Approval policy, sandbox boundaries, output guardrails, and hash-chained audit trails |
@@ -145,7 +146,8 @@ npm run desktop
 - **Multi-agent operations**: agents can coordinate across local workspaces,
   hosted HybridAI proxies, and trusted peer HybridClaw instances with A2A
   pairing, explicit addressing, inbound envelopes, reply-back delivery status,
-  and admin-visible trust.
+  admin-visible trust, and an A2A local mode that closes unrelated external
+  surfaces.
 - **Prompt-level credential isolation**: encrypted secrets and SecretRefs keep
   credential values out of model context while tools receive only the scoped
   credential material needed at execution time.
@@ -164,8 +166,8 @@ npm run desktop
   surface.
 - **Operator visibility**: `/admin` covers channels, connectors, approvals,
   audit, statistics, output guard, secrets, scoped tokens, fleet topology, A2A
-  inbox/trust, distillation, and browser PDF previews without requiring shell
-  access.
+  inbox/trust, tunnel configuration and health, distillation, and browser PDF
+  previews without requiring shell access.
 - **Business-ready extension model**: packaged skills, plugins, MCP servers,
   and SecretRef-backed HTTP tools share the same approval and credential
   boundaries.
@@ -240,7 +242,7 @@ Core pieces:
 | Build desktop releases | [Desktop Release Builds](https://hybridaione.github.io/hybridclaw/docs/developer-guide/desktop-release) |
 | Contribute | [CONTRIBUTING.md](./CONTRIBUTING.md), [docs/content/README.md](./docs/content/README.md) |
 
-Latest release: [v0.28.1](https://github.com/HybridAIOne/hybridclaw/releases/tag/v0.28.1).
+Latest release: [v0.28.2](https://github.com/HybridAIOne/hybridclaw/releases/tag/v0.28.2).
 Release notes: [CHANGELOG.md](./CHANGELOG.md)
 
 ## Development

--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hybridaione/hybridclaw-console",
   "private": true,
-  "version": "0.28.1",
+  "version": "0.28.2",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && vite build",

--- a/container/npm-shrinkwrap.json
+++ b/container/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
         "@mozilla/readability": "0.6.0",

--- a/container/package-lock.json
+++ b/container/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
         "@mozilla/readability": "0.6.0",

--- a/container/package.json
+++ b/container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "type": "module",
   "main": "dist/index.js",
   "packageManager": "npm@11.10.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@hybridaione/hybridclaw-desktop",
   "productName": "HybridClaw",
   "private": true,
-  "version": "0.28.1",
+  "version": "0.28.2",
   "type": "module",
   "description": "macOS wrapper for the HybridClaw chat and admin web surfaces",
   "author": "HybridAI One",

--- a/docs/content/README.md
+++ b/docs/content/README.md
@@ -27,6 +27,34 @@ doc at once, start from [For Agents](./agents.md).
 
 ## Latest Highlights
 
+- HybridClaw v0.28.2 adds A2A local mode for keeping peer Agent Card and
+  delivery routes reachable while disabling unrelated external chat, APIs,
+  webhooks, channel runtimes, and channel delivery; tunnel configuration and
+  lifecycle controls move to a dedicated admin surface.
+- Google Workspace authorization from a local console or the desktop app uses
+  the Desktop-client loopback flow, while LAN, tunnel, and public consoles use
+  a Web client and display the exact server-computed callback URI to register.
+- Provider replies stream live to clients without replaying final text or
+  retrying after visible partial output, and HybridAI cumulative/delta chunks
+  no longer duplicate content.
+- Turns for the same session are serialized across gateway, host, and container
+  execution while interactive input preempts active full-auto work before the
+  queue; WhatsApp also records outbound chunks early enough to stop self-chat
+  echoes from starting new turns.
+- In-loop compaction keeps tool calls paired with every result, direct Anthropic
+  and Ollama client-tool requests use their correct compatible payloads and
+  endpoints, and direct Anthropic streams have no fixed total-duration cap.
+- Trace exports bind completed audit turns to their exact stored assistant
+  messages, local providers stay disabled until configured, and unused Codex
+  health warnings no longer clutter gateway status.
+- Microsoft Teams credentials set or rotated in `/admin/secrets` refresh the
+  running adapter without a restart, and Chrome can render inline PDF artifact
+  previews without relaxing the blob's fixed PDF content type.
+- Internal architecture docs specify a configurable model-tier ladder,
+  deterministic escalation, privacy zones, quality/speed targeting, auditable
+  savings, phased delivery gates, and a sovereign HybridRouter fine-tuning
+  roadmap. The SSO and per-user identity design covers trusted-proxy and OIDC
+  login, IdP group-to-role mapping, per-user sessions, and per-agent ACLs.
 - HybridClaw v0.28.1 adds an explicitly warned unofficial LINE
   personal-account channel scoped to Keep Memo self-chat, with QR/PIN setup,
   persistent encrypted-message state, self-only inbound and outbound checks,

--- a/docs/content/developer-guide/desktop-release.md
+++ b/docs/content/developer-guide/desktop-release.md
@@ -50,6 +50,45 @@ export APPLE_APP_SPECIFIC_PASSWORD="<app-specific password>"
 Use an app-specific password or an equivalent keychain profile. Do not commit
 these values or store them in release notes.
 
+## Prepare Release Metadata
+
+Set the new version in the root `package.json`, then synchronize every product
+manifest and generated lockfile entry:
+
+```bash
+npm run version:sync
+```
+
+Review the four generated lockfile diffs before approving them. A normal
+version-only release changes only the product `version` fields; dependency
+versions, resolved artifacts, integrity values, and lifecycle-script entries
+must remain unchanged.
+
+Because the dependency policy hashes complete lockfiles, even version-only
+edits require refreshed entries in
+`scripts/dependency-policy-baseline.json`. Calculate the final hashes with:
+
+```bash
+shasum -a 256 \
+  package-lock.json \
+  npm-shrinkwrap.json \
+  container/package-lock.json \
+  container/npm-shrinkwrap.json
+```
+
+Copy those four hashes into the matching baseline entries, preserve unrelated
+lockfile entries, and verify the approval before committing:
+
+```bash
+npm run deps:policy
+npm run release:check
+npm --prefix container run release:check
+```
+
+`HYBRIDCLAW_ALLOW_LOCKFILE_CHANGES=1` only lets the pre-commit hook proceed
+after a maintainer has reviewed the diff. It does not update or replace the
+baseline, and CI rejects stale hashes.
+
 ## Release Order
 
 Do not publish the public GitHub Release first and then start building the

--- a/docs/content/developer-guide/runtime.md
+++ b/docs/content/developer-guide/runtime.md
@@ -262,6 +262,12 @@ rejected at the boundary rather than being treated as legacy ids.
 For the routing rules and operator guidance, see
 [Session Routing](./session-routing.md).
 
+Gateway chat serializes turns by session id, and the host/container runners
+apply the same per-session guard at their execution boundary. Different
+sessions can still run concurrently. Interactive input preempts an active
+full-auto turn before it waits on the session queue, so operator intervention
+does not sit behind the autonomous run it is meant to stop.
+
 ## Web Surfaces And API Auth
 
 HybridClaw's built-in browser surfaces share one auth model:

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -238,7 +238,18 @@ saved revision history directly.
   the auth token can stay empty in config when you store `TWILIO_AUTH_TOKEN`
   in the encrypted runtime secret store or use a SecretRef-backed
   `voice.twilio.authToken`
-- `deployment.mode`, `deployment.public_url`, `deployment.a2a_local_mode`, `deployment.tunnel.provider`, and `deployment.tunnel.health_check_interval_ms` declare whether the gateway runs behind a cloud URL or a local tunnel; cloud mode requires `deployment.public_url`, while local mode requires a tunnel provider such as `manual`, `ssh`, `ngrok`, `cloudflare`, or `tailscale`. Enable `deployment.a2a_local_mode` from `/admin/a2a-trust` to keep loopback and authenticated admin management available while exposing A2A and blocking external chat, APIs, webhooks, channel runtimes, and channel delivery.
+- `deployment.mode`, `deployment.public_url`, `deployment.a2a_local_mode`,
+  `deployment.tunnel.provider`, and
+  `deployment.tunnel.health_check_interval_ms` declare whether the gateway runs
+  behind a cloud URL or a local tunnel; cloud mode requires
+  `deployment.public_url`, while local mode requires a tunnel provider such as
+  `manual`, `ssh`, `ngrok`, `cloudflare`, or `tailscale`. Use the dedicated
+  tunnel settings page in `/admin` to select a provider, validate and save its
+  public URL, start or stop managed providers, reconnect, and inspect health or
+  provider errors. Enable `deployment.a2a_local_mode` from `/admin/a2a-trust`
+  to keep loopback and authenticated admin management available while exposing
+  A2A and blocking external chat, APIs, webhooks, channel runtimes, and channel
+  delivery.
 - `HYBRIDCLAW_IDENTITY_DISCOVERY_ZONE` enables DNS-style canonical identity discovery for A2A cross-instance delivery; outbound A2A resolves canonical recipients in this order: local canonical agents from `deployment.public_url` or the active tunnel URL, trusted peer instances from the A2A public-key trust ledger, then DNS-style discovery.
 - DNS-style A2A identity discovery trusts the returned URL and public key as operator-provided discovery data; use DNSSEC or out-of-band verification for production peers before relying on first-seen DNS records.
 - The built-in ngrok tunnel provider reads `NGROK_AUTHTOKEN` from the encrypted runtime secret store and health-checks active tunnels every 30 seconds by default

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "hasInstallScript": true,
       "workspaces": [
         "desktop",
@@ -84,7 +84,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "dependencies": {
         "@tanstack/react-query": "5.101.0",
         "@tanstack/react-router": "1.170.11",
@@ -109,7 +109,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
         "@mozilla/readability": "0.6.0",
@@ -396,7 +396,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "hasInstallScript": true,
       "workspaces": [
         "desktop",
@@ -84,7 +84,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "dependencies": {
         "@tanstack/react-query": "5.101.0",
         "@tanstack/react-router": "1.170.11",
@@ -109,7 +109,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
         "@mozilla/readability": "0.6.0",
@@ -396,7 +396,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "type": "module",
   "description": "Enterprise-ready self-hosted AI assistant runtime with sandboxed execution, secure credentials, approvals, and memory",
   "repository": {

--- a/scripts/dependency-policy-baseline.json
+++ b/scripts/dependency-policy-baseline.json
@@ -1,9 +1,9 @@
 {
   "lockfiles": {
-    "package-lock.json": "e3e5e50ec64c25186960af101c82836ed54116b224d127d2274794596a4b368b",
-    "npm-shrinkwrap.json": "e3e5e50ec64c25186960af101c82836ed54116b224d127d2274794596a4b368b",
-    "container/package-lock.json": "5bbadacac681e18b0dba9faf97693d84abc7fba5764fa9951254baecdd70d9fd",
-    "container/npm-shrinkwrap.json": "5bbadacac681e18b0dba9faf97693d84abc7fba5764fa9951254baecdd70d9fd",
+    "package-lock.json": "6b6bea422a1300bb1329ff6316a1ef57bc43f50505a8748bf57663a97efcb377",
+    "npm-shrinkwrap.json": "6b6bea422a1300bb1329ff6316a1ef57bc43f50505a8748bf57663a97efcb377",
+    "container/package-lock.json": "a3d00f6e8dba50b4d22fd799c4b37ac7682543c6b80dd5690d8bc6a8910ef50d",
+    "container/npm-shrinkwrap.json": "a3d00f6e8dba50b4d22fd799c4b37ac7682543c6b80dd5690d8bc6a8910ef50d",
     "plugins/brevo-email/package-lock.json": "3377225eb3bdbb252eaa28ad420b9a725ea1da533417388557aa1984730229b5"
   }
 }


### PR DESCRIPTION
## Summary

- bump HybridClaw from 0.28.1 to 0.28.2 across root, console, desktop, container, lockfile, and shrinkwrap metadata
- publish complete release notes for every change merged since v0.28.1
- refresh the README and docs highlights for A2A local mode, tunnel administration, Google OAuth behavior, streaming/session fixes, provider health, Teams credential reloads, trace attribution, and architecture design docs
- document per-session execution serialization and the dedicated tunnel administration workflow
- approve the final release lockfile hashes and document baseline refresh as a required release step in both the canonical agent playbook and desktop release guide

## Why

The post-v0.28.1 fixes and documentation work are ready for a patch release. The existing Unreleased section covered only Teams credential reloads and model streaming, while the README still identified v0.28.1 as the latest release.

Version synchronization changes complete lockfile bytes even when dependency versions are unchanged. The dependency-policy baseline therefore must carry the final lockfile hashes; the pre-commit override alone does not satisfy CI.

## Impact

This prepares v0.28.2 release metadata and user-facing documentation without changing runtime implementation. Package contents and dependency versions are unchanged apart from the synchronized product version fields.

## Validation

- `npm run format`
- `npm run lint`
- `npm run deps:policy`
- `npm run release:check`
- `npm --prefix container run release:check`
- `npm run version:check`
- `git diff --check`

Both root and container package-content checks passed, all product package versions are aligned at 0.28.2, and the refreshed lockfile baseline passes dependency policy.