### PR TITLE
Stabilize conversation prefixes for Anthropic prompt caching

### DIFF
--- a/container/shared/dynamic-context.d.ts
+++ b/container/shared/dynamic-context.d.ts
@@ -1,0 +1,5 @@
+export declare const DYNAMIC_CONTEXT_MESSAGE_PREFIX = '<context>\nDate (UTC): ';
+
+export declare function isDynamicContextMessageText(
+  value: unknown,
+): value is string;

--- a/container/shared/dynamic-context.js
+++ b/container/shared/dynamic-context.js
@@ -1,0 +1,10 @@
+export const DYNAMIC_CONTEXT_MESSAGE_PREFIX = '<context>\nDate (UTC): ';
+
+export function isDynamicContextMessageText(value) {
+  if (typeof value !== 'string') return false;
+  const text = value.trimStart();
+  return (
+    text.startsWith(DYNAMIC_CONTEXT_MESSAGE_PREFIX) &&
+    text.includes('\n</context>')
+  );
+}

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -1051,11 +1051,13 @@ async function processRequest(
     event: 'before_agent_start',
     messageCount: messages.length,
   });
-  let history: ChatMessage[] = collapseSystemMessages(
-    skipContainerSystemPrompt
-      ? messages
-      : injectRuntimeCapabilitiesMessage(messages),
-  );
+  const preparedHistory = skipContainerSystemPrompt
+    ? messages.map((message) => ({ ...message }))
+    : injectRuntimeCapabilitiesMessage(messages);
+  let history: ChatMessage[] =
+    provider === 'anthropic'
+      ? preparedHistory
+      : collapseSystemMessages(preparedHistory);
   const toolsUsed: string[] = [];
   const toolExecutions: ToolExecution[] = [];
   const toolCallHistory: ToolCallHistoryEntry[] = [];

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -354,6 +354,7 @@ function injectSkillCacheHint(messages: ChatMessage[]): ChatMessage[] {
       `You already selected skill guidance from \`${cachedSelectedSkillPath}\` earlier in this session.`,
       'Reuse that skill now and do not reread the SKILL.md unless the task scope changed or a missing detail requires it.',
     ].join('\n'),
+    'last',
   );
 }
 

