### PR TITLE
fix: replace secret show with secret status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2117,7 +2117,7 @@
   auto-captures tokens using config constants instead of raw environment
   variables.
 - **Secret CLI simplification**: Removed the `[--raw]` option from
-  `secret show` and `secret set`, streamlining the operator-facing surface.
+  `secret status` and `secret set`, streamlining the operator-facing surface.
 - **CI pipeline split**: Unit tests now run as parallel lint and test jobs
   with a shared `setup-node-workspace` composite action and PR-level
   concurrency groups that cancel stale runs.
@@ -2471,7 +2471,7 @@
   plaintext secret files.
 - **SecretRefs and named secrets**: Selected runtime config fields can now
   resolve secret-bearing values from `env` or encrypted `store` references,
-  local TUI and web sessions expose `/secret list|set|unset|show|route ...`,
+  local TUI and web sessions expose `/secret list|set|status|unset|route ...`,
   and generic named secrets can be stored without adding new top-level env
   variables.
 - **Secret-backed HTTP requests**: Added the `http_request` tool plus

--- a/docs/content/channels/local-config-and-secrets.md
+++ b/docs/content/channels/local-config-and-secrets.md
@@ -16,7 +16,7 @@ encrypted secrets without leaving the chat surface.
 /config check
 /config reload
 /secret set <NAME> <value>
-/secret show <NAME>
+/secret status <NAME>
 /secret unset <NAME>
 /secret list
 ```

--- a/docs/content/getting-started/authentication.md
+++ b/docs/content/getting-started/authentication.md
@@ -167,7 +167,7 @@ gateway-side auth routing from local TUI and local web chat sessions:
 ```bash
 hybridclaw secret list
 hybridclaw secret set <NAME> <VALUE>
-hybridclaw secret show <NAME>
+hybridclaw secret status <NAME>
 hybridclaw secret unset <NAME>
 hybridclaw secret route list
 hybridclaw secret route add <url-prefix> <secret-name|google-oauth|microsoft-oauth> [header] [prefix|none]
@@ -177,7 +177,7 @@ hybridclaw secret route remove <url-prefix> [header]
 ```text
 /secret list
 /secret set <NAME> <VALUE>
-/secret show <NAME>
+/secret status <NAME>
 /secret unset <NAME>
 /secret route list
 /secret route add <url-prefix> <secret-name|google-oauth|microsoft-oauth> [header] [prefix|none]

--- a/docs/content/reference/commands.md
+++ b/docs/content/reference/commands.md
@@ -343,7 +343,7 @@ CLI and local TUI/web slash-command surface:
 ```bash
 hybridclaw secret list
 hybridclaw secret set <name> <value>
-hybridclaw secret show <name>
+hybridclaw secret status <name>
 hybridclaw secret unset <name>
 hybridclaw secret route list
 hybridclaw secret route add <url-prefix> <secret-name|google-oauth|microsoft-oauth> [header] [prefix|none]
