### PR TITLE
fix: expose prompt-cache usage through the OpenAI-compatible API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Prompt-cache usage is now visible through the OpenAI-compatible API**: the
+  gateway parsed upstream cache reads and writes internally but dropped them
+  when building the response, so clients could not tell a cold cache from a
+  fully cached prompt. `usage` now carries `prompt_tokens_details.cached_tokens`
+  (and `cache_creation_input_tokens` when the provider reports cache writes),
+  emitted only when the provider actually reported cache usage — a missing
+  field means "not reported" while an explicit `0` means "no cache hit". The
+  tool-aware passthrough path previously hard-coded cache usage to zero and now
+  reads both OpenAI-style (`prompt_tokens_details.cached_tokens`) and
+  Anthropic-style (`cache_read_input_tokens`) spellings.
+
+  `Manifesto: Principle IX - A coworker thinks before they spend.`
+
 ### Added
 
 - **Dependency license gate**: `scripts/check-dependency-policy.mjs` now scans

--- a/src/gateway/openai-compatible-model.ts
+++ b/src/gateway/openai-compatible-model.ts
@@ -31,6 +31,24 @@ export type OpenAICompatibleToolChoice =
       };
     };
 
+// Upstream usage payload. Cache fields are optional and spelled differently
+// per provider family (OpenAI-style prompt_tokens_details.cached_tokens vs
+// Anthropic-style cache_read_input_tokens), so accept both spellings rather
+// than dropping cache usage for whichever provider did not match.
+export interface OpenAICompatibleUsagePayload {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  cached_tokens?: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+  prompt_tokens_details?: {
+    cached_tokens?: number;
+  };
+}
+
 export interface OpenAICompatibleModelResponse {
   id: string;
   model: string;
@@ -42,13 +60,7 @@ export interface OpenAICompatibleModelResponse {
     };
     finish_reason: string;
   }>;
-  usage?: {
-    prompt_tokens?: number;
-    completion_tokens?: number;
-    total_tokens?: number;
-    input_tokens?: number;
-    output_tokens?: number;
-  };
+  usage?: OpenAICompatibleUsagePayload;
 }
 
 interface OpenAICompatibleModelCallParams {
@@ -665,26 +677,29 @@ export async function callOpenAICompatibleModelStream(
   };
 }
 
