### PR TITLE
feat: add direct OpenAI API provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Direct OpenAI API provider**: `openai/...` models use the OpenAI Responses
+  API with encrypted `OPENAI_API_KEY` storage, streaming, function calling,
+  stateless encrypted reasoning-item replay, model catalog metadata, CLI auth,
+  gateway health, and doctor diagnostics. Codex OAuth remains available under
+  the separate `openai-codex/...` provider.
+  `Manifesto: Principle IV - Model freedom without lock-in.`
 - **Dependency license gate**: `scripts/check-dependency-policy.mjs` now scans
   every tracked `package-lock.json` and fails on GPL, AGPL, and SSPL-family
   licenses unless the exact `name@version` and license pair is approved under

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,5 @@
 {
-  "version": 35,
+  "version": 36,
   "security": {
     "trustModelAccepted": false,
     "trustModelAcceptedAt": "",
@@ -355,6 +355,15 @@
   "codex": {
     "baseUrl": "https://chatgpt.com/backend-api/codex",
     "turnRuntime": "hybridclaw"
+  },
+  "openai": {
+    "enabled": false,
+    "baseUrl": "https://api.openai.com/v1",
+    "models": [
+      "openai/gpt-5.6-sol",
+      "openai/gpt-5.6-terra",
+      "openai/gpt-5.6-luna"
+    ]
   },
   "anthropic": {
     "enabled": false,

--- a/console/src/routes/chat/model-switch-select.tsx
+++ b/console/src/routes/chat/model-switch-select.tsx
@@ -79,6 +79,7 @@ export interface ParsedModel {
 type KnownProvider =
   | 'Local'
   | 'HybridAI'
+  | 'OpenAI API'
   | 'OpenAI Codex'
   | 'Anthropic'
   | 'OpenRouter'
@@ -103,6 +104,7 @@ type KnownProvider =
 // providers silently fall through to the kebab-to-Title fallback in pretty().
 const PROVIDER_LABELS: Record<GatewayModelProviderKey, KnownProvider> = {
   hybridai: 'HybridAI',
+  openai: 'OpenAI API',
   codex: 'OpenAI Codex',
   anthropic: 'Anthropic',
   openrouter: 'OpenRouter',

--- a/container/shared/model-names.js
+++ b/container/shared/model-names.js
@@ -1,6 +1,7 @@
 export const HYBRIDAI_MODEL_PREFIX = 'hybridai/';
 
 export const NON_HYBRID_PROVIDER_PREFIXES = [
+  'openai/',
   'openai-codex/',
   'openrouter/',
   'mistral/',

--- a/container/shared/provider-context.js
+++ b/container/shared/provider-context.js
@@ -1,5 +1,6 @@
 const API_KEY_REQUIRED_PROVIDERS = new Set([
   'hybridai',
+  'openai',
   'openai-codex',
   'anthropic',
   'openrouter',

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -1536,6 +1536,13 @@ async function processRequest(
     ) {
       assistantMessage.anthropic_content = choice.message.anthropic_content;
     }
+    if (
+      choice.message.openai_response_items &&
+      choice.message.openai_response_items.length > 0
+    ) {
+      assistantMessage.openai_response_items =
+        choice.message.openai_response_items;
+    }
 
     history.push(assistantMessage);
     if (toolCalls.length === 0) {

--- a/container/src/providers/openai-codex.ts
+++ b/container/src/providers/openai-codex.ts
@@ -54,11 +54,16 @@ interface CodexStreamAccumulator {
 }
 
 const CODEX_DEFAULT_INSTRUCTIONS = 'You are Codex, a coding assistant.';
+const OPENAI_DEFAULT_INSTRUCTIONS = 'You are a helpful assistant.';
 
 function normalizeCodexModelName(model: string): string {
   const trimmed = model.trim();
-  if (!trimmed.toLowerCase().startsWith('openai-codex/')) return trimmed;
-  return trimmed.slice('openai-codex/'.length) || trimmed;
+  for (const prefix of ['openai-codex/', 'openai/']) {
+    if (trimmed.toLowerCase().startsWith(prefix)) {
+      return trimmed.slice(prefix.length) || trimmed;
+    }
+  }
+  return trimmed;
 }
 
 function normalizeMessageText(content: ChatMessage['content']): string {
@@ -70,8 +75,17 @@ function normalizeMessageText(content: ChatMessage['content']): string {
     .join('\n');
 }
 
-function logCodexTransport(message: string): void {
-  console.error(`[codex] ${message}`);
+function providerTransportLabel(
+  provider: NormalizedCallArgs['provider'],
+): 'codex' | 'openai' {
+  return provider === 'openai' ? 'openai' : 'codex';
+}
+
+function logCodexTransport(
+  provider: NormalizedCallArgs['provider'],
+  message: string,
+): void {
+  console.error(`[${providerTransportLabel(provider)}] ${message}`);
 }
 
 function convertContentPart(
@@ -103,6 +117,9 @@ function convertMessageToResponsesInput(
   }
 
   if (message.role === 'assistant' && Array.isArray(message.tool_calls)) {
+    if (Array.isArray(message.openai_response_items)) {
+      items.push(...message.openai_response_items);
+    }
     for (const toolCall of message.tool_calls) {
       items.push({
         type: 'function_call',
@@ -143,29 +160,41 @@ function convertToolsToResponsesTools(
   }));
 }
 
-function extractCodexInstructions(messages: ChatMessage[]): string {
+function extractCodexInstructions(
+  messages: ChatMessage[],
+  provider: NormalizedCallArgs['provider'],
+): string {
   const instructions = messages
     .filter((message) => message.role === 'system')
     .map((message) => normalizeMessageText(message.content).trim())
     .filter((message) => message.length > 0)
     .join('\n\n');
 
-  return instructions || CODEX_DEFAULT_INSTRUCTIONS;
+  return (
+    instructions ||
+    (provider === 'openai'
+      ? OPENAI_DEFAULT_INSTRUCTIONS
+      : CODEX_DEFAULT_INSTRUCTIONS)
+  );
 }
 
 function buildCodexRequestBody(
-  model: string,
-  messages: ChatMessage[],
-  tools: ToolDefinition[],
+  args: NormalizedCallArgs,
 ): Record<string, unknown> {
   const body: Record<string, unknown> = {
-    model: normalizeCodexModelName(model),
+    model: normalizeCodexModelName(args.model),
     store: false,
-    instructions: extractCodexInstructions(messages),
-    input: messages.flatMap(convertMessageToResponsesInput),
+    instructions: extractCodexInstructions(args.messages, args.provider),
+    input: args.messages.flatMap(convertMessageToResponsesInput),
   };
-  if (tools.length > 0) {
-    body.tools = convertToolsToResponsesTools(tools);
+  if (args.provider === 'openai' && args.maxTokens != null) {
+    body.max_output_tokens = args.maxTokens;
+  }
+  if (args.provider === 'openai') {
+    body.include = ['reasoning.encrypted_content'];
+  }
+  if (args.tools.length > 0) {
+    body.tools = convertToolsToResponsesTools(args.tools);
     body.tool_choice = 'auto';
     body.parallel_tool_calls = true;
   }
@@ -219,11 +248,16 @@ function adaptCodexResponse(
   let role = 'assistant';
   const contentParts: Array<{ type: 'text'; text: string }> = [];
   const toolCalls: ToolCall[] = [];
+  const responseItems: Array<Record<string, unknown>> = [];
 
   for (const entry of output) {
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
     const item = entry as Record<string, unknown>;
     const type = typeof item.type === 'string' ? item.type : '';
+
+    if (type === 'reasoning' && typeof item.encrypted_content === 'string') {
+      responseItems.push(item);
+    }
 
     if (type === 'message') {
       if (typeof item.role === 'string' && item.role) role = item.role;
@@ -240,7 +274,9 @@ function adaptCodexResponse(
               ? part.text
               : typeof part.output_text === 'string'
                 ? part.output_text
-                : '';
+                : typeof part.refusal === 'string'
+                  ? part.refusal
+                  : '';
           if (text) contentParts.push({ type: 'text', text });
         }
       }
@@ -287,6 +323,9 @@ function adaptCodexResponse(
           role,
           content: textContent,
           ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+          ...(responseItems.length > 0
+            ? { openai_response_items: responseItems }
+            : {}),
         },
         finish_reason: toolCalls.length > 0 ? 'tool_calls' : 'stop',
       },
@@ -307,6 +346,7 @@ function isCodexEmptyVisibleCompletion(
 function assertNonEmptyCodexResponse(
   response: ChatCompletionResponse,
   fallbackModel: string,
+  provider: NormalizedCallArgs['provider'],
 ): void {
   if (!isCodexEmptyVisibleCompletion(response)) return;
   const choice = response.choices[0];
@@ -317,9 +357,11 @@ function assertNonEmptyCodexResponse(
       ? 'null'
       : typeof content;
   logCodexTransport(
+    provider,
     `empty completion model=${normalizeCodexModelName(fallbackModel)} responseModel=${response.model || '<missing>'} finish=${choice?.finish_reason || '<missing>'} contentType=${contentType}`,
   );
-  throw new Error('Codex Responses API returned no output items');
+  const label = provider === 'openai' ? 'OpenAI' : 'Codex';
+  throw new Error(`${label} Responses API returned no output items`);
 }
 
 function resolveCodexOutputIndex(
@@ -738,7 +780,7 @@ export async function callOpenAICodexProvider(
   // The Codex backend currently requires `stream: true` even for callers that
   // want a single final response body. Use the streaming transport internally
   // and suppress text-delta callbacks for the non-streaming runtime path.
-  return callOpenAICodexProviderStream({
+  return callOpenAIResponsesProviderStreamInternal({
     ...args,
     onTextDelta: () => undefined,
   });
@@ -747,12 +789,34 @@ export async function callOpenAICodexProvider(
 export async function callOpenAICodexProviderStream(
   args: NormalizedStreamCallArgs,
 ): Promise<ChatCompletionResponse> {
+  return callOpenAIResponsesProviderStreamInternal(args);
+}
+
+export async function callOpenAIResponsesProvider(
+  args: NormalizedCallArgs,
+): Promise<ChatCompletionResponse> {
+  return callOpenAIResponsesProviderStreamInternal({
+    ...args,
+    onTextDelta: () => undefined,
+  });
+}
+
+export async function callOpenAIResponsesProviderStream(
+  args: NormalizedStreamCallArgs,
+): Promise<ChatCompletionResponse> {
+  return callOpenAIResponsesProviderStreamInternal(args);
+}
+
+async function callOpenAIResponsesProviderStreamInternal(
+  args: NormalizedStreamCallArgs,
+): Promise<ChatCompletionResponse> {
   const startedAt = Date.now();
   logCodexTransport(
+    args.provider,
     `stream request start model=${normalizeCodexModelName(args.model)} messages=${args.messages.length} tools=${args.tools.length}`,
   );
   const body = {
-    ...buildCodexRequestBody(args.model, args.messages, args.tools),
+    ...buildCodexRequestBody(args),
     stream: true,
   };
   if (args.debugModelResponses) {
@@ -777,6 +841,7 @@ export async function callOpenAICodexProviderStream(
     body: JSON.stringify(body),
   });
   logCodexTransport(
+    args.provider,
     `stream response headers model=${normalizeCodexModelName(args.model)} status=${response.status} durationMs=${Date.now() - startedAt} contentType=${response.headers.get('content-type') || '<missing>'}`,
   );
 
@@ -802,7 +867,7 @@ export async function callOpenAICodexProviderStream(
       });
     }
     const adapted = adaptCodexResponse(payload, args.model);
-    assertNonEmptyCodexResponse(adapted, args.model);
+    assertNonEmptyCodexResponse(adapted, args.model, args.provider);
     emitResponseTextDeltas(adapted, args.onTextDelta);
     return adapted;
   }
@@ -818,7 +883,7 @@ export async function callOpenAICodexProviderStream(
       });
     }
     const adapted = adaptCodexResponse(payload, args.model);
-    assertNonEmptyCodexResponse(adapted, args.model);
+    assertNonEmptyCodexResponse(adapted, args.model, args.provider);
     emitResponseTextDeltas(adapted, args.onTextDelta);
     return adapted;
   }
@@ -855,6 +920,7 @@ export async function callOpenAICodexProviderStream(
         if (firstEventMs == null) {
           firstEventMs = Date.now() - startedAt;
           logCodexTransport(
+            args.provider,
             `stream first event model=${normalizeCodexModelName(args.model)} durationMs=${firstEventMs} event=${event.event || '<default>'}`,
           );
         }
@@ -877,6 +943,7 @@ export async function callOpenAICodexProviderStream(
         if (firstEventMs == null) {
           firstEventMs = Date.now() - startedAt;
           logCodexTransport(
+            args.provider,
             `stream first event model=${normalizeCodexModelName(args.model)} durationMs=${firstEventMs} event=${event.event || '<default>'}`,
           );
         }
@@ -895,13 +962,15 @@ export async function callOpenAICodexProviderStream(
   }
 
   if (!sawPayload) {
-    throw new Error('Codex streaming response ended without payload');
+    const label = args.provider === 'openai' ? 'OpenAI' : 'Codex';
+    throw new Error(`${label} streaming response ended without payload`);
   }
 
   logCodexTransport(
+    args.provider,
     `stream complete model=${normalizeCodexModelName(args.model)} durationMs=${Date.now() - startedAt}`,
   );
   const adapted = buildCodexStreamResponse(streamState, args.model);
-  assertNonEmptyCodexResponse(adapted, args.model);
+  assertNonEmptyCodexResponse(adapted, args.model, args.provider);
   return adapted;
 }

--- a/container/src/providers/provider-ids.ts
+++ b/container/src/providers/provider-ids.ts
@@ -1,5 +1,6 @@
 export const RUNTIME_PROVIDER_IDS = [
   'hybridai',
+  'openai',
   'openai-codex',
   'anthropic',
   'openrouter',
@@ -43,6 +44,7 @@ export type OpenAICompatRuntimeProvider =
   (typeof OPENAI_COMPAT_RUNTIME_PROVIDER_IDS)[number];
 
 const RUNTIME_PROVIDER_MODEL_PREFIXES: Array<[RuntimeProvider, string]> = [
+  ['openai', 'openai/'],
   ['openai-codex', 'openai-codex/'],
   ['anthropic', 'anthropic/'],
   ['openrouter', 'openrouter/'],

--- a/container/src/providers/router.ts
+++ b/container/src/providers/router.ts
@@ -29,6 +29,8 @@ import {
 import {
   callOpenAICodexProvider,
   callOpenAICodexProviderStream,
+  callOpenAIResponsesProvider,
+  callOpenAIResponsesProviderStream,
 } from './openai-codex.js';
 import { isOpenAICompatRuntimeProvider } from './provider-ids.js';
 import {
@@ -126,6 +128,9 @@ export async function callProviderModel(
   if (args.provider === 'openai-codex') {
     return callOpenAICodexProvider(args);
   }
+  if (args.provider === 'openai') {
+    return callOpenAIResponsesProvider(args);
+  }
   if (args.provider === 'ollama') {
     return callOllamaProvider(args);
   }
@@ -143,6 +148,9 @@ export async function callProviderModelStream(
   }
   if (args.provider === 'openai-codex') {
     return callOpenAICodexProviderStream(args);
+  }
+  if (args.provider === 'openai') {
+    return callOpenAIResponsesProviderStream(args);
   }
   if (args.provider === 'ollama') {
     return callOllamaProviderStream(args);
@@ -218,13 +226,14 @@ function shouldStreamVisionRequest(
     provider === undefined ||
     provider === 'hybridai' ||
     provider === 'anthropic' ||
+    provider === 'openai' ||
     provider === 'openai-codex'
   );
 }
 
 function buildVisionMessages(params: RoutedVisionCallParams): ChatMessage[] {
   const messages: ChatMessage[] = [];
-  if (params.provider === 'openai-codex') {
+  if (params.provider === 'openai-codex' || params.provider === 'openai') {
     messages.push({
       role: 'system',
       content: params.instructions?.trim() || DEFAULT_VISION_INSTRUCTIONS,

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -42,6 +42,7 @@ export interface ChatMessage {
   tool_calls?: ToolCall[];
   tool_call_id?: string;
   anthropic_content?: AnthropicContentBlock[];
+  openai_response_items?: Array<Record<string, unknown>>;
 }
 
 export interface ToolCall {
@@ -62,6 +63,7 @@ export interface ChatCompletionResponse {
       tool_calls?: ToolCall[];
       reasoning_content?: string | null;
       anthropic_content?: AnthropicContentBlock[];
+      openai_response_items?: Array<Record<string, unknown>>;
     };
     finish_reason: string;
   }>;
@@ -130,6 +132,7 @@ export interface PluginRuntimeToolDefinition {
 export interface TaskModelPolicy {
   provider?:
     | 'hybridai'
+    | 'openai'
     | 'openai-codex'
     | 'anthropic'
     | 'openrouter'
@@ -233,6 +236,7 @@ export interface ContainerInput {
   baseUrl: string;
   provider?:
     | 'hybridai'
+    | 'openai'
     | 'openai-codex'
     | 'anthropic'
     | 'openrouter'

--- a/docs/content/getting-started/authentication.md
+++ b/docs/content/getting-started/authentication.md
@@ -17,6 +17,7 @@ hybridclaw auth login hybridai --base-url http://localhost:5000
 hybridclaw auth login codex --device-code
 hybridclaw auth login codex --browser
 hybridclaw auth login codex --import
+hybridclaw auth login openai gpt-5.6-sol --api-key sk-...
 hybridclaw auth login anthropic anthropic/claude-sonnet-4-6 --method api-key --api-key sk-ant-...
 hybridclaw auth login anthropic anthropic/claude-sonnet-4-6 --method claude-cli
 hybridclaw auth login openrouter anthropic/claude-sonnet-4 --api-key sk-or-...
@@ -39,6 +40,7 @@ hybridclaw auth login msteams --app-id <msteams-app-id> --tenant-id <msteams-ten
 hybridclaw auth login slack --bot-token xoxb-... --app-token xapp-...
 hybridclaw auth status hybridai
 hybridclaw auth status codex
+hybridclaw auth status openai
 hybridclaw auth status anthropic
 hybridclaw auth status openrouter
 hybridclaw auth status mistral
@@ -58,6 +60,7 @@ hybridclaw auth status msteams
 hybridclaw auth status slack
 hybridclaw auth logout hybridai
 hybridclaw auth logout codex
+hybridclaw auth logout openai
 hybridclaw auth logout anthropic
 hybridclaw auth logout openrouter
 hybridclaw auth logout mistral
@@ -87,6 +90,9 @@ hybridclaw auth whatsapp reset
   and `--base-url` updates `hybridai.baseUrl` before login.
 - `hybridclaw auth login codex` prefers browser PKCE locally and device code on
   headless or remote shells.
+- `hybridclaw auth login openai` stores `OPENAI_API_KEY`, enables the direct
+  OpenAI Responses API transport, and can set an `openai/...` model as the
+  global default. This is separate from Codex OAuth and `openai-codex/...`.
 - `hybridclaw auth login anthropic --method api-key` stores
   `ANTHROPIC_API_KEY`, enables the direct Anthropic Messages API transport,
   and can set an `anthropic/...` model as the global default.
@@ -94,12 +100,14 @@ hybridclaw auth whatsapp reset
   `claude -p` transport after `claude auth login`. That transport currently
   requires host sandbox mode because the Claude CLI credentials and binary
   live on the host.
-- `hybridclaw auth login openrouter`, `hybridclaw auth login mistral`,
-  `hybridclaw auth login huggingface`, and the other API-key providers
-  (`anthropic`, `gemini`, `deepseek`, `xai`, `zai`, `kimi`, `minimax`,
-  `dashscope`, `xiaomi`, `kilo`) can take `--api-key`, otherwise they fall
-  back to the matching environment variable (e.g. `ANTHROPIC_API_KEY`,
-  `OPENROUTER_API_KEY`, `MISTRAL_API_KEY`, `HF_TOKEN`, `GEMINI_API_KEY`,
+- `hybridclaw auth login openai`, `hybridclaw auth login openrouter`,
+  `hybridclaw auth login mistral`, `hybridclaw auth login huggingface`, and the
+  other API-key providers (`anthropic`, `gemini`, `deepseek`, `xai`, `zai`,
+  `kimi`, `minimax`, `dashscope`, `xiaomi`, `kilo`) can take `--api-key`,
+  otherwise they fall back to the matching environment variable (e.g.
+  `ANTHROPIC_API_KEY`,
+  `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `MISTRAL_API_KEY`, `HF_TOKEN`,
+  `GEMINI_API_KEY`,
   `DEEPSEEK_API_KEY`, `XAI_API_KEY`, `ZAI_API_KEY`, `KIMI_API_KEY`,
   `MINIMAX_API_KEY`, `DASHSCOPE_API_KEY`, `XIAOMI_API_KEY`, `KILO_API_KEY`),
   or prompt interactively.
@@ -420,8 +428,8 @@ Use `customer_client` to find MCC children, `billing_setup.resource_name` for
 
 ## Where Credentials Live
 
-- `~/.hybridclaw/credentials.json` stores HybridAI, Anthropic, OpenRouter,
-  Mistral, Hugging Face, Gemini, DeepSeek, xAI, Z.AI, Kimi, MiniMax,
+- `~/.hybridclaw/credentials.json` stores HybridAI, OpenAI API, Anthropic,
+  OpenRouter, Mistral, Hugging Face, Gemini, DeepSeek, xAI, Z.AI, Kimi, MiniMax,
   DashScope, Xiaomi, Kilo Code, Google OAuth for `gog`, Discord, Slack,
   Telegram, email, Teams, BlueBubbles iMessage, vLLM, web/gateway auth tokens,
   related runtime secrets, and named `/secret set` values in encrypted form

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -145,6 +145,9 @@ saved revision history directly.
   standard HybridClaw tool loop or `app-server` for the native Codex app-server
   turn loop on `openai-codex/*` models. `codex.runtime` is accepted as a
   compatibility alias; new config should use `codex.turnRuntime`.
+- `openai.enabled`, `openai.baseUrl`, and `openai.models` configure the direct
+  OpenAI Responses API provider. Store its API key as `OPENAI_API_KEY` in the
+  encrypted runtime secret store and select models with the `openai/` prefix.
 - `HYBRIDAI_FALLBACK_CHAIN` accepts a JSON array of fallback entries with
   `model`, optional `baseUrl`, `keyEnv`, `chatbotId`, and `agentId`. Gateway
   model calls use the chain for auth and rate-limit failures, then cool down

--- a/docs/content/reference/faq.md
+++ b/docs/content/reference/faq.md
@@ -100,8 +100,9 @@ including a persistent macOS LaunchAgent tunnel, see
 
 ## What AI models does it support?
 
-HybridClaw supports HybridAI models, OpenAI Codex models, and external API
-providers including OpenRouter, Mistral, Hugging Face, Google Gemini, DeepSeek,
+HybridClaw supports HybridAI models, direct OpenAI API models, OpenAI Codex
+models, and external API providers including OpenRouter, Mistral, Hugging Face,
+Google Gemini, DeepSeek,
 xAI / Grok, Z.AI / GLM, Kimi / Moonshot, MiniMax, DashScope / Qwen, Xiaomi
 MiMo, and Kilo Code. It also supports local backends including Ollama, LM
 Studio, llama.cpp, and vLLM.

--- a/docs/content/reference/model-selection.md
+++ b/docs/content/reference/model-selection.md
@@ -8,6 +8,7 @@ sidebar_position: 2
 
 Model prefixes:
 
+- Direct OpenAI API models use `openai/`
 - Codex models use `openai-codex/`
 - Anthropic models use `anthropic/`
 - OpenRouter models use `openrouter/`
@@ -31,6 +32,8 @@ The shipped default Codex model is `openai-codex/gpt-5-codex`.
 Examples:
 
 ```text
+/model list openai
+/model set openai/gpt-5.6-sol
 /model set openai-codex/gpt-5-codex
 /model list codex
 /model default openai-codex/gpt-5-codex
@@ -62,7 +65,8 @@ Examples:
 ## Scope Rules
 
 - `hybridai.defaultModel` in `~/.hybridclaw/config.json` is the global default;
-  it can point at a HybridAI model, an `openai-codex/...` model, an
+  it can point at a HybridAI model, an `openai/...` model, an
+  `openai-codex/...` model, an
   `anthropic/...` model, an `openrouter/...` model, a `mistral/...` model, a
   `huggingface/...` model, a `gemini/...` model, a `deepseek/...` model, a
   `xai/...` model, a `kilo/...` model, or a local backend model such as
@@ -148,6 +152,8 @@ docs should use `codex.turnRuntime`.
 
 ## Allowed Model Lists
 
+- `openai.models` controls the configured direct OpenAI API model list shown
+  in selectors and status output
 - `codex.models` controls the allowed Codex model list shown in selectors and
   status output
 - `anthropic.models` acts as the pinned Anthropic model list shown in
@@ -178,6 +184,9 @@ docs should use `codex.turnRuntime`.
 
 ## Provider Routing
 
+- when the selected model starts with `openai/`, HybridClaw calls the OpenAI
+  Responses API with `OPENAI_API_KEY`; this direct API-key provider is separate
+  from the Codex OAuth provider
 - when the selected model starts with `openai-codex/`, HybridClaw resolves
   OAuth credentials through the Codex provider instead of `HYBRIDAI_API_KEY`;
   Codex turns use the HybridClaw loop by default, or the native Codex app-server

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2203,6 +2203,7 @@ function isWhatsAppAuthLockError(err: unknown): err is Error {
 function printMissingEnvVarError(message: string, envVar?: string): void {
   const envVarMessage: Record<string, string> = {
     HYBRIDAI_API_KEY: 'HybridAI provider is not configured.',
+    OPENAI_API_KEY: 'OpenAI API provider is not configured.',
     ANTHROPIC_API_KEY: 'Anthropic provider is not configured.',
     OPENROUTER_API_KEY: 'OpenRouter provider is not configured.',
     MISTRAL_API_KEY: 'Mistral provider is not configured.',
@@ -2210,6 +2211,7 @@ function printMissingEnvVarError(message: string, envVar?: string): void {
   };
   const envVarHint: Record<string, string> = {
     HYBRIDAI_API_KEY: `Run \`hybridclaw auth login hybridai\`, or store HYBRIDAI_API_KEY with \`hybridclaw secret set HYBRIDAI_API_KEY <key>\` or in TUI with \`/secret set HYBRIDAI_API_KEY <key>\`, then run the command again.`,
+    OPENAI_API_KEY: `Run \`hybridclaw auth login openai\`, or store OPENAI_API_KEY with \`hybridclaw secret set OPENAI_API_KEY <key>\` or in TUI with \`/secret set OPENAI_API_KEY <key>\`, then run the command again.`,
     ANTHROPIC_API_KEY: `Run \`hybridclaw auth login anthropic --method api-key\`, or run \`claude auth login\` and then \`hybridclaw auth login anthropic --method claude-cli\`, or store ANTHROPIC_API_KEY with \`hybridclaw secret set ANTHROPIC_API_KEY <key>\` or in TUI with \`/secret set ANTHROPIC_API_KEY <key>\`, then run the command again.`,
     OPENROUTER_API_KEY: `Run \`hybridclaw auth login openrouter\`, or store OPENROUTER_API_KEY with \`hybridclaw secret set OPENROUTER_API_KEY <key>\` or in TUI with \`/secret set OPENROUTER_API_KEY <key>\`, then run the command again.`,
     MISTRAL_API_KEY: `Run \`hybridclaw auth login mistral\`, or store MISTRAL_API_KEY with \`hybridclaw secret set MISTRAL_API_KEY <key>\` or in TUI with \`/secret set MISTRAL_API_KEY <key>\`, then run the command again.`,

--- a/src/cli/auth-command.ts
+++ b/src/cli/auth-command.ts
@@ -560,6 +560,7 @@ async function resolveGenericProviderApiKey(
 interface RouterProviderConfigFlowOptions {
   args: string[];
   providerId:
+    | 'openai'
     | 'openrouter'
     | 'mistral'
     | 'huggingface'
@@ -780,6 +781,7 @@ async function configureAnthropic(args: string[]): Promise<void> {
 interface GenericProviderAuthDef {
   /** Provider ID used in CLI and config. */
   id:
+    | 'openai'
     | 'gemini'
     | 'deepseek'
     | 'xai'
@@ -808,6 +810,17 @@ interface GenericProviderAuthDef {
 }
 
 const GENERIC_PROVIDER_AUTH_DEFS: readonly GenericProviderAuthDef[] = [
+  {
+    id: 'openai',
+    label: 'OpenAI API',
+    defaultModel: 'openai/gpt-5.6-sol',
+    defaultBaseUrl: 'https://api.openai.com/v1',
+    baseUrlSuffixPattern: /\/v1$/i,
+    baseUrlSuffix: '/v1',
+    secretKey: 'OPENAI_API_KEY',
+    envVarNames: ['OPENAI_API_KEY'],
+    aliases: getProviderAliasesFor('openai'),
+  },
   {
     id: 'gemini',
     label: 'Google Gemini',
@@ -949,9 +962,15 @@ async function configureGenericProvider(
         const section = draft[def.id] as {
           enabled: boolean;
           baseUrl: string;
+          models: string[];
         };
         section.enabled = true;
         section.baseUrl = normalizedBaseUrl;
+        if (def.id === 'openai') {
+          section.models = Array.from(
+            new Set([fullModelName, ...section.models]),
+          );
+        }
         if (parsed.setDefault) {
           draft.hybridai.defaultModel = fullModelName;
         }
@@ -961,6 +980,7 @@ async function configureGenericProvider(
 
 type UnifiedProvider =
   | 'hybridai'
+  | 'openai'
   | 'codex'
   | 'anthropic'
   | 'openrouter'
@@ -1075,7 +1095,7 @@ function parseUnifiedProviderArgs(args: string[]): {
     const provider = normalizeUnifiedProvider(rawProvider);
     if (!provider) {
       throw new Error(
-        `Unknown provider "${rawProvider}". Use \`hybridai\`, \`codex\`, \`anthropic\`, \`openrouter\`, \`mistral\`, \`huggingface\`, \`google\`, \`hubspot\`, \`microsoft365\`, \`gemini\`, \`deepseek\`, \`xai\`, \`zai\`, \`kimi\`, \`minimax\`, \`dashscope\`, \`xiaomi\`, \`kilo\`, \`local\`, \`msteams\`, or \`slack\`.`,
+        `Unknown provider "${rawProvider}". Use \`hybridai\`, \`openai\`, \`codex\`, \`anthropic\`, \`openrouter\`, \`mistral\`, \`huggingface\`, \`google\`, \`hubspot\`, \`microsoft365\`, \`gemini\`, \`deepseek\`, \`xai\`, \`zai\`, \`kimi\`, \`minimax\`, \`dashscope\`, \`xiaomi\`, \`kilo\`, \`local\`, \`msteams\`, or \`slack\`.`,
       );
     }
     return {
@@ -1089,7 +1109,7 @@ function parseUnifiedProviderArgs(args: string[]): {
     const provider = normalizeUnifiedProvider(rawProvider);
     if (!provider) {
       throw new Error(
-        `Unknown provider "${rawProvider}". Use \`hybridai\`, \`codex\`, \`anthropic\`, \`openrouter\`, \`mistral\`, \`huggingface\`, \`google\`, \`hubspot\`, \`microsoft365\`, \`gemini\`, \`deepseek\`, \`xai\`, \`zai\`, \`kimi\`, \`minimax\`, \`dashscope\`, \`xiaomi\`, \`kilo\`, \`local\`, \`msteams\`, or \`slack\`.`,
+        `Unknown provider "${rawProvider}". Use \`hybridai\`, \`openai\`, \`codex\`, \`anthropic\`, \`openrouter\`, \`mistral\`, \`huggingface\`, \`google\`, \`hubspot\`, \`microsoft365\`, \`gemini\`, \`deepseek\`, \`xai\`, \`zai\`, \`kimi\`, \`minimax\`, \`dashscope\`, \`xiaomi\`, \`kilo\`, \`local\`, \`msteams\`, or \`slack\`.`,
       );
     }
     return {
@@ -1110,6 +1130,7 @@ function isLocalProviderModel(modelName: string): boolean {
 }
 
 type ApiKeyProviderConfigKey =
+  | 'openai'
   | 'openrouter'
   | 'mistral'
   | 'huggingface'
@@ -2609,7 +2630,7 @@ async function handleAuthLoginCommand(normalizedArgs: string[]): Promise<void> {
   const parsed = parseUnifiedProviderArgs(normalizedArgs);
   if (!parsed.provider) {
     throw new Error(
-      `Unknown auth login provider "${normalizedArgs[0]}". Use \`hybridai\`, \`codex\`, \`anthropic\`, \`openrouter\`, \`mistral\`, \`huggingface\`, \`google\`, \`hubspot\`, \`microsoft365\`, \`gemini\`, \`deepseek\`, \`xai\`, \`zai\`, \`kimi\`, \`minimax\`, \`dashscope\`, \`xiaomi\`, \`kilo\`, \`local\`, \`msteams\`, or \`slack\`.`,
+      `Unknown auth login provider "${normalizedArgs[0]}". Use \`hybridai\`, \`openai\`, \`codex\`, \`anthropic\`, \`openrouter\`, \`mistral\`, \`huggingface\`, \`google\`, \`hubspot\`, \`microsoft365\`, \`gemini\`, \`deepseek\`, \`xai\`, \`zai\`, \`kimi\`, \`minimax\`, \`dashscope\`, \`xiaomi\`, \`kilo\`, \`local\`, \`msteams\`, or \`slack\`.`,
     );
   }
   if (isHelpRequest(parsed.remaining)) {
@@ -2918,7 +2939,7 @@ async function handleProviderActionCommand(
   const parsed = parseUnifiedProviderArgs(normalizedArgs);
   if (!parsed.provider) {
     throw new Error(
-      `Unknown ${action} provider "${normalizedArgs[0]}". Use \`hybridai\`, \`codex\`, \`anthropic\`, \`openrouter\`, \`mistral\`, \`huggingface\`, \`google\`, \`hubspot\`, \`microsoft365\`, \`gemini\`, \`deepseek\`, \`xai\`, \`zai\`, \`kimi\`, \`minimax\`, \`dashscope\`, \`xiaomi\`, \`kilo\`, \`local\`, \`msteams\`, or \`slack\`.`,
+      `Unknown ${action} provider "${normalizedArgs[0]}". Use \`hybridai\`, \`openai\`, \`codex\`, \`anthropic\`, \`openrouter\`, \`mistral\`, \`huggingface\`, \`google\`, \`hubspot\`, \`microsoft365\`, \`gemini\`, \`deepseek\`, \`xai\`, \`zai\`, \`kimi\`, \`minimax\`, \`dashscope\`, \`xiaomi\`, \`kilo\`, \`local\`, \`msteams\`, or \`slack\`.`,
     );
   }
   if (parsed.remaining.length > 0) {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -245,9 +245,9 @@ export function printAuthUsage(): void {
 
 Commands:
   hybridclaw auth login
-  hybridclaw auth login <hybridai|codex|anthropic|openrouter|mistral|huggingface|google|hubspot|microsoft365|local|msteams|slack> ...
-  hybridclaw auth status <hybridai|codex|anthropic|openrouter|mistral|huggingface|google|hubspot|microsoft365|local|msteams|slack>
-  hybridclaw auth logout <hybridai|codex|anthropic|openrouter|mistral|huggingface|google|hubspot|microsoft365|local|msteams|slack>
+  hybridclaw auth login <hybridai|openai|codex|anthropic|openrouter|mistral|huggingface|google|hubspot|microsoft365|local|msteams|slack> ...
+  hybridclaw auth status <hybridai|openai|codex|anthropic|openrouter|mistral|huggingface|google|hubspot|microsoft365|local|msteams|slack>
+  hybridclaw auth logout <hybridai|openai|codex|anthropic|openrouter|mistral|huggingface|google|hubspot|microsoft365|local|msteams|slack>
   hybridclaw auth whatsapp reset
   hybridclaw auth line reset
 
@@ -256,6 +256,7 @@ Examples:
   hybridclaw auth login hybridai --browser
   hybridclaw auth login hybridai --base-url http://localhost:5000
   hybridclaw auth login codex --import
+  hybridclaw auth login openai --api-key sk-... --set-default
   hybridclaw auth login anthropic --method claude-cli --set-default
   hybridclaw auth login anthropic anthropic/claude-sonnet-4-6 --method api-key --api-key sk-ant-...
   hybridclaw auth login openrouter anthropic/claude-sonnet-4 --api-key sk-or-...

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -40,6 +40,8 @@ export class MissingRequiredEnvVarError extends Error {
         'HybridAI provider is not configured. Use `/auth login hybridai` in the TUI, or switch to a model from another configured provider.',
       OPENROUTER_API_KEY:
         'OpenRouter provider is not configured. Use `/auth login openrouter` in the TUI, or switch to a model from another configured provider.',
+      OPENAI_API_KEY:
+        'OpenAI API provider is not configured. Use `/auth login openai` in the TUI, or switch to a model from another configured provider.',
       MISTRAL_API_KEY:
         'Mistral provider is not configured. Use `/auth login mistral` in the TUI, or switch to a model from another configured provider.',
       HF_TOKEN:
@@ -426,6 +428,8 @@ export let HYBRIDAI_MAX_TOKENS = 4_096;
 export let HYBRIDAI_ENABLE_RAG = true;
 export let CODEX_BASE_URL = CODEX_DEFAULT_BASE_URL;
 export let CODEX_RUNTIME: RuntimeConfig['codex']['runtime'] = 'hybridclaw';
+export let OPENAI_ENABLED = false;
+export let OPENAI_BASE_URL = 'https://api.openai.com/v1';
 export let ANTHROPIC_ENABLED = false;
 export let ANTHROPIC_BASE_URL = 'https://api.anthropic.com/v1';
 export let ANTHROPIC_METHOD: RuntimeConfig['anthropic']['method'] = 'api-key';
@@ -1005,6 +1009,8 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
   HYBRIDAI_ENABLE_RAG = config.hybridai.enableRag;
   CODEX_BASE_URL = config.codex.baseUrl;
   CODEX_RUNTIME = config.codex.turnRuntime;
+  OPENAI_ENABLED = config.openai.enabled;
+  OPENAI_BASE_URL = config.openai.baseUrl;
   ANTHROPIC_ENABLED = config.anthropic.enabled;
   ANTHROPIC_BASE_URL = config.anthropic.baseUrl;
   ANTHROPIC_METHOD = config.anthropic.method;

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -150,7 +150,7 @@ import {
 import { DEFAULT_RUNTIME_HOME_DIR } from './runtime-paths.js';
 
 export const CONFIG_FILE_NAME = 'config.json';
-export const CONFIG_VERSION = 35;
+export const CONFIG_VERSION = 36;
 export const SECURITY_POLICY_VERSION = '2026-02-28';
 export const DEFAULT_HYBRIDAI_MODEL = 'gpt-5.4-mini';
 export const DEFAULT_HYBRIDAI_ONBOARDING_MODEL = '';
@@ -1111,6 +1111,11 @@ export interface RuntimeConfig {
     turnRuntime: CodexTurnRuntime;
     models: string[];
   };
+  openai: {
+    enabled: boolean;
+    baseUrl: string;
+    models: string[];
+  };
   anthropic: {
     enabled: boolean;
     baseUrl: string;
@@ -1399,6 +1404,11 @@ const DEFAULT_CODEX_MODEL_LIST = [
   'openai-codex/gpt-5.1-codex-max',
   'openai-codex/gpt-5.2',
   'openai-codex/gpt-5.1-codex-mini',
+] as const;
+const DEFAULT_OPENAI_MODEL_LIST = [
+  'openai/gpt-5.6-sol',
+  'openai/gpt-5.6-terra',
+  'openai/gpt-5.6-luna',
 ] as const;
 const DEFAULT_ANTHROPIC_MODEL_LIST = ['anthropic/claude-sonnet-4-6'] as const;
 const DEFAULT_ANTHROPIC_METHOD: AnthropicMethod = 'api-key';
@@ -1798,6 +1808,11 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
     runtime: 'hybridclaw',
     turnRuntime: 'hybridclaw',
     models: [...DEFAULT_CODEX_MODEL_LIST],
+  },
+  openai: {
+    enabled: false,
+    baseUrl: 'https://api.openai.com/v1',
+    models: [...DEFAULT_OPENAI_MODEL_LIST],
   },
   anthropic: {
     enabled: false,
@@ -6950,6 +6965,7 @@ function normalizeRuntimeConfig(
   const rawEmail = isRecord(raw.email) ? raw.email : {};
   const rawHybridAi = isRecord(raw.hybridai) ? raw.hybridai : {};
   const rawCodex = isRecord(raw.codex) ? raw.codex : {};
+  const rawOpenAI = isRecord(raw.openai) ? raw.openai : {};
   const rawAnthropic = isRecord(raw.anthropic) ? raw.anthropic : {};
   const rawOpenRouter = isRecord(raw.openrouter) ? raw.openrouter : {};
   const rawMistral = isRecord(raw.mistral) ? raw.mistral : {};
@@ -7243,6 +7259,10 @@ function normalizeRuntimeConfig(
     rawCodex.models,
     DEFAULT_RUNTIME_CONFIG.codex.models,
   );
+  const openAIModelList = normalizeStringArray(
+    rawOpenAI.models,
+    DEFAULT_RUNTIME_CONFIG.openai.models,
+  );
   const anthropicModelList = normalizeStringArray(
     rawAnthropic.models,
     DEFAULT_RUNTIME_CONFIG.anthropic.models,
@@ -7307,6 +7327,7 @@ function normalizeRuntimeConfig(
       hybridaiOnboardingModel: hybridOnboardingModel,
       remoteModels: [
         codexModelList,
+        openAIModelList,
         anthropicModelList,
         openRouterModelList,
         mistralModelList,
@@ -7763,6 +7784,17 @@ function normalizeRuntimeConfig(
       runtime: normalizeCodexTurnRuntimeConfig(rawCodex),
       turnRuntime: normalizeCodexTurnRuntimeConfig(rawCodex),
       models: codexModelList,
+    },
+    openai: {
+      enabled: normalizeBoolean(
+        rawOpenAI.enabled,
+        DEFAULT_RUNTIME_CONFIG.openai.enabled,
+      ),
+      baseUrl: normalizeBaseUrl(
+        rawOpenAI.baseUrl,
+        DEFAULT_RUNTIME_CONFIG.openai.baseUrl,
+      ),
+      models: openAIModelList,
     },
     anthropic: {
       enabled: normalizeBoolean(

--- a/src/doctor/checks/providers.ts
+++ b/src/doctor/checks/providers.ts
@@ -13,6 +13,7 @@ import {
   probeHuggingFace,
   probeHybridAI,
   probeMistral,
+  probeOpenAI,
   probeOpenRouter,
 } from '../provider-probes.js';
 import type { DiagResult } from '../types.js';
@@ -20,6 +21,7 @@ import { makeResult, severityFrom, toErrorMessage } from '../utils.js';
 
 type ProviderKey =
   | 'hybridai'
+  | 'openai'
   | 'codex'
   | 'anthropic'
   | 'openrouter'
@@ -116,6 +118,7 @@ export async function checkProviders(): Promise<DiagResult[]> {
   );
   const discoveredModels = await readDiscoveredModelNamesSafely();
   const anthropicEnabled = config.anthropic?.enabled === true;
+  const openAIEnabled = config.openai?.enabled === true;
   const openRouterEnabled = config.openrouter?.enabled === true;
   const hybridaiModels = dedupeStrings([
     ...discoveredModels.hybridai,
@@ -124,6 +127,10 @@ export async function checkProviders(): Promise<DiagResult[]> {
   const codexModels = dedupeStrings([
     ...discoveredModels.codex,
     defaultProvider === 'openai-codex' ? config.hybridai.defaultModel : '',
+  ]);
+  const openAIModels = dedupeStrings([
+    ...(config.openai?.models ?? []),
+    defaultProvider === 'openai' ? config.hybridai.defaultModel : '',
   ]);
   const anthropicModels = dedupeStrings([
     ...(config.anthropic?.models ?? []),
@@ -154,6 +161,18 @@ export async function checkProviders(): Promise<DiagResult[]> {
       inactiveMessage: codexStatus.reloginRequired
         ? 'Login required'
         : 'Not authenticated',
+    },
+    {
+      key: 'openai',
+      label: 'OpenAI API',
+      active: defaultProvider === 'openai',
+      configured: openAIEnabled || defaultProvider === 'openai',
+      configuredModelCount: openAIModels.length,
+      probe:
+        openAIEnabled || defaultProvider === 'openai'
+          ? () => probeOpenAI()
+          : null,
+      inactiveMessage: 'Provider disabled',
     },
     {
       key: 'anthropic',

--- a/src/doctor/provider-probes.ts
+++ b/src/doctor/provider-probes.ts
@@ -15,6 +15,8 @@ import {
   HUGGINGFACE_ENABLED,
   MISTRAL_BASE_URL,
   MISTRAL_ENABLED,
+  OPENAI_BASE_URL,
+  OPENAI_ENABLED,
   OPENROUTER_BASE_URL,
   OPENROUTER_ENABLED,
 } from '../config/config.js';
@@ -24,6 +26,7 @@ import {
 } from '../providers/anthropic-utils.js';
 import { CODEX_CLIENT_VERSION } from '../providers/codex-constants.js';
 import { fetchHybridAIBots } from '../providers/hybridai-bots.js';
+import { readOpenAIAPIKey } from '../providers/openai.js';
 import { readApiKeyForOpenAICompatProvider } from '../providers/openai-compat-remote.js';
 import { buildOpenRouterAttributionHeaders } from '../providers/openrouter-utils.js';
 import {
@@ -97,6 +100,30 @@ export async function probeOpenRouter(): Promise<ProviderProbeResult> {
   if (!response.ok) {
     throw new Error(`HTTP ${response.status}`);
   }
+
+  const payload = (await response.json()) as { data?: unknown[] };
+  return {
+    reachable: true,
+    detail: `${Date.now() - startedAt}ms`,
+    modelCount: Array.isArray(payload.data) ? payload.data.length : 0,
+  };
+}
+
+export async function probeOpenAI(): Promise<ProviderProbeResult> {
+  if (!OPENAI_ENABLED) {
+    return { reachable: false, detail: 'Provider disabled' };
+  }
+  const apiKey = readOpenAIAPIKey({ required: false });
+  if (!apiKey) {
+    return { reachable: false, detail: 'API key missing' };
+  }
+
+  const startedAt = Date.now();
+  const response = await fetch(`${normalizeBaseUrl(OPENAI_BASE_URL)}/models`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
   const payload = (await response.json()) as { data?: unknown[] };
   return {

--- a/src/gateway/gateway-provider-service.ts
+++ b/src/gateway/gateway-provider-service.ts
@@ -10,6 +10,7 @@ import type {
   ModelCatalogProviderFilter,
   ModelCatalogRefreshFailure,
 } from '../providers/model-catalog.js';
+import { readOpenAIAPIKey } from '../providers/openai.js';
 import { getOpenAICompatProviderLastError } from '../providers/openai-compat-discovery.js';
 import { readApiKeyForOpenAICompatProvider } from '../providers/openai-compat-remote.js';
 import type { GatewayStatus } from './gateway-types.js';
@@ -34,6 +35,7 @@ const PROVIDER_META: Record<
   ProviderMeta
 > = {
   hybridai: { label: 'HybridAI', loginName: 'hybridai' },
+  openai: { label: 'OpenAI API', loginName: 'openai' },
   'openai-codex': { label: 'Codex', loginName: 'codex' },
   anthropic: { label: 'Anthropic', loginName: 'anthropic' },
   openrouter: { label: 'OpenRouter', loginName: 'openrouter' },
@@ -186,6 +188,18 @@ export function diagnoseProviderForModels(
       }
       if (providerHealth?.codex?.reachable !== true) {
         return unreachable(filter, null);
+      }
+      return null;
+    }
+    case 'openai': {
+      if (!config.openai.enabled) {
+        return disabled(filter, buildProviderEnableCommand(filter));
+      }
+      if (!readOpenAIAPIKey({ required: false })) {
+        return unauthorized(filter);
+      }
+      if (providerHealth?.openai?.reachable !== true) {
+        return unreachable(filter, config.openai.baseUrl);
       }
       return null;
     }

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -11833,13 +11833,13 @@ export async function handleGatewayCommand(
           if (providerFilterArg && !providerFilter) {
             return badCommand(
               'Unknown Provider',
-              'Usage: `model list [hybridai|codex|anthropic|openrouter|mistral|huggingface|local|ollama|lmstudio|llamacpp|vllm]`',
+              'Usage: `model list [hybridai|openai|codex|anthropic|openrouter|mistral|huggingface|local|ollama|lmstudio|llamacpp|vllm]`',
             );
           }
           if (listModifierArg && !expandedModelList) {
             return badCommand(
               'Usage',
-              'Usage: `model list [hybridai|codex|anthropic|openrouter|mistral|huggingface|local|ollama|lmstudio|llamacpp|vllm]`',
+              'Usage: `model list [hybridai|openai|codex|anthropic|openrouter|mistral|huggingface|local|ollama|lmstudio|llamacpp|vllm]`',
             );
           }
           if (providerFilter && gatewayStatus) {

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -1386,6 +1386,7 @@ export interface GatewayAdminModelsResponse {
         | 'auto'
         | 'disabled'
         | 'hybridai'
+        | 'openai'
         | 'openai-codex'
         | 'anthropic'
         | 'openrouter'

--- a/src/gateway/provider-status.ts
+++ b/src/gateway/provider-status.ts
@@ -9,6 +9,7 @@ import { getRuntimeConfig } from '../config/runtime-config.js';
 import { getDiscoveredCodexModelNames } from '../providers/codex-discovery.js';
 import { getDiscoveredHuggingFaceModelNames } from '../providers/huggingface-discovery.js';
 import { getDiscoveredMistralModelNames } from '../providers/mistral-discovery.js';
+import { readOpenAIAPIKey } from '../providers/openai.js';
 import { readApiKeyForOpenAICompatProvider } from '../providers/openai-compat-remote.js';
 import { getDiscoveredOpenRouterModelNames } from '../providers/openrouter-discovery.js';
 import { dedupeStrings } from '../utils/normalized-strings.js';
@@ -77,6 +78,12 @@ export function buildGatewayProviderHealth(params: {
     };
   }
   const optionalRemoteProviders = [
+    {
+      key: 'openai',
+      enabled: runtimeConfig.openai.enabled,
+      authenticated: Boolean(readOpenAIAPIKey({ required: false })),
+      modelCount: dedupeStrings(runtimeConfig.openai.models).length,
+    },
     {
       key: 'openrouter',
       enabled: runtimeConfig.openrouter.enabled,
@@ -176,6 +183,7 @@ export async function getGatewayAdminProviderStatus(
     ).map(([name, value]) => [name, { ...value }]),
   ) as NonNullable<GatewayStatus['providerHealth']>;
   const remoteOpenAiCompatKeys = [
+    'openai',
     'openrouter',
     'mistral',
     'huggingface',

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -12,7 +12,7 @@ import {
   vllmProvider,
 } from './local-openai-compat.js';
 import { mistralProvider } from './mistral.js';
-import { openAIProvider } from './openai.js';
+import { openAIAPIProvider, openAIProvider } from './openai.js';
 import {
   dashscopeProvider,
   deepseekProvider,
@@ -33,6 +33,7 @@ import type {
 } from './types.js';
 
 const KNOWN_PROVIDERS: AIProvider[] = [
+  openAIAPIProvider,
   openAIProvider,
   anthropicProvider,
   openrouterProvider,
@@ -60,6 +61,7 @@ const KNOWN_PROVIDER_BY_ID = new Map<AIProviderId, AIProvider>(
 
 const runtimeConfig = getRuntimeConfig();
 const ACTIVE_PROVIDERS: AIProvider[] = [
+  ...(runtimeConfig.openai.enabled ? [openAIAPIProvider] : []),
   openAIProvider,
   anthropicProvider,
   ...(runtimeConfig.openrouter.enabled ? [openrouterProvider] : []),

--- a/src/providers/model-catalog.ts
+++ b/src/providers/model-catalog.ts
@@ -67,7 +67,7 @@ import {
   type ModelRoutingZone,
   normalizeModelRoutingZone,
 } from './model-routing.js';
-import { OPENAI_CODEX_MODEL_PREFIX } from './openai.js';
+import { OPENAI_CODEX_MODEL_PREFIX, OPENAI_MODEL_PREFIX } from './openai.js';
 import {
   discoverOpenAICompatRemoteModels,
   getDiscoveredOpenAICompatRemoteModelNames,
@@ -141,6 +141,7 @@ const PREFIX_BY_PROVIDER: Record<
   Exclude<ModelCatalogProviderFilter, 'hybridai' | 'local'>,
   string
 > = {
+  openai: OPENAI_MODEL_PREFIX,
   'openai-codex': OPENAI_CODEX_MODEL_PREFIX,
   anthropic: ANTHROPIC_MODEL_PREFIX,
   openrouter: OPENROUTER_MODEL_PREFIX,
@@ -327,6 +328,8 @@ function collectModelsForProvider(
   switch (filter) {
     case 'hybridai':
       return [HYBRIDAI_MODEL, ...getDiscoveredHybridAIModelNames()];
+    case 'openai':
+      return config.openai.enabled ? config.openai.models : [];
     case 'openai-codex':
       return getDiscoveredCodexModelNames();
     case 'anthropic': {
@@ -377,6 +380,7 @@ export function getAvailableModelList(provider?: string): string[] {
     ? collectModelsForProvider(normalizedProvider)
     : [
         HYBRIDAI_MODEL,
+        ...(config.openai.enabled ? config.openai.models : []),
         ...getDiscoveredCodexModelNames(),
         ...collectModelsForProvider('anthropic'),
         ...getDiscoveredHybridAIModelNames(),
@@ -481,6 +485,7 @@ export async function refreshModelCatalogMetadata(
     await discoverAllLocalModels();
     return;
   }
+  if (hasModelPrefix(normalized, OPENAI_MODEL_PREFIX)) return;
   if (hasModelPrefix(normalized, OPENAI_CODEX_MODEL_PREFIX)) {
     await discoverCodexModels();
     return;
@@ -572,6 +577,9 @@ function resolveKnownModelPricingUsdPerToken(
         output: null,
       }
     );
+  }
+  if (hasModelPrefix(model, OPENAI_MODEL_PREFIX)) {
+    return { input: null, output: null };
   }
   return (
     getDiscoveredHybridAIModelPricingUsdPerToken(model) ??

--- a/src/providers/model-metadata.ts
+++ b/src/providers/model-metadata.ts
@@ -180,6 +180,24 @@ const STATIC_MODEL_METADATA: Record<string, StaticModelMetadataEntry> = {
     capabilities: coreModelCapabilities,
     sources: [MODEL_METADATA_SOURCES.openaiModels],
   },
+  'gpt-5.6-sol': {
+    contextWindow: 1_050_000,
+    maxTokens: 128_000,
+    capabilities: coreModelCapabilities,
+    sources: [MODEL_METADATA_SOURCES.openaiModels],
+  },
+  'gpt-5.6-terra': {
+    contextWindow: 1_050_000,
+    maxTokens: 128_000,
+    capabilities: coreModelCapabilities,
+    sources: [MODEL_METADATA_SOURCES.openaiModels],
+  },
+  'gpt-5.6-luna': {
+    contextWindow: 400_000,
+    maxTokens: 128_000,
+    capabilities: coreModelCapabilities,
+    sources: [MODEL_METADATA_SOURCES.openaiModels],
+  },
   'claude-haiku-4-5': {
     contextWindow: 200_000,
     maxTokens: 64_000,

--- a/src/providers/openai-compat-discovery.ts
+++ b/src/providers/openai-compat-discovery.ts
@@ -45,6 +45,7 @@ const ENABLED_BY_ID: Record<RuntimeProviderId, (() => boolean) | undefined> = {
   xiaomi: () => XIAOMI_ENABLED,
   kilo: () => KILO_ENABLED,
   hybridai: undefined,
+  openai: undefined,
   'openai-codex': undefined,
   anthropic: undefined,
   openrouter: undefined,

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,15 +1,59 @@
 import { resolveCodexCredentials } from '../auth/codex-auth.js';
-import { CODEX_BASE_URL } from '../config/config.js';
+import {
+  CODEX_BASE_URL,
+  OPENAI_API_KEY,
+  OPENAI_BASE_URL,
+} from '../config/config.js';
+import { resolveStaticModelCatalogMetadata } from './model-metadata.js';
+import { readProviderApiKey } from './provider-api-key-utils.js';
 import { createModelMatcher, normalizeAgentId } from './provider-utils.js';
 import type {
   AIProvider,
   ResolvedModelRuntimeCredentials,
   ResolveProviderRuntimeParams,
 } from './types.js';
+import { normalizeBaseUrl } from './utils.js';
 
+export const OPENAI_MODEL_PREFIX = 'openai/';
 export const OPENAI_CODEX_MODEL_PREFIX = 'openai-codex/';
 
+export const isOpenAIModel = createModelMatcher(OPENAI_MODEL_PREFIX);
 export const isOpenAICodexModel = createModelMatcher(OPENAI_CODEX_MODEL_PREFIX);
+
+export function readOpenAIAPIKey(opts?: { required?: boolean }): string {
+  return readProviderApiKey(
+    () => [process.env.OPENAI_API_KEY, OPENAI_API_KEY],
+    'OPENAI_API_KEY',
+    opts,
+  );
+}
+
+async function resolveOpenAIAPIRuntimeCredentials(
+  params: ResolveProviderRuntimeParams,
+): Promise<ResolvedModelRuntimeCredentials> {
+  const metadata = resolveStaticModelCatalogMetadata(params.model);
+  return {
+    provider: 'openai',
+    providerMethod: 'api-key',
+    model: params.model,
+    apiKey: readOpenAIAPIKey({ required: true }),
+    baseUrl: normalizeBaseUrl(OPENAI_BASE_URL),
+    chatbotId: '',
+    enableRag: false,
+    requestHeaders: {},
+    agentId: normalizeAgentId(params.agentId),
+    isLocal: false,
+    contextWindow: metadata.contextWindow ?? undefined,
+    maxTokens: metadata.maxTokens ?? undefined,
+  };
+}
+
+export const openAIAPIProvider: AIProvider = {
+  id: 'openai',
+  matchesModel: isOpenAIModel,
+  requiresChatbotId: () => false,
+  resolveRuntimeCredentials: resolveOpenAIAPIRuntimeCredentials,
+};
 
 async function resolveOpenAIRuntimeCredentials(
   params: ResolveProviderRuntimeParams,

--- a/src/providers/provider-ids.ts
+++ b/src/providers/provider-ids.ts
@@ -7,6 +7,7 @@ export const LOCAL_BACKEND_IDS = [
 
 export const RUNTIME_PROVIDER_IDS = [
   'hybridai',
+  'openai',
   'openai-codex',
   'anthropic',
   'openrouter',

--- a/src/providers/task-routing.ts
+++ b/src/providers/task-routing.ts
@@ -39,6 +39,7 @@ const AUXILIARY_TASKS: AuxiliaryTask[] = [...TASK_MODEL_KEYS, 'cv_narration'];
 const ENV_OVERRIDE_PREFIXES = ['AUXILIARY_', 'CONTEXT_'] as const;
 const RUNTIME_PROVIDER_PREFIXES: Record<RuntimeProvider, string> = {
   hybridai: '',
+  openai: 'openai/',
   'openai-codex': 'openai-codex/',
   anthropic: 'anthropic/',
   openrouter: 'openrouter/',

--- a/src/tui-banner.ts
+++ b/src/tui-banner.ts
@@ -246,6 +246,8 @@ function chunkCommands(width: number): string[] {
 
 function resolveProviderLabel(model: string): string {
   switch (detectRuntimeProviderPrefix(model)) {
+    case 'openai':
+      return 'OpenAI API';
     case 'openai-codex':
       return 'Codex';
     case 'openrouter':

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -4313,6 +4313,36 @@ describe('CLI hybridai commands', () => {
     expect(logSpy).toHaveBeenCalledWith('Tenant ID: teams-tenant-id');
   });
 
+  it('configures the direct OpenAI API provider from auth login', async () => {
+    const { cli, saveRuntimeSecrets, updateRuntimeConfig } =
+      await importFreshCli();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await cli.main([
+      'auth',
+      'login',
+      'openai',
+      'gpt-5.6-sol',
+      '--api-key',
+      'openai-secret-key',
+    ]);
+
+    expect(saveRuntimeSecrets).toHaveBeenCalledWith({
+      OPENAI_API_KEY: 'openai-secret-key',
+    });
+    const nextConfig = updateRuntimeConfig.mock.results[0]?.value as {
+      hybridai: { defaultModel: string };
+      openai: { enabled: boolean; models: string[] };
+    };
+    expect(nextConfig.openai.enabled).toBe(true);
+    expect(nextConfig.openai.models[0]).toBe('openai/gpt-5.6-sol');
+    expect(nextConfig.hybridai.defaultModel).toBe('openai/gpt-5.6-sol');
+    expect(logSpy).toHaveBeenCalledWith('Provider: openai');
+    expect(logSpy).toHaveBeenCalledWith(
+      'Configured model: openai/gpt-5.6-sol',
+    );
+  });
+
   it('configures OpenRouter from auth login with --api-key', async () => {
     const {
       cli,

--- a/tests/model-catalog.test.ts
+++ b/tests/model-catalog.test.ts
@@ -124,6 +124,25 @@ test('model catalog metadata resolves context and capabilities from static data'
   expect(flagship.pricingUsdPerToken).toEqual({ input: null, output: null });
 });
 
+test('direct OpenAI catalog exposes configured models only when enabled', async () => {
+  const homeDir = makeTempHome();
+  writeRuntimeConfig(homeDir, (config) => {
+    config.openai.enabled = true;
+    config.openai.models = ['openai/gpt-5.6-sol', 'openai/custom-model'];
+  });
+  const { catalog } = await importFreshCatalog(homeDir);
+
+  expect(catalog.getAvailableModelList('openai')).toEqual([
+    'openai/custom-model',
+    'openai/gpt-5.6-sol',
+  ]);
+  expect(catalog.getModelCatalogMetadata('openai/gpt-5.6-sol')).toMatchObject({
+    contextWindow: 1_050_000,
+    maxTokens: 128_000,
+    pricingUsdPerToken: { input: null, output: null },
+  });
+});
+
 test('static context and vision lookups share versioned metadata', async () => {
   const homeDir = makeTempHome();
   writeRuntimeConfig(homeDir);

--- a/tests/model-metadata.test.ts
+++ b/tests/model-metadata.test.ts
@@ -188,3 +188,21 @@ test('Claude Sonnet 5 has current context and output limits', () => {
     },
   });
 });
+
+test.each([
+  ['openai/gpt-5.6-sol', 1_050_000],
+  ['openai/gpt-5.6-terra', 1_050_000],
+  ['openai/gpt-5.6-luna', 400_000],
+])('%s has current OpenAI context and output limits', (model, contextWindow) => {
+  expect(resolveStaticModelCatalogMetadata(model)).toMatchObject({
+    known: true,
+    contextWindow,
+    maxTokens: 128_000,
+    capabilities: {
+      vision: true,
+      tools: true,
+      jsonMode: true,
+      reasoning: true,
+    },
+  });
+});

--- a/tests/openai-api-provider.test.ts
+++ b/tests/openai-api-provider.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+  callOpenAIResponsesProvider,
+  callOpenAIResponsesProviderStream,
+} from '../container/src/providers/openai-codex.js';
+import type { ChatMessage, ToolDefinition } from '../container/src/types.js';
+
+const messages: ChatMessage[] = [
+  { role: 'system', content: 'Be concise.' },
+  { role: 'user', content: 'Check the weather.' },
+];
+const tools: ToolDefinition[] = [
+  {
+    type: 'function',
+    function: {
+      name: 'get_weather',
+      description: 'Get weather for a city',
+      parameters: {
+        type: 'object',
+        properties: { city: { type: 'string' } },
+        required: ['city'],
+      },
+    },
+  },
+];
+const baseArgs = {
+  provider: 'openai' as const,
+  providerMethod: 'api-key',
+  baseUrl: 'https://api.openai.com/v1',
+  apiKey: 'openai-key',
+  model: 'openai/gpt-5.6-sol',
+  chatbotId: '',
+  enableRag: false,
+  requestHeaders: {},
+  messages,
+  tools,
+  maxTokens: 512,
+  isLocal: false,
+  contextWindow: 1_050_000,
+  thinkingFormat: undefined,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('OpenAI API provider', () => {
+  test('sends Responses API requests with tools and adapts function calls', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe('https://api.openai.com/v1/responses');
+      expect(new Headers(init?.headers).get('authorization')).toBe(
+        'Bearer openai-key',
+      );
+      const body = JSON.parse(String(init?.body || '{}')) as Record<
+        string,
+        unknown
+      >;
+      expect(body).toMatchObject({
+        model: 'gpt-5.6-sol',
+        store: false,
+        stream: true,
+        instructions: 'Be concise.',
+        max_output_tokens: 512,
+        include: ['reasoning.encrypted_content'],
+        tool_choice: 'auto',
+        parallel_tool_calls: true,
+        tools: [
+          {
+            type: 'function',
+            name: 'get_weather',
+            description: 'Get weather for a city',
+            parameters: {
+              type: 'object',
+              properties: { city: { type: 'string' } },
+              required: ['city'],
+            },
+          },
+        ],
+      });
+      expect(body.input).toEqual([
+        { role: 'user', content: 'Check the weather.' },
+      ]);
+      return new Response(
+        JSON.stringify({
+          id: 'resp_openai_1',
+          model: 'gpt-5.6-sol',
+          output: [
+            {
+              type: 'reasoning',
+              id: 'rs_1',
+              encrypted_content: 'encrypted-reasoning-state',
+              summary: [],
+            },
+            {
+              type: 'function_call',
+              id: 'fc_1',
+              call_id: 'call_1',
+              name: 'get_weather',
+              arguments: '{"city":"Berlin"}',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await callOpenAIResponsesProvider(baseArgs);
+
+    expect(response.choices[0]?.message.tool_calls).toEqual([
+      {
+        id: 'call_1',
+        type: 'function',
+        function: {
+          name: 'get_weather',
+          arguments: '{"city":"Berlin"}',
+        },
+      },
+    ]);
+    expect(response.choices[0]?.finish_reason).toBe('tool_calls');
+    expect(response.choices[0]?.message.openai_response_items).toEqual([
+      {
+        type: 'reasoning',
+        id: 'rs_1',
+        encrypted_content: 'encrypted-reasoning-state',
+        summary: [],
+      },
+    ]);
+
+    fetchMock.mockClear();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body || '{}')) as {
+          input?: unknown[];
+        };
+        expect(body.input).toEqual([
+          {
+            type: 'reasoning',
+            id: 'rs_1',
+            encrypted_content: 'encrypted-reasoning-state',
+            summary: [],
+          },
+          {
+            type: 'function_call',
+            call_id: 'call_1',
+            name: 'get_weather',
+            arguments: '{"city":"Berlin"}',
+          },
+          {
+            type: 'function_call_output',
+            call_id: 'call_1',
+            output: 'Sunny',
+          },
+        ]);
+        return new Response(
+          JSON.stringify({
+            id: 'resp_openai_2',
+            model: 'gpt-5.6-sol',
+            output: [
+              {
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'It is sunny.' }],
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+      }),
+    );
+
+    const continuation = await callOpenAIResponsesProvider({
+      ...baseArgs,
+      messages: [
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: response.choices[0]?.message.tool_calls,
+          openai_response_items:
+            response.choices[0]?.message.openai_response_items,
+        },
+        {
+          role: 'tool',
+          content: 'Sunny',
+          tool_call_id: 'call_1',
+        },
+      ],
+    });
+    expect(continuation.choices[0]?.message.content).toBe('It is sunny.');
+  });
+
+  test('streams text deltas and reports OpenAI-specific empty responses', async () => {
+    const encoder = new TextEncoder();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  'event: response.output_text.delta\r\n' +
+                    'data: {"type":"response.output_text.delta","delta":"Hello"}\r\n\r\n' +
+                    'event: response.completed\r\n' +
+                    'data: {"type":"response.completed","response":{"id":"resp_openai_2","model":"gpt-5.6-sol","output":[]}}\r\n\r\n',
+                ),
+              );
+              controller.close();
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+          },
+        ),
+      ),
+    );
+    const deltas: string[] = [];
+
+    const response = await callOpenAIResponsesProviderStream({
+      ...baseArgs,
+      tools: [],
+      onTextDelta: (delta) => deltas.push(delta),
+    });
+
+    expect(deltas).toEqual(['Hello']);
+    expect(response.choices[0]?.message.content).toBe('Hello');
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              id: 'resp_openai_3',
+              model: 'gpt-5.6-sol',
+              output: [],
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          ),
+      ),
+    );
+
+    await expect(
+      callOpenAIResponsesProvider({ ...baseArgs, tools: [] }),
+    ).rejects.toThrow('OpenAI Responses API returned no output items');
+  });
+});

--- a/tests/provider-context-validation.test.ts
+++ b/tests/provider-context-validation.test.ts
@@ -30,6 +30,22 @@ describe('provider context validation', () => {
     ).toBe('compression is not configured: missing API key context.');
   });
 
+  test('requires an API key and infers the direct OpenAI provider', () => {
+    expect(
+      getProviderContextError({
+        provider: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: '',
+        model: 'openai/gpt-5.6-sol',
+        chatbotId: '',
+        toolName: 'compression',
+      }),
+    ).toBe('compression is not configured: missing API key context.');
+    expect(
+      resolveRuntimeProviderContext(undefined, 'openai/gpt-5.6-sol'),
+    ).toBe('openai');
+  });
+
   test('requires an API key for Hugging Face contexts', () => {
     expect(
       getProviderContextError({

--- a/tests/providers.factory.test.ts
+++ b/tests/providers.factory.test.ts
@@ -9,6 +9,7 @@ const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_DISABLE_CONFIG_WATCHER =
   process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
 const ORIGINAL_HYBRIDAI_API_KEY = process.env.HYBRIDAI_API_KEY;
+const ORIGINAL_OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const ORIGINAL_OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
 const ORIGINAL_MISTRAL_API_KEY = process.env.MISTRAL_API_KEY;
 const ORIGINAL_ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
@@ -81,6 +82,7 @@ afterEach(() => {
     ORIGINAL_DISABLE_CONFIG_WATCHER,
   );
   restoreEnvVar('HYBRIDAI_API_KEY', ORIGINAL_HYBRIDAI_API_KEY);
+  restoreEnvVar('OPENAI_API_KEY', ORIGINAL_OPENAI_API_KEY);
   restoreEnvVar('OPENROUTER_API_KEY', ORIGINAL_OPENROUTER_API_KEY);
   restoreEnvVar('MISTRAL_API_KEY', ORIGINAL_MISTRAL_API_KEY);
   restoreEnvVar('ANTHROPIC_API_KEY', ORIGINAL_ANTHROPIC_API_KEY);
@@ -99,6 +101,7 @@ afterEach(() => {
 test('provider factory resolves adapters by model family', async () => {
   const homeDir = makeTempHome();
   writeRuntimeConfig(homeDir, (config) => {
+    config.openai.enabled = true;
     config.openrouter.enabled = true;
     config.mistral.enabled = true;
     config.huggingface.enabled = true;
@@ -115,6 +118,7 @@ test('provider factory resolves adapters by model family', async () => {
   const factory = await importFreshFactory(homeDir);
 
   expect(factory.resolveModelProvider('gpt-5-nano')).toBe('hybridai');
+  expect(factory.resolveModelProvider('openai/gpt-5.6-sol')).toBe('openai');
   expect(factory.resolveModelProvider('openai-codex/gpt-5-codex')).toBe(
     'openai-codex',
   );
@@ -149,6 +153,7 @@ test('provider factory resolves adapters by model family', async () => {
   );
 
   expect(factory.modelRequiresChatbotId('gpt-5-nano')).toBe(true);
+  expect(factory.modelRequiresChatbotId('openai/gpt-5.6-sol')).toBe(false);
   expect(factory.modelRequiresChatbotId('openai-codex/gpt-5-codex')).toBe(
     false,
   );
@@ -328,6 +333,36 @@ test('provider factory resolves OpenRouter runtime credentials', async () => {
     agentId: 'main',
     isLocal: false,
     contextWindow: 262_144,
+  });
+});
+
+test('provider factory resolves OpenAI API runtime credentials', async () => {
+  const homeDir = makeTempHome();
+  writeRuntimeConfig(homeDir, (config) => {
+    config.openai.enabled = true;
+    config.openai.baseUrl = 'https://api.openai.com/v1/';
+  });
+  process.env.OPENAI_API_KEY = 'openai-provider-test';
+  const factory = await importFreshFactory(homeDir);
+
+  const credentials = await factory.resolveModelRuntimeCredentials({
+    model: 'openai/gpt-5.6-sol',
+    agentId: 'main',
+  });
+
+  expect(credentials).toMatchObject({
+    provider: 'openai',
+    providerMethod: 'api-key',
+    model: 'openai/gpt-5.6-sol',
+    apiKey: 'openai-provider-test',
+    baseUrl: 'https://api.openai.com/v1',
+    chatbotId: '',
+    enableRag: false,
+    requestHeaders: {},
+    agentId: 'main',
+    isLocal: false,
+    contextWindow: 1_050_000,
+    maxTokens: 128_000,
   });
 });
 

--- a/tests/tui-banner.test.ts
+++ b/tests/tui-banner.test.ts
@@ -143,6 +143,27 @@ test('does not stretch the panel wider than the wordmark span on medium terminal
   expect(lines).toContainEqual(expect.stringContaining('░██     ░██'));
 });
 
+test('labels direct OpenAI API models separately from Codex', () => {
+  const lines = renderTuiStartupBanner({
+    columns: 120,
+    info: {
+      currentModel: 'openai/gpt-5.6-sol',
+      defaultModel: 'openai/gpt-5.6-sol',
+      sandboxMode: 'container',
+      gatewayBaseUrl: 'http://127.0.0.1:3000',
+      hybridAIBaseUrl: 'https://api.hybridai.one/v1',
+      chatbotId: '',
+      version: '0.8.0',
+      skillCategories: [],
+    },
+    palette,
+  }).map(stripAnsi);
+
+  expect(lines).toContainEqual(
+    expect.stringContaining('model     openai/gpt-5.6-sol (OpenAI API)'),
+  );
+});
+
 test('falls back to a stacked banner and compact title on narrow terminals', () => {
   const lines = renderTuiStartupBanner({
     columns: 68,


### PR DESCRIPTION
## Summary

- add a direct `openai/...` provider backed by the OpenAI Responses API
- support streaming, function tools, vision routing, refusals, and stateless encrypted reasoning-item replay
- add encrypted API-key authentication, runtime configuration, model catalog metadata, CLI flows, gateway health, doctor diagnostics, and console/TUI labels
- document the provider while keeping Codex OAuth isolated under `openai-codex/...`

## Why

HybridClaw supported Codex OAuth and OpenAI-compatible gateways, but did not offer a first-class provider for calling the OpenAI model API directly with `OPENAI_API_KEY`. This adds that path without changing existing Codex behavior or adding an SDK dependency.

## Validation

- `npm run format`
- `npm run lint`
- `npm --prefix container run lint`
- 281 focused Vitest tests covering the Responses transport, provider factory, model catalog, metadata, context validation, CLI login, and TUI labeling
- `git diff --check`

A full unit run was also attempted: 5,376 of 5,380 tests passed. Three parallel-sensitive failures passed when rerun individually; the remaining host-runner failure was caused by the temporary dependency symlink used in this isolated worktree. No live OpenAI request was made because no API credential was available.