@@ -357,7 +357,7 @@ hybridclaw env unset <name>
 ```text
 /secret list
 /secret set <name> <value>
-/secret show <name>
+/secret status <name>
 /secret unset <name>
 /secret route list
 /secret route add <url-prefix> <secret-name|google-oauth|microsoft-oauth> [header] [prefix|none]
@@ -370,7 +370,7 @@ hybridclaw env unset <name>
 
 - local-only surface: `/secret ...` is available from local TUI and local web
   chat sessions, not from Discord or other remote channels
-- `hybridclaw secret show <name>` reports whether the secret is stored; it
+- `hybridclaw secret status <name>` reports whether the secret is stored; it
   never outputs decrypted values. Secrets are only resolved gateway-side via
   `<secret:NAME>` placeholders or auth rules
 - stored secret names must use uppercase letters, digits, and underscores
@@ -722,7 +722,7 @@ plugins and explicit skill invocations can add dynamic slash commands; use
 | `/ralph [info|on|off|set n]` | local and chat channels | Configure the Ralph loop |
 | `/reset [yes|no]` | local and chat channels | Run the confirmed workspace reset flow |
 | `/schedule add|list|remove|toggle ...` | local and chat channels | Manage scheduled tasks for the session |
-| `/secret [list|set|show|unset|route]` | local TUI/web | Manage encrypted secrets and HTTP auth routes |
+| `/secret [list|set|status|unset|route]` | local TUI/web | Manage encrypted secrets and HTTP auth routes |
 | `/second-opinion [compare|validate|fact-check]` | local and chat channels | Ask a stronger configured model to compare, validate, or fact-check |
 | `/sessions [active|clear-active|prune --older-than <duration> [--dry-run|--confirm]]` | local and chat channels | Inspect active session tracking or prune old persisted sessions |
 | `/show [all|thinking|tools|none]` | local and chat channels | Control thinking/tool activity visibility |
@@ -797,7 +797,7 @@ reserved for the R5.3 signal when that spend-tracking enforcement lands.
 - Local TUI and web chat sessions expose `/config`, `/config check`,
   `/config reload`, `/config get <key>`, `/config set <key> <value>`,
   `/concierge`, `/auth status <provider>`, and
-  `/secret list|set|unset|show|route`
+  `/secret list|set|status|unset|route`
   alongside the existing runtime commands
 - local TUI and web chat also expose `/dream [info|on|off|now]` for nightly
   memory-consolidation status, scheduler toggling, and manual runs

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -443,7 +443,7 @@ Local TUI/web sessions and the local CLI manage this store through:
 ```bash
 hybridclaw secret list
 hybridclaw secret set <NAME> <VALUE>
-hybridclaw secret show <NAME>
+hybridclaw secret status <NAME>
 hybridclaw secret unset <NAME>
 hybridclaw secret route list
 hybridclaw secret route add <url-prefix> <secret-name|google-oauth|microsoft-oauth> [header] [prefix|none]
@@ -453,7 +453,7 @@ hybridclaw secret route remove <url-prefix> [header]
 ```text
 /secret list
 /secret set <NAME> <VALUE>
-/secret show <NAME>
+/secret status <NAME>
 /secret unset <NAME>
 /secret route list
 /secret route add <url-prefix> <secret-name|google-oauth|microsoft-oauth> [header] [prefix|none]

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -189,7 +189,7 @@ Interactive slash commands inside TUI:
   /ralph [info|on|off|set n]
   /reset [yes|no]
   /schedule add "<cron>" <prompt> | at "<ISO time>" <prompt> | every <ms> <prompt>
-  /secret list   /secret set <name> <value>   /secret show <name>   /secret unset <name>   /secret route ...
+  /secret list   /secret set <name> <value>   /secret status <name>   /secret unset <name>   /secret route ...
   /sessions [active|clear-active|prune --older-than <duration> [--dry-run|--confirm]]
   /show [all|thinking|tools|none]
   /skill config|list|inspect <name>|inspect --all|runs <name>|install <skill> <dependency>|learn <name> [--apply|--reject|--rollback]|history <name>|unblock <name>|sync [--skip-skill-scan] <source>|import [--force] [--skip-skill-scan] <source>
@@ -887,7 +887,7 @@ export function printSecretUsage(): void {
 Commands:
   hybridclaw secret list
   hybridclaw secret set <name> <value>
-  hybridclaw secret show <name>
+  hybridclaw secret status <name>
   hybridclaw secret unset <name>
   hybridclaw secret route list
   hybridclaw secret route add <url-prefix> <secret-name|google-oauth|microsoft-oauth> [header] [prefix|none]
@@ -896,7 +896,7 @@ Commands:
 Examples:
   hybridclaw secret list
   hybridclaw secret set SF_FULL_USERNAME you@example.com
-  hybridclaw secret show SF_FULL_USERNAME
+  hybridclaw secret status SF_FULL_USERNAME
   hybridclaw secret unset SF_FULL_USERNAME
   hybridclaw secret route add https://staging.hybridai.one/api/v1/ STAGING_HYBRIDAI_API_KEY X-API-Key none
   hybridclaw secret route add https://analyticsdata.googleapis.com/ google-oauth Authorization Bearer
@@ -905,7 +905,7 @@ Examples:
 Notes:
   - \`secret\` reads and writes the encrypted store at ${runtimeSecretsPath()}.
   - Secret names must use uppercase letters, digits, and underscores.
-  - \`show\` reports whether a secret is stored; it never outputs decrypted values. Secrets are only resolved gateway-side via \`<secret:NAME>\` placeholders or auth rules.
+  - \`status\` reports whether a secret is stored; it never outputs decrypted values. Secrets are only resolved gateway-side via \`<secret:NAME>\` placeholders or auth rules.
   - \`route add\` writes \`tools.httpRequest.authRules[]\` in ${runtimeConfigPath()} with a store-backed secret ref, the Google OAuth runtime token provider, or the Microsoft Graph OAuth runtime token provider.
   - Use \`prefix\` for \`Bearer <secret>\` or \`none\` for raw header injection.`);
 }

