### PR TITLE
feat: gate dependency licenses on GPL/AGPL/SSPL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,6 +271,14 @@ hybridclaw gateway status             # gateway liveness, PID, build/version dia
   when practical, or copy the updated lockfile to its shrinkwrap pair and
   update the baseline hash after reviewing the lockfile diff. Run
   `npm run deps:policy` before handing off.
+- `npm run deps:policy` also enforces the license gate: packages with
+  GPL/AGPL/SSPL-family licenses fail unless their exact
+  `"<name>@<version>": "<license>"` pair is approved under `licenses` in
+  `scripts/dependency-policy-baseline.json` (add entries only after license
+  review). Weak-copyleft (LGPL/MPL/EPL/…) and unknown licenses are reported
+  but allowed; dual-licensed `(X OR Y)` packages count as their most
+  permissive option. See the header of `scripts/check-dependency-policy.mjs`
+  for the full policy.
 
 ### Git Discipline
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Added
+
+- **Dependency license gate**: `scripts/check-dependency-policy.mjs` now scans
+  every tracked `package-lock.json` and fails on GPL, AGPL, and SSPL-family
+  licenses unless the exact `name@version` and license pair is approved under
+  `licenses` in `scripts/dependency-policy-baseline.json`. Weak-copyleft
+  licenses such as LGPL and MPL, and packages with missing license metadata,
+  are reported without failing, and dual-licensed packages resolve to their
+  most permissive option. The gate runs in every existing dependency-policy
+  entry point: the pre-commit hook, the CI lint job, `npm run deps:policy`,
+  and `npm run release:check`.
+
+  `Manifesto: Principle VII - A coworker you can trust with real responsibility.`
+
 ## [0.28.2](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.2) - 2026-07-17
 
 ### Added

--- a/scripts/check-dependency-policy.mjs
+++ b/scripts/check-dependency-policy.mjs
@@ -1,5 +1,38 @@
 #!/usr/bin/env node
 
+// Dependency policy gate. Entry points: `npm run deps:policy`, the Husky
+// pre-commit hook (`--staged`), the CI lint job on pull requests
+// (`--base <sha>`), and `npm run release:check`.
+//
+// Enforced checks:
+// 1. Direct dependencies in tracked package.json files must be exact pins
+//    (or file:/link:/workspace:/pinned npm.jsr.io tarball specs).
+// 2. Each npm-shrinkwrap.json must byte-match its package-lock.json pair.
+// 3. Lockfile changes must be approved via the SHA-256 hashes under
+//    "lockfiles" in scripts/dependency-policy-baseline.json, and new
+//    dependency lifecycle scripts require explicit review.
+// 4. License gate over every tracked package-lock.json (shrinkwraps are
+//    covered by check 2), read from the lockfile `license` metadata:
+//    - Forbidden (fails): strong copyleft and source-restricted families —
+//      GPL, AGPL, SSPL. A package is only accepted when the "licenses"
+//      section of scripts/dependency-policy-baseline.json contains its exact
+//      "<name>@<version>": "<license>" pair, added after license review.
+//      Stale or mismatched baseline entries fail so the exception list stays
+//      honest.
+//    - Reported but allowed: weak/file-level copyleft (LGPL, MPL, EPL, EUPL,
+//      CDDL, OSL, CPAL), source-available/non-commercial (BUSL, CC-BY-NC),
+//      and packages with missing or unparseable license metadata (review
+//      those manually).
+//    - SPDX expressions: `OR` resolves to the most permissive branch, so
+//      dual-licensed packages such as jszip "(MIT OR GPL-3.0-or-later)"
+//      count as MIT and pass. `AND` resolves to the most restrictive part,
+//      and `WITH <exception>` is classified by its base license id.
+//
+// Escape hatches for local work in progress (CI never sets them):
+// HYBRIDCLAW_ALLOW_LOCKFILE_CHANGES=1,
+// HYBRIDCLAW_ALLOW_DEPENDENCY_LIFECYCLE_SCRIPTS=1, and
+// HYBRIDCLAW_ALLOW_LICENSE_VIOLATIONS=1 (license failures become warnings).
+
 import { spawnSync } from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
