### PR TITLE
feat: implement Phase 2 deterministic model routing

### DIFF
--- a/container/shared/provider-fallback.d.ts
+++ b/container/shared/provider-fallback.d.ts
@@ -1,4 +1,4 @@
-export type FallbackReason = 'auth' | 'rate_limit' | 'other';
+export type FallbackReason = 'auth' | 'rate_limit' | 'server_error' | 'other';
 
 export function classifyProviderError(err: unknown): FallbackReason;
 export function shouldFallbackProviderError(err: unknown): boolean;

--- a/container/shared/provider-fallback.js
+++ b/container/shared/provider-fallback.js
@@ -1,12 +1,24 @@
 export function classifyProviderError(err) {
   const text = err instanceof Error ? err.message : String(err);
   if (/(^|\D)401(\D|$)|(^|\D)403(\D|$)/.test(text)) return 'auth';
-  if (/unauthorized|forbidden|invalid api key|permission denied/i.test(text)) {
+  if (
+    /unauthorized|forbidden|invalid api key|missing api key|no api key|api key.*required|credentials?.*not configured|permission denied/i.test(
+      text,
+    )
+  ) {
     return 'auth';
   }
   if (/(^|\D)429(\D|$)/.test(text)) return 'rate_limit';
   if (/rate[- ]?limit|too many requests|quota|billing/i.test(text)) {
     return 'rate_limit';
+  }
+  if (/(^|\D)5\d\d(\D|$)/.test(text)) return 'server_error';
+  if (
+    /internal server error|bad gateway|service unavailable|gateway timeout/i.test(
+      text,
+    )
+  ) {
+    return 'server_error';
   }
   return 'other';
 }

--- a/plugins/tier-router/hybridclaw.plugin.yaml
+++ b/plugins/tier-router/hybridclaw.plugin.yaml
@@ -1,0 +1,9 @@
+id: tier-router
+name: Tier Router
+version: 0.1.0
+description: Selects deterministic model-routing tiers without remote classifier calls.
+kind: middleware
+entrypoint: src/index.js
+configSchema:
+  type: object
+  additionalProperties: false

--- a/plugins/tier-router/src/index.js
+++ b/plugins/tier-router/src/index.js
@@ -1,0 +1,51 @@
+import { classifyRoutingTurn, resolveTierRoutingDecision } from './routing.js';
+
+const MAX_PENDING_ESCALATIONS = 10_000;
+
+export default {
+  id: 'tier-router',
+  kind: 'middleware',
+  register(api) {
+    const manualEscalations = new Set();
+
+    api.registerMiddleware({
+      id: 'tier-router',
+      priority: -100,
+      routing(context) {
+        const manualEscalate =
+          !context.explicitModelPinned &&
+          classifyRoutingTurn(context) === 'agent' &&
+          manualEscalations.delete(context.sessionId);
+        const decision = resolveTierRoutingDecision(
+          api.config.routing,
+          context,
+          manualEscalate,
+        );
+        if (!decision) return { action: 'allow' };
+        return {
+          action: 'allow',
+          metadata: { tierRouter: decision },
+        };
+      },
+    });
+
+    api.registerCommand({
+      name: 'escalate',
+      description: 'Start the next unpinned agent turn one routing tier higher',
+      handler(_args, context) {
+        if (!api.config.routing?.enabled) {
+          return 'Model routing is disabled.';
+        }
+        if (
+          !manualEscalations.has(context.sessionId) &&
+          manualEscalations.size >= MAX_PENDING_ESCALATIONS
+        ) {
+          const oldestSessionId = manualEscalations.values().next().value;
+          if (oldestSessionId) manualEscalations.delete(oldestSessionId);
+        }
+        manualEscalations.add(context.sessionId);
+        return 'The next agent turn will start one routing tier higher.';
+      },
+    });
+  },
+};

--- a/plugins/tier-router/src/routing.js
+++ b/plugins/tier-router/src/routing.js
@@ -1,0 +1,73 @@
+export const TIER_ROUTING_METADATA_KEY = 'tierRouter';
+
+function tierIndex(tiers, name) {
+  return tiers.findIndex((tier) => tier.name === name);
+}
+
+function sourceMatches(source, expected) {
+  return source === expected || source.startsWith(`${expected}.`);
+}
+
+export function classifyRoutingTurn(context) {
+  const source = String(context.source || '');
+  if (
+    sourceMatches(source, 'heartbeat') ||
+    context.channelType === 'heartbeat'
+  ) {
+    return 'heartbeat';
+  }
+  if (
+    sourceMatches(source, 'scheduler') ||
+    context.channelType === 'scheduler'
+  ) {
+    return 'scheduler';
+  }
+  if (sourceMatches(source, 'fullauto')) return 'fullauto';
+  return 'agent';
+}
+
+export function findModelRoutingTier(tiers, model) {
+  const normalized = String(model || '').trim();
+  if (!normalized) return null;
+  return tiers.find((tier) => tier.models.includes(normalized))?.name || null;
+}
+
+export function resolveTierRoutingDecision(config, context, manualEscalate) {
+  if (
+    !config?.enabled ||
+    !Array.isArray(config.tiers) ||
+    !config.tiers.length
+  ) {
+    return null;
+  }
+  if (context.explicitModelPinned) return null;
+
+  const taxonomy = classifyRoutingTurn(context);
+  let startIndex = 0;
+  let reason = `system-${taxonomy}`;
+  if (taxonomy === 'agent') {
+    const agentTier = findModelRoutingTier(config.tiers, context.agentModel);
+    startIndex = Math.max(
+      0,
+      tierIndex(config.tiers, agentTier || config.defaultStart),
+    );
+    reason = agentTier ? 'agent-start' : 'default-start';
+    const stickyIndex = tierIndex(config.tiers, context.stickyTier);
+    if (stickyIndex > startIndex) {
+      startIndex = stickyIndex;
+      reason = 'sticky-tier';
+    }
+    if (manualEscalate && startIndex < config.tiers.length - 1) {
+      startIndex += 1;
+      reason = 'manual-escalate';
+    }
+  }
+  const tier = config.tiers[startIndex];
+  if (!tier?.models?.length) return null;
+  return {
+    taxonomy,
+    startTier: tier.name,
+    model: tier.models[0],
+    reason,
+  };
+}

--- a/src/agent/middleware.ts
+++ b/src/agent/middleware.ts
@@ -31,6 +31,8 @@ export interface AgentTurnContext {
   channelType?: string;
   model?: string;
   currentModel?: string;
+  agentModel?: string;
+  stickyTier?: string;
   chatbotId?: string;
   isInteractiveSource?: boolean;
   explicitModelPinned?: boolean;

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -3066,6 +3066,7 @@ function normalizeRuntimePluginEntry(
 function normalizeRuntimePluginsConfig(
   value: unknown,
   fallback: RuntimePluginsConfig,
+  modelRoutingEnabled = false,
 ): RuntimePluginsConfig {
   const raw = isRecord(value) ? value : {};
   const listSource = Array.isArray(raw.list) ? raw.list : fallback.list;
@@ -3076,6 +3077,18 @@ function normalizeRuntimePluginsConfig(
     if (!normalized || seen.has(normalized.id)) continue;
     seen.add(normalized.id);
     list.push(normalized);
+  }
+  if (modelRoutingEnabled) {
+    const tierRouter = list.find((entry) => entry.id === 'tier-router');
+    if (tierRouter) {
+      if (!tierRouter.enabled || tierRouter.path) {
+        throw new Error(
+          'routing.enabled requires the bundled tier-router plugin to be enabled without a custom path.',
+        );
+      }
+    } else {
+      list.push({ id: 'tier-router', enabled: true, config: {} });
+    }
   }
   return { list };
 }
@@ -7439,6 +7452,7 @@ function normalizeRuntimeConfig(
     plugins: normalizeRuntimePluginsConfig(
       rawPlugins,
       DEFAULT_RUNTIME_CONFIG.plugins,
+      modelRouting.enabled,
     ),
     adaptiveSkills: {
       enabled: normalizeBoolean(

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -68,11 +68,16 @@ import {
   modelRequiresChatbotId,
   resolveModelProvider,
 } from '../providers/factory.js';
+import { getModelCatalogMetadata } from '../providers/model-catalog.js';
 import {
   collectModelLookupCandidates,
   matchesModelFamily,
 } from '../providers/model-lookup.js';
 import { isGpt5ModelId } from '../providers/model-metadata.js';
+import {
+  type ResolvedLadder,
+  resolveLadder,
+} from '../providers/model-routing.js';
 import { buildSessionContext } from '../session/session-context.js';
 import { resolveSessionResetChannelKind } from '../session/session-reset.js';
 import { maybeAutoTitleSession } from '../session/session-title.js';
@@ -173,6 +178,15 @@ import {
   recordBootstrapOnboardingStart,
   recordBootstrapOnboardingUserReply,
 } from './hatching-completion.js';
+import {
+  executeModelRouting,
+  type ModelRoutingAttempt,
+} from './model-routing-execution.js';
+import {
+  consumeStickyModelRoutingTier,
+  peekStickyModelRoutingTier,
+  setStickyModelRoutingTier,
+} from './model-routing-state.js';
 import { isSupportedProactiveChannelId } from './proactive-delivery.js';
 import { forwardGatewayMessageToProxyAgent } from './proxy-agent.js';
 import {
@@ -574,12 +588,27 @@ interface ConciergeRouterMetadata {
   components?: GatewayMessageComponents;
 }
 
+interface TierRouterMetadata {
+  taxonomy?: string;
+  startTier?: string;
+  model?: string;
+  reason?: string;
+}
+
 function getConciergeRouterMetadata(
   event: MiddlewareEvent | undefined,
 ): ConciergeRouterMetadata | null {
   const raw = event?.metadata?.conciergeRouter;
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
   return raw as ConciergeRouterMetadata;
+}
+
+function getTierRouterMetadata(
+  event: MiddlewareEvent | undefined,
+): TierRouterMetadata | null {
+  const raw = event?.metadata?.tierRouter;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  return raw as TierRouterMetadata;
 }
 
 function resolvePluginRoutingModel(params: {
@@ -1270,13 +1299,14 @@ async function handleGatewayMessageInner(
     isFirstTurn: turnIndex === 1,
   });
   const explicitModelPinned = Boolean(
-    req.model?.trim() ||
-      session.model?.trim() ||
-      resolveAgentModel(resolvedAgent) ||
-      onboardingModelPinned,
+    req.model?.trim() || session.model?.trim() || onboardingModelPinned,
   );
   let routingExecutionNotice: string | null = null;
+  let tierRoutingLadder: ResolvedLadder | null = null;
   if (pluginManager?.hasMiddleware('routing')) {
+    const stickyTier = isInteractiveSource
+      ? peekStickyModelRoutingTier(req.sessionId)
+      : undefined;
     const routingOutcome = await pluginManager.applyMiddleware('routing', {
       sessionId: req.sessionId,
       userId: req.userId,
@@ -1286,6 +1316,8 @@ async function handleGatewayMessageInner(
       channelType,
       model: model || undefined,
       currentModel: model,
+      agentModel: resolveAgentModel(resolvedAgent) || undefined,
+      stickyTier,
       chatbotId,
       isInteractiveSource,
       explicitModelPinned,
@@ -1299,6 +1331,10 @@ async function handleGatewayMessageInner(
       Boolean(event.metadata?.conciergeRouter),
     );
     const routingMetadata = getConciergeRouterMetadata(routingEvent);
+    const tierRoutingEvent = routingOutcome.events.find((event) =>
+      Boolean(event.metadata?.tierRouter),
+    );
+    const tierRoutingMetadata = getTierRouterMetadata(tierRoutingEvent);
     for (const event of routingOutcome.events) {
       if (event.action === 'allow') continue;
       logger.info(
@@ -1394,6 +1430,20 @@ async function handleGatewayMessageInner(
           : routingOutcome.userContent;
     } else {
       effectiveUserTurnContentExpanded = routingOutcome.userContent;
+    }
+    if (tierRoutingMetadata?.startTier) {
+      tierRoutingLadder = resolveLadder(getRuntimeConfig().routing, {
+        startTier: tierRoutingMetadata.startTier,
+      });
+      if (!tierRoutingLadder.exhausted && tierRoutingLadder.startTier) {
+        if (isInteractiveSource) {
+          consumeStickyModelRoutingTier(req.sessionId);
+        }
+        model =
+          tierRoutingLadder.tiers[tierRoutingLadder.startIndex]?.models[0] ||
+          model;
+        provider = resolveModelProvider(model);
+      }
     }
   }
   const postRoutingModel = resolveOnboardingTurnModel({
@@ -2014,40 +2064,152 @@ async function handleGatewayMessageInner(
       });
     }
     agentStage = 'awaiting-agent-output';
-    const output = await runAgent({
-      sessionId: req.executionSessionId || req.sessionId,
-      messages,
-      chatbotId,
-      enableRag,
-      executorModeOverride: req.executorModeOverride,
-      model,
-      agentId,
-      addressEnvelope: req.addressEnvelope,
-      workspacePathOverride: req.workspacePathOverride,
-      workspaceDisplayRootOverride: req.workspaceDisplayRootOverride,
-      skipContainerSystemPrompt: promptPartDefaults.promptMode === 'none',
-      maxTokens: req.maxTokens,
-      maxWallClockMs: req.maxWallClockMs,
-      inactivityTimeoutMs: req.inactivityTimeoutMs,
-      bashProxy: req.bashProxy,
-      channelId: req.channelId,
-      ralphMaxIterations: resolveSessionRalphIterations(session),
-      fullAutoEnabled,
-      fullAutoNeverApproveTools: neverAutoApproveTools,
-      scheduleSideEffectsEnabled: !isGoalContinuationSource(source),
-      scheduledTasks,
-      allowedTools: promptPartDefaults.toolsDisabled ? [] : undefined,
-      blockedTools: mediaPolicy.blockedTools,
-      onTextDelta: emitTextDeltas,
-      onThinkingDelta: emitThinkingDeltas,
-      onToolProgress,
-      onApprovalProgress,
-      abortSignal: activeGatewayRequest.signal,
-      media,
-      audioTranscriptsPrepended: audioPrelude.transcripts.length > 0,
-      pluginTools: pluginManager?.getToolDefinitions() ?? [],
-      escalationTarget: resolveAgentEscalationTarget(resolvedAgent.id),
-    });
+    const invokeAgent = (params: {
+      model: string;
+      chatbotId: string;
+      onTextDelta?: (delta: string) => void;
+      onThinkingDelta?: (delta: string) => void;
+      onToolProgress?: (event: ToolProgressEvent) => void;
+      onApprovalProgress?: (approval: PendingApproval) => void;
+    }) =>
+      runAgent({
+        sessionId: req.executionSessionId || req.sessionId,
+        messages,
+        chatbotId: params.chatbotId,
+        enableRag,
+        executorModeOverride: req.executorModeOverride,
+        model: params.model,
+        agentId,
+        addressEnvelope: req.addressEnvelope,
+        workspacePathOverride: req.workspacePathOverride,
+        workspaceDisplayRootOverride: req.workspaceDisplayRootOverride,
+        skipContainerSystemPrompt: promptPartDefaults.promptMode === 'none',
+        maxTokens: req.maxTokens,
+        maxWallClockMs: req.maxWallClockMs,
+        inactivityTimeoutMs: req.inactivityTimeoutMs,
+        bashProxy: req.bashProxy,
+        channelId: req.channelId,
+        ralphMaxIterations: resolveSessionRalphIterations(session),
+        fullAutoEnabled,
+        fullAutoNeverApproveTools: neverAutoApproveTools,
+        scheduleSideEffectsEnabled: !isGoalContinuationSource(source),
+        scheduledTasks,
+        allowedTools: promptPartDefaults.toolsDisabled ? [] : undefined,
+        blockedTools: mediaPolicy.blockedTools,
+        onTextDelta: params.onTextDelta,
+        onThinkingDelta: params.onThinkingDelta,
+        onToolProgress: params.onToolProgress,
+        onApprovalProgress: params.onApprovalProgress,
+        abortSignal: activeGatewayRequest.signal,
+        media,
+        audioTranscriptsPrepended: audioPrelude.transcripts.length > 0,
+        pluginTools: pluginManager?.getToolDefinitions() ?? [],
+        escalationTarget: resolveAgentEscalationTarget(resolvedAgent.id),
+      });
+    let routingAttempts: ModelRoutingAttempt[] | null = null;
+    let output: ContainerOutput;
+    if (tierRoutingLadder?.enabled && !tierRoutingLadder.exhausted) {
+      const bufferedEvents = new WeakMap<
+        ContainerOutput,
+        {
+          text: string[];
+          thinking: string[];
+          tools: ToolProgressEvent[];
+          approvals: PendingApproval[];
+          chatbotId: string;
+        }
+      >();
+      const routed = await executeModelRouting({
+        ladder: tierRoutingLadder,
+        agentId,
+        chatbotId,
+        onEscalation: (event) => {
+          recordAuditEvent({
+            sessionId: req.sessionId,
+            runId,
+            event: { type: 'route.escalated', ...event },
+          });
+        },
+        invoke: async (runtime, routedModel) => {
+          const buffered = {
+            text: [] as string[],
+            thinking: [] as string[],
+            tools: [] as ToolProgressEvent[],
+            approvals: [] as PendingApproval[],
+            chatbotId: runtime.chatbotId || chatbotId,
+          };
+          const attemptOutput = await invokeAgent({
+            model: routedModel,
+            chatbotId: runtime.chatbotId || chatbotId,
+            onTextDelta: (delta) => buffered.text.push(delta),
+            onThinkingDelta: (delta) => buffered.thinking.push(delta),
+            onToolProgress: (event) => buffered.tools.push(event),
+            onApprovalProgress: (approval) => buffered.approvals.push(approval),
+          });
+          bufferedEvents.set(attemptOutput, buffered);
+          return attemptOutput;
+        },
+      });
+      output = routed.output;
+      model = routed.model;
+      provider = resolveModelProvider(model);
+      routingAttempts = routed.attempts;
+      const finalEvents = bufferedEvents.get(output);
+      chatbotId = finalEvents?.chatbotId || chatbotId;
+      for (const delta of finalEvents?.text || []) emitTextDeltas?.(delta);
+      for (const delta of finalEvents?.thinking || []) {
+        emitThinkingDeltas?.(delta);
+      }
+      for (const event of finalEvents?.tools || []) onToolProgress(event);
+      for (const approval of finalEvents?.approvals || []) {
+        onApprovalProgress(approval);
+      }
+      if (
+        routed.escalated &&
+        getRuntimeConfig().routing.escalationStickyTurns
+      ) {
+        setStickyModelRoutingTier(
+          req.sessionId,
+          routed.tier,
+          getRuntimeConfig().routing.escalationStickyTurns,
+        );
+      }
+    } else {
+      output = await runAgent({
+        sessionId: req.executionSessionId || req.sessionId,
+        messages,
+        chatbotId,
+        enableRag,
+        executorModeOverride: req.executorModeOverride,
+        model,
+        agentId,
+        addressEnvelope: req.addressEnvelope,
+        workspacePathOverride: req.workspacePathOverride,
+        workspaceDisplayRootOverride: req.workspaceDisplayRootOverride,
+        skipContainerSystemPrompt: promptPartDefaults.promptMode === 'none',
+        maxTokens: req.maxTokens,
+        maxWallClockMs: req.maxWallClockMs,
+        inactivityTimeoutMs: req.inactivityTimeoutMs,
+        bashProxy: req.bashProxy,
+        channelId: req.channelId,
+        ralphMaxIterations: resolveSessionRalphIterations(session),
+        fullAutoEnabled,
+        fullAutoNeverApproveTools: neverAutoApproveTools,
+        scheduleSideEffectsEnabled: !isGoalContinuationSource(source),
+        scheduledTasks,
+        allowedTools: promptPartDefaults.toolsDisabled ? [] : undefined,
+        blockedTools: mediaPolicy.blockedTools,
+        onTextDelta: emitTextDeltas,
+        onThinkingDelta: emitThinkingDeltas,
+        onToolProgress,
+        onApprovalProgress,
+        abortSignal: activeGatewayRequest.signal,
+        media,
+        audioTranscriptsPrepended: audioPrelude.transcripts.length > 0,
+        pluginTools: pluginManager?.getToolDefinitions() ?? [],
+        escalationTarget: resolveAgentEscalationTarget(resolvedAgent.id),
+      });
+    }
     agentStage = 'processing-agent-output';
     const storedUserContent = buildStoredUserTurnContent(
       userTurnContent,
@@ -2101,41 +2263,97 @@ async function handleGatewayMessageInner(
       runId,
       toolExecutions,
     });
-    const usagePayload = buildTokenUsageAuditPayload(
-      messages,
-      output.result,
-      output.tokenUsage,
-    );
-    recordAuditEvent({
-      sessionId: req.sessionId,
-      runId,
-      event: {
-        type: 'model.usage',
-        provider,
+    let costUsd = 0;
+    if (!routingAttempts) {
+      const usagePayload = buildTokenUsageAuditPayload(
+        messages,
+        output.result,
+        output.tokenUsage,
+      );
+      recordAuditEvent({
+        sessionId: req.sessionId,
+        runId,
+        event: {
+          type: 'model.usage',
+          provider,
+          model,
+          runtime: resolveTurnRuntimeAuditLabel(model, output),
+          codexRuntime: output.codexRuntime || null,
+          durationMs: Date.now() - startedAt,
+          toolCallCount: toolExecutions.length,
+          ...usagePayload,
+        },
+      });
+      costUsd = await resolveUsageCostUsdAfterMetadataRefresh({
         model,
-        runtime: resolveTurnRuntimeAuditLabel(model, output),
-        codexRuntime: output.codexRuntime || null,
-        durationMs: Date.now() - startedAt,
-        toolCallCount: toolExecutions.length,
-        ...usagePayload,
-      },
-    });
-    const costUsd = await resolveUsageCostUsdAfterMetadataRefresh({
-      model,
-      tokenUsage: output.tokenUsage,
-      usage: usagePayload,
-    });
-    enqueueTokenUsage({
-      sessionId: req.sessionId,
-      agentId,
-      model,
-      inputTokens: firstNumber([usagePayload.promptTokens]) || 0,
-      outputTokens: firstNumber([usagePayload.completionTokens]) || 0,
-      totalTokens: firstNumber([usagePayload.totalTokens]) || 0,
-      toolCalls: toolExecutions.length,
-      costUsd,
-      auditRunId: runId,
-    });
+        tokenUsage: output.tokenUsage,
+        usage: usagePayload,
+      });
+      enqueueTokenUsage({
+        sessionId: req.sessionId,
+        agentId,
+        model,
+        inputTokens: firstNumber([usagePayload.promptTokens]) || 0,
+        outputTokens: firstNumber([usagePayload.completionTokens]) || 0,
+        totalTokens: firstNumber([usagePayload.totalTokens]) || 0,
+        toolCalls: toolExecutions.length,
+        costUsd,
+        auditRunId: runId,
+      });
+    } else {
+      for (let index = 0; index < routingAttempts.length; index += 1) {
+        const attempt = routingAttempts[index];
+        const attemptToolExecutions = attempt.output.toolExecutions || [];
+        const usagePayload = buildTokenUsageAuditPayload(
+          messages,
+          attempt.output.result,
+          attempt.output.tokenUsage,
+        );
+        const routeZone = getModelCatalogMetadata(attempt.model).zone;
+        recordAuditEvent({
+          sessionId: req.sessionId,
+          runId,
+          event: {
+            type: 'model.usage',
+            provider: resolveModelProvider(attempt.model),
+            model: attempt.model,
+            runtime: resolveTurnRuntimeAuditLabel(
+              attempt.model,
+              attempt.output,
+            ),
+            codexRuntime: attempt.output.codexRuntime || null,
+            durationMs: attempt.durationMs,
+            toolCallCount: attemptToolExecutions.length,
+            routeTier: attempt.tier,
+            routeZone,
+            routeReason: attempt.routeReason,
+            escalated: attempt.escalated,
+            ...usagePayload,
+          },
+        });
+        const attemptCostUsd = await resolveUsageCostUsdAfterMetadataRefresh({
+          model: attempt.model,
+          tokenUsage: attempt.output.tokenUsage,
+          usage: usagePayload,
+        });
+        if (index === routingAttempts.length - 1) costUsd = attemptCostUsd;
+        enqueueTokenUsage({
+          sessionId: req.sessionId,
+          agentId,
+          model: attempt.model,
+          inputTokens: firstNumber([usagePayload.promptTokens]) || 0,
+          outputTokens: firstNumber([usagePayload.completionTokens]) || 0,
+          totalTokens: firstNumber([usagePayload.totalTokens]) || 0,
+          toolCalls: attemptToolExecutions.length,
+          costUsd: attemptCostUsd,
+          auditRunId: runId,
+          routeTier: attempt.tier,
+          routeZone,
+          routeReason: attempt.routeReason,
+          escalated: attempt.escalated,
+        });
+      }
+    }
     for (const event of buildMediaGenerationUsageEvents({
       sessionId: req.sessionId,
       agentId,

--- a/src/gateway/model-routing-execution.ts
+++ b/src/gateway/model-routing-execution.ts
@@ -1,0 +1,240 @@
+import { isSilentReply } from '../agent/silent-reply.js';
+import { resolveModelRuntimeCredentials } from '../providers/factory.js';
+import type {
+  ResolvedLadder,
+  ResolvedModelRoutingTier,
+} from '../providers/model-routing.js';
+import type { ResolvedModelRuntimeCredentials } from '../providers/types.js';
+import type { ContainerOutput } from '../types/container.js';
+import {
+  callWithProviderFallback,
+  classifyProviderError,
+  type FallbackReason,
+} from './provider-fallback.js';
+
+export type ModelRoutingEscalationTrigger =
+  | 'provider_auth'
+  | 'provider_rate_limit'
+  | 'provider_server_error'
+  | 'malformed_tool_call'
+  | 'empty_output'
+  | 'narrate_only';
+
+export interface ModelRoutingAttempt {
+  tier: string;
+  model: string;
+  output: ContainerOutput;
+  durationMs: number;
+  routeReason: string;
+  escalated: boolean;
+}
+
+export interface ModelRoutingEscalationEvent {
+  fromTier: string;
+  toTier: string;
+  reason: ModelRoutingEscalationTrigger;
+}
+
+export interface ModelRoutingExecutionResult {
+  output: ContainerOutput;
+  model: string;
+  tier: string;
+  attempts: ModelRoutingAttempt[];
+  escalated: boolean;
+}
+
+interface ExecuteModelRoutingParams {
+  ladder: ResolvedLadder;
+  agentId: string;
+  chatbotId?: string;
+  invoke: (
+    runtime: ResolvedModelRuntimeCredentials,
+    model: string,
+  ) => Promise<ContainerOutput>;
+  onEscalation?: (event: ModelRoutingEscalationEvent) => void;
+  resolveRuntime?: typeof resolveModelRuntimeCredentials;
+}
+
+class RoutingAttemptError extends Error {
+  constructor(
+    message: string,
+    readonly trigger: ModelRoutingEscalationTrigger,
+    readonly output: ContainerOutput,
+  ) {
+    super(message);
+    this.name = 'RoutingAttemptError';
+  }
+}
+
+const MALFORMED_TOOL_CALL_RE =
+  /malformed tool (?:arguments|call)|invalid tool (?:arguments|call)|tool call.*(?:malformed|invalid)/i;
+const EMPTY_OUTPUT_RE =
+  /empty completion|empty response|no response from api|without visible text or tool calls/i;
+const NARRATE_ONLY_RE =
+  /^(?:sure[,!.]?\s*)?(?:i(?:'ll| will|'m going to)|let me)\s+(?:look|check|investigate|work|start|review|analy[sz]e|handle|take care|do|prepare|create|build|fix|update|implement)\b[^\n]{0,360}$/i;
+
+function providerTrigger(
+  reason: FallbackReason,
+): ModelRoutingEscalationTrigger | null {
+  if (reason === 'auth') return 'provider_auth';
+  if (reason === 'rate_limit') return 'provider_rate_limit';
+  if (reason === 'server_error') return 'provider_server_error';
+  return null;
+}
+
+function isRetrySafe(output: ContainerOutput): boolean {
+  return !output.pendingApproval && (output.toolExecutions?.length ?? 0) === 0;
+}
+
+export function classifyModelRoutingOutput(
+  output: ContainerOutput,
+): ModelRoutingEscalationTrigger | null {
+  if (!isRetrySafe(output)) return null;
+  const error = String(output.error || '').trim();
+  if (MALFORMED_TOOL_CALL_RE.test(error)) return 'malformed_tool_call';
+  if (error) {
+    const trigger = providerTrigger(classifyProviderError(error));
+    if (trigger) return trigger;
+  }
+  if (EMPTY_OUTPUT_RE.test(error)) return 'empty_output';
+  if (output.status !== 'success') return null;
+  const result = String(output.result || '').trim();
+  if (!result) {
+    return (output.artifacts?.length ?? 0) > 0 ? null : 'empty_output';
+  }
+  if (isSilentReply(result)) return null;
+  return NARRATE_ONLY_RE.test(result) ? 'narrate_only' : null;
+}
+
+function routeErrorMessage(
+  output: ContainerOutput,
+  trigger: ModelRoutingEscalationTrigger,
+): string {
+  return (
+    String(output.error || '').trim() || `Model routing trigger: ${trigger}`
+  );
+}
+
+function tierFallbackChain(
+  tier: ResolvedModelRoutingTier,
+  agentId: string,
+  chatbotId?: string,
+) {
+  return tier.models.slice(1).map((model) => ({
+    model,
+    agentId,
+    ...(chatbotId ? { chatbotId } : {}),
+  }));
+}
+
+export async function executeModelRouting(
+  params: ExecuteModelRoutingParams,
+): Promise<ModelRoutingExecutionResult> {
+  const tiers = params.ladder.tiers.slice(params.ladder.startIndex);
+  if (!params.ladder.enabled || params.ladder.exhausted || tiers.length === 0) {
+    throw new Error('Model routing execution requires a non-empty ladder.');
+  }
+  const resolveRuntime =
+    params.resolveRuntime ?? resolveModelRuntimeCredentials;
+  const attempts: ModelRoutingAttempt[] = [];
+  let lastOutput: ContainerOutput | null = null;
+  let lastModel = tiers[0]?.models[0] || '';
+
+  for (let tierOffset = 0; tierOffset < tiers.length; tierOffset += 1) {
+    const tier = tiers[tierOffset];
+    if (!tier?.models[0]) continue;
+    const primaryModel = tier.models[0];
+    let weakOutputRetried = false;
+    let nextAttemptReason =
+      tierOffset === 0 ? params.ladder.reason : 'tier-escalation';
+    let tierTrigger: ModelRoutingEscalationTrigger | null = null;
+
+    try {
+      const primaryRuntime = await resolveRuntime({
+        model: primaryModel,
+        agentId: params.agentId,
+        ...(params.chatbotId ? { chatbotId: params.chatbotId } : {}),
+      });
+      const output = await callWithProviderFallback({
+        primaryRuntime,
+        primaryModel,
+        chain: tierFallbackChain(tier, params.agentId, params.chatbotId),
+        onFallback: (_activation, reason) => {
+          nextAttemptReason = `provider_${reason}`;
+        },
+        invoke: async (runtime, model) => {
+          for (;;) {
+            const startedAt = Date.now();
+            const attemptOutput = await params.invoke(runtime, model);
+            const trigger = classifyModelRoutingOutput(attemptOutput);
+            attempts.push({
+              tier: tier.name,
+              model,
+              output: attemptOutput,
+              durationMs: Date.now() - startedAt,
+              routeReason: nextAttemptReason,
+              escalated: tierOffset > 0,
+            });
+            lastOutput = attemptOutput;
+            lastModel = model;
+            if (!trigger) return attemptOutput;
+            tierTrigger = trigger;
+            if (
+              (trigger === 'empty_output' || trigger === 'narrate_only') &&
+              !weakOutputRetried
+            ) {
+              weakOutputRetried = true;
+              nextAttemptReason = `${trigger}_retry`;
+              continue;
+            }
+            throw new RoutingAttemptError(
+              routeErrorMessage(attemptOutput, trigger),
+              trigger,
+              attemptOutput,
+            );
+          }
+        },
+      });
+      return {
+        output,
+        model: lastModel,
+        tier: tier.name,
+        attempts,
+        escalated: tierOffset > 0,
+      };
+    } catch (error) {
+      if (error instanceof RoutingAttemptError) {
+        tierTrigger = error.trigger;
+      } else {
+        tierTrigger = providerTrigger(classifyProviderError(error));
+      }
+      const nextTier = tiers[tierOffset + 1];
+      if (!tierTrigger || !nextTier) {
+        if (lastOutput) {
+          return {
+            output: lastOutput,
+            model: lastModel,
+            tier: tier.name,
+            attempts,
+            escalated: tierOffset > 0,
+          };
+        }
+        throw error;
+      }
+      params.onEscalation?.({
+        fromTier: tier.name,
+        toTier: nextTier.name,
+        reason: tierTrigger,
+      });
+    }
+  }
+  if (!lastOutput)
+    throw new Error('Model routing exhausted without an attempt.');
+  return {
+    output: lastOutput,
+    model: lastModel,
+    tier: tiers.at(-1)?.name || '',
+    attempts,
+    escalated: tiers.length > 1,
+  };
+}

--- a/src/gateway/model-routing-state.ts
+++ b/src/gateway/model-routing-state.ts
@@ -1,0 +1,62 @@
+interface StickyRouteState {
+  tier: string;
+  remainingTurns: number;
+}
+
+const stickyRoutes = new Map<string, StickyRouteState>();
+const MAX_STICKY_ROUTE_SESSIONS = 10_000;
+
+export function peekStickyModelRoutingTier(
+  sessionId: string,
+): string | undefined {
+  return stickyRoutes.get(sessionId.trim())?.tier;
+}
+
+export function consumeStickyModelRoutingTier(
+  sessionId: string,
+): string | undefined {
+  const key = sessionId.trim();
+  const state = stickyRoutes.get(key);
+  if (!key || !state) return undefined;
+  if (state.remainingTurns <= 1) {
+    stickyRoutes.delete(key);
+  } else {
+    stickyRoutes.set(key, {
+      ...state,
+      remainingTurns: state.remainingTurns - 1,
+    });
+  }
+  return state.tier;
+}
+
+export function setStickyModelRoutingTier(
+  sessionId: string,
+  tier: string,
+  turns: number,
+): void {
+  const key = sessionId.trim();
+  const normalizedTier = tier.trim();
+  if (!key || !normalizedTier || turns <= 0) {
+    stickyRoutes.delete(key);
+    return;
+  }
+  if (
+    !stickyRoutes.has(key) &&
+    stickyRoutes.size >= MAX_STICKY_ROUTE_SESSIONS
+  ) {
+    const oldestKey = stickyRoutes.keys().next().value;
+    if (oldestKey) stickyRoutes.delete(oldestKey);
+  }
+  stickyRoutes.set(key, {
+    tier: normalizedTier,
+    remainingTurns: Math.floor(turns),
+  });
+}
+
+export function clearStickyModelRoutingTier(sessionId?: string): void {
+  if (sessionId) {
+    stickyRoutes.delete(sessionId.trim());
+    return;
+  }
+  stickyRoutes.clear();
+}

--- a/src/providers/task-routing.ts
+++ b/src/providers/task-routing.ts
@@ -248,9 +248,20 @@ export async function resolveTaskModelPolicy(
 ): Promise<TaskModelPolicy | undefined> {
   const configured = getConfiguredTaskSelection(task);
   const providerSelection = getSelectedTaskProvider(task);
-  const rawModel = getSelectedTaskModel(task);
+  let rawModel = getSelectedTaskModel(task);
   const maxTokens = normalizeMaxTokens(configured.maxTokens);
   if (providerSelection === 'disabled') return undefined;
+
+  if (providerSelection === 'auto' && !rawModel) {
+    const routing = getRuntimeConfig().routing;
+    const bottomTier = routing.enabled ? routing.tiers[0] : undefined;
+    rawModel =
+      (task === 'vision'
+        ? bottomTier?.models.find((candidate) =>
+            isModelVisionCapable(candidate),
+          ) || bottomTier?.models[0]
+        : bottomTier?.models[0]) || '';
+  }
 
   if (providerSelection === 'auto' && !rawModel) {
     // For the vision task, verify that the session/fallback model actually

--- a/tests/gateway-service.concierge.test.ts
+++ b/tests/gateway-service.concierge.test.ts
@@ -473,7 +473,7 @@ test('explicit session model pins bypass the concierge', async () => {
   expect(latest?.model).toBe('openai-codex/gpt-5.4');
 });
 
-test('explicit agent model pins bypass the concierge', async () => {
+test('agent default models remain routing preferences instead of hard pins', async () => {
   callAuxiliaryModelMock.mockResolvedValue({
     provider: 'hybridai',
     model: 'gemini-3-flash',
@@ -504,10 +504,6 @@ test('explicit agent model pins bypass the concierge', async () => {
     callAuxiliaryModelMock.mock.calls.filter(
       ([params]) => params?.task !== 'session_title',
     ),
-  ).toEqual([]);
-  expect(runAgentMock).toHaveBeenCalledTimes(1);
-  const request = runAgentMock.mock.calls[0]?.[0] as
-    | { model?: string }
-    | undefined;
-  expect(request?.model).toBe('openai-codex/gpt-5.4');
+  ).toHaveLength(1);
+  expect(runAgentMock).not.toHaveBeenCalled();
 });

--- a/tests/gateway-service.tier-routing.test.ts
+++ b/tests/gateway-service.tier-routing.test.ts
@@ -1,0 +1,215 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
+
+const { runAgentMock } = vi.hoisted(() => ({ runAgentMock: vi.fn() }));
+
+vi.mock('../src/agent/agent.js', () => ({ runAgent: runAgentMock }));
+
+const ORIGINAL_HOME = process.env.HOME;
+const makeTempHome = useTempDir('hybridclaw-tier-routing-home-');
+
+async function createFixture() {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+  vi.resetModules();
+
+  const { initDatabase, updateSessionModel } = await import(
+    '../src/memory/db.ts'
+  );
+  initDatabase({ quiet: true });
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  updateRuntimeConfig((draft) => {
+    draft.local.backends.lmstudio.enabled = true;
+    draft.routing.enabled = true;
+    draft.routing.defaultStart = 'economy';
+    draft.routing.escalationStickyTurns = 3;
+    draft.routing.tiers = [
+      { name: 'economy', models: ['lmstudio/test-cheap'] },
+      { name: 'general', models: ['lmstudio/test-strong'] },
+    ];
+    draft.auxiliaryModels.session_title.provider = 'disabled';
+  });
+  const workspacePath = path.join(homeDir, 'workspace');
+  fs.mkdirSync(workspacePath, { recursive: true });
+  const { handleGatewayMessage } = await import(
+    '../src/gateway/gateway-chat-service.ts'
+  );
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  return {
+    handleGatewayMessage,
+    homeDir,
+    memoryService,
+    updateRuntimeConfig,
+    updateSessionModel,
+    workspacePath,
+  };
+}
+
+useCleanMocks({
+  restoreAllMocks: true,
+  cleanup: () => {
+    runAgentMock.mockReset();
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+    else process.env.HOME = ORIGINAL_HOME;
+    delete process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+  },
+  resetModules: true,
+});
+
+test('gateway escalates once, emits route telemetry, and hides failed deltas', async () => {
+  runAgentMock.mockImplementation(async (params) => {
+    if (params.model === 'lmstudio/test-cheap') {
+      params.onTextDelta?.('discarded failed output');
+      return {
+        status: 'error',
+        result: '',
+        error: 'Provider returned HTTP 503',
+        toolsUsed: [],
+        toolExecutions: [],
+      };
+    }
+    params.onTextDelta?.('successful output');
+    return {
+      status: 'success',
+      result: 'successful output',
+      toolsUsed: [],
+      toolExecutions: [],
+    };
+  });
+  const fixture = await createFixture();
+  const deltas: string[] = [];
+  const sessionId = 'session-tier-routing';
+  const result = await fixture.handleGatewayMessage({
+    sessionId,
+    guildId: null,
+    channelId: 'tui',
+    userId: 'user-1',
+    username: 'user',
+    content: 'Complete the task.',
+    chatbotId: 'bot_test',
+    workspacePathOverride: fixture.workspacePath,
+    onTextDelta: (delta) => deltas.push(delta),
+  });
+
+  expect(result).toMatchObject({
+    status: 'success',
+    result: 'successful output',
+    model: 'lmstudio/test-strong',
+  });
+  expect(runAgentMock.mock.calls.map(([params]) => params.model)).toEqual([
+    'lmstudio/test-cheap',
+    'lmstudio/test-strong',
+  ]);
+  expect(deltas).toEqual(['successful output']);
+
+  runAgentMock.mockClear();
+  await fixture.handleGatewayMessage({
+    sessionId,
+    guildId: null,
+    channelId: 'tui',
+    userId: 'user-1',
+    username: 'user',
+    content: 'Continue.',
+    chatbotId: 'bot_test',
+    workspacePathOverride: fixture.workspacePath,
+  });
+  expect(runAgentMock.mock.calls.map(([params]) => params.model)).toEqual([
+    'lmstudio/test-strong',
+  ]);
+
+  const { getAuditWirePath } = await import('../src/audit/audit-trail.ts');
+  const wire = fs
+    .readFileSync(getAuditWirePath(sessionId), 'utf-8')
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line));
+  expect(
+    wire.filter((record) => record.event?.type === 'route.escalated'),
+  ).toHaveLength(1);
+  expect(
+    wire.find((record) => record.event?.type === 'route.escalated')?.event,
+  ).toMatchObject({
+    fromTier: 'economy',
+    toTier: 'general',
+    reason: 'provider_server_error',
+  });
+  expect(
+    wire.filter((record) => record.event?.type === 'model.usage'),
+  ).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        event: expect.objectContaining({
+          routeTier: 'economy',
+          escalated: false,
+        }),
+      }),
+      expect.objectContaining({
+        event: expect.objectContaining({
+          routeTier: 'general',
+          escalated: true,
+        }),
+      }),
+    ]),
+  );
+});
+
+test('an explicit session model remains a hard pin', async () => {
+  runAgentMock.mockResolvedValue({
+    status: 'success',
+    result: 'pinned result',
+    toolsUsed: [],
+    toolExecutions: [],
+  });
+  const fixture = await createFixture();
+  const sessionId = 'session-tier-pinned';
+  fixture.memoryService.getOrCreateSession(sessionId, null, 'tui');
+  fixture.updateSessionModel(sessionId, 'lmstudio/pinned');
+
+  const result = await fixture.handleGatewayMessage({
+    sessionId,
+    guildId: null,
+    channelId: 'tui',
+    userId: 'user-1',
+    username: 'user',
+    content: 'Use my pinned model.',
+    chatbotId: 'bot_test',
+    workspacePathOverride: fixture.workspacePath,
+  });
+
+  expect(result.model).toBe('lmstudio/pinned');
+  expect(runAgentMock).toHaveBeenCalledTimes(1);
+  expect(runAgentMock.mock.calls[0]?.[0].model).toBe('lmstudio/pinned');
+});
+
+test('a heartbeat turn starts on the bottom rung', async () => {
+  runAgentMock.mockResolvedValue({
+    status: 'success',
+    result: 'heartbeat complete',
+    toolsUsed: [],
+    toolExecutions: [],
+  });
+  const fixture = await createFixture();
+  fixture.updateRuntimeConfig((draft) => {
+    draft.routing.defaultStart = 'general';
+  });
+
+  await fixture.handleGatewayMessage({
+    sessionId: 'session-tier-heartbeat',
+    guildId: null,
+    channelId: 'heartbeat',
+    userId: 'system',
+    username: null,
+    content: 'Run the heartbeat checklist.',
+    chatbotId: 'bot_test',
+    source: 'heartbeat',
+    workspacePathOverride: fixture.workspacePath,
+  });
+
+  expect(runAgentMock).toHaveBeenCalledTimes(1);
+  expect(runAgentMock.mock.calls[0]?.[0].model).toBe('lmstudio/test-cheap');
+});

--- a/tests/model-routing-execution.test.ts
+++ b/tests/model-routing-execution.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test, vi } from 'vitest';
+import {
+  classifyModelRoutingOutput,
+  executeModelRouting,
+} from '../src/gateway/model-routing-execution.js';
+import { resolveLadder } from '../src/providers/model-routing.js';
+import type { ResolvedModelRuntimeCredentials } from '../src/providers/types.js';
+import type { ContainerOutput } from '../src/types/container.js';
+
+const config = {
+  enabled: true,
+  tiers: [
+    { name: 'economy', models: ['local/small'] },
+    { name: 'general', models: ['hybridai/medium'] },
+  ],
+  defaultStart: 'economy',
+  escalationStickyTurns: 3,
+};
+
+function runtime(model: string): ResolvedModelRuntimeCredentials {
+  return {
+    provider: model.startsWith('local/') ? 'ollama' : 'hybridai',
+    apiKey: 'test-key',
+    baseUrl: 'https://example.com/v1',
+    chatbotId: '',
+    enableRag: false,
+    requestHeaders: {},
+    agentId: 'main',
+    isLocal: model.startsWith('local/'),
+  };
+}
+
+function output(
+  value: Partial<ContainerOutput> & Pick<ContainerOutput, 'status'>,
+): ContainerOutput {
+  return { result: '', toolsUsed: [], ...value };
+}
+
+describe('model routing escalation classification', () => {
+  test.each([
+    [output({ status: 'error', error: 'Provider returned HTTP 401' }), 'provider_auth'],
+    [output({ status: 'error', error: 'Provider returned HTTP 429' }), 'provider_rate_limit'],
+    [output({ status: 'error', error: 'Provider returned HTTP 503' }), 'provider_server_error'],
+    [output({ status: 'error', error: 'Model emitted malformed tool arguments for `bash`' }), 'malformed_tool_call'],
+    [output({ status: 'success', result: '' }), 'empty_output'],
+    [output({ status: 'success', result: "I'll investigate this for you." }), 'narrate_only'],
+  ])('classifies %#', (candidate, trigger) => {
+    expect(classifyModelRoutingOutput(candidate)).toBe(trigger);
+  });
+
+  test('does not retry after a tool side effect or approval boundary', () => {
+    expect(
+      classifyModelRoutingOutput(
+        output({
+          status: 'error',
+          error: 'HTTP 503',
+          toolExecutions: [{ name: 'bash' } as never],
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      classifyModelRoutingOutput(
+        output({
+          status: 'error',
+          error: 'HTTP 503',
+          pendingApproval: { approvalId: 'approval-1' } as never,
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+test('cheap-tier provider failure escalates once and returns the next rung', async () => {
+  const invoke = vi
+    .fn()
+    .mockResolvedValueOnce(output({ status: 'error', error: 'HTTP 503' }))
+    .mockResolvedValueOnce(output({ status: 'success', result: 'done' }));
+  const onEscalation = vi.fn();
+  const result = await executeModelRouting({
+    ladder: resolveLadder(config),
+    agentId: 'main',
+    resolveRuntime: async ({ model }) => runtime(model),
+    invoke,
+    onEscalation,
+  });
+
+  expect(result.output.result).toBe('done');
+  expect(result.model).toBe('hybridai/medium');
+  expect(result.attempts).toHaveLength(2);
+  expect(result.escalated).toBe(true);
+  expect(onEscalation).toHaveBeenCalledTimes(1);
+  expect(onEscalation).toHaveBeenCalledWith({
+    fromTier: 'economy',
+    toTier: 'general',
+    reason: 'provider_server_error',
+  });
+});
+
+test('empty output receives one same-rung retry before escalation', async () => {
+  const invoke = vi
+    .fn()
+    .mockResolvedValueOnce(output({ status: 'success', result: '' }))
+    .mockResolvedValueOnce(output({ status: 'success', result: 'completed' }));
+  const onEscalation = vi.fn();
+  const result = await executeModelRouting({
+    ladder: resolveLadder(config),
+    agentId: 'main',
+    resolveRuntime: async ({ model }) => runtime(model),
+    invoke,
+    onEscalation,
+  });
+
+  expect(result.model).toBe('local/small');
+  expect(result.attempts.map((attempt) => attempt.routeReason)).toEqual([
+    'default-start',
+    'empty_output_retry',
+  ]);
+  expect(onEscalation).not.toHaveBeenCalled();
+});
+
+test('a failed turn with tool execution is returned without rerouting', async () => {
+  const failed = output({
+    status: 'error',
+    error: 'HTTP 503',
+    toolExecutions: [{ name: 'bash' } as never],
+  });
+  const invoke = vi.fn().mockResolvedValue(failed);
+  const onEscalation = vi.fn();
+  const result = await executeModelRouting({
+    ladder: resolveLadder(config),
+    agentId: 'main',
+    resolveRuntime: async ({ model }) => runtime(model),
+    invoke,
+    onEscalation,
+  });
+
+  expect(result.output).toBe(failed);
+  expect(invoke).toHaveBeenCalledTimes(1);
+  expect(onEscalation).not.toHaveBeenCalled();
+});

--- a/tests/model-routing-state.test.ts
+++ b/tests/model-routing-state.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, expect, test } from 'vitest';
+import {
+  clearStickyModelRoutingTier,
+  consumeStickyModelRoutingTier,
+  peekStickyModelRoutingTier,
+  setStickyModelRoutingTier,
+} from '../src/gateway/model-routing-state.js';
+
+afterEach(() => clearStickyModelRoutingTier());
+
+test('sticky routing is honored for its configured turn window then de-escalates', () => {
+  setStickyModelRoutingTier('session-1', 'advanced', 3);
+  expect(peekStickyModelRoutingTier('session-1')).toBe('advanced');
+  expect(peekStickyModelRoutingTier('session-1')).toBe('advanced');
+  expect(consumeStickyModelRoutingTier('session-1')).toBe('advanced');
+  expect(consumeStickyModelRoutingTier('session-1')).toBe('advanced');
+  expect(consumeStickyModelRoutingTier('session-1')).toBe('advanced');
+  expect(consumeStickyModelRoutingTier('session-1')).toBeUndefined();
+});

--- a/tests/provider-fallback.test.ts
+++ b/tests/provider-fallback.test.ts
@@ -79,12 +79,15 @@ describe('loadFallbackChainFromEnv', () => {
 });
 
 describe('classifyProviderError', () => {
-  test('identifies auth, rate-limit, and unknown failures', async () => {
+  test('identifies auth, rate-limit, server, and unknown failures', async () => {
     const mod = await importModule();
     expect(mod.classifyProviderError(new Error('failed with 401: bad'))).toBe(
       'auth',
     );
     expect(mod.classifyProviderError(new Error('Forbidden: blocked'))).toBe(
+      'auth',
+    );
+    expect(mod.classifyProviderError(new Error('No API key configured'))).toBe(
       'auth',
     );
     expect(mod.classifyProviderError(new Error('HTTP 429 too many'))).toBe(
@@ -93,7 +96,10 @@ describe('classifyProviderError', () => {
     expect(mod.classifyProviderError(new Error('daily quota exhausted'))).toBe(
       'rate_limit',
     );
-    expect(mod.classifyProviderError(new Error('500 internal'))).toBe('other');
+    expect(mod.classifyProviderError(new Error('500 internal'))).toBe(
+      'server_error',
+    );
+    expect(mod.classifyProviderError(new Error('socket closed'))).toBe('other');
   });
 });
 
@@ -211,9 +217,15 @@ describe('callWithProviderFallback', () => {
     );
   });
 
-  test('non-auth / non-rate-limit errors surface without fallback', async () => {
+  test('server errors fall back and unknown errors surface', async () => {
     const mod = await importModule();
-    const invoke = vi.fn().mockRejectedValueOnce(new Error('500 server down'));
+    resolveModelRuntimeCredentials.mockResolvedValueOnce(
+      runtimeFixture('openrouter'),
+    );
+    const invoke = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('500 server down'))
+      .mockResolvedValueOnce({ id: 'fallback' });
     await expect(
       mod.callWithProviderFallback({
         primaryRuntime: runtimeFixture('openai'),
@@ -221,8 +233,20 @@ describe('callWithProviderFallback', () => {
         chain: [{ model: 'openrouter/a' }],
         invoke,
       }),
-    ).rejects.toThrow('500 server down');
-    expect(invoke).toHaveBeenCalledTimes(1);
+    ).resolves.toEqual({ id: 'fallback' });
+
+    const unknownInvoke = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('socket closed'));
+    await expect(
+      mod.callWithProviderFallback({
+        primaryRuntime: runtimeFixture('openai'),
+        primaryModel: 'gpt-4o',
+        chain: [{ model: 'openrouter/a' }],
+        invoke: unknownInvoke,
+      }),
+    ).rejects.toThrow('socket closed');
+    expect(unknownInvoke).toHaveBeenCalledTimes(1);
   });
 
   test('primary cooldown skips straight to fallback on next request', async () => {

--- a/tests/providers.task-routing.test.ts
+++ b/tests/providers.task-routing.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import { afterEach, expect, test, vi } from 'vitest';
 import type { RuntimeConfig } from '../src/config/runtime-config.js';
+import { TASK_MODEL_KEYS } from '../src/types/models.js';
 
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_DISABLE_CONFIG_WATCHER =
@@ -142,6 +143,61 @@ test('resolves configured vision task model policy on the host', async () => {
   expect(taskModels?.compression?.maxTokens).toBeUndefined();
   expect(taskModels?.web_extract?.maxTokens).toBeUndefined();
   expect(taskModels?.session_search?.maxTokens).toBeUndefined();
+});
+
+test('routes default auxiliary tasks to the bottom configured rung', async () => {
+  const homeDir = makeTempHome();
+  writeRuntimeConfig(homeDir, (config) => {
+    config.local.backends.lmstudio.enabled = true;
+    config.routing = {
+      ...config.routing,
+      enabled: true,
+      defaultStart: 'general',
+      tiers: [
+        {
+          name: 'economy',
+          models: ['lmstudio/qwen/qwen2.5-vl'],
+        },
+        { name: 'general', models: ['gpt-4.1-mini'] },
+      ],
+    };
+  });
+  const taskRouting = await importFreshTaskRouting(homeDir);
+
+  for (const task of [...TASK_MODEL_KEYS, 'cv_narration'] as const) {
+    await expect(
+      taskRouting.resolveTaskModelPolicy(task, { agentId: 'main' }),
+    ).resolves.toMatchObject({
+      provider: 'lmstudio',
+      model: 'lmstudio/qwen/qwen2.5-vl',
+    });
+  }
+  const { getRuntimeConfig } = await import('../src/config/runtime-config.ts');
+  expect(getRuntimeConfig().plugins.list).toContainEqual(
+    expect.objectContaining({ id: 'tier-router', enabled: true }),
+  );
+});
+
+test('fails closed when routing enables an explicitly disabled tier router', async () => {
+  const homeDir = makeTempHome();
+  writeRuntimeConfig(homeDir, (config) => {
+    config.routing = {
+      ...config.routing,
+      enabled: true,
+      defaultStart: 'economy',
+      tiers: [{ name: 'economy', models: ['gpt-4.1-mini'] }],
+    };
+    config.plugins.list = [
+      { id: 'tier-router', enabled: false, config: {} },
+    ];
+  });
+
+  await importFreshTaskRouting(homeDir);
+  const { getRuntimeConfig } = await import('../src/config/runtime-config.ts');
+  expect(getRuntimeConfig().routing.enabled).toBe(false);
+  expect(getRuntimeConfig().plugins.list).not.toContainEqual(
+    expect.objectContaining({ id: 'tier-router', enabled: true }),
+  );
 });
 
 test('resolves configured auxiliary task through named local endpoint', async () => {

--- a/tests/tier-router-plugin.test.ts
+++ b/tests/tier-router-plugin.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test, vi } from 'vitest';
+import tierRouterPlugin from '../plugins/tier-router/src/index.js';
+import {
+  classifyRoutingTurn,
+  resolveTierRoutingDecision,
+} from '../plugins/tier-router/src/routing.js';
+
+const routing = {
+  enabled: true,
+  tiers: [
+    { name: 'economy', models: ['local/small'] },
+    { name: 'general', models: ['hai/medium'] },
+    { name: 'advanced', models: ['cloud/frontier'] },
+  ],
+  defaultStart: 'general',
+  escalationStickyTurns: 3,
+};
+
+describe('tier-router decision table', () => {
+  test.each([
+    [{ source: 'heartbeat' }, 'heartbeat'],
+    [{ channelType: 'heartbeat' }, 'heartbeat'],
+    [{ source: 'scheduler' }, 'scheduler'],
+    [{ channelType: 'scheduler' }, 'scheduler'],
+    [{ source: 'fullauto' }, 'fullauto'],
+    [{ source: 'fullauto.fanout' }, 'fullauto'],
+    [{ source: 'discord' }, 'agent'],
+  ])('classifies %o as %s', (context, expected) => {
+    expect(classifyRoutingTurn(context)).toBe(expected);
+  });
+
+  test.each(['heartbeat', 'scheduler', 'fullauto'])(
+    '%s turns start on the bottom rung',
+    (source) => {
+      expect(resolveTierRoutingDecision(routing, { source }, false)).toMatchObject(
+        {
+          taxonomy: source,
+          startTier: 'economy',
+          model: 'local/small',
+        },
+      );
+    },
+  );
+
+  test('uses an agent model as a start preference and sticky state as a floor', () => {
+    expect(
+      resolveTierRoutingDecision(
+        routing,
+        { source: 'discord', agentModel: 'local/small' },
+        false,
+      ),
+    ).toMatchObject({ startTier: 'economy', reason: 'agent-start' });
+    expect(
+      resolveTierRoutingDecision(
+        routing,
+        {
+          source: 'discord',
+          agentModel: 'local/small',
+          stickyTier: 'advanced',
+        },
+        false,
+      ),
+    ).toMatchObject({ startTier: 'advanced', reason: 'sticky-tier' });
+  });
+
+  test('never routes an explicitly pinned request or session', () => {
+    expect(
+      resolveTierRoutingDecision(
+        routing,
+        { source: 'discord', explicitModelPinned: true },
+        true,
+      ),
+    ).toBeNull();
+  });
+});
+
+test('/escalate raises exactly the next unpinned agent turn', async () => {
+  const api = {
+    config: { routing },
+    registerMiddleware: vi.fn(),
+    registerCommand: vi.fn(),
+  };
+  tierRouterPlugin.register(api);
+  const middleware = api.registerMiddleware.mock.calls[0]?.[0];
+  const command = api.registerCommand.mock.calls[0]?.[0];
+  expect(command.name).toBe('escalate');
+
+  await command.handler([], { sessionId: 'session-1' });
+  expect(
+    middleware.routing({
+      sessionId: 'session-1',
+      source: 'heartbeat',
+      explicitModelPinned: false,
+    }),
+  ).toMatchObject({
+    metadata: { tierRouter: { startTier: 'economy' } },
+  });
+  expect(
+    middleware.routing({
+      sessionId: 'session-1',
+      source: 'discord',
+      explicitModelPinned: true,
+    }),
+  ).toEqual({ action: 'allow' });
+  const context = {
+    sessionId: 'session-1',
+    source: 'discord',
+    explicitModelPinned: false,
+  };
+  expect(middleware.routing(context)).toMatchObject({
+    metadata: {
+      tierRouter: { startTier: 'advanced', reason: 'manual-escalate' },
+    },
+  });
+  expect(middleware.routing(context)).toMatchObject({
+    metadata: {
+      tierRouter: { startTier: 'general', reason: 'default-start' },
+    },
+  });
+});


### PR DESCRIPTION
## Summary

- add the bundled deterministic `tier-router` middleware and automatically enable it with model routing
- route heartbeat, scheduler, full-auto, and default auxiliary tasks from the bottom tier
- use agent models as start-tier preferences while preserving request, session, and onboarding pins as hard overrides
- execute agent turns through within-tier provider fallback and across-tier escalation
- add sticky tiers, de-escalation, and the one-shot `/escalate` command
- record `route.escalated` audit events and per-attempt routing fields in model usage telemetry

## User-facing impact

Yes, but there are no console or UI changes in this phase:

- operators can use `/escalate` to start the next unpinned agent turn one tier higher
- routed turns can transparently retry weak empty/narrate-only responses and escalate on classified auth, rate-limit, 5xx, or malformed-tool failures
- an agent's configured model is now a routing start preference rather than a hard pin; explicit request and session model selections remain pinned
- route tier, zone, reason, and escalation status are observable in audit and usage records

## Safety and failure boundaries

- never retry after a tool execution or while an approval is pending
- buffer streamed attempt events and discard deltas from failed attempts
- do not escalate unknown provider errors
- fail closed if routing is enabled while the bundled tier router is disabled or replaced
- keep explicit request/session model pins outside the ladder
- bound in-memory sticky and pending-escalation state

## Validation

- `npm run format`
- `npm run lint`
- `npm --prefix container run lint`
- `npm run build`
- targeted routing, gateway, fallback, task taxonomy, middleware, and concierge tests: 111 passed
- console tests: 830 passed
- desktop tests: 25 passed
- `git diff --check`

A full `npm run test:unit` run encountered four failures in `tests/gateway-service.fullauto.test.ts`. All four reproduced with every Phase 2 tracked implementation file restored to `HEAD`, so they are existing baseline failures rather than changes introduced here.

The live-fleet golden E2E exit gate was not run locally because it requires the deployed model fleet and credentials.