--- a/src/cli/secret-command.ts
+++ b/src/cli/secret-command.ts
@@ -162,11 +162,11 @@ export async function handleSecretCommand(args: string[]): Promise<void> {
     return;
   }
 
-  if (sub === 'show' || sub === 'status') {
+  if (sub === 'status') {
     const secretName = String(normalized[1] || '').trim();
     if (!secretName) {
       printSecretUsage();
-      throw new Error('Usage: `hybridclaw secret show <name>`');
+      throw new Error('Usage: `hybridclaw secret status <name>`');
     }
     assertSecretName(secretName);
     const stored = readStoredRuntimeSecret(secretName);
@@ -347,6 +347,6 @@ export async function handleSecretCommand(args: string[]): Promise<void> {
 
   printSecretUsage();
   throw new Error(
-    'Unknown secret subcommand. Use `hybridclaw secret list|set|show|unset|route`.',
+    'Unknown secret subcommand. Use `hybridclaw secret list|set|status|unset|route`.',
   );
 }

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -304,7 +304,7 @@ const LOCAL_SESSION_HELP_PRESENTATIONS: Record<
     description: 'Add a scheduled task',
   },
   secret: {
-    command: '/secret [list|set|show|unset|route]',
+    command: '/secret [list|set|status|unset|route]',
     description: 'Manage stored secrets and URL auth routes',
   },
   voice: {
@@ -1699,6 +1699,12 @@ function buildSlashCommandCatalogDefinitions(
           description: 'Store an encrypted named secret',
         },
         {
+          id: 'secret.status',
+          label: '/secret status <name>',
+          insertText: '/secret status ',
+          description: 'Report whether an encrypted named secret is stored',
+        },
+        {
           id: 'secret.route.add',
           label:
             '/secret route add <url-prefix> <secret-name|google-oauth|microsoft-oauth>',
@@ -1715,8 +1721,8 @@ function buildSlashCommandCatalogDefinitions(
           choices: [
             { name: 'list', value: 'list' },
             { name: 'set', value: 'set' },
+            { name: 'status', value: 'status' },
             { name: 'unset', value: 'unset' },
-            { name: 'show', value: 'show' },
             { name: 'route', value: 'route' },
           ],
         },
@@ -3220,7 +3226,7 @@ export function parseCanonicalSlashCommandArgs(
       const value = normalizeStringOption(interaction, 'value');
       if (!action && !name && !value) return ['secret'];
       if (action === 'list' && !name && !value) return ['secret', 'list'];
-      if ((action === 'unset' || action === 'show') && name && !value) {
+      if ((action === 'unset' || action === 'status') && name && !value) {
         return ['secret', action, name];
       }
       if (action === 'set' && name && value) {

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -12561,10 +12561,10 @@ export async function handleGatewayCommand(
           );
         }
 
-        if (sub === 'show' || sub === 'status') {
+        if (sub === 'status') {
           const secretName = parseIdArg(req.args, 2);
           if (!secretName) {
-            return badCommand('Usage', 'Usage: `secret show <name>`');
+            return badCommand('Usage', 'Usage: `secret status <name>`');
           }
           if (!isRuntimeSecretName(secretName)) {
             return badCommand(
@@ -12583,7 +12583,7 @@ export async function handleGatewayCommand(
 
         return badCommand(
           'Usage',
-          'Usage: `secret list`, `secret set <name> <value>`, `secret unset <name>`, `secret show <name>`, or `secret route list|add|remove ...`',
+          'Usage: `secret list`, `secret set <name> <value>`, `secret status <name>`, `secret unset <name>`, or `secret route list|add|remove ...`',
         );
       }
 

--- a/tests/command-registry.test.ts
+++ b/tests/command-registry.test.ts
@@ -605,6 +605,18 @@ test('registers secret as a local slash/text command', async () => {
       getSubcommand: () => null,
     }),
   ).toEqual(['secret', 'set', 'STAGING_HYBRIDAI_API_KEY', 'demo_key_2024']);
+  expect(
+    parseCanonicalSlashCommandArgs({
+      commandName: 'secret',
+      getString: (name) =>
+        name === 'action'
+          ? 'status'
+          : name === 'name'
+            ? 'STAGING_HYBRIDAI_API_KEY'
+            : null,
+      getSubcommand: () => null,
+    }),
+  ).toEqual(['secret', 'status', 'STAGING_HYBRIDAI_API_KEY']);
   expect(mapCanonicalCommandToGatewayArgs(['secret'])).toEqual(['secret']);
   expect(
     mapCanonicalCommandToGatewayArgs([

--- a/tests/fixtures/salesforce_helper_assertions.py
+++ b/tests/fixtures/salesforce_helper_assertions.py
@@ -294,7 +294,7 @@ def route_check(module: Any) -> None:
 
 def secret_scan(path: str) -> None:
     content = pathlib.Path(path).read_text()
-    assert "secret show" not in content, "Script must not read secrets via CLI"
+    assert "secret status" not in content, "Script must not inspect secrets via CLI"
     assert "secret set" not in content, (
         "Script must not write secrets via CLI - use captureResponseSecrets"
     )

--- a/tests/gateway-service.secret-command.test.ts
+++ b/tests/gateway-service.secret-command.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from 'vitest';
+import { setupGatewayTest } from './helpers/gateway-test-setup.js';
+
+const { setupHome } = setupGatewayTest({
+  tempHomePrefix: 'hybridclaw-gateway-secret-command-',
+});
+
+test('secret status reports metadata without exposing the stored value', async () => {
+  setupHome();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { saveNamedRuntimeSecrets } = await import(
+    '../src/security/runtime-secrets.ts'
+  );
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  saveNamedRuntimeSecrets({ API_TOKEN: 'test-secret-value' });
+
+  const result = await handleGatewayCommand({
+    sessionId: 'session-secret-status',
+    guildId: null,
+    channelId: 'tui',
+    args: ['secret', 'status', 'API_TOKEN'],
+  });
+
+  expect(result.kind).toBe('info');
+  if (result.kind !== 'info') {
+    throw new Error(`Unexpected result kind: ${result.kind}`);
+  }
+  expect(result.title).toBe('Secret Status');
+  expect(result.text).toBe('Name: API_TOKEN\nStored: yes');
+  expect(result.text).not.toContain('test-secret-value');
+});
+
+test('secret status remains local-only and the removed alias is rejected', async () => {
+  setupHome();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  const removedAlias = await handleGatewayCommand({
+    sessionId: 'session-secret-alias',
+    guildId: null,
+    channelId: 'web',
+    args: ['secret', 'show', 'API_TOKEN'],
+  });
+  expect(removedAlias.kind).toBe('error');
+  if (removedAlias.kind !== 'error') {
+    throw new Error(`Unexpected result kind: ${removedAlias.kind}`);
+  }
+  expect(removedAlias.title).toBe('Usage');
+  expect(removedAlias.text).toContain('secret status <name>');
+
+  const remoteStatus = await handleGatewayCommand({
+    sessionId: 'session-secret-remote',
+    guildId: 'guild-1',
+    channelId: 'discord-channel-1',
+    args: ['secret', 'status', 'API_TOKEN'],
+  });
+  expect(remoteStatus.kind).toBe('error');
+  if (remoteStatus.kind !== 'error') {
+    throw new Error(`Unexpected result kind: ${remoteStatus.kind}`);
+  }
+  expect(remoteStatus.title).toBe('Secret Command Restricted');
+  expect(remoteStatus.text).toContain(
+    'only available from local TUI/web sessions',
+  );
+});

--- a/tests/local-cli.test.ts
+++ b/tests/local-cli.test.ts
@@ -244,7 +244,7 @@ test('help secret prints secret command usage', async () => {
   );
 });
 
-test('secret set, show, and unset manage encrypted secrets', async () => {
+test('secret set, status, and unset manage encrypted secrets', async () => {
   const homeDir = makeTempHome();
   const cli = await importFreshCli(homeDir);
   const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -267,21 +267,27 @@ test('secret set, show, and unset manage encrypted secrets', async () => {
   );
 
   logSpy.mockClear();
-  await cli.main(['secret', 'show', 'SF_FULL_USERNAME']);
+  await cli.main(['secret', 'status', 'SF_FULL_USERNAME']);
   expect(logSpy.mock.calls.map(([line]) => String(line))).toEqual([
     'Name: SF_FULL_USERNAME',
     'Stored: yes',
     `Path: ${runtimeSecrets.runtimeSecretsPath()}`,
   ]);
 
-  // --raw is no longer supported; show never outputs decrypted values
+  // Extra arguments are ignored; status never outputs decrypted values.
   logSpy.mockClear();
-  await cli.main(['secret', 'show', 'SF_FULL_USERNAME', '--raw']);
+  await cli.main(['secret', 'status', 'SF_FULL_USERNAME', '--raw']);
   expect(logSpy.mock.calls.map(([line]) => String(line))).toEqual([
     'Name: SF_FULL_USERNAME',
     'Stored: yes',
     `Path: ${runtimeSecrets.runtimeSecretsPath()}`,
   ]);
+
+  await expect(
+    cli.main(['secret', 'show', 'SF_FULL_USERNAME']),
+  ).rejects.toThrow(
+    'Unknown secret subcommand. Use `hybridclaw secret list|set|status|unset|route`.',
+  );
 
   await cli.main(['secret', 'unset', 'SF_FULL_USERNAME']);
   expect(runtimeSecrets.readStoredRuntimeSecret('SF_FULL_USERNAME')).toBeNull();

--- a/tests/tui-slash-menu.test.ts
+++ b/tests/tui-slash-menu.test.ts
@@ -29,6 +29,7 @@ test('builds canonical, choice-based, and TUI-only slash menu entries', () => {
   expect(labels).toContain('/aux list');
   expect(labels).toContain('/secret list');
   expect(labels).toContain('/secret set <name> <value>');
+  expect(labels).toContain('/secret status <name>');
   expect(labels).toContain('/env list');
   expect(labels).toContain('/env set <name> <value>');
   expect(labels).toContain('/voice <info|call>');


### PR DESCRIPTION
## Summary

- remove the obsolete `hybridclaw secret show` and `/secret show` aliases
- keep `secret status` as the sole command for reporting whether a named secret is stored
- update CLI help, local command menus, documentation, and changelog references
- add gateway and CLI coverage for the renamed command and removed alias

## Why

`secret show` never displayed a secret value; it only reported storage metadata. The `status` name accurately reflects that behavior and avoids implying that secret plaintext can be read back.

## Impact

Operators should use `hybridclaw secret status <name>` or `/secret status <name>`. The removed `show` form now returns usage guidance. `list`, `set`, `unset`, and `route` behavior is unchanged.

The security boundary remains intact: secret status is limited to local TUI/web sessions on the gateway surface and returns presence metadata without plaintext secret values.

## Validation

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- targeted Vitest suites: 91 tests passed
- Salesforce skill suite: 10 tests passed
- stale-reference scan for `hybridclaw secret show` and `/secret show`
