### PR TITLE
chore(deps): pin ua-parser-js to 1.x to drop AGPL from the tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,18 @@
   most permissive option. The gate runs in every existing dependency-policy
   entry point: the pre-commit hook, the CI lint job, `npm run deps:policy`,
   and `npm run release:check`.
+  `Manifesto: Principle VII - A coworker you can trust with real responsibility.`
 
+### Changed
+
+- **AGPL removed from the dependency tree**: `camoufox-js` now resolves
+  `ua-parser-js` 1.0.41 (MIT) through a scoped npm override instead of 2.0.10
+  (AGPL-3.0-or-later), retiring the `ua-parser-js@2.0.10` AGPL exception from
+  the license baseline. Known regression: `camoufox-js` matches the v2 spelling
+  `"macOS"` when deriving the target OS, so under v1 (`"Mac OS"`) every macOS
+  fingerprint is treated as Linux and receives Linux fonts, WebGL strings, and
+  environment variables. Camofox stealth is degraded for macOS fingerprints
+  until `determineUAOS` is patched.
   `Manifesto: Principle VII - A coworker you can trust with real responsibility.`
 
 ## [0.28.2](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.2) - 2026-07-17

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7342,6 +7342,32 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/camoufox-js/node_modules/ua-parser-js": {
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.41.tgz",
+      "integrity": "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001780",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
@@ -8594,26 +8620,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/detect-europe-js": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
-      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -10952,26 +10958,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
-    },
-    "node_modules/is-standalone-pwa": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
-      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ],
       "license": "MIT"
     },
     "node_modules/is-stream": {
@@ -15435,57 +15421,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/ua-is-frozen": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
-      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/ua-parser-js": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.10.tgz",
-      "integrity": "sha512-t+3Ktbq0Ies2vaSezfOaWiolH4OigQIO1dk+1xDpOydB1COVPocVYOrEV5rqZ0kFY9XYG1v9LutCyMgYBpABcw==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "license": "AGPL-3.0-or-later",
-      "dependencies": {
-        "detect-europe-js": "^0.1.2",
-        "is-standalone-pwa": "^0.1.1",
-        "ua-is-frozen": "^0.1.2"
-      },
-      "bin": {
-        "ua-parser-js": "script/cli.js"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/uc.micro": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7342,6 +7342,32 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/camoufox-js/node_modules/ua-parser-js": {
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.41.tgz",
+      "integrity": "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001780",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
@@ -8594,26 +8620,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/detect-europe-js": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
-      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -10952,26 +10958,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
-    },
-    "node_modules/is-standalone-pwa": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
-      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ],
       "license": "MIT"
     },
     "node_modules/is-stream": {
@@ -15435,57 +15421,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/ua-is-frozen": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
-      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/ua-parser-js": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.10.tgz",
-      "integrity": "sha512-t+3Ktbq0Ies2vaSezfOaWiolH4OigQIO1dk+1xDpOydB1COVPocVYOrEV5rqZ0kFY9XYG1v9LutCyMgYBpABcw==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "license": "AGPL-3.0-or-later",
-      "dependencies": {
-        "detect-europe-js": "^0.1.2",
-        "is-standalone-pwa": "^0.1.1",
-        "ua-is-frozen": "^0.1.2"
-      },
-      "bin": {
-        "ua-parser-js": "script/cli.js"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/uc.micro": {

--- a/package.json
+++ b/package.json
@@ -174,6 +174,9 @@
     "cheerio": {
       "undici": "7.28.0"
     },
+    "camoufox-js": {
+      "ua-parser-js": "1.0.41"
+    },
     "shell-quote": "1.8.4",
     "thrift": "0.23.0",
     "tmp": "0.2.7"

--- a/scripts/dependency-policy-baseline.json
+++ b/scripts/dependency-policy-baseline.json
@@ -1,13 +1,12 @@
 {
   "lockfiles": {
-    "package-lock.json": "6b6bea422a1300bb1329ff6316a1ef57bc43f50505a8748bf57663a97efcb377",
-    "npm-shrinkwrap.json": "6b6bea422a1300bb1329ff6316a1ef57bc43f50505a8748bf57663a97efcb377",
+    "package-lock.json": "e79294fbcff7aaeb4ba3e311b1e01bf6a931ad7fc6dfbf4a2610d7c62a28b713",
+    "npm-shrinkwrap.json": "e79294fbcff7aaeb4ba3e311b1e01bf6a931ad7fc6dfbf4a2610d7c62a28b713",
     "container/package-lock.json": "a3d00f6e8dba50b4d22fd799c4b37ac7682543c6b80dd5690d8bc6a8910ef50d",
     "container/npm-shrinkwrap.json": "a3d00f6e8dba50b4d22fd799c4b37ac7682543c6b80dd5690d8bc6a8910ef50d",
     "plugins/brevo-email/package-lock.json": "3377225eb3bdbb252eaa28ad420b9a725ea1da533417388557aa1984730229b5"
   },
   "licenses": {
-    "libsignal@6.0.0": "GPL-3.0",
-    "ua-parser-js@2.0.10": "AGPL-3.0-or-later"
+    "libsignal@6.0.0": "GPL-3.0"
   }
 }


### PR DESCRIPTION
## Summary

- **Problem:** `camoufox-js@0.10.2` pulled in `ua-parser-js@2.0.10`, which is `AGPL-3.0-or-later` — the only AGPL package in the dependency tree.
- **Why it matters:** AGPL in the tree is a licensing blocker for enterprise self-hosted deployment.
- **What changed:** An npm override scoped to `camoufox-js` forces `ua-parser-js@1.0.41` (MIT). Zero AGPL packages remain in the lock.
- **What did not change:** No product source. No container lockfiles. `camoufox-js` itself stays at 0.10.2.
- **Also:** retires the now-obsolete `ua-parser-js@2.0.10` AGPL exception from the `licenses` baseline added in #1339.

The override is scoped to `camoufox-js` rather than applied globally, so a future consumer that genuinely needs v2 won't silently receive v1. It is pinned exactly (`1.0.41`, not `^1.0.41`) per `scripts/check-dependency-policy.mjs`, matching the existing `cheerio` precedent in the `overrides` block. `camoufox-js` was the only consumer.

## ⚠️ Known regression — please read before approving

This ships a **deliberate, accepted** behavioral regression. `camoufox-js` `determineUAOS()` (`dist/utils.js:115`) matches on the v2 spelling:

```js
if (parsedUA.startsWith("macOS")) return "mac";
if (parsedUA.startsWith("Windows")) return "win";
return "lin";
```

v1 returns `"Mac OS"` for macOS UAs, so **every macOS fingerprint falls through to `"lin"`**.

This is **not** conditional on user config. `getTargetOS(config)` (`utils.js:359`) runs *after* `mergeInto(config, fromBrowserforge(...))`, which always populates `config["navigator.userAgent"]` — so it executes on every Camoufox launch. `targetOS` then feeds `updateFonts` (`:378`), `sampleWebGL` (`:446`, `:449`), and `getEnvVars` (`:478`).

Net effect: affected launches ship a **macOS user agent alongside Linux fonts, WebGL strings, and env vars** — a self-inconsistent fingerprint, which is the exact detection signal camoufox exists to suppress. It fails **silently**, with no error.

Reviewers should decide whether degraded Camofox stealth on macOS fingerprints is acceptable in the window before the follow-up patch lands. If Camofox is being used for stealth work today, this is arguably a blocker rather than a known issue.

### Rebased onto the new license gate

This branch was cut before #1339 landed the dependency license gate, which baselined `ua-parser-js@2.0.10: AGPL-3.0-or-later` as an approved exception. CI correctly failed the first push: the merge combined that exception with a lockfile where the package no longer exists, and the gate flags stale baseline entries.

Rebased onto `origin/main` and removed the exception — retiring it is precisely the outcome this PR is for. `libsignal@6.0.0 (GPL-3.0)` remains baselined and is untouched. The gate now reports zero AGPL packages and no stale entries.

## Change Type

- [x] Tooling or workflow

## Linked Context

- Related: client-bundle license audit (libsignal GPL-3, ua-parser-js@2 AGPL)
- Follow-up: patch `determineUAOS` to accept both `"Mac OS"` and `"macOS"`; requires introducing patch infrastructure (repo has no `patches/` dir or `patch-package` today)

## Manifesto Principle

- Principle: **VII — A coworker you can trust with real responsibility.** License provenance is part of what makes a deployment defensible to an enterprise reviewer.
- Changelog tag added: `Manifesto: Principle VII - A coworker you can trust with real responsibility.`

## Validation

```bash
node ./scripts/check-dependency-policy.mjs --base "$(git rev-parse origin/main)"  # exit 0 (CI lint form)
node ./scripts/check-dependency-policy.mjs                                        # exit 0 (release:check form)
cmp package-lock.json npm-shrinkwrap.json                                         # byte-identical
npx biome check CHANGELOG.md package.json scripts/dependency-policy-baseline.json
```

Both policy-check invocations that CI runs pass post-rebase. `npm run release:check` still reports missing `dist/*` and `console/dist/*` locally — build artifacts CI produces in an earlier step; the dependency-policy stage that actually failed is green.

- **Verified manually:** `ua-parser-js@2.0.10` is gone from the lock; `camoufox-js` resolves a nested `ua-parser-js@1.0.41` with `"license": "MIT"`. `grep AGPL package-lock.json` returns nothing.
- **Edge cases checked:** Confirmed `camoufox-js` was the sole consumer. Confirmed the new entry has `hasInstallScript: false`, so no new dependency lifecycle scripts. Confirmed container lockfiles are unchanged and still match their baseline hashes.
- **Regression reproduced empirically** against camoufox's own `fingerprint-generator`, replaying `determineUAOS` verbatim — **8/8** macOS Firefox fingerprints misroute (`v1=lin` vs `v2=mac`). Windows and Linux are unaffected; both versions agree. The other `UAParser` call site, `checkCustomFingerprint`, only reads `getBrowser().name` and behaves identically across versions.
- **Skipped checks and why:** No full `npm run test:unit` / `typecheck` — this PR touches no TypeScript, and `ua-parser-js` is a transitive dependency of `camoufox-js` with no direct import anywhere in `src/`.

### Process note for reviewers

`npm install --package-lock-only` writes to `npm-shrinkwrap.json` when it exists (it takes precedence), silently leaving `package-lock.json` stale. Since `scripts/sync-shrinkwraps.mjs` copies `package-lock.json` → shrinkwrap, the shrinkwrap edit would have been overwritten and lost. The correct sequence is: move the shrinkwrap aside, regenerate `package-lock.json`, then run the sync script. **`npm run deps:update-lockfile` has this same ordering hazard** and may deserve a separate fix.

## Docs And Config Impact

- [x] No docs or config impact

CHANGELOG updated under `## Unreleased`, including the known regression.

## Risk Notes

- Security-sensitive paths touched? **No** (no source changes)
- Gateway, audit, approval, or container boundaries touched? **No**
- Anti-detection posture affected? **Yes** — see the known-regression section. The failure mode is a silently inconsistent browser fingerprint on macOS, degrading stealth rather than causing an error.

## Evidence

- [x] Reproduction output: 8/8 macOS fingerprints misrouted under v1, verified with camoufox's own generator
- [x] `check-dependency-policy.mjs --base main` exits 0
- [ ] No new automated test — the regression test belongs with the follow-up patch that fixes it