@@ -13,6 +46,7 @@ const SHRINKWRAP_PAIRS = [
 ];
 const ALLOW_LOCKFILE_CHANGES = 'HYBRIDCLAW_ALLOW_LOCKFILE_CHANGES';
 const ALLOW_LIFECYCLE_SCRIPTS = 'HYBRIDCLAW_ALLOW_DEPENDENCY_LIFECYCLE_SCRIPTS';
+const ALLOW_LICENSE_VIOLATIONS = 'HYBRIDCLAW_ALLOW_LICENSE_VIOLATIONS';
 
 const args = new Set(process.argv.slice(2));
 const checkStaged = args.has('--staged');
@@ -31,6 +65,10 @@ function parseValueArg(name) {
 function fail(message) {
   console.error(`dependency-policy: ${message}`);
   process.exitCode = 1;
+}
+
+function report(message) {
+  console.warn(`dependency-policy: ${message}`);
 }
 
 function runGit(gitArgs, options = {}) {
@@ -66,22 +104,22 @@ function isIgnoredDir(name) {
   );
 }
 
-function walkPackageJsons(dir, out = []) {
+function walkFilesNamed(dir, fileName, out = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     if (entry.isDirectory()) {
       if (!isIgnoredDir(entry.name))
-        walkPackageJsons(path.join(dir, entry.name), out);
+        walkFilesNamed(path.join(dir, entry.name), fileName, out);
       continue;
     }
-    if (entry.isFile() && entry.name === 'package.json') {
+    if (entry.isFile() && entry.name === fileName) {
       out.push(path.join(dir, entry.name));
     }
   }
   return out;
 }
 
-function listPackageJsons() {
-  const output = gitOutput(['ls-files', '*package.json']);
+function listTrackedFilesNamed(fileName) {
+  const output = gitOutput(['ls-files', `*${fileName}`]);
   if (output != null) {
     return output
       .split('\n')
@@ -89,7 +127,11 @@ function listPackageJsons() {
       .filter(Boolean)
       .map((filePath) => path.resolve(process.cwd(), filePath));
   }
-  return walkPackageJsons(process.cwd());
+  return walkFilesNamed(process.cwd(), fileName);
+}
+
+function listPackageJsons() {
+  return listTrackedFilesNamed('package.json');
 }
 
 function isPinnedExternalSpec(spec) {
@@ -162,6 +204,203 @@ function checkShrinkwrapsMatchLocks() {
         `${shrinkwrap} must match ${lockfile}; run npm run deps:update-lockfile.`,
       );
     }
+  }
+}
+
+const LICENSE_ALLOWED = 0;
+const LICENSE_REPORTED = 1;
+const LICENSE_FORBIDDEN = 2;
+
+function licenseIdSeverity(id) {
+  const normalized = id.toUpperCase();
+  if (normalized.startsWith('LGPL')) return LICENSE_REPORTED;
+  if (/^(AGPL|GPL|SSPL)/.test(normalized)) return LICENSE_FORBIDDEN;
+  if (/^(MPL|EPL|EUPL|CDDL|OSL|CPAL|BUSL|CC-BY-NC|UNLICENSED)/.test(normalized))
+    return LICENSE_REPORTED;
+  return LICENSE_ALLOWED;
+}
+
+function parseSpdxSeverity(expression) {
+  const tokens = expression
+    .replace(/([()])/g, ' $1 ')
+    .split(/\s+/)
+    .filter(Boolean);
+  let index = 0;
+
+  function parseUnit() {
+    const token = tokens[index++];
+    if (token === '(') {
+      const severity = parseOr();
+      if (tokens[index++] !== ')') throw new Error('expected )');
+      return severity;
+    }
+    if (token === undefined || token === ')' || /^(AND|OR|WITH)$/i.test(token))
+      throw new Error(`unexpected token ${token}`);
+    const severity = licenseIdSeverity(token);
+    if (index < tokens.length && /^WITH$/i.test(tokens[index])) {
+      index += 1;
+      const exception = tokens[index++];
+      if (exception === undefined || exception === '(' || exception === ')')
+        throw new Error('expected license exception id');
+    }
+    return severity;
+  }
+
+  function parseAnd() {
+    let severity = parseUnit();
+    while (index < tokens.length && /^AND$/i.test(tokens[index])) {
+      index += 1;
+      severity = Math.max(severity, parseUnit());
+    }
+    return severity;
+  }
+
+  function parseOr() {
+    let severity = parseAnd();
+    while (index < tokens.length && /^OR$/i.test(tokens[index])) {
+      index += 1;
+      severity = Math.min(severity, parseAnd());
+    }
+    return severity;
+  }
+
+  const severity = parseOr();
+  if (index !== tokens.length) throw new Error('trailing tokens');
+  return severity;
+}
+
+function classifyLicense(license) {
+  const raw =
+    typeof license === 'string'
+      ? license
+      : license &&
+          typeof license === 'object' &&
+          typeof license.type === 'string'
+        ? license.type
+        : '';
+  const expression = raw.trim();
+  if (!expression)
+    return { severity: LICENSE_REPORTED, unknown: true, expression: null };
+  try {
+    return {
+      severity: parseSpdxSeverity(expression),
+      unknown: false,
+      expression,
+    };
+  } catch {
+    return { severity: LICENSE_REPORTED, unknown: true, expression };
+  }
+}
+
+function lockfileLicenseEntries(lockfile) {
+  const entries = new Map();
+  const packages =
+    lockfile && typeof lockfile === 'object' ? lockfile.packages : null;
+  if (!packages || typeof packages !== 'object') return entries;
+  for (const [packagePath, entry] of Object.entries(packages)) {
+    if (!entry || typeof entry !== 'object') continue;
+    if (entry.link === true) continue;
+    const marker = packagePath.lastIndexOf('node_modules/');
+    if (marker === -1) continue;
+    const name =
+      typeof entry.name === 'string' && entry.name
+        ? entry.name
+        : packagePath.slice(marker + 'node_modules/'.length);
+    const version =
+      typeof entry.version === 'string' ? entry.version : 'unknown';
+    const key = `${name}@${version}`;
+    if (!entries.has(key)) entries.set(key, entry.license);
+  }
+  return entries;
+}
+
+function readLicenseBaseline() {
+  const parsed = readJsonFile(LOCKFILE_BASELINE_PATH);
+  if (!parsed || typeof parsed !== 'object') return {};
+  const licenses = parsed.licenses;
+  return licenses && typeof licenses === 'object' ? licenses : {};
+}
+
+function listPackageLocks() {
+  const repoRoot = process.cwd();
+  return listTrackedFilesNamed('package-lock.json')
+    .map((filePath) => path.relative(repoRoot, filePath))
+    .sort();
+}
+
+function checkLicenses() {
+  const baseline = readLicenseBaseline();
+  const usedBaselineKeys = new Set();
+  const failLicense =
+    process.env[ALLOW_LICENSE_VIOLATIONS] === '1'
+      ? (message) =>
+          report(`${ALLOW_LICENSE_VIOLATIONS}=1 override: ${message}`)
+      : fail;
+
+  for (const lockfilePath of listPackageLocks()) {
+    const lockfile = readJsonFile(lockfilePath);
+    if (!lockfile) {
+      failLicense(`${lockfilePath} could not be parsed for the license scan.`);
+      continue;
+    }
+    const baselined = [];
+    const reported = new Map();
+    const unknown = [];
+    const entries = [...lockfileLicenseEntries(lockfile)].sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    for (const [key, license] of entries) {
+      const {
+        severity,
+        unknown: isUnknown,
+        expression,
+      } = classifyLicense(license);
+      if (severity === LICENSE_FORBIDDEN) {
+        if (Object.hasOwn(baseline, key) && baseline[key] === expression) {
+          usedBaselineKeys.add(key);
+          baselined.push(`${key} (${expression})`);
+        } else if (Object.hasOwn(baseline, key)) {
+          usedBaselineKeys.add(key);
+          failLicense(
+            `${lockfilePath}: ${key} license ${JSON.stringify(expression)} does not match its "licenses" baseline entry ${JSON.stringify(baseline[key])} in ${LOCKFILE_BASELINE_PATH}; re-review the package and update the entry.`,
+          );
+        } else {
+          failLicense(
+            `${lockfilePath}: ${key} has forbidden license ${JSON.stringify(expression)} (GPL/AGPL/SSPL family). Remove the dependency or, after license review, add ${JSON.stringify(key)}: ${JSON.stringify(expression)} to "licenses" in ${LOCKFILE_BASELINE_PATH}.`,
+          );
+        }
+        continue;
+      }
+      if (isUnknown) {
+        unknown.push(
+          expression ? `${key} (${JSON.stringify(expression)})` : key,
+        );
+      } else if (severity === LICENSE_REPORTED) {
+        if (!reported.has(expression)) reported.set(expression, []);
+        reported.get(expression).push(key);
+      }
+    }
+    if (baselined.length > 0)
+      report(
+        `${lockfilePath}: baselined copyleft exceptions: ${baselined.join(', ')}.`,
+      );
+    for (const [expression, keys] of [...reported].sort(([a], [b]) =>
+      a.localeCompare(b),
+    ))
+      report(
+        `${lockfilePath}: ${expression} (allowed, reported): ${keys.join(', ')}.`,
+      );
+    if (unknown.length > 0)
+      report(
+        `${lockfilePath}: unknown license metadata (review manually): ${unknown.join(', ')}.`,
+      );
+  }
+
+  for (const key of Object.keys(baseline).sort()) {
+    if (usedBaselineKeys.has(key)) continue;
+    failLicense(
+      `stale "licenses" baseline entry ${key} matches no lockfile package; remove it from ${LOCKFILE_BASELINE_PATH}.`,
+    );
   }
 }
 
@@ -336,5 +575,6 @@ function checkStagedLockfiles() {
 
 checkPinnedDirectDependencies();
 checkShrinkwrapsMatchLocks();
+checkLicenses();
 if (baseRef) checkChangedLockfilesAgainstBase(baseRef);
 if (checkStaged) checkStagedLockfiles();

--- a/scripts/dependency-policy-baseline.json
+++ b/scripts/dependency-policy-baseline.json
@@ -5,5 +5,9 @@
     "container/package-lock.json": "a3d00f6e8dba50b4d22fd799c4b37ac7682543c6b80dd5690d8bc6a8910ef50d",
     "container/npm-shrinkwrap.json": "a3d00f6e8dba50b4d22fd799c4b37ac7682543c6b80dd5690d8bc6a8910ef50d",
     "plugins/brevo-email/package-lock.json": "3377225eb3bdbb252eaa28ad420b9a725ea1da533417388557aa1984730229b5"
+  },
+  "licenses": {
+    "libsignal@6.0.0": "GPL-3.0",
+    "ua-parser-js@2.0.10": "AGPL-3.0-or-later"
   }
 }


### PR DESCRIPTION
## Summary

- **Problem:** `scripts/check-dependency-policy.mjs` guarded lockfile changes and lifecycle scripts, but nothing checked licenses. The 2026-07-18 audit found two copyleft packages sitting in the runtime tree unnoticed: `libsignal@6.0.0` (GPL-3.0, via `@whiskeysockets/baileys`) and `ua-parser-js@2.0.10` (AGPL-3.0-or-later, via `camoufox-js`).
- **Why it matters:** licenses are the remaining unguarded axis of dependency risk for client-bundled deliveries, and a transitive GPL/AGPL dep can arrive in a routine lockfile bump with no signal.
- **What changed:** a license gate in the same script, failing on GPL/AGPL/SSPL unless the exact `name@version` and license pair is approved in the existing baseline file. The two audited packages are baselined so this PR is a no-op on current `main` content.
- **What did not change:** no dependency was added, removed, or repinned; no lockfile or shrinkwrap bytes changed; the existing pinned-deps, shrinkwrap-match, lockfile-hash, and lifecycle-script checks are untouched.

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Tests
- [ ] Refactor required for the fix
- [x] Tooling or workflow
- [x] Security hardening

## Linked Context

- Closes #
- Related #

## Manifesto Principle

- Principle: **VII. A coworker you can trust with real responsibility** — supply-chain provenance and license compliance are part of what makes a deployment auditable rather than a demo.
- Changelog tag added or updated: `Manifesto: Principle VII - A coworker you can trust with real responsibility.`

## How it works

**Data source.** The scan parses the `license` metadata in every tracked `package-lock.json` (root, `container/`, `plugins/brevo-email/`) rather than walking `node_modules`. Lockfile v3 carries a license for 1258 of 1273 entries, so the gate is deterministic from committed bytes and needs no install or network — important for the pre-commit path. Shrinkwraps are skipped because the existing check already forces them to byte-match their lock pair.

**Classification.**

| Bucket | Licenses | Behavior |
| --- | --- | --- |
| Forbidden | GPL, AGPL, SSPL | Fails unless baselined |
| Reported | LGPL, MPL, EPL, EUPL, CDDL, OSL, CPAL, BUSL, CC-BY-NC | Prints, exit 0 |
| Reported | missing or unparseable metadata | Prints, exit 0 |
| Allowed | everything else | Silent |

SPDX expressions go through a small recursive parser: `OR` resolves to its most permissive branch, `AND` to its most restrictive, and `WITH <exception>` classifies by base license id. So `jszip`'s `(MIT OR GPL-3.0-or-later)` counts as MIT and passes, while sharp's `Apache-2.0 AND LGPL-3.0-or-later` reports as LGPL.

**Baseline.** Approvals live in a new `licenses` section of `scripts/dependency-policy-baseline.json`, keyed `"name@version": "license"`, deliberately mirroring how lockfile hashes are already approved there. The pairing is exact in both directions: a version bump invalidates the approval, a changed license string fails with a re-review message, and an entry that matches no lockfile package fails as stale. The exception list cannot silently rot as dependencies move.

**Wiring.** The check runs unconditionally inside the script, so all four existing entry points pick it up with no changes to CI YAML, `package.json`, or the Husky hook: pre-commit (`--staged`), the CI lint job on PRs (`--base <sha>`), `npm run deps:policy`, and `npm run release:check`.

**Escape hatch.** `HYBRIDCLAW_ALLOW_LICENSE_VIOLATIONS=1` downgrades license failures to warnings for local work in progress, matching the two existing override env vars. CI never sets it.

## Validation

```bash
node scripts/check-dependency-policy.mjs            # exit 0
node scripts/check-dependency-policy.mjs --staged   # exit 0
node scripts/check-dependency-policy.mjs --base HEAD # exit 0
npx biome check scripts/check-dependency-policy.mjs scripts/dependency-policy-baseline.json
npm run format
npm run lint
```

- **Verified manually:** all three script modes pass against the real repo. The two baselined exceptions print, LGPL/MPL packages report grouped by license expression, and `jszip`/`@zone-eu/mailsplit` pass silently via OR-resolution. The pre-commit hook ran the gate live while creating this PR's commit (output in Evidence).
- **Edge cases checked**, via a throwaway fixture lockfile:
  - unbaselined GPL and AGPL both fail with an actionable message naming the exact baseline line to add;
  - an npm-aliased package resolves to its real name through `entry.name` (`node_modules/alias` → `real-agpl@4.0.0`), so aliasing does not evade the gate;
  - `GPL-2.0-only WITH Classpath-exception-2.0` is caught by its base id;
  - baselining an exact pair passes; changing the version or the license string fails; an entry matching nothing fails as stale;
  - `(MIT OR GPL-3.0-or-later)` passes, `Apache-2.0 AND LGPL-3.0-or-later` reports, `(MIT AND (LGPL-2.1-or-later OR BSD-3-Clause))` resolves through nested parens;
  - `link: true` workspace entries and the lockfile root are skipped, so first-party workspace packages are not scanned as third-party;
  - unparseable (`SEE LICENSE IN LICENSE.md`) and absent license fields land in the reported bucket rather than throwing;
  - `HYBRIDCLAW_ALLOW_LICENSE_VIOLATIONS=1` turns the failures into warnings and returns exit 0.
- **Skipped checks and why:** no unit test file was added — `scripts/` has no existing JS test harness (only `install.test.sh`), and adding one for a single script felt out of scope for this PR. The fixture above was run manually. Happy to add a permanent fixture-based test if reviewers want the coverage.

## Docs And Config Impact

- [x] README, docs, or examples updated — `AGENTS.md` gained a bullet in the dependency section; the full policy is documented in the `check-dependency-policy.mjs` header per the repo's convention of keeping script policy next to the script.
- [x] Config or environment behavior changed — new `licenses` section in the baseline file, new `HYBRIDCLAW_ALLOW_LICENSE_VIOLATIONS` env var.
- [ ] Templates or workspace bootstrap files changed
- [ ] No docs or config impact

`templates/` was not touched, so `src/workspace.ts` is unaffected.

## Risk Notes

- Security-sensitive paths touched? **No** — this is CI tooling; it reads lockfiles and writes to stdout/stderr. It touches no runtime, gateway, or credential path.
- Gateway, audit, approval, or container boundaries touched? **No.**
- Main failure mode is a **false positive blocking CI** on a future dependency bump. That is the intended behavior, and the message names the exact baseline entry to add after review; `HYBRIDCLAW_ALLOW_LICENSE_VIOLATIONS=1` unblocks local work meanwhile. The inverse risk is worth stating plainly: this gate checks *declared* metadata, so a package that omits or misstates its license lands in the reported bucket rather than failing. It raises the floor on accidental copyleft ingestion; it is not tamper-proof against a hostile publisher.

## Secret Handling Checklist

Not applicable — no secret material is read, stored, injected, displayed, logged, or documented. The script's only inputs are tracked lockfiles and `package.json` files, and its only outputs are policy messages on stdout/stderr.

## Evidence

Pre-commit hook output while committing this change (the gate running in a real entry point):

```
dependency-policy: package-lock.json: baselined copyleft exceptions: libsignal@6.0.0 (GPL-3.0), ua-parser-js@2.0.10 (AGPL-3.0-or-later).
dependency-policy: package-lock.json: LGPL-3.0-or-later (allowed, reported): @img/sharp-libvips-darwin-arm64@1.2.4, @img/sharp-libvips-darwin-x64@1.2.4, ... (10 packages)
dependency-policy: package-lock.json: MPL-2.0 (allowed, reported): camoufox-js@0.10.2, lightningcss@1.32.0, ... (13 packages)
dependency-policy: package-lock.json: unknown license metadata (review manually): @jsr/evex__linejs-types@3.1.4, @jsr/evex__linejs@3.1.3, @jsr/evex__loose-types@1.0.1, khroma@2.1.0, node-bignumber@1.2.2, qrcode-terminal@0.12.0.
```

Failing output before, on the fixture with the baseline removed:

```
dependency-policy: package-lock.json: gpl-pkg@1.0.0 has forbidden license "GPL-3.0" (GPL/AGPL/SSPL family). Remove the dependency or, after license review, add "gpl-pkg@1.0.0": "GPL-3.0" to "licenses" in scripts/dependency-policy-baseline.json.
exit=1
```

- [x] Failing output before and passing output after
- [ ] Screenshot or recording
- [x] Log snippet
- [ ] New or updated test coverage

## Notes for reviewers

Two things the scan surfaced that this PR deliberately does **not** act on:

1. **The two baselined packages are baselined, not fixed.** Per the audit, `ua-parser-js` has a clean remediation (an npm `overrides` pin to `^1.0.41`, MIT, same API, single call site in `camoufox-js`), while `libsignal` is statically imported through the WhatsApp channel and needs a product decision about bundling. Both belong in follow-up PRs; the baseline records them as known and reviewed so this gate can land green today.
2. **Six packages declare no license at all** — `khroma`, `node-bignumber`, `qrcode-terminal`, and three `@jsr/evex__linejs*` packages. They are reported on every run but do not fail. Worth a separate look; failing on them today would block CI on pre-existing state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