-export function mapOpenAICompatibleUsageToTokenStats(usage?: {
-  prompt_tokens?: number;
-  completion_tokens?: number;
-  total_tokens?: number;
-  input_tokens?: number;
-  output_tokens?: number;
-}): TokenUsageStats | undefined {
+export function mapOpenAICompatibleUsageToTokenStats(
+  usage?: OpenAICompatibleUsagePayload,
+): TokenUsageStats | undefined {
   if (!usage) return undefined;
   const promptTokens = usage.prompt_tokens ?? usage.input_tokens ?? 0;
   const completionTokens = usage.completion_tokens ?? usage.output_tokens ?? 0;
   const totalTokens = usage.total_tokens ?? promptTokens + completionTokens;
+  const cacheReadTokens =
+    usage.prompt_tokens_details?.cached_tokens ??
+    usage.cached_tokens ??
+    usage.cache_read_input_tokens;
+  const cacheWriteTokens = usage.cache_creation_input_tokens;
+  const cacheUsageAvailable =
+    cacheReadTokens !== undefined || cacheWriteTokens !== undefined;
   return {
     modelCalls: 1,
     apiUsageAvailable: true,
     apiPromptTokens: promptTokens,
     apiCompletionTokens: completionTokens,
     apiTotalTokens: totalTokens,
-    apiCacheUsageAvailable: false,
-    apiCacheReadTokens: 0,
-    apiCacheWriteTokens: 0,
+    apiCacheUsageAvailable: cacheUsageAvailable,
+    apiCacheReadTokens: cacheReadTokens ?? 0,
+    apiCacheWriteTokens: cacheWriteTokens ?? 0,
     estimatedPromptTokens: promptTokens,
     estimatedCompletionTokens: completionTokens,
     estimatedTotalTokens: totalTokens,

--- a/src/gateway/openai-compatible-response.ts
+++ b/src/gateway/openai-compatible-response.ts
@@ -37,6 +37,8 @@ export function mapOpenAICompatibleUsage(tokenUsage?: TokenUsageStats): {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
+  prompt_tokens_details?: { cached_tokens: number };
+  cache_creation_input_tokens?: number;
 } {
   const promptTokens = tokenUsage?.apiUsageAvailable
     ? tokenUsage.apiPromptTokens
@@ -51,6 +53,20 @@ export function mapOpenAICompatibleUsage(tokenUsage?: TokenUsageStats): {
     prompt_tokens: promptTokens,
     completion_tokens: completionTokens,
     total_tokens: totalTokens,
+    // Only emitted when the upstream provider actually reported cache usage,
+    // so a missing field means "not reported" and an explicit 0 means "no
+    // cache hit" — collapsing the two would make a cold cache indistinguishable
+    // from a provider that does not report caching at all.
+    ...(tokenUsage?.apiCacheUsageAvailable
+      ? {
+          prompt_tokens_details: {
+            cached_tokens: tokenUsage.apiCacheReadTokens,
+          },
+          ...(tokenUsage.apiCacheWriteTokens > 0
+            ? { cache_creation_input_tokens: tokenUsage.apiCacheWriteTokens }
+            : {}),
+        }
+      : {}),
   };
 }
 

--- a/tests/openai-compatible-model.test.ts
+++ b/tests/openai-compatible-model.test.ts
@@ -3,7 +3,9 @@ import { afterEach, expect, test, vi } from 'vitest';
 import {
   callOpenAICompatibleModel,
   callOpenAICompatibleModelStream,
+  mapOpenAICompatibleUsageToTokenStats,
 } from '../src/gateway/openai-compatible-model.js';
+import { mapOpenAICompatibleUsage } from '../src/gateway/openai-compatible-response.js';
 
 function makeEventStreamResponse(chunks: string[]): Response {
   const encoder = new TextEncoder();
@@ -658,3 +660,89 @@ test.each([
     expect(result.choices[0]?.message.content).toBe('ok');
   },
 );
+
+test('maps OpenAI-style cached prompt tokens into token stats', () => {
+  const stats = mapOpenAICompatibleUsageToTokenStats({
+    prompt_tokens: 14203,
+    completion_tokens: 10,
+    total_tokens: 14213,
+    prompt_tokens_details: { cached_tokens: 14203 },
+  });
+
+  expect(stats).toMatchObject({
+    apiPromptTokens: 14203,
+    apiCacheUsageAvailable: true,
+    apiCacheReadTokens: 14203,
+  });
+});
+
+test('maps Anthropic-style cache usage into token stats', () => {
+  const stats = mapOpenAICompatibleUsageToTokenStats({
+    input_tokens: 5000,
+    output_tokens: 20,
+    cache_read_input_tokens: 4000,
+    cache_creation_input_tokens: 1000,
+  });
+
+  expect(stats).toMatchObject({
+    apiCacheUsageAvailable: true,
+    apiCacheReadTokens: 4000,
+    apiCacheWriteTokens: 1000,
+  });
+});
+
+test('reports a cold cache as available with zero reads', () => {
+  const stats = mapOpenAICompatibleUsageToTokenStats({
+    prompt_tokens: 20,
+    completion_tokens: 5,
+    prompt_tokens_details: { cached_tokens: 0 },
+  });
+
+  // An explicit 0 is a real cache miss and must stay distinguishable from a
+  // provider that reports no cache fields at all.
+  expect(stats?.apiCacheUsageAvailable).toBe(true);
+  expect(stats?.apiCacheReadTokens).toBe(0);
+});
+
+test('leaves cache usage unavailable when the provider reports none', () => {
+  const stats = mapOpenAICompatibleUsageToTokenStats({
+    prompt_tokens: 20,
+    completion_tokens: 5,
+  });
+
+  expect(stats?.apiCacheUsageAvailable).toBe(false);
+});
+
+test('emits cache usage in the OpenAI-compatible response only when reported', () => {
+  const withCache = mapOpenAICompatibleUsage({
+    modelCalls: 1,
+    apiUsageAvailable: true,
+    apiPromptTokens: 37651,
+    apiCompletionTokens: 21,
+    apiTotalTokens: 37672,
+    apiCacheUsageAvailable: true,
+    apiCacheReadTokens: 37000,
+    apiCacheWriteTokens: 651,
+    estimatedPromptTokens: 0,
+    estimatedCompletionTokens: 0,
+    estimatedTotalTokens: 0,
+  });
+  expect(withCache.prompt_tokens_details).toEqual({ cached_tokens: 37000 });
+  expect(withCache.cache_creation_input_tokens).toBe(651);
+
+  const withoutCache = mapOpenAICompatibleUsage({
+    modelCalls: 1,
+    apiUsageAvailable: true,
+    apiPromptTokens: 100,
+    apiCompletionTokens: 10,
+    apiTotalTokens: 110,
+    apiCacheUsageAvailable: false,
+    apiCacheReadTokens: 0,
+    apiCacheWriteTokens: 0,
+    estimatedPromptTokens: 0,
+    estimatedCompletionTokens: 0,
+    estimatedTotalTokens: 0,
+  });
+  expect(withoutCache.prompt_tokens_details).toBeUndefined();
+  expect(withoutCache.cache_creation_input_tokens).toBeUndefined();
+});


### PR DESCRIPTION
## Summary

- Problem: HybridClaw parses upstream prompt-cache reads and writes in the container layer (`container/src/token-usage.ts`), and `TokenUsageStats` carries them as `apiCacheReadTokens` / `apiCacheWriteTokens` — but the gateway dropped them when building the OpenAI-compatible response. Clients could not tell a cold cache from a fully cached prompt through HybridClaw's own API.
- Why it matters: The gateway assembles very large agent prompts (~37K tokens on a trivial request in local measurement), so whether that prefix is cached dominates both latency and cost. Cache performance was unobservable at exactly the layer where it matters most, which made "is the prefix being re-processed every request?" unanswerable without bypassing the gateway.
- What changed: `mapOpenAICompatibleUsage` now emits `prompt_tokens_details.cached_tokens`, plus `cache_creation_input_tokens` when the provider reports cache writes. A second drop point in the tool-aware passthrough path (`mapOpenAICompatibleUsageToTokenStats`) hard-coded `apiCacheUsageAvailable: false` and both counts to `0`; it now reads OpenAI-style and Anthropic-style spellings. Adds 5 unit tests and a CHANGELOG entry.
- What did not change: No latency, routing, prompt-assembly, or caching *behavior* — this is purely reporting fields that were already computed. Non-cache usage numbers are byte-identical.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Tests
- [ ] Refactor required for the fix
- [ ] Tooling or workflow
- [ ] Security hardening

## Linked Context

- Closes #
- Related #

## Manifesto Principle

- Principle: IX — A coworker thinks before they spend (you cannot control prompt-cache spend you cannot measure).
- Changelog tag added or updated: `Manifesto: Principle IX - A coworker thinks before they spend.`

## Design note for reviewers

Cache fields are emitted **only when the provider actually reported cache usage**. This preserves a distinction that matters for diagnosis: a **missing** field means "provider did not report caching", while an explicit **`0`** means "reported, and it was a genuine miss". Always emitting `cached_tokens: 0` would make a cold cache indistinguishable from a provider that has no caching at all — which is precisely the ambiguity that made this bug hard to spot.

## Validation

```bash
npx tsc --noEmit -p tsconfig.json                        # clean
npx biome check <changed files>                          # clean
npx vitest run tests/openai-compatible-model.test.ts     # 18 passed (5 new)
npx vitest run tests/                                    # see note below
```

- Verified manually: traced the full path — `container/src/token-usage.ts:159` parses the cache fields, `TokenUsageStats` (`src/types/usage.ts:7-9`) carries them, and both gateway emit paths (non-streaming `buildOpenAICompatibleCompletionResponse` and streaming `buildOpenAICompatibleStreamUsageChunk`) route through the single mapper that was dropping them, so one fix covers both.
- Edge cases checked: OpenAI-style `prompt_tokens_details.cached_tokens`; Anthropic-style `cache_read_input_tokens` + `cache_creation_input_tokens`; bare `cached_tokens`; explicit `0` (cold cache, must stay reported); provider reporting no cache fields at all (must stay unreported); cache write of 0 (omitted rather than emitted as noise).
- **Full-suite note:** `npx vitest run tests/` reports 10 failures in 5 files (`admin-terminal`, `eval-command`, `gateway-admin-tokens`, `host-runner.redaction`, `host-runner.worker-restart`). These are **pre-existing on `main`** — I stashed this branch's changes and ran the suite against unmodified `origin/main`, which produced an identical failure set (5 files / 10 tests). Passed counts differ by exactly 5, which is the 5 tests added here. None of the failing files touch the OpenAI-compatible layer.
- Skipped checks and why: no live provider call — the change is a pure mapping of already-parsed fields, covered by unit tests against both provider usage shapes.

## Docs And Config Impact

- [x] README, docs, or examples updated (CHANGELOG entry)
- [ ] Config or environment behavior changed
- [ ] Templates or workspace bootstrap files changed
- [ ] No docs or config impact

## Risk Notes

- Security-sensitive paths touched? No — token *counts* only; no prompt content, credentials, or identifiers are added to responses.
- Gateway, audit, approval, or container boundaries touched? Gateway response shape only, additively. Existing `prompt_tokens` / `completion_tokens` / `total_tokens` are unchanged, and the new keys are optional, so OpenAI-compatible clients that ignore unknown fields are unaffected.

## Evidence

Before — cache columns blank through the gateway while the same model reports a 100% hit when called directly (local benchmark, identical repeated requests):

```
arm                stream  in tok  cached
gateway(hybridai)  off     37646   -             <- data existed internally, never emitted
hai                off     14203   14203 (100%)  <- upstream reports it fine
```

After — unit coverage asserting both provider shapes, the cold-cache `0` case, and the not-reported case:

```
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