--- a/container/src/providers/anthropic.ts
+++ b/container/src/providers/anthropic.ts
@@ -395,10 +395,20 @@ function convertMessageContent(
 function convertMessages(
   messages: ChatMessage[],
 ): Array<Record<string, unknown>> {
-  const normalized = collapseSystemMessages(messages);
   const converted: Array<Record<string, unknown>> = [];
+  let pendingDynamicContext: ChatMessage | null = null;
 
-  for (const message of normalized) {
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index];
+    if (
+      message.role === 'user' &&
+      typeof message.content === 'string' &&
+      isGeneratedDynamicContextText(message.content) &&
+      messages[index + 1]?.role === 'user'
+    ) {
+      pendingDynamicContext = message;
+      continue;
+    }
     if (message.role === 'system') continue;
 
     if (message.role === 'tool') {
@@ -449,6 +459,16 @@ function convertMessages(
       }
     }
 
+    if (message.role === 'user' && pendingDynamicContext) {
+      const dynamicContext = convertMessageContent(pendingDynamicContext);
+      if (typeof dynamicContext === 'string' && dynamicContext.trim()) {
+        blocks.push({ type: 'text', text: dynamicContext });
+      } else if (Array.isArray(dynamicContext)) {
+        blocks.push(...dynamicContext);
+      }
+      pendingDynamicContext = null;
+    }
+
     if (blocks.length === 0) continue;
     converted.push({
       role: message.role,
@@ -459,12 +479,57 @@ function convertMessages(
   return converted;
 }
 
+function isGeneratedDynamicContextText(text: string): boolean {
+  return text.trimStart().startsWith('<context>\nDate (UTC): ');
+}
+
+function extractSystemPromptBlocks(messages: ChatMessage[]): string[] {
+  const blocks = messages
+    .filter((message) => message.role === 'system')
+    .map((message) => normalizeMessageText(message.content).trim())
+    .filter(Boolean);
+  if (blocks.length <= 3) return blocks;
+  return [blocks[0], blocks[1], blocks.slice(2).join('\n\n')];
+}
+
 function extractSystemPrompt(messages: ChatMessage[]): string | undefined {
-  const normalized = collapseSystemMessages(messages);
-  const system = normalized[0];
-  if (system?.role !== 'system') return undefined;
-  const text = normalizeMessageText(system.content).trim();
-  return text || undefined;
+  const prompt = extractSystemPromptBlocks(messages).join('\n\n');
+  return prompt || undefined;
+}
+
+function isDynamicContextBlock(block: Record<string, unknown>): boolean {
+  return (
+    block.type === 'text' &&
+    typeof block.text === 'string' &&
+    isGeneratedDynamicContextText(block.text)
+  );
+}
+
+function markLastStableMessageBlockForCaching(
+  messages: Array<Record<string, unknown>>,
+): void {
+  for (
+    let messageIndex = messages.length - 1;
+    messageIndex >= 0;
+    messageIndex -= 1
+  ) {
+    const content = messages[messageIndex]?.content;
+    if (!Array.isArray(content) || content.length === 0) continue;
+    for (
+      let blockIndex = content.length - 1;
+      blockIndex >= 0;
+      blockIndex -= 1
+    ) {
+      const block = content[blockIndex];
+      if (!isRecord(block) || isDynamicContextBlock(block)) continue;
+      messages[messageIndex].content = [
+        ...content.slice(0, blockIndex),
+        { ...block, cache_control: { type: 'ephemeral' } },
+        ...content.slice(blockIndex + 1),
+      ];
+      return;
+    }
+  }
 }
 
 function convertTools(
@@ -482,25 +547,25 @@ function buildRequestBody(
   args: NormalizedCallArgs,
   stream: boolean,
 ): Record<string, unknown> {
+  const messages = convertMessages(args.messages);
+  markLastStableMessageBlockForCaching(messages);
   const request: Record<string, unknown> = {
     model: stripAnthropicModelPrefix(args.model),
     max_tokens:
       typeof args.maxTokens === 'number' && args.maxTokens > 0
         ? Math.floor(args.maxTokens)
         : 4096,
-    messages: convertMessages(args.messages),
+    messages,
     stream,
   };
 
-  const system = extractSystemPrompt(args.messages);
-  if (system) {
-    request.system = [
-      {
-        type: 'text',
-        text: system,
-        cache_control: { type: 'ephemeral' },
-      },
-    ];
+  const system = extractSystemPromptBlocks(args.messages);
+  if (system.length > 0) {
+    request.system = system.map((text) => ({
+      type: 'text',
+      text,
+      cache_control: { type: 'ephemeral' },
+    }));
   }
 
   const tools = convertTools(args.tools);

--- a/container/src/providers/anthropic.ts
+++ b/container/src/providers/anthropic.ts
@@ -5,6 +5,7 @@ import {
   normalizeAnthropicBaseUrl,
   stripAnthropicModelPrefix,
 } from '../../shared/anthropic-utils.js';
+import { isDynamicContextMessageText } from '../../shared/dynamic-context.js';
 import { collapseSystemMessages } from '../system-messages.js';
 import type {
   AnthropicContentBlock,
@@ -403,7 +404,7 @@ function convertMessages(
     if (
       message.role === 'user' &&
       typeof message.content === 'string' &&
-      isGeneratedDynamicContextText(message.content) &&
+      isDynamicContextMessageText(message.content) &&
       messages[index + 1]?.role === 'user'
     ) {
       pendingDynamicContext = message;
@@ -479,10 +480,6 @@ function convertMessages(
   return converted;
 }
 
-function isGeneratedDynamicContextText(text: string): boolean {
-  return text.trimStart().startsWith('<context>\nDate (UTC): ');
-}
-
 function extractSystemPromptBlocks(messages: ChatMessage[]): string[] {
   const blocks = messages
     .filter((message) => message.role === 'system')
@@ -501,7 +498,7 @@ function isDynamicContextBlock(block: Record<string, unknown>): boolean {
   return (
     block.type === 'text' &&
     typeof block.text === 'string' &&
-    isGeneratedDynamicContextText(block.text)
+    isDynamicContextMessageText(block.text)
   );
 }
 

--- a/container/src/system-messages.ts
+++ b/container/src/system-messages.ts
@@ -43,21 +43,22 @@ export function mergeSystemMessage(
   messages: ChatMessage[],
   instruction: string,
 ): ChatMessage[] {
-  const collapsed = collapseSystemMessages(messages);
+  const merged = messages.map((message) => ({ ...message }));
   const normalizedInstruction = instruction.trim();
-  if (!normalizedInstruction) return collapsed;
+  if (!normalizedInstruction) return merged;
 
-  if (collapsed[0]?.role === 'system') {
-    const existing = contentToText(collapsed[0].content).trim();
-    if (existing.includes(normalizedInstruction)) return collapsed;
-    collapsed[0] = {
+  const systemIndex = merged.findIndex((message) => message.role === 'system');
+  if (systemIndex >= 0) {
+    const existing = contentToText(merged[systemIndex].content).trim();
+    if (existing.includes(normalizedInstruction)) return merged;
+    merged[systemIndex] = {
       role: 'system',
       content: existing
         ? `${existing}\n\n${normalizedInstruction}`
         : normalizedInstruction,
     };
-    return collapsed;
+    return merged;
   }
 
-  return [{ role: 'system', content: normalizedInstruction }, ...collapsed];
+  return [{ role: 'system', content: normalizedInstruction }, ...merged];
 }

--- a/container/src/system-messages.ts
+++ b/container/src/system-messages.ts
@@ -42,12 +42,22 @@ export function collapseSystemMessages(messages: ChatMessage[]): ChatMessage[] {
 export function mergeSystemMessage(
   messages: ChatMessage[],
   instruction: string,
+  target: 'first' | 'last' = 'first',
 ): ChatMessage[] {
   const merged = messages.map((message) => ({ ...message }));
   const normalizedInstruction = instruction.trim();
   if (!normalizedInstruction) return merged;
 
-  const systemIndex = merged.findIndex((message) => message.role === 'system');
+  let systemIndex = -1;
+  if (target === 'first') {
+    systemIndex = merged.findIndex((message) => message.role === 'system');
+  } else {
+    for (let index = merged.length - 1; index >= 0; index -= 1) {
+      if (merged[index].role !== 'system') continue;
+      systemIndex = index;
+      break;
+    }
+  }
   if (systemIndex >= 0) {
     const existing = contentToText(merged[systemIndex].content).trim();
     if (existing.includes(normalizedInstruction)) return merged;

--- a/docs/content/developer-guide/runtime.md
+++ b/docs/content/developer-guide/runtime.md
@@ -224,7 +224,16 @@ HybridClaw separates the static system prompt from per-turn dynamic context.
 selected prompt parts, tools, skills, and channel contract. Wall-clock data,
 host metadata, today's `memory/YYYY-MM-DD.md` note, session summaries, and
 retrieval snippets belong in the user-role dynamic context block that is
-inserted immediately after the system prompt and before conversation history.
+placed after retained conversation history, next to the latest user turn.
+History budgets drop a contiguous prefix of complete old turns; retained
+messages are never sliced or rewritten.
+
+Anthropic requests keep the system prompt in volatility-ordered cache blocks:
+static core instructions, workspace and durable memory, then skills. The
+provider adds cache breakpoints at those boundaries and at the last stable
+message content block. Turn-local dynamic context follows that message
+breakpoint, so tool-loop iterations and later turns can reuse the unchanged
+conversation prefix.
 
 This split keeps provider prompt-prefix caches effective without removing
 useful turn-local context from the model. It also gives trace exports a stable

--- a/src/agent/conversation.ts
+++ b/src/agent/conversation.ts
@@ -7,7 +7,6 @@ import {
   optimizeHistoryMessagesForPrompt,
 } from '../session/token-efficiency.js';
 import {
-  expandSkillInvocation,
   loadSkills,
   resolveSkillInvocationForTurn,
   type Skill,
@@ -23,7 +22,7 @@ import {
 import {
   buildRetrievedContextPrompt,
   buildSessionSummaryPrompt,
-  buildSystemPromptFromHooks,
+  buildSystemPromptBlocksFromHooks,
   type PromptMode,
   type PromptPartName,
   type PromptRuntimeInfo,
@@ -126,7 +125,6 @@ export function buildConversationContext(params: {
   sessionSummary?: string | null;
   retrievedContext?: string | null;
   history: HistoryMessage[];
-  expandLatestHistoryUser?: boolean;
   promptMode?: PromptMode;
   skillPromptMode?: SkillPromptMode;
   includePromptParts?: PromptPartName[];
@@ -142,7 +140,6 @@ export function buildConversationContext(params: {
     sessionSummary,
     retrievedContext,
     history,
-    expandLatestHistoryUser = false,
     promptMode = 'full',
     skillPromptMode = 'full',
     includePromptParts,
@@ -170,7 +167,7 @@ export function buildConversationContext(params: {
           previousUserContent,
         })
       : null;
-  const systemPrompt = buildSystemPromptFromHooks({
+  const systemPromptBlocks = buildSystemPromptBlocksFromHooks({
     agentId,
     skills,
     explicitSkillInvocation,
@@ -186,14 +183,11 @@ export function buildConversationContext(params: {
   });
 
   const messages: ChatMessage[] = [];
-  if (systemPrompt) {
-    messages.push({ role: 'system', content: systemPrompt });
+  if (systemPromptBlocks.length > 0) {
     messages.push(
-      buildDynamicContextMessage({
-        agentId,
-        retrievedContext,
-        sessionSummary,
-      }),
+      ...systemPromptBlocks.map(
+        (content): ChatMessage => ({ role: 'system', content }),
+      ),
     );
   }
 
@@ -204,21 +198,18 @@ export function buildConversationContext(params: {
     }),
   );
 
-  if (expandLatestHistoryUser && historyMessages.length > 0) {
-    const latest = historyMessages[historyMessages.length - 1];
-    if (latest.role === 'user' && typeof latest.content === 'string') {
-      latest.content = expandSkillInvocation(latest.content, skills);
-    }
-  }
-
-  const optimizedHistory = optimizeHistoryMessagesForPrompt(
-    historyMessages.map((message) => ({
-      role: message.role,
-      content: typeof message.content === 'string' ? message.content : '',
-    })),
-  );
+  const optimizedHistory = optimizeHistoryMessagesForPrompt(historyMessages);
 
   messages.push(...optimizedHistory.messages);
+  if (systemPromptBlocks.length > 0) {
+    messages.push(
+      buildDynamicContextMessage({
+        agentId,
+        retrievedContext,
+        sessionSummary,
+      }),
+    );
+  }
   return {
     messages,
     skills,

--- a/src/agent/conversation.ts
+++ b/src/agent/conversation.ts
@@ -1,5 +1,6 @@
 import os from 'node:os';
 
+import { DYNAMIC_CONTEXT_MESSAGE_PREFIX } from '../../container/shared/dynamic-context.js';
 import { normalizeSkillConfigChannelKind } from '../channels/channel-registry.js';
 import { scheduleCloudMemorySync } from '../memory/cloud-memory.js';
 import {
@@ -56,7 +57,9 @@ export function buildDynamicContextMessage(
 ): ChatMessage {
   const now = options instanceof Date ? options : options.now || new Date();
   const agentId = options instanceof Date ? undefined : options.agentId;
-  const lines = ['<context>', `Date (UTC): ${now.toISOString().slice(0, 10)}`];
+  const lines = [
+    `${DYNAMIC_CONTEXT_MESSAGE_PREFIX}${now.toISOString().slice(0, 10)}`,
+  ];
   const dynamicSections: string[] = [];
   if (!(options instanceof Date)) {
     dynamicSections.push(

--- a/src/agent/prompt-hooks.ts
+++ b/src/agent/prompt-hooks.ts
@@ -125,6 +125,14 @@ const BOOTSTRAP_SUBPARTS = new Set<PromptPartName>([
   'boot',
 ]);
 
+const STATIC_CORE_WORKSPACE_FILES = new Set([
+  'AGENTS.md',
+  'SOUL.md',
+  'IDENTITY.md',
+  'USER.md',
+  'TOOLS.md',
+]);
+
 function buildPromptPartSelection(context: PromptHookContext): {
   include: Set<PromptPartName>;
   omit: Set<PromptPartName>;
@@ -261,16 +269,50 @@ function buildBootstrapHook(context: PromptHookContext): string {
   const cloudMemoryPrompt = isBootstrapPartSelected('memory-file', context)
     ? buildCloudMemoryPrompt(context.agentId)
     : '';
-  const skillsPrompt = context.explicitSkillInvocation
-    ? ''
-    : isBootstrapPartSelected('skills', context)
-      ? context.skillPromptMode === 'compact'
-        ? buildCompactSkillsPrompt(context.skills)
-        : buildSkillsSection(buildSkillsPrompt(context.skills))
-      : '';
+  const skillsPrompt = buildSelectedSkillsPrompt(context);
   return [contextPrompt, cloudMemoryPrompt, skillsPrompt]
     .filter(Boolean)
     .join('\n\n');
+}
+
+function buildSelectedSkillsPrompt(context: PromptHookContext): string {
+  if (!isBootstrapPartSelected('skills', context)) return '';
+  return context.skillPromptMode === 'compact'
+    ? buildCompactSkillsPrompt(context.skills)
+    : buildSkillsSection(buildSkillsPrompt(context.skills));
+}
+
+function buildBootstrapSystemBlocks(context: PromptHookContext): {
+  staticCore: string;
+  workspaceMemory: string;
+  skills: string;
+} {
+  const contextFiles = loadStaticBootstrapFiles(context.agentId).filter(
+    (file) => {
+      const part = WORKSPACE_FILE_PROMPT_PARTS[file.name];
+      return part ? isBootstrapPartSelected(part, context) : true;
+    },
+  );
+  const staticCoreFiles = contextFiles.filter((file) =>
+    STATIC_CORE_WORKSPACE_FILES.has(file.name),
+  );
+  const workspaceMemoryFiles = contextFiles.filter(
+    (file) => !STATIC_CORE_WORKSPACE_FILES.has(file.name),
+  );
+  const cloudMemoryPrompt = isBootstrapPartSelected('memory-file', context)
+    ? buildCloudMemoryPrompt(context.agentId)
+    : '';
+
+  return {
+    staticCore: buildContextPrompt(staticCoreFiles),
+    workspaceMemory: [
+      buildContextPrompt(workspaceMemoryFiles),
+      cloudMemoryPrompt,
+    ]
+      .filter(Boolean)
+      .join('\n\n'),
+    skills: buildSelectedSkillsPrompt(context),
+  };
 }
 
 function buildCloudMemoryPrompt(agentId: string): string {
@@ -871,4 +913,33 @@ export function buildSystemPromptFromHooks(context: PromptHookContext): string {
   return runPromptHooks(context)
     .map((hookResult) => hookResult.content)
     .join('\n\n');
+}
+
+export function buildSystemPromptBlocksFromHooks(
+  context: PromptHookContext,
+): string[] {
+  const hookResults = runPromptHooks(context);
+  const bootstrapEnabled = hookResults.some(
+    (hookResult) => hookResult.name === 'bootstrap',
+  );
+  const bootstrap = bootstrapEnabled
+    ? buildBootstrapSystemBlocks(context)
+    : { staticCore: '', workspaceMemory: '', skills: '' };
+  const staticCore = [
+    bootstrap.staticCore,
+    ...hookResults
+      .filter(
+        (hookResult) =>
+          hookResult.name !== 'bootstrap' &&
+          hookResult.name !== 'memory' &&
+          hookResult.name !== 'retrieval',
+      )
+      .map((hookResult) => hookResult.content),
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+
+  return [staticCore, bootstrap.workspaceMemory, bootstrap.skills].filter(
+    Boolean,
+  );
 }

--- a/src/agent/prompt-hooks.ts
+++ b/src/agent/prompt-hooks.ts
@@ -259,18 +259,8 @@ function buildCompactSkillsPrompt(skills: Skill[]): string {
 }
 
 function buildBootstrapHook(context: PromptHookContext): string {
-  const contextFiles = loadStaticBootstrapFiles(context.agentId).filter(
-    (file) => {
-      const part = WORKSPACE_FILE_PROMPT_PARTS[file.name];
-      return part ? isBootstrapPartSelected(part, context) : true;
-    },
-  );
-  const contextPrompt = buildContextPrompt(contextFiles);
-  const cloudMemoryPrompt = isBootstrapPartSelected('memory-file', context)
-    ? buildCloudMemoryPrompt(context.agentId)
-    : '';
-  const skillsPrompt = buildSelectedSkillsPrompt(context);
-  return [contextPrompt, cloudMemoryPrompt, skillsPrompt]
+  const blocks = buildBootstrapSystemBlocks(context);
+  return [blocks.staticCore, blocks.workspaceMemory, blocks.skills]
     .filter(Boolean)
     .join('\n\n');
 }

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -1750,8 +1750,6 @@ async function handleGatewayMessageInner(
       historyCharsIncluded: historyStats.includedChars,
       historyCharsDropped: historyStats.droppedChars,
       historyMaxChars: historyStats.maxTotalChars,
-      historyMaxMessageChars: historyStats.maxMessageChars,
-      perMessageTruncatedCount: historyStats.perMessageTruncatedCount,
       middleCompressionApplied: historyStats.middleCompressionApplied,
       historyEstimatedTokens: estimateTokenCountFromMessages(
         messages.slice(historyStart),

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -1735,8 +1735,8 @@ async function handleGatewayMessageInner(
       allowedTools: promptPartDefaults.toolsDisabled ? [] : undefined,
       blockedTools: mediaPolicy.blockedTools,
     });
-  const historyStart =
-    messages.length > 0 && messages[0].role === 'system' ? 1 : 0;
+  let historyStart = 0;
+  while (messages[historyStart]?.role === 'system') historyStart += 1;
   recordAuditEvent({
     sessionId: req.sessionId,
     runId,

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -1010,24 +1010,42 @@ function sanitizeRequestLogMessages(messages: ChatMessage[]): ChatMessage[] {
 export function readSystemPromptMessage(
   messages: ChatMessage[],
 ): string | null {
-  const firstMessage = messages[0];
-  if (firstMessage?.role !== 'system') return null;
-  return typeof firstMessage.content === 'string' && firstMessage.content.trim()
-    ? firstMessage.content
-    : null;
+  const blocks = messages
+    .filter((message) => message.role === 'system')
+    .map((message) =>
+      typeof message.content === 'string' ? message.content.trim() : '',
+    )
+    .filter(Boolean);
+  return blocks.length > 0 ? blocks.join('\n\n') : null;
 }
 
 export function readDynamicContextMessage(
   messages: ChatMessage[],
 ): string | null {
-  const dynamicContextMessage = messages.find(
-    (message) =>
-      message.role === 'user' &&
-      typeof message.content === 'string' &&
-      message.content.trimStart().startsWith('<context>'),
-  );
+  const dynamicContextMessage = messages.find((message) => {
+    if (message.role !== 'user') return false;
+    if (typeof message.content === 'string') {
+      return message.content.trimStart().startsWith('<context>');
+    }
+    return message.content?.some(
+      (part) =>
+        part.type === 'text' && part.text.trimStart().startsWith('<context>'),
+    );
+  });
   if (!dynamicContextMessage) return null;
-  const content = sanitizeRequestLogValue(dynamicContextMessage.content);
+  const dynamicContextPart = Array.isArray(dynamicContextMessage.content)
+    ? dynamicContextMessage.content.find(
+        (part) =>
+          part.type === 'text' && part.text.trimStart().startsWith('<context>'),
+      )
+    : null;
+  const rawContent =
+    typeof dynamicContextMessage.content === 'string'
+      ? dynamicContextMessage.content
+      : dynamicContextPart?.type === 'text'
+        ? dynamicContextPart.text
+        : null;
+  const content = sanitizeRequestLogValue(rawContent);
   return typeof content === 'string' && content.trim() ? content : null;
 }
 

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { CronExpressionParser } from 'cron-parser';
+import { isDynamicContextMessageText } from '../../container/shared/dynamic-context.js';
 import { buildMcpServerNamespaces } from '../../container/shared/mcp-tool-namespaces.js';
 import {
   currentDateStampInTimezone,
@@ -1022,31 +1023,25 @@ export function readSystemPromptMessage(
 export function readDynamicContextMessage(
   messages: ChatMessage[],
 ): string | null {
-  const dynamicContextMessage = messages.find((message) => {
-    if (message.role !== 'user') return false;
-    if (typeof message.content === 'string') {
-      return message.content.trimStart().startsWith('<context>');
-    }
-    return message.content?.some(
-      (part) =>
-        part.type === 'text' && part.text.trimStart().startsWith('<context>'),
-    );
-  });
-  if (!dynamicContextMessage) return null;
-  const dynamicContextPart = Array.isArray(dynamicContextMessage.content)
-    ? dynamicContextMessage.content.find(
-        (part) =>
-          part.type === 'text' && part.text.trimStart().startsWith('<context>'),
-      )
-    : null;
-  const rawContent =
-    typeof dynamicContextMessage.content === 'string'
-      ? dynamicContextMessage.content
-      : dynamicContextPart?.type === 'text'
-        ? dynamicContextPart.text
-        : null;
-  const content = sanitizeRequestLogValue(rawContent);
-  return typeof content === 'string' && content.trim() ? content : null;
+  for (const message of messages) {
+    if (message.role !== 'user') continue;
+    const dynamicContextPart = Array.isArray(message.content)
+      ? message.content.find(
+          (part) =>
+            part.type === 'text' && isDynamicContextMessageText(part.text),
+        )
+      : null;
+    const dynamicContextText =
+      typeof message.content === 'string'
+        ? message.content
+        : dynamicContextPart?.type === 'text'
+          ? dynamicContextPart.text
+          : null;
+    if (!isDynamicContextMessageText(dynamicContextText)) continue;
+    const content = sanitizeRequestLogValue(dynamicContextText);
+    return typeof content === 'string' && content.trim() ? content : null;
+  }
+  return null;
 }
 
 function sanitizeRequestLogToolExecutions(

--- a/src/gateway/openai-compatible.ts
+++ b/src/gateway/openai-compatible.ts
@@ -377,6 +377,21 @@ async function buildToolAwareMessages(params: {
       workspacePath,
     },
   });
+  const dynamicContext = messages.at(-1);
+  const latestInputMessage = input.messages.at(-1);
+  if (
+    dynamicContext?.role === 'user' &&
+    typeof dynamicContext.content === 'string' &&
+    dynamicContext.content.trimStart().startsWith('<context>\nDate (UTC): ') &&
+    latestInputMessage?.role === 'user'
+  ) {
+    return [
+      ...messages.slice(0, -1),
+      ...input.messages.slice(0, -1),
+      dynamicContext,
+      latestInputMessage,
+    ];
+  }
   return [...messages, ...input.messages];
 }
 

--- a/src/gateway/openai-compatible.ts
+++ b/src/gateway/openai-compatible.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import path from 'node:path';
+import { isDynamicContextMessageText } from '../../container/shared/dynamic-context.js';
 import { buildConversationContext } from '../agent/conversation.js';
 import { stopSessionExecution } from '../agent/executor.js';
 import { createSilentReplyStreamFilter } from '../agent/silent-reply-stream.js';
@@ -381,8 +382,7 @@ async function buildToolAwareMessages(params: {
   const latestInputMessage = input.messages.at(-1);
   if (
     dynamicContext?.role === 'user' &&
-    typeof dynamicContext.content === 'string' &&
-    dynamicContext.content.trimStart().startsWith('<context>\nDate (UTC): ') &&
+    isDynamicContextMessageText(dynamicContext.content) &&
     latestInputMessage?.role === 'user'
   ) {
     return [

--- a/src/session/token-efficiency.ts
+++ b/src/session/token-efficiency.ts
@@ -53,7 +53,7 @@ export function sliceTailAtCodePointBoundary(
 
 interface PromptHistoryMessage {
   role: ChatMessage['role'];
-  content: string;
+  content: ChatMessage['content'];
 }
 
 export interface HistoryOptimizationOptions {
@@ -83,28 +83,34 @@ function normalizePositiveInt(value: number, fallback: number): number {
 }
 
 function sumChars(messages: PromptHistoryMessage[]): number {
-  return messages.reduce((total, message) => total + message.content.length, 0);
+  return messages.reduce(
+    (total, message) => total + messageContentChars(message.content),
+    0,
+  );
 }
 
-function trimToRecentWithinBudget(
+function messageContentChars(content: ChatMessage['content']): number {
+  if (typeof content === 'string') return content.length;
+  if (!Array.isArray(content)) return 0;
+  return JSON.stringify(content).length;
+}
+
+function groupHistoryTurns(
   messages: PromptHistoryMessage[],
-  maxTotalChars: number,
-): PromptHistoryMessage[] {
-  if (messages.length === 0 || maxTotalChars <= 0) return [];
+): PromptHistoryMessage[][] {
+  const turns: PromptHistoryMessage[][] = [];
+  let currentTurn: PromptHistoryMessage[] = [];
 
-  const kept: PromptHistoryMessage[] = [];
-  let usedChars = 0;
-
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    const message = messages[i];
-    const size = message.content.length;
-    if (size > maxTotalChars) continue;
-    if (usedChars + size > maxTotalChars) continue;
-    kept.push(message);
-    usedChars += size;
+  for (const message of messages) {
+    if (message.role === 'user' && currentTurn.length > 0) {
+      turns.push(currentTurn);
+      currentTurn = [];
+    }
+    currentTurn.push(message);
   }
+  if (currentTurn.length > 0) turns.push(currentTurn);
 
-  return kept.reverse();
+  return turns;
 }
 
 export function estimateTokenCountFromText(
@@ -219,77 +225,33 @@ export function optimizeHistoryMessagesForPrompt(
     options?.maxMessageChars ?? DEFAULT_HISTORY_MAX_MESSAGE_CHARS,
     DEFAULT_HISTORY_MAX_MESSAGE_CHARS,
   );
-  const protectHeadMessages = Math.max(
-    0,
-    Math.floor(
-      options?.protectHeadMessages ?? DEFAULT_HISTORY_PROTECT_HEAD_MESSAGES,
-    ),
-  );
-  const protectTailMessages = Math.max(
-    0,
-    Math.floor(
-      options?.protectTailMessages ?? DEFAULT_HISTORY_PROTECT_TAIL_MESSAGES,
-    ),
-  );
-
   const originalCount = messages.length;
-  const originalChars = messages.reduce(
-    (total, message) => total + message.content.length,
-    0,
-  );
-  let perMessageTruncatedCount = 0;
-
-  const normalized = messages.map((message) => {
-    const bounded = truncateMessageContent(message.content, maxMessageChars);
-    if (bounded !== message.content) perMessageTruncatedCount += 1;
-    return {
-      role: message.role,
-      content: bounded,
-    };
-  });
-
-  const preBudgetChars = sumChars(normalized);
-  let included = [...normalized];
+  const originalChars = sumChars(messages);
+  const preBudgetChars = originalChars;
+  let included = [...messages];
   let middleCompressionApplied = false;
 
   if (preBudgetChars > maxTotalChars) {
     middleCompressionApplied = true;
-    const headCount = Math.min(protectHeadMessages, normalized.length);
-    const tailCount = Math.min(
-      protectTailMessages,
-      Math.max(0, normalized.length - headCount),
-    );
-    const middleStart = headCount;
-    const middleEnd = normalized.length - tailCount;
-    const head = normalized.slice(0, headCount);
-    const middle = normalized.slice(middleStart, middleEnd);
-    const tail = normalized.slice(middleEnd);
-
-    const base = [...head, ...tail];
-    const baseChars = sumChars(base);
-
-    if (baseChars >= maxTotalChars) {
-      included = trimToRecentWithinBudget(base, maxTotalChars);
-    } else {
-      const selectedMiddleRev: PromptHistoryMessage[] = [];
-      let usedChars = baseChars;
-      for (let i = middle.length - 1; i >= 0; i -= 1) {
-        const candidate = middle[i];
-        const nextSize = candidate.content.length;
-        if (usedChars + nextSize > maxTotalChars) continue;
-        selectedMiddleRev.push(candidate);
-        usedChars += nextSize;
+    const turns = groupHistoryTurns(messages);
+    let firstIncludedTurn = turns.length;
+    let includedTurnChars = 0;
+    for (let index = turns.length - 1; index >= 0; index -= 1) {
+      const turnChars = sumChars(turns[index]);
+      if (
+        firstIncludedTurn < turns.length &&
+        includedTurnChars + turnChars > maxTotalChars
+      ) {
+        break;
       }
-      const selectedMiddle = selectedMiddleRev.reverse();
-      included = [...head, ...selectedMiddle, ...tail];
-      if (sumChars(included) > maxTotalChars) {
-        included = trimToRecentWithinBudget(included, maxTotalChars);
-      }
+      firstIncludedTurn = index;
+      includedTurnChars += turnChars;
     }
+    included = turns.slice(firstIncludedTurn).flat();
   }
 
   const includedChars = sumChars(included);
-  const droppedCount = Math.max(0, normalized.length - included.length);
+  const droppedCount = Math.max(0, messages.length - included.length);
   const droppedChars = Math.max(0, preBudgetChars - includedChars);
 
   return {
@@ -304,7 +266,7 @@ export function optimizeHistoryMessagesForPrompt(
       droppedChars,
       maxTotalChars,
       maxMessageChars,
-      perMessageTruncatedCount,
+      perMessageTruncatedCount: 0,
       middleCompressionApplied,
     },
   };

--- a/src/session/token-efficiency.ts
+++ b/src/session/token-efficiency.ts
@@ -2,13 +2,9 @@ import type { ChatMessage } from '../types/api.js';
 
 export const DEFAULT_CHARS_PER_TOKEN = 4;
 export const DEFAULT_HISTORY_MAX_TOTAL_CHARS = 24_000;
-export const DEFAULT_HISTORY_MAX_MESSAGE_CHARS = 1_200;
-export const DEFAULT_HISTORY_PROTECT_HEAD_MESSAGES = 4;
-export const DEFAULT_HISTORY_PROTECT_TAIL_MESSAGES = 8;
 export const DEFAULT_BOOTSTRAP_HEAD_RATIO = 0.7;
 export const DEFAULT_BOOTSTRAP_TAIL_RATIO = 0.2;
 
-const MESSAGE_TRUNCATED_MARKER = '\n...[truncated]';
 const HEAD_TAIL_TRUNCATED_MARKER = '\n\n...[truncated]...\n\n';
 
 function isHighSurrogate(code: number): boolean {
@@ -58,9 +54,6 @@ interface PromptHistoryMessage {
 
 export interface HistoryOptimizationOptions {
   maxTotalChars: number;
-  maxMessageChars: number;
-  protectHeadMessages: number;
-  protectTailMessages: number;
 }
 
 export interface HistoryOptimizationStats {
@@ -72,8 +65,6 @@ export interface HistoryOptimizationStats {
   includedChars: number;
   droppedChars: number;
   maxTotalChars: number;
-  maxMessageChars: number;
-  perMessageTruncatedCount: number;
   middleCompressionApplied: boolean;
 }
 
@@ -159,23 +150,6 @@ export function estimateTokenCountFromMessages(
   return total;
 }
 
-export function truncateMessageContent(
-  content: string,
-  maxChars: number,
-): string {
-  if (!Number.isFinite(maxChars) || maxChars <= 0) return '';
-  if (content.length <= maxChars) return content;
-
-  const bodyMax = Math.max(
-    0,
-    Math.floor(maxChars) - MESSAGE_TRUNCATED_MARKER.length,
-  );
-  if (bodyMax <= 0) {
-    return sliceHeadAtCodePointBoundary(content, Math.floor(maxChars));
-  }
-  return `${sliceHeadAtCodePointBoundary(content, bodyMax)}${MESSAGE_TRUNCATED_MARKER}`;
-}
-
 export function truncateHeadTailText(
   content: string,
   maxChars: number,
@@ -221,10 +195,6 @@ export function optimizeHistoryMessagesForPrompt(
     options?.maxTotalChars ?? DEFAULT_HISTORY_MAX_TOTAL_CHARS,
     DEFAULT_HISTORY_MAX_TOTAL_CHARS,
   );
-  const maxMessageChars = normalizePositiveInt(
-    options?.maxMessageChars ?? DEFAULT_HISTORY_MAX_MESSAGE_CHARS,
-    DEFAULT_HISTORY_MAX_MESSAGE_CHARS,
-  );
   const originalCount = messages.length;
   const originalChars = sumChars(messages);
   const preBudgetChars = originalChars;
@@ -236,6 +206,8 @@ export function optimizeHistoryMessagesForPrompt(
     const turns = groupHistoryTurns(messages);
     let firstIncludedTurn = turns.length;
     let includedTurnChars = 0;
+    // Keep the newest turn whole even when it exceeds the soft history budget.
+    // Rewriting it here would change the cached prefix on the next turn.
     for (let index = turns.length - 1; index >= 0; index -= 1) {
       const turnChars = sumChars(turns[index]);
       if (
@@ -265,8 +237,6 @@ export function optimizeHistoryMessagesForPrompt(
       includedChars,
       droppedChars,
       maxTotalChars,
-      maxMessageChars,
-      perMessageTruncatedCount: 0,
       middleCompressionApplied,
     },
   };

--- a/tests/container.anthropic-provider.test.ts
+++ b/tests/container.anthropic-provider.test.ts
@@ -107,6 +107,22 @@ describe('Anthropic container provider', () => {
             cache_control: { type: 'ephemeral' },
           },
         ]);
+        expect(body.messages).toEqual([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'hello',
+                cache_control: { type: 'ephemeral' },
+              },
+              {
+                type: 'text',
+                text: '<context>\nDate (UTC): 2026-05-13\n</context>',
+              },
+            ],
+          },
+        ]);
         return new Response(
           JSON.stringify({
             id: 'msg_cache',
@@ -143,6 +159,85 @@ describe('Anthropic container provider', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(result.usage?.cache_creation_input_tokens).toBe(1200);
+  });
+
+  test('uses three volatility-ordered system breakpoints and caches the stable user block before dynamic context', async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<
+          string,
+          unknown
+        >;
+        expect(body.system).toEqual([
+          {
+            type: 'text',
+            text: 'Static core',
+            cache_control: { type: 'ephemeral' },
+          },
+          {
+            type: 'text',
+            text: 'Workspace memory',
+            cache_control: { type: 'ephemeral' },
+          },
+          {
+            type: 'text',
+            text: 'Skills catalog',
+            cache_control: { type: 'ephemeral' },
+          },
+        ]);
+        expect(body.messages).toEqual([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'hello',
+                cache_control: { type: 'ephemeral' },
+              },
+              {
+                type: 'text',
+                text: '<context>\nDate (UTC): 2026-05-13\n</context>',
+              },
+            ],
+          },
+        ]);
+        return new Response(
+          JSON.stringify({
+            id: 'msg_blocks',
+            model: 'claude-sonnet-4-6',
+            role: 'assistant',
+            stop_reason: 'end_turn',
+            content: [{ type: 'text', text: 'cached' }],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+      },
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await callAnthropicProvider({
+      ...baseArgs,
+      messages: [
+        { role: 'system', content: 'Static core' },
+        { role: 'system', content: 'Workspace memory' },
+        { role: 'system', content: 'Skills catalog' },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'hello' },
+            {
+              type: 'text',
+              text: '<context>\nDate (UTC): 2026-05-13\n</context>',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   test('does not impose a total-duration timeout on streaming API requests', async () => {
@@ -282,6 +377,7 @@ describe('Anthropic container provider', () => {
             type: 'tool_result',
             tool_use_id: 'tool_1',
             content: 'ok',
+            cache_control: { type: 'ephemeral' },
           },
         ],
       },

--- a/tests/container.model-router.test.ts
+++ b/tests/container.model-router.test.ts
@@ -33,7 +33,13 @@ describe('container model router', () => {
         expect(body.messages).toEqual([
           {
             role: 'user',
-            content: [{ type: 'text', text: 'hello' }],
+            content: [
+              {
+                type: 'text',
+                text: 'hello',
+                cache_control: { type: 'ephemeral' },
+              },
+            ],
           },
         ]);
         return new Response(

--- a/tests/container.system-messages.test.ts
+++ b/tests/container.system-messages.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'vitest';
+
+import { mergeSystemMessage } from '../container/src/system-messages.js';
+
+test('merges volatile instructions into the last system block', () => {
+  const messages = mergeSystemMessage(
+    [
+      { role: 'system', content: 'static core' },
+      { role: 'system', content: 'workspace memory' },
+      { role: 'system', content: 'skills catalog' },
+      { role: 'user', content: 'continue' },
+    ],
+    '[SkillSelectionCache]\nReuse the selected skill.',
+    'last',
+  );
+
+  expect(messages).toEqual([
+    { role: 'system', content: 'static core' },
+    { role: 'system', content: 'workspace memory' },
+    {
+      role: 'system',
+      content:
+        'skills catalog\n\n[SkillSelectionCache]\nReuse the selected skill.',
+    },
+    { role: 'user', content: 'continue' },
+  ]);
+});

--- a/tests/dynamic-context.test.ts
+++ b/tests/dynamic-context.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from 'vitest';
+
+import {
+  DYNAMIC_CONTEXT_MESSAGE_PREFIX,
+  isDynamicContextMessageText,
+} from '../container/shared/dynamic-context.js';
+import { buildDynamicContextMessage } from '../src/agent/conversation.js';
+import { readDynamicContextMessage } from '../src/gateway/gateway-service.js';
+
+test('dynamic context builder and detectors share one stable contract', () => {
+  const message = buildDynamicContextMessage(
+    new Date('2026-07-20T12:00:00.000Z'),
+  );
+
+  expect(message.content).toEqual(
+    expect.stringContaining(`${DYNAMIC_CONTEXT_MESSAGE_PREFIX}2026-07-20`),
+  );
+  expect(isDynamicContextMessageText(message.content)).toBe(true);
+});
+
+test('does not identify generic context-tagged user text as generated context', () => {
+  expect(isDynamicContextMessageText('<context>user-provided text</context>'))
+    .toBe(false);
+  expect(
+    isDynamicContextMessageText(
+      '<context>\nDate (UTC): 2026-07-20\nmissing closing tag',
+    ),
+  ).toBe(false);
+});
+
+test('gateway logging ignores generic context-tagged user messages', () => {
+  const generated = '<context>\nDate (UTC): 2026-07-20\n</context>';
+
+  expect(
+    readDynamicContextMessage([
+      { role: 'user', content: '<context>pasted XML-like text</context>' },
+      { role: 'assistant', content: 'response' },
+      { role: 'user', content: generated },
+    ]),
+  ).toBe(generated);
+});

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -5645,6 +5645,17 @@ describe('gateway HTTP server', () => {
 
   test('accepts OpenAI chat completions requests with client tools and returns tool calls', async () => {
     const state = await importFreshHealth();
+    state.buildConversationContext.mockReturnValueOnce({
+      messages: [
+        { role: 'system', content: 'Mock HybridClaw system prompt' },
+        {
+          role: 'user',
+          content: '<context>\nDate (UTC): 2026-07-18\n</context>',
+        },
+      ],
+      skills: [],
+      historyStats: {},
+    });
     state.callOpenAICompatibleModel.mockResolvedValueOnce({
       id: 'resp_tool',
       model: 'gpt-5',
@@ -5729,6 +5740,14 @@ describe('gateway HTTP server', () => {
     ]);
     expect(payload.choices[0]?.finish_reason).toBe('tool_calls');
     expect(state.callOpenAICompatibleModel).toHaveBeenCalledTimes(1);
+    const modelMessages = state.callOpenAICompatibleModel.mock.calls[0]?.[0]
+      ?.messages as Array<{ role: string; content: string }>;
+    expect(modelMessages.at(-1)).toEqual({
+      role: 'user',
+      content: 'Find customer 42',
+    });
+    expect(modelMessages.at(-2)?.role).toBe('user');
+    expect(modelMessages.at(-2)?.content).toMatch(/^<context>/);
     expect(state.handleGatewayMessage).not.toHaveBeenCalled();
   });
 

--- a/tests/gateway-service.bootstrap-autostart.test.ts
+++ b/tests/gateway-service.bootstrap-autostart.test.ts
@@ -139,8 +139,10 @@ test('ensureGatewayBootstrapAutostart stores prelude and bootstrap opener once p
     true,
   );
   const systemPrompt =
-    request?.messages?.find((message) => message.role === 'system')?.content ||
-    '';
+    request?.messages
+      ?.filter((message) => message.role === 'system')
+      .map((message) => message.content)
+      .join('\n\n') || '';
   expect(systemPrompt).toContain('## SOUL.md');
   expect(systemPrompt).toContain('## IDENTITY.md');
   expect(systemPrompt).toContain('## USER.md');

--- a/tests/gateway-service.skill-followup.test.ts
+++ b/tests/gateway-service.skill-followup.test.ts
@@ -39,6 +39,33 @@ function writeInvocableSkill(runtimeHomeDir: string, skillName: string): void {
   );
 }
 
+function promptContentText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((part) =>
+      part &&
+      typeof part === 'object' &&
+      'type' in part &&
+      part.type === 'text' &&
+      'text' in part &&
+      typeof part.text === 'string'
+        ? part.text
+        : '',
+    )
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function requestSystemPrompt(
+  messages: Array<{ content: unknown; role: string }> | undefined,
+): string {
+  return (messages || [])
+    .filter((message) => message.role === 'system')
+    .map((message) => promptContentText(message.content))
+    .join('\n\n');
+}
+
 test('inherits the previous explicit skill for a short follow-up turn', async () => {
   setupHome();
 
@@ -89,17 +116,17 @@ test('inherits the previous explicit skill for a short follow-up turn', async ()
         messages?: Array<{ content: string; role: string }>;
       }
     | undefined;
-  const systemMessage = request?.messages?.[0];
   const userMessage = request?.messages?.at(-1);
+  const systemPrompt = requestSystemPrompt(request?.messages);
 
-  expect(systemMessage?.role).toBe('system');
-  expect(systemMessage?.content).not.toContain('## Skills (mandatory)');
+  expect(systemPrompt).toContain('## Skills (mandatory)');
   expect(userMessage?.role).toBe('user');
-  expect(userMessage?.content).toContain('[Explicit skill invocation]');
-  expect(userMessage?.content).toContain(
+  const userPrompt = promptContentText(userMessage?.content);
+  expect(userPrompt).toContain('[Explicit skill invocation]');
+  expect(userPrompt).toContain(
     'Use the "render-demo" skill for this request.',
   );
-  expect(userMessage?.content).toContain(
+  expect(userPrompt).toContain(
     'Skill input: Continue and render the video',
   );
 });
@@ -154,14 +181,14 @@ test('does not inherit the previous explicit skill for a new slash-style turn', 
         messages?: Array<{ content: string; role: string }>;
       }
     | undefined;
-  const systemMessage = request?.messages?.[0];
   const userMessage = request?.messages?.at(-1);
+  const systemPrompt = requestSystemPrompt(request?.messages);
 
-  expect(systemMessage?.role).toBe('system');
-  expect(systemMessage?.content).toContain('## Skills (mandatory)');
+  expect(systemPrompt).toContain('## Skills (mandatory)');
   expect(userMessage?.role).toBe('user');
-  expect(userMessage?.content).toBe('/help');
-  expect(userMessage?.content).not.toContain('[Explicit skill invocation]');
+  const userPrompt = promptContentText(userMessage?.content);
+  expect(userPrompt).toContain('/help');
+  expect(userPrompt).not.toContain('[Explicit skill invocation]');
 });
 
 test('inherits the most recent explicit skill for a later follow-up turn', async () => {
@@ -240,11 +267,12 @@ test('inherits the most recent explicit skill for a later follow-up turn', async
   const userMessage = request?.messages?.at(-1);
 
   expect(userMessage?.role).toBe('user');
-  expect(userMessage?.content).toContain('[Explicit skill invocation]');
-  expect(userMessage?.content).toContain(
+  const userPrompt = promptContentText(userMessage?.content);
+  expect(userPrompt).toContain('[Explicit skill invocation]');
+  expect(userPrompt).toContain(
     'Use the "voiceover-demo" skill for this request.',
   );
-  expect(userMessage?.content).toContain(
+  expect(userPrompt).toContain(
     'Skill input: Continue and polish the narration',
   );
 });

--- a/tests/prompt-hooks-stability.test.ts
+++ b/tests/prompt-hooks-stability.test.ts
@@ -82,7 +82,38 @@ test('buildSystemPromptFromHooks is byte-stable across same-date turns', async (
   }
 });
 
-test('buildConversationContext appends dynamic context before history', async () => {
+test('system prompt blocks isolate workspace memory updates from the static core', async () => {
+  const agentId = 'system-block-agent';
+  await createWorkspaceWithBootstrapFiles(agentId);
+  const { agentWorkspaceDir } = await import('../src/infra/ipc.js');
+  const { buildSystemPromptBlocksFromHooks } = await import(
+    '../src/agent/prompt-hooks.js'
+  );
+
+  const first = buildSystemPromptBlocksFromHooks({
+    agentId,
+    skills: [],
+  });
+  fs.writeFileSync(
+    path.join(agentWorkspaceDir(agentId), 'MEMORY.md'),
+    '# MEMORY.md\n\n- Updated durable memory.\n',
+    'utf-8',
+  );
+  const second = buildSystemPromptBlocksFromHooks({
+    agentId,
+    skills: [],
+  });
+
+  expect(first).toHaveLength(2);
+  expect(second).toHaveLength(2);
+  expect(first[0]).toBe(second[0]);
+  expect(first[0]).not.toContain('Stable durable memory.');
+  expect(first[1]).toContain('Stable durable memory.');
+  expect(second[1]).toContain('Updated durable memory.');
+  expect(first[1]).not.toBe(second[1]);
+});
+
+test('buildConversationContext appends dynamic context after unchanged history', async () => {
   vi.useFakeTimers();
 
   try {
@@ -103,17 +134,23 @@ test('buildConversationContext appends dynamic context before history', async ()
       },
     });
 
-    expect(context.messages[0]?.role).toBe('system');
-    expect(context.messages[0]?.content).not.toContain('Date (UTC):');
-    expect(context.messages[0]?.content).not.toContain('Current Date & Time:');
-    expect(context.messages[0]?.content).not.toContain('Stable per-turn note.');
-    expect(context.messages[0]?.content).not.toContain(
+    const systemMessages = context.messages.filter(
+      (message) => message.role === 'system',
+    );
+    const systemPrompt = systemMessages
+      .map((message) => String(message.content || ''))
+      .join('\n\n');
+    expect(systemMessages.length).toBeGreaterThanOrEqual(2);
+    expect(systemPrompt).not.toContain('Date (UTC):');
+    expect(systemPrompt).not.toContain('Current Date & Time:');
+    expect(systemPrompt).not.toContain('Stable per-turn note.');
+    expect(systemPrompt).not.toContain(
       'Relevant Memory Recall',
     );
-    expect(context.messages[0]?.content).not.toContain(
+    expect(systemPrompt).not.toContain(
       'External retrieval result.',
     );
-    expect(context.messages[1]).toEqual(
+    expect(context.messages.at(-1)).toEqual(
       buildDynamicContextMessage({
         agentId,
         now: new Date('2026-05-13T12:00:00.000Z'),
@@ -121,24 +158,31 @@ test('buildConversationContext appends dynamic context before history', async ()
         retrievedContext: 'External retrieval result.',
       }),
     );
-    expect(context.messages[1]?.content).toContain('Date (UTC): 2026-05-13');
-    expect(context.messages[1]?.content).toContain(
+    const dynamicContextMessage = context.messages.at(-1);
+    expect(dynamicContextMessage?.content).toContain(
+      'Date (UTC): 2026-05-13',
+    );
+    expect(dynamicContextMessage?.content).toContain(
       'Current Date & Time: Wednesday, May 13th, 2026',
     );
-    expect(context.messages[1]?.content).toContain('Host:');
-    expect(context.messages[1]?.content).toContain(
+    expect(dynamicContextMessage?.content).toContain('Host:');
+    expect(dynamicContextMessage?.content).toContain(
       '## Daily Memory (memory/2026-05-13.md)',
     );
-    expect(context.messages[1]?.content).toContain('Stable per-turn note.');
-    expect(context.messages[1]?.content).toContain(
+    expect(dynamicContextMessage?.content).toContain('Stable per-turn note.');
+    expect(dynamicContextMessage?.content).toContain(
       '## Session Summary\nCompressed and recalled context',
     );
-    expect(context.messages[1]?.content).toContain('Relevant Memory Recall');
-    expect(context.messages[1]?.content).toContain('## Retrieved Context');
-    expect(context.messages[1]?.content).toContain(
+    expect(dynamicContextMessage?.content).toContain('Relevant Memory Recall');
+    expect(dynamicContextMessage?.content).toContain('## Retrieved Context');
+    expect(dynamicContextMessage?.content).toContain(
       'External retrieval result.',
     );
-    expect(context.messages[2]).toEqual({ role: 'user', content: 'Hello' });
+    expect(context.messages.at(-2)).toEqual({
+      role: 'user',
+      content: 'Hello',
+    });
+
   } finally {
     vi.useRealTimers();
   }

--- a/tests/prompt-hooks.tool-summary.test.ts
+++ b/tests/prompt-hooks.tool-summary.test.ts
@@ -282,7 +282,7 @@ test('buildSystemPromptFromHooks omits mandatory routing instructions when no sk
   expect(prompt).not.toContain('<available_skills>');
 });
 
-test('buildSystemPromptFromHooks omits the skill catalog when the user explicitly invoked a skill', () => {
+test('buildSystemPromptFromHooks keeps the skill catalog stable when the user explicitly invoked a skill', () => {
   const pdfSkill = makeSkill();
   const appleMusicSkill = makeSkill({
     name: 'apple-music',
@@ -301,11 +301,11 @@ test('buildSystemPromptFromHooks omits the skill catalog when the user explicitl
     },
   });
 
-  expect(prompt).not.toContain('## Skills (mandatory)');
+  expect(prompt).toContain('## Skills (mandatory)');
   expect(prompt).not.toContain('## Skill (mandatory)');
-  expect(prompt).not.toContain('<available_skills>');
-  expect(prompt).not.toContain('<name>pdf</name>');
-  expect(prompt).not.toContain('<name>apple-music</name>');
+  expect(prompt).toContain('<available_skills>');
+  expect(prompt).toContain('<name>pdf</name>');
+  expect(prompt).toContain('<name>apple-music</name>');
 });
 
 test('buildSystemPromptFromHooks uses the provided workspace path in runtime metadata', () => {

--- a/tests/runtime-capabilities.test.ts
+++ b/tests/runtime-capabilities.test.ts
@@ -98,6 +98,28 @@ describe('runtime capability hints', () => {
     });
   });
 
+  test('adds runtime hints to the static core without collapsing later system blocks', async () => {
+    const { injectRuntimeCapabilitiesMessage } = await import(
+      '../container/src/runtime-capabilities.ts'
+    );
+
+    const messages = injectRuntimeCapabilitiesMessage(
+      [
+        { role: 'system', content: 'static core' },
+        { role: 'system', content: 'workspace memory' },
+        { role: 'system', content: 'skills catalog' },
+        { role: 'user', content: 'Create a PPTX.' },
+      ],
+      { hasSoffice: false, hasPdftoppm: false },
+    );
+
+    expect(messages).toHaveLength(4);
+    expect(messages[0]?.content).toContain('static core');
+    expect(messages[0]?.content).toContain('## Runtime Capabilities');
+    expect(messages[1]?.content).toBe('workspace memory');
+    expect(messages[2]?.content).toBe('skills catalog');
+  });
+
   test('runtime hint marks PPTX render-and-review as required when dependencies exist', async () => {
     const { buildRuntimeCapabilitiesMessage } = await import(
       '../container/src/runtime-capabilities.ts'

--- a/tests/session-trace-export.test.ts
+++ b/tests/session-trace-export.test.ts
@@ -609,13 +609,15 @@ test('trace export keeps consecutive buildConversationContext system prompts byt
           workspacePath: '/workspace/trace-static-prefix',
         },
       });
-      const systemMessage = messages[0];
-      if (systemMessage?.role !== 'system') {
+      const systemMessages = messages.filter(
+        (message) => message.role === 'system',
+      );
+      if (systemMessages.length === 0) {
         throw new Error(
           'Expected buildConversationContext to emit a system message.',
         );
       }
-      const dynamicContextMessage = messages[1];
+      const dynamicContextMessage = messages.at(-1);
       if (
         dynamicContextMessage?.role !== 'user' ||
         typeof dynamicContextMessage.content !== 'string'
@@ -625,7 +627,9 @@ test('trace export keeps consecutive buildConversationContext system prompts byt
         );
       }
       return {
-        systemPrompt: String(systemMessage.content || ''),
+        systemPrompt: systemMessages
+          .map((message) => String(message.content || ''))
+          .join('\n\n'),
         dynamicContext: dynamicContextMessage.content,
       };
     };

--- a/tests/token-efficiency.basic.test.ts
+++ b/tests/token-efficiency.basic.test.ts
@@ -5,7 +5,6 @@ import {
   estimateTokenCountFromText,
   optimizeHistoryMessagesForPrompt,
   truncateHeadTailText,
-  truncateMessageContent,
 } from '../src/session/token-efficiency.js';
 import type { ChatMessage } from '../src/types/api.js';
 
@@ -42,11 +41,6 @@ test('estimateTokenCountFromMessages handles null message content', () => {
 
 test('prompt truncation does not split UTF-16 surrogate pairs', () => {
   const content = `prefix ${'a'.repeat(20)} 🏠 suffix`;
-  const truncated = truncateMessageContent(content, 30);
-  expect(truncated).not.toContain('\ud83d\n');
-  expect(truncated).not.toMatch(/[\ud800-\udbff](?![\udc00-\udfff])/u);
-  expect(truncated).not.toMatch(/(?<![\ud800-\udbff])[\udc00-\udfff]/u);
-
   const headTail = truncateHeadTailText(content, 36, 0.85, 0.15);
   expect(headTail).not.toMatch(/[\ud800-\udbff](?![\udc00-\udfff])/u);
   expect(headTail).not.toMatch(/(?<![\ud800-\udbff])[\udc00-\udfff]/u);
@@ -62,14 +56,12 @@ test('history optimization drops whole old turns without changing retained bytes
 
   const optimized = optimizeHistoryMessagesForPrompt(messages, {
     maxTotalChars: 110,
-    maxMessageChars: 10,
   });
 
   expect(optimized.messages).toEqual(messages.slice(2));
   expect(optimized.messages[0]?.content).toBe(messages[2]?.content);
   expect(optimized.messages[1]?.content).toBe(messages[3]?.content);
   expect(optimized.stats.droppedCount).toBe(2);
-  expect(optimized.stats.perMessageTruncatedCount).toBe(0);
 });
 
 test('history optimization retains the newest whole turn when it exceeds the budget', () => {

--- a/tests/token-efficiency.basic.test.ts
+++ b/tests/token-efficiency.basic.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from 'vitest';
 import {
   estimateTokenCountFromMessages,
   estimateTokenCountFromText,
+  optimizeHistoryMessagesForPrompt,
   truncateHeadTailText,
   truncateMessageContent,
 } from '../src/session/token-efficiency.js';
@@ -49,4 +50,42 @@ test('prompt truncation does not split UTF-16 surrogate pairs', () => {
   const headTail = truncateHeadTailText(content, 36, 0.85, 0.15);
   expect(headTail).not.toMatch(/[\ud800-\udbff](?![\udc00-\udfff])/u);
   expect(headTail).not.toMatch(/(?<![\ud800-\udbff])[\udc00-\udfff]/u);
+});
+
+test('history optimization drops whole old turns without changing retained bytes', () => {
+  const messages: ChatMessage[] = [
+    { role: 'user', content: `old user ${'a'.repeat(40)}` },
+    { role: 'assistant', content: `old answer ${'b'.repeat(40)}` },
+    { role: 'user', content: `kept user ${'c'.repeat(40)}` },
+    { role: 'assistant', content: `kept answer ${'d'.repeat(40)}` },
+  ];
+
+  const optimized = optimizeHistoryMessagesForPrompt(messages, {
+    maxTotalChars: 110,
+    maxMessageChars: 10,
+  });
+
+  expect(optimized.messages).toEqual(messages.slice(2));
+  expect(optimized.messages[0]?.content).toBe(messages[2]?.content);
+  expect(optimized.messages[1]?.content).toBe(messages[3]?.content);
+  expect(optimized.stats.droppedCount).toBe(2);
+  expect(optimized.stats.perMessageTruncatedCount).toBe(0);
+});
+
+test('history optimization retains the newest whole turn when it exceeds the budget', () => {
+  const newestTurn: ChatMessage[] = [
+    { role: 'user', content: 'latest user request' },
+    { role: 'assistant', content: 'x'.repeat(200) },
+  ];
+  const optimized = optimizeHistoryMessagesForPrompt(
+    [
+      { role: 'user', content: 'old request' },
+      { role: 'assistant', content: 'old answer' },
+      ...newestTurn,
+    ],
+    { maxTotalChars: 50 },
+  );
+
+  expect(optimized.messages).toEqual(newestTurn);
+  expect(optimized.stats.includedChars).toBeGreaterThan(50);
 });


### PR DESCRIPTION
## Summary

- move per-turn time, summaries, retrieved context, and daily memory after retained conversation history, next to the latest user turn
- truncate history by dropping complete oldest turns without rewriting retained message bytes
- keep the skills catalog stable on explicit skill-invocation turns
- split Anthropic system prompts into volatility-ordered static core, workspace/memory, and skills cache blocks
- add the fourth standard cache breakpoint to the last stable message block, including tool-loop results
- preserve existing collapsed-system behavior for non-Anthropic providers and document the prompt-cache contract

## Why

Dynamic context previously appeared immediately after the system message, so every turn changed bytes near the start of the prompt. History optimization also sliced individual messages, continuously changing retained prefixes. Anthropic received one large system block and no multi-turn message breakpoint, so a memory update invalidated the entire system cache and tool-loop/follow-up growth produced cache writes instead of reads.

## Impact

Retained conversation history is append-only until complete old turns are evicted. Anthropic can reuse the static system prefix across workspace-memory changes, reuse earlier system boundaries across skills changes, and reuse stable conversation prefixes across tool iterations and follow-up turns.

## Validation

- `npm run lint`
- `npm --prefix container run lint`
- `npm run build`
- 454 focused gateway, prompt, history, and provider regression tests
- 38 final core prompt/cache regression tests after cleanup
- broad unit run exercised 5,345 tests; the affected stale assertion was fixed and rerun, and the transient embedding-provider failure passed standalone. The remaining local limitation is a host-runner fixture that requires a missing `container/node_modules/.bin/agent-browser` binary.
