### PR TITLE
feat: redesign admin navigation information architecture

### DIFF
--- a/console/src/components/admin-nav.ts
+++ b/console/src/components/admin-nav.ts
@@ -17,9 +17,6 @@ export function resolveCurrentAdminNavItem(
   if (pathname.startsWith('/admin/skills/')) {
     return { to: '/admin/skills', label: 'Skill' };
   }
-  if (pathname === '/admin/teams') {
-    return { to: '/admin/teams', label: 'App Setup' };
-  }
 
   return ALL_NAV_ITEMS.find((item) => item.to === pathname) ?? ALL_NAV_ITEMS[0];
 }

--- a/console/src/components/app-shell.test.tsx
+++ b/console/src/components/app-shell.test.tsx
@@ -3,9 +3,9 @@ import { resolveCurrentAdminNavItem } from './admin-nav';
 
 describe('resolveCurrentAdminNavItem', () => {
   it('resolves a nav item by exact path', () => {
-    expect(resolveCurrentAdminNavItem('/admin/approvals')).toMatchObject({
-      to: '/admin/approvals',
-      label: 'Approvals',
+    expect(resolveCurrentAdminNavItem('/admin/network-policy')).toMatchObject({
+      to: '/admin/network-policy',
+      label: 'Network Policy',
     });
   });
 
@@ -23,11 +23,15 @@ describe('resolveCurrentAdminNavItem', () => {
     });
   });
 
-  it('resolves Teams setup to the app setup page title', () => {
-    expect(resolveCurrentAdminNavItem('/admin/teams')).toMatchObject({
-      to: '/admin/teams',
-      label: 'App Setup',
+  it('uses distinct labels for the agent admin surfaces', () => {
+    expect(resolveCurrentAdminNavItem('/admin/agents')).toMatchObject({
+      label: 'Workspace Files',
     });
+    expect(resolveCurrentAdminNavItem('/admin/agent-scoreboard')).toMatchObject(
+      {
+        label: 'Agent Scoreboard',
+      },
+    );
   });
 
   it('falls back to the first nav item when no match is found', () => {

--- a/console/src/components/sidebar/navigation.test.ts
+++ b/console/src/components/sidebar/navigation.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { SIDEBAR_NAV_GROUPS } from './navigation';
+
+describe('SIDEBAR_NAV_GROUPS', () => {
+  it('uses the task-oriented Phase 1 information architecture', () => {
+    expect(
+      SIDEBAR_NAV_GROUPS.map((group) => ({
+        label: group.label,
+        items: group.items.map(({ to, label }) => ({ to, label })),
+      })),
+    ).toEqual([
+      {
+        label: 'Overview',
+        items: [
+          { to: '/admin', label: 'Dashboard' },
+          { to: '/admin/statistics', label: 'Statistics' },
+          { to: '/admin/sessions', label: 'Sessions' },
+          { to: '/admin/audit', label: 'Audit Log' },
+        ],
+      },
+      {
+        label: 'Agents',
+        items: [
+          { to: '/admin/agent-scoreboard', label: 'Agent Scoreboard' },
+          { to: '/admin/agents', label: 'Workspace Files' },
+          { to: '/admin/skills', label: 'Skills' },
+          { to: '/admin/jobs', label: 'Work Queue' },
+          { to: '/admin/scheduler', label: 'Schedules' },
+        ],
+      },
+      {
+        label: 'Connectivity',
+        items: [
+          { to: '/admin/channels', label: 'Channels' },
+          { to: '/admin/email', label: 'Mailbox' },
+          { to: '/admin/connectors', label: 'Connectors' },
+          { to: '/admin/mcp', label: 'MCP Servers' },
+          { to: '/admin/a2a-inbox', label: 'A2A Inbox' },
+          { to: '/admin/a2a-trust', label: 'A2A Trust' },
+          { to: '/admin/fleet-topology', label: 'Fleet Topology' },
+        ],
+      },
+      {
+        label: 'Models',
+        items: [{ to: '/admin/models', label: 'Providers' }],
+      },
+      {
+        label: 'Security',
+        items: [
+          { to: '/admin/network-policy', label: 'Network Policy' },
+          { to: '/admin/output-guard', label: 'Output Guard' },
+          { to: '/admin/secrets', label: 'Secrets' },
+          { to: '/admin/tokens', label: 'API Tokens' },
+        ],
+      },
+      {
+        label: 'System',
+        items: [
+          { to: '/admin/gateway', label: 'Gateway' },
+          { to: '/admin/config', label: 'Settings' },
+          { to: '/admin/logs', label: 'Logs' },
+          { to: '/admin/plugins', label: 'Plugins' },
+          { to: '/admin/tools', label: 'Tools' },
+          { to: '/admin/terminal', label: 'Terminal' },
+        ],
+      },
+      {
+        label: 'Labs',
+        items: [
+          { to: '/admin/harness-evolution', label: 'Harness Evolution' },
+          { to: '/admin/distill', label: 'Distill' },
+        ],
+      },
+    ]);
+  });
+
+  it('does not expose the same route from more than one sidebar item', () => {
+    const routes = SIDEBAR_NAV_GROUPS.flatMap((group) =>
+      group.items.map((item) => item.to),
+    );
+
+    expect(new Set(routes).size).toBe(routes.length);
+  });
+});

--- a/console/src/components/sidebar/navigation.ts
+++ b/console/src/components/sidebar/navigation.ts
@@ -45,52 +45,82 @@ export const SIDEBAR_NAV_GROUPS: ReadonlyArray<SidebarNavGroup> = [
     items: [
       { to: '/admin', label: 'Dashboard', icon: Dashboard },
       { to: '/admin/statistics', label: 'Statistics', icon: Statistics },
-      { to: '/admin/approvals', label: 'Approvals', icon: Policy },
-      { to: '/admin/audit', label: 'Audit', icon: Audit },
-      { to: '/admin/jobs', label: 'Jobs', icon: Jobs },
+      { to: '/admin/sessions', label: 'Sessions', icon: Sessions },
+      { to: '/admin/audit', label: 'Audit Log', icon: Audit },
+    ],
+  },
+  {
+    label: 'Agents',
+    items: [
+      {
+        to: '/admin/agent-scoreboard',
+        label: 'Agent Scoreboard',
+        icon: AgentGroup,
+      },
+      { to: '/admin/agents', label: 'Workspace Files', icon: Files },
+      { to: '/admin/skills', label: 'Skills', icon: Lightbulb },
+      { to: '/admin/jobs', label: 'Work Queue', icon: Jobs },
+      { to: '/admin/scheduler', label: 'Schedules', icon: Scheduler },
+    ],
+  },
+  {
+    label: 'Connectivity',
+    items: [
+      { to: '/admin/channels', label: 'Channels', icon: Channels },
+      {
+        to: '/admin/email',
+        label: 'Mailbox',
+        icon: Email,
+        requiresEmail: true,
+      },
+      { to: '/admin/connectors', label: 'Connectors', icon: Plugins },
+      { to: '/admin/mcp', label: 'MCP Servers', icon: Cog },
+      { to: '/admin/a2a-inbox', label: 'A2A Inbox', icon: Chat },
+      { to: '/admin/a2a-trust', label: 'A2A Trust', icon: Policy },
+      {
+        to: '/admin/fleet-topology',
+        label: 'Fleet Topology',
+        icon: Server,
+      },
+    ],
+  },
+  {
+    label: 'Models',
+    items: [{ to: '/admin/models', label: 'Providers', icon: Models }],
+  },
+  {
+    label: 'Security',
+    items: [
+      {
+        to: '/admin/network-policy',
+        label: 'Network Policy',
+        icon: Policy,
+      },
+      { to: '/admin/output-guard', label: 'Output Guard', icon: Policy },
+      { to: '/admin/secrets', label: 'Secrets', icon: Secrets },
+      { to: '/admin/tokens', label: 'API Tokens', icon: Secrets },
+    ],
+  },
+  {
+    label: 'System',
+    items: [
+      { to: '/admin/gateway', label: 'Gateway', icon: Gateway },
+      { to: '/admin/config', label: 'Settings', icon: Config },
+      { to: '/admin/logs', label: 'Logs', icon: Logs },
+      { to: '/admin/plugins', label: 'Plugins', icon: Plugins },
+      { to: '/admin/tools', label: 'Tools', icon: Tools },
+      { to: '/admin/terminal', label: 'Terminal', icon: Terminal },
+    ],
+  },
+  {
+    label: 'Labs',
+    items: [
       {
         to: '/admin/harness-evolution',
         label: 'Harness Evolution',
         icon: Harness,
       },
       { to: '/admin/distill', label: 'Distill', icon: Flask },
-    ],
-  },
-  {
-    label: 'A2A',
-    items: [
-      { to: '/admin/a2a-inbox', label: 'Inbox', icon: Chat },
-      { to: '/admin/a2a-trust', label: 'Trust', icon: Policy },
-    ],
-  },
-  {
-    label: 'Runtime',
-    items: [
-      { to: '/admin/terminal', label: 'Terminal', icon: Terminal },
-      { to: '/admin/gateway', label: 'Gateway', icon: Gateway },
-      { to: '/admin/logs', label: 'Logs', icon: Logs },
-      { to: '/admin/fleet-topology', label: 'Fleet', icon: Server },
-      { to: '/admin/sessions', label: 'Sessions', icon: Sessions },
-      { to: '/admin/channels', label: 'Channels', icon: Channels },
-      { to: '/admin/email', label: 'Email', icon: Email, requiresEmail: true },
-      { to: '/admin/models', label: 'Models', icon: Models },
-      { to: '/admin/scheduler', label: 'Scheduler', icon: Scheduler },
-      { to: '/admin/connectors', label: 'Connectors', icon: Plugins },
-      { to: '/admin/mcp', label: 'MCP', icon: Cog },
-    ],
-  },
-  {
-    label: 'Configuration',
-    items: [
-      { to: '/admin/agents', label: 'Agent Files', icon: Files },
-      { to: '/admin/agent-scoreboard', label: 'Agents', icon: AgentGroup },
-      { to: '/admin/skills', label: 'Skills', icon: Lightbulb },
-      { to: '/admin/plugins', label: 'Plugins', icon: Plugins },
-      { to: '/admin/output-guard', label: 'Output Guard', icon: Policy },
-      { to: '/admin/tools', label: 'Tools', icon: Tools },
-      { to: '/admin/secrets', label: 'Secrets', icon: Secrets },
-      { to: '/admin/tokens', label: 'API Tokens', icon: Secrets },
-      { to: '/admin/config', label: 'Config', icon: Config },
     ],
   },
 ];

--- a/console/src/components/sidebar/sidebar.test.tsx
+++ b/console/src/components/sidebar/sidebar.test.tsx
@@ -499,9 +499,12 @@ describe('AppSidebar', () => {
     expect(screen.getByText('HybridClaw')).toBeDefined();
     expect(screen.getByText('Admin console')).toBeDefined();
     expect(screen.getByText('Overview')).toBeDefined();
-    expect(screen.getByText('A2A')).toBeDefined();
-    expect(screen.getByText('Runtime')).toBeDefined();
-    expect(screen.getByText('Configuration')).toBeDefined();
+    expect(screen.getByText('Agents')).toBeDefined();
+    expect(screen.getByText('Connectivity')).toBeDefined();
+    expect(screen.getByText('Models')).toBeDefined();
+    expect(screen.getByText('Security')).toBeDefined();
+    expect(screen.getByText('System')).toBeDefined();
+    expect(screen.getByText('Labs')).toBeDefined();
   });
 
   it('renders all nav item labels', () => {

--- a/console/src/router.test.ts
+++ b/console/src/router.test.ts
@@ -1,0 +1,40 @@
+import { createMemoryHistory } from '@tanstack/react-router';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let router: typeof import('./router')['router'];
+
+describe('legacy admin routes', () => {
+  beforeAll(async () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+    });
+
+    ({ router } = await import('./router'));
+    router.update({
+      history: createMemoryHistory({ initialEntries: ['/admin'] }),
+    });
+    await router.load();
+  });
+
+  beforeEach(async () => {
+    await router.navigate({ to: '/admin' });
+  });
+
+  it('redirects Approvals bookmarks to Network Policy', async () => {
+    await router.navigate({ to: '/admin/approvals' });
+
+    expect(router.state.location.pathname).toBe('/admin/network-policy');
+  });
+
+  it('redirects Teams setup bookmarks to the Connectors subview', async () => {
+    await router.navigate({ to: '/admin/teams' });
+
+    expect(router.state.location.pathname).toBe('/admin/connectors');
+    expect(router.state.location.hash).toBe('teams-sso');
+  });
+});

--- a/console/src/router.tsx
+++ b/console/src/router.tsx
@@ -3,6 +3,7 @@ import {
   createRoute,
   createRouter,
   Outlet,
+  redirect,
   useRouterState,
 } from '@tanstack/react-router';
 import { lazy, Suspense, useEffect } from 'react';
@@ -140,10 +141,18 @@ const statisticsRoute = createRoute({
   component: StatisticsPage,
 });
 
-const approvalsRoute = createRoute({
+const networkPolicyRoute = createRoute({
+  getParentRoute: () => adminLayoutRoute,
+  path: '/admin/network-policy',
+  component: ApprovalsPage,
+});
+
+const legacyApprovalsRoute = createRoute({
   getParentRoute: () => adminLayoutRoute,
   path: '/admin/approvals',
-  component: ApprovalsPage,
+  beforeLoad: () => {
+    throw redirect({ to: '/admin/network-policy', replace: true });
+  },
 });
 
 const a2aInboxRoute = createRoute({
@@ -209,10 +218,16 @@ const channelsRoute = createRoute({
   component: ChannelsPage,
 });
 
-const teamsRoute = createRoute({
+const legacyTeamsRoute = createRoute({
   getParentRoute: () => adminLayoutRoute,
   path: '/admin/teams',
-  component: TeamsPage,
+  beforeLoad: () => {
+    throw redirect({
+      to: '/admin/connectors',
+      hash: 'teams-sso',
+      replace: true,
+    });
+  },
 });
 
 const emailRoute = createRoute({
@@ -266,10 +281,18 @@ const mcpRoute = createRoute({
   component: McpPage,
 });
 
+function ConnectorsRouteComponent() {
+  const hash = useRouterState({
+    select: (state) => state.location.hash.replace(/^#/, ''),
+  });
+
+  return hash === 'teams-sso' ? <TeamsPage /> : <ConnectorsPage />;
+}
+
 const connectorsRoute = createRoute({
   getParentRoute: () => adminLayoutRoute,
   path: '/admin/connectors',
-  component: ConnectorsPage,
+  component: ConnectorsRouteComponent,
 });
 
 const auditRoute = createRoute({
@@ -370,7 +393,8 @@ const routeTree = rootRoute.addChildren([
   adminLayoutRoute.addChildren([
     dashboardRoute,
     statisticsRoute,
-    approvalsRoute,
+    networkPolicyRoute,
+    legacyApprovalsRoute,
     a2aInboxRoute,
     a2aTrustRoute,
     agentFilesRoute,
@@ -381,7 +405,7 @@ const routeTree = rootRoute.addChildren([
     fleetTopologyRoute,
     sessionsRoute,
     channelsRoute,
-    teamsRoute,
+    legacyTeamsRoute,
     emailRoute,
     configRoute,
     modelsRoute,

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -519,7 +519,9 @@ describe('ChannelsPage', () => {
       .closest('details') as HTMLDetailsElement | null;
     expect(advancedSettings?.open).toBe(false);
     const appSetupLink = screen.getByRole('link', { name: 'App Setup' });
-    expect(appSetupLink.getAttribute('href')).toBe('/admin/teams');
+    expect(appSetupLink.getAttribute('href')).toBe(
+      '/admin/connectors#teams-sso',
+    );
     const setupInstructions = screen
       .getByText('Teams app setup instructions')
       .closest('details') as HTMLDetailsElement | null;

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -2562,7 +2562,7 @@ function TeamsChannelEditor(_props: {
       <div className="button-row">
         <Button
           variant="outline"
-          render={<a href="/admin/teams">App Setup</a>}
+          render={<a href="/admin/connectors#teams-sso">App Setup</a>}
         />
       </div>
 

--- a/console/src/routes/config.test.tsx
+++ b/console/src/routes/config.test.tsx
@@ -206,7 +206,7 @@ describe('ConfigPage', () => {
       screen
         .getByRole('link', { name: 'Manage network policy' })
         .getAttribute('href'),
-    ).toBe('/admin/approvals');
+    ).toBe('/admin/network-policy');
     const actionPriceInput = screen.getByLabelText(
       'Action price USD',
     ) as HTMLInputElement;

--- a/console/src/routes/config.tsx
+++ b/console/src/routes/config.tsx
@@ -1169,7 +1169,10 @@ export function ConfigPage() {
                         />
                       </Field>
                       <div className="button-row">
-                        <Link to="/admin/approvals" className="ghost-button">
+                        <Link
+                          to="/admin/network-policy"
+                          className="ghost-button"
+                        >
                           Manage network policy
                         </Link>
                       </div>

--- a/console/src/routes/jobs.tsx
+++ b/console/src/routes/jobs.tsx
@@ -433,7 +433,7 @@ function JobDetailCard(props: {
                 }).catch(logNavigationError);
                 return;
               }
-              void navigate({ to: '/admin/approvals' }).catch(
+              void navigate({ to: '/admin/network-policy' }).catch(
                 logNavigationError,
               );
             }}

--- a/docs/content/channels/admin-console.md
+++ b/docs/content/channels/admin-console.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Console
-description: Manage channels, connectors, agents, human distillation, approvals, config, secrets, output guard, audit, jobs, and browser-based operator workflows from /admin.
+description: Manage channels, connectors, agents, human distillation, network policy, settings, secrets, output guard, audit, jobs, and browser-based operator workflows from /admin.
 sidebar_position: 10
 ---
 
@@ -9,9 +9,10 @@ sidebar_position: 10
 If the gateway is already running, open
 `http://127.0.0.1:9090/admin` when you want browser-based operator workflows
 instead of the CLI. The channel setup page lives at `/admin/channels`, and the
-agent prompt-file editor lives at `/admin/agents`. The approvals page at
-`/admin/approvals` shows live pending approvals and lets operators add, edit,
-and delete the current workspace network policy rules for a selected agent.
+agent prompt-file editor lives at `/admin/agents`. The Network Policy page at
+`/admin/network-policy` shows live pending approvals and lets operators add,
+edit, and delete the current workspace network policy rules for a selected
+agent.
 The connector setup page at `/admin/connectors` manages HybridAI, Google
 Workspace, GitHub, and Microsoft 365 connection flows.
 The human distillation page at `/admin/distill` manages subjects, consent,
@@ -53,13 +54,14 @@ pairing requests.
 - `/admin/distill` creates distillation subjects, records consent artefacts,
   registers or uploads source material, manages corpus documents, starts runs,
   and opens generated run reports
-- `/admin/approvals` shows unresolved approval prompts across sessions and the
-  selected agent workspace's current `policy.yaml` network rules in one place
-- `/admin/approvals` can add, edit, and delete network rules without switching
+- `/admin/network-policy` shows unresolved approval prompts across sessions and
+  the selected agent workspace's current `policy.yaml` network rules in one
+  place
+- `/admin/network-policy` can add, edit, and delete network rules without switching
   to the CLI or editing `policy.yaml` by hand
-- `/admin/approvals` can also change the workspace network default between
+- `/admin/network-policy` can also change the workspace network default between
   `deny` and `allow`
-- `/admin/approvals` can apply bundled network policy templates from the
+- `/admin/network-policy` can apply bundled network policy templates from the
   browser
 - `/admin/a2a-inbox` lists A2A threads by most recent message and opens each thread with sender, recipient, timestamp, intent, and content
 - `/admin/a2a-inbox` is read-only
@@ -148,8 +150,9 @@ scoped to the built-in allowlist and is not a general workspace file browser.
   single overview page
 - you want to distill a consented coworker agent from source material without
   stitching CLI commands together by hand
-- you want to inspect pending approvals and compare them with the declarative
-  network policy without switching to `/chat` or opening the workspace files
+- you want to inspect pending approvals on the Network Policy page and compare
+  them with the declarative policy without switching to `/chat` or opening the
+  workspace files
 - you want to add, edit, or remove network policy rules from the browser
 - you want to inspect A2A coordination threads without impersonating a recipient agent
 - you want to check child-instance reachability or update A2A trust-ledger peers

--- a/docs/content/extensibility/skills.md
+++ b/docs/content/extensibility/skills.md
@@ -152,7 +152,7 @@ use:
 - `web_fetch`, `web_search`, or browser tools can be used to inspect official
   API documentation while authoring or repairing a skill, not as the runtime
   API client when the helper already covers the operation.
-- `/policy`, `hybridclaw policy ...`, and `/admin/approvals` manage workspace
+- `/policy`, `hybridclaw policy ...`, and `/admin/network-policy` manage workspace
   network policy for HTTP access.
 - `hybridclaw gateway status` distinguishes stale builds, gateway PID state,
   sandbox mode, and runtime version before diagnosing gateway behavior.


### PR DESCRIPTION
## Summary

- regroup the existing admin destinations into Overview, Agents, Connectivity, Models, Security, System, and Labs
- clarify ambiguous labels, including Network Policy, Agent Scoreboard, Workspace Files, Providers, Settings, and MCP Servers
- make `/admin/network-policy` canonical while redirecting legacy `/admin/approvals` bookmarks
- move Teams setup under the Connectors-owned `#teams-sso` subview while preserving the existing setup screen and redirecting `/admin/teams`
- update internal links, admin documentation, and navigation/redirect regression coverage

## Why

The previous sidebar was a long mixed-purpose list with ambiguous names and hidden destinations. Phase 1 establishes the task-oriented information architecture from the admin console audit without changing page internals or implementing the later page merges.

## Impact

Operators get a more predictable sidebar map and clearer page names. Existing Approvals and Teams bookmarks continue to work through compatibility redirects, and Teams setup remains reachable from the Channels workflow.

## Validation

- `npm run lint`
- `npm --prefix console run typecheck`
- `npm --prefix console run build`
- `npm --prefix console test` — 85 files, 834 tests passed
- targeted Biome checks and `git diff --check`