### PR TITLE
feat: recognize Codex 5.6 models (Sol, Terra, Luna)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **Codex 5.6 models**: `openai-codex/gpt-5.6-sol`, `openai-codex/gpt-5.6-terra`,
+  and `openai-codex/gpt-5.6-luna` are now recognised as forward-compatible Codex
+  models, so they are selectable as soon as the Codex account offers them
+  instead of waiting for the discovery endpoint to list them.
+
+  `Manifesto: Principle VIII - A coworker doesn't break overnight.`
+
 - **Dependency license gate**: `scripts/check-dependency-policy.mjs` now scans
   every tracked `package-lock.json` and fails on GPL, AGPL, and SSPL-family
   licenses unless the exact `name@version` and license pair is approved under

--- a/src/providers/codex-discovery.ts
+++ b/src/providers/codex-discovery.ts
@@ -55,6 +55,18 @@ const CODEX_FORWARD_COMPAT_MODELS = [
       'openai-codex/gpt-5.2-codex',
     ],
   },
+  {
+    model: 'openai-codex/gpt-5.6-sol',
+    templateModels: ['openai-codex/gpt-5.5', 'openai-codex/gpt-5.4'],
+  },
+  {
+    model: 'openai-codex/gpt-5.6-terra',
+    templateModels: ['openai-codex/gpt-5.5', 'openai-codex/gpt-5.4'],
+  },
+  {
+    model: 'openai-codex/gpt-5.6-luna',
+    templateModels: ['openai-codex/gpt-5.5', 'openai-codex/gpt-5.4'],
+  },
 ] as const;
 
 function normalizeCodexModelName(modelId: string): string {

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -422,7 +422,7 @@ test('getGatewayStatus includes Codex auth state', async () => {
   expect(status.providerHealth?.codex).toMatchObject({
     kind: 'remote',
     reachable: true,
-    modelCount: 9,
+    modelCount: 12,
   });
   const codexRequest = fetchMock.mock.calls
     .map(([input, init]) => ({
@@ -522,7 +522,7 @@ test('getGatewayAdminModels discovers Codex models from the models endpoint', as
   const result = await getGatewayAdminModels();
 
   expect(result.providerStatus?.codex).toMatchObject({
-    modelCount: 9,
+    modelCount: 12,
   });
   const codexRequest = fetchMock.mock.calls
     .map(([input, init]) => ({

--- a/tests/model-catalog.test.ts
+++ b/tests/model-catalog.test.ts
@@ -668,6 +668,9 @@ test('available model catalog discovers Codex models from the models endpoint', 
     'openai-codex/gpt-5.4',
     'openai-codex/gpt-5.4-mini',
     'openai-codex/gpt-5.5',
+    'openai-codex/gpt-5.6-luna',
+    'openai-codex/gpt-5.6-sol',
+    'openai-codex/gpt-5.6-terra',
   ]);
   const codexRequest = fetchMock.mock.calls
     .map(([input, init]) => ({
@@ -1043,6 +1046,9 @@ test('available model catalog discovers Codex models from the current models pay
     'openai-codex/gpt-5.4',
     'openai-codex/gpt-5.4-mini',
     'openai-codex/gpt-5.5',
+    'openai-codex/gpt-5.6-luna',
+    'openai-codex/gpt-5.6-sol',
+    'openai-codex/gpt-5.6-terra',
   ]);
   expect(catalog.getAvailableModelList('codex')).not.toContain(
     'openai-codex/GPT-5.2 Codex (Preview)',


### PR DESCRIPTION
## Summary

- Problem: The Codex model picker now offers **5.6 Sol**, **5.6 Terra**, and **5.6 Luna**, but HybridClaw's forward-compat Codex list in `src/providers/codex-discovery.ts` topped out at `gpt-5.5` / `gpt-5.3-codex-spark`.
- Why it matters: Forward-compat entries exist so a newly-released Codex model is selectable immediately rather than only once the Codex discovery endpoint starts listing it. Without them the 5.6 line is invisible to model selection and routing.
- What changed: Added `openai-codex/gpt-5.6-sol`, `openai-codex/gpt-5.6-terra`, and `openai-codex/gpt-5.6-luna`, each templated off `gpt-5.5`/`gpt-5.4`. Updated the two `tests/model-catalog.test.ts` fixtures that assert the exact Codex catalog, and added a CHANGELOG entry.
- What did not change: No discovery, auth, routing, or request-shape logic. Live discovery still wins; these entries only surface a model the account may already have.

## Change Type

- [x] Feature
- [ ] Bug fix
- [ ] Docs
- [ ] Tests
- [ ] Refactor required for the fix
- [ ] Tooling or workflow
- [ ] Security hardening

## Linked Context

- Closes #
- Related #

## Manifesto Principle

- Principle: VIII — A coworker doesn't break overnight (a new provider model is usable on release day rather than after a discovery-endpoint lag).
- Changelog tag added or updated: `Manifesto: Principle VIII - A coworker doesn't break overnight.`

## Validation

```bash
npx vitest run tests/codex-discovery.test.ts tests/model-catalog.test.ts   # 25 passed
npx vitest run tests/gateway-status.test.ts                                # 75 passed
npx tsc --noEmit -p tsconfig.json                                          # clean
npx vitest run tests/                                                      # see note below
```

- Verified manually: confirmed the naming convention against the existing catalog — the picker's "5.3 Codex Spark" maps to `gpt-5.3-codex-spark` and "5.5" to `gpt-5.5`, so "5.6 Luna" maps to `gpt-5.6-luna`. `gpt-5.6-luna` is independently confirmed to exist as a real model id (it serves successfully through both the HybridAI API and OpenAI directly).
- Edge cases checked: forward-compat entries only apply when a template model was discovered, so an account without `gpt-5.4`/`gpt-5.5` does not get phantom 5.6 entries; `appendForwardCompatCodexModels` dedupes against live discovery, so no duplicates once the endpoint reports them.
- **CI fix (commit 2):** the first push failed CI on two `tests/gateway-status.test.ts` fixtures asserting the exact Codex provider `modelCount` (9 -> 12). I had only run the two test files I expected to be affected; the full suite would have caught it locally. Now fixed and the full suite has been run.
- **Full-suite note:** `npx vitest run tests/` reports failures in `admin-terminal`, `eval-command`, `host-runner.*`, and (run-to-run) `discord-webhook` / `whatsapp.inbound` / `gateway-admin-tokens`. These are pre-existing and flaky on `main` — the set churns between runs and none touch Codex or model discovery. All Codex, model-catalog, and gateway-status tests pass.
- Skipped checks and why: no live Codex call — this changes a static list only, and discovery behavior is covered by the existing mocked tests.

## Docs And Config Impact

- [x] README, docs, or examples updated (CHANGELOG entry)
- [ ] Config or environment behavior changed
- [ ] Templates or workspace bootstrap files changed
- [ ] No docs or config impact

## Risk Notes

- Security-sensitive paths touched? No
- Gateway, audit, approval, or container boundaries touched? No

Worth a reviewer's eye: the `sol` and `terra` model ids are inferred from the picker's display names by the established convention, whereas `luna` is directly confirmed. If Codex uses different slugs for those two, they would surface as selectable names that fail at call time — trivially fixable, but worth confirming against `GET /v1/models` on a Codex-enabled account.

## Evidence

```
 Test Files  2 passed (2)
      Tests  25 passed (25)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
