### PR TITLE
feat: establish canonical admin settings ownership

### DIFF
--- a/console/src/components/managed-elsewhere-banner.module.css
+++ b/console/src/components/managed-elsewhere-banner.module.css
@@ -1,0 +1,41 @@
+.banner {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, var(--primary) 24%, var(--line));
+  border-left: 3px solid var(--primary);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--primary) 7%, var(--panel-bg));
+}
+
+.banner div {
+  display: grid;
+  gap: 2px;
+}
+
+.banner strong {
+  color: var(--text);
+  font-size: 0.8125rem;
+}
+
+.banner span {
+  color: var(--muted-foreground);
+  font-size: 0.8125rem;
+}
+
+.banner a {
+  color: var(--primary);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .banner {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/console/src/components/managed-elsewhere-banner.tsx
+++ b/console/src/components/managed-elsewhere-banner.tsx
@@ -1,0 +1,19 @@
+import { Link } from '@tanstack/react-router';
+import styles from './managed-elsewhere-banner.module.css';
+import type { AdminConfigSectionOwner } from './sidebar/navigation';
+
+export function ManagedElsewhereBanner({
+  owner,
+}: {
+  owner: AdminConfigSectionOwner;
+}) {
+  return (
+    <aside className={styles.banner} aria-label="Managed elsewhere">
+      <div>
+        <strong>Managed elsewhere</strong>
+        <span>This section is managed on the {owner.label} page.</span>
+      </div>
+      <Link to={owner.to}>Open {owner.label} →</Link>
+    </aside>
+  );
+}

--- a/console/src/components/provider-health.module.css
+++ b/console/src/components/provider-health.module.css
@@ -70,10 +70,10 @@
 }
 
 .rowTop {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, max-content) minmax(0, 1fr);
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  gap: 16px;
 }
 
 .nameGroup {
@@ -150,15 +150,20 @@
 .meta {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 8px;
-  flex-shrink: 0;
+  min-width: 0;
 }
 
 .detail {
+  min-width: 0;
+  flex: 1 1 auto;
   font-size: 11px;
   color: #6b7280;
   font-family: "SFMono-Regular", "JetBrains Mono", "Fira Code", monospace;
-  white-space: nowrap;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  text-align: right;
 }
 
 .modelCount {
@@ -169,10 +174,12 @@
 }
 
 .statusLabel {
+  flex-shrink: 0;
   font-size: 10px;
   color: #9ca3af;
   text-transform: uppercase;
   letter-spacing: 0.05em;
+  white-space: nowrap;
 }
 
 .manageBtn {
@@ -223,6 +230,24 @@
 .compactOverflow {
   color: #9ca3af;
   font-size: 11px;
+}
+
+@media (max-width: 720px) {
+  .rowTop {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 7px;
+  }
+
+  .meta {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    padding-left: 12px;
+  }
+
+  .detail {
+    flex-basis: 100%;
+    text-align: left;
+  }
 }
 
 .loginBtn {

--- a/console/src/components/provider-health.module.css
+++ b/console/src/components/provider-health.module.css
@@ -15,10 +15,6 @@
   overflow: hidden;
 }
 
-.panelCompact {
-  min-width: 0;
-}
-
 .panelHeader {
   padding: 12px 16px 11px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.06);
@@ -182,56 +178,6 @@
   white-space: nowrap;
 }
 
-.manageBtn {
-  border: 0;
-  padding: 0;
-  background: transparent;
-  color: #4f46e5;
-  cursor: pointer;
-  font-size: 11.5px;
-  font-weight: 600;
-}
-
-.manageBtn:hover {
-  text-decoration: underline;
-}
-
-.compactBody {
-  display: grid;
-  gap: 10px;
-  padding: 12px 16px;
-  color: #6b7280;
-  font-size: 12px;
-}
-
-.compactSummary strong {
-  color: #111827;
-  font-variant-numeric: tabular-nums;
-}
-
-.compactSummary .compactAttention {
-  color: #b45309;
-}
-
-.compactProviders {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px 12px;
-}
-
-.compactProvider {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  color: #4b5563;
-  font-size: 11px;
-}
-
-.compactOverflow {
-  color: #9ca3af;
-  font-size: 11px;
-}
-
 @media (max-width: 720px) {
   .rowTop {
     grid-template-columns: minmax(0, 1fr);
@@ -248,32 +194,6 @@
     flex-basis: 100%;
     text-align: left;
   }
-}
-
-.loginBtn {
-  font-size: 11.5px;
-  font-weight: 500;
-  padding: 3px 9px;
-  border-radius: 5px;
-  border: 1px solid rgba(217, 119, 6, 0.45);
-  background: rgba(255, 251, 235, 0.9);
-  color: #92400e;
-  cursor: pointer;
-  white-space: nowrap;
-  line-height: 1.5;
-  transition:
-    background 0.1s ease,
-    border-color 0.1s ease;
-  flex-shrink: 0;
-}
-
-.loginBtn:hover {
-  background: #fef3c7;
-  border-color: #d97706;
-}
-
-.loginBtn:active {
-  background: #fde68a;
 }
 
 .inactiveFooter {
@@ -370,37 +290,8 @@
   color: #4b5563;
 }
 
-:global(html[data-theme="dark"]) .statusLabel,
-:global(html[data-theme="dark"]) .compactBody,
-:global(html[data-theme="dark"]) .compactOverflow {
+:global(html[data-theme="dark"]) .statusLabel {
   color: #6b7280;
-}
-
-:global(html[data-theme="dark"]) .manageBtn {
-  color: #a5b4fc;
-}
-
-:global(html[data-theme="dark"]) .compactSummary strong {
-  color: #e5edf7;
-}
-
-:global(html[data-theme="dark"]) .compactSummary .compactAttention {
-  color: #fbbf24;
-}
-
-:global(html[data-theme="dark"]) .compactProvider {
-  color: #9ca3af;
-}
-
-:global(html[data-theme="dark"]) .loginBtn {
-  background: rgba(245, 158, 11, 0.09);
-  border-color: rgba(245, 158, 11, 0.3);
-  color: #fbbf24;
-}
-
-:global(html[data-theme="dark"]) .loginBtn:hover {
-  background: rgba(245, 158, 11, 0.15);
-  border-color: rgba(245, 158, 11, 0.5);
 }
 
 :global(html[data-theme="dark"]) .inactiveFooter {

--- a/console/src/components/provider-health.module.css
+++ b/console/src/components/provider-health.module.css
@@ -15,6 +15,10 @@
   overflow: hidden;
 }
 
+.panelCompact {
+  min-width: 0;
+}
+
 .panelHeader {
   padding: 12px 16px 11px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.06);
@@ -95,6 +99,10 @@
   box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.15);
   animation: pulse 2s ease-in-out infinite;
 }
+.dotCatalog {
+  background: #64748b;
+  box-shadow: 0 0 0 2px rgba(100, 116, 139, 0.15);
+}
 .dotDown {
   background: #ef4444;
   box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.15);
@@ -158,6 +166,63 @@
   color: #9ca3af;
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
+}
+
+.statusLabel {
+  font-size: 10px;
+  color: #9ca3af;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.manageBtn {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: #4f46e5;
+  cursor: pointer;
+  font-size: 11.5px;
+  font-weight: 600;
+}
+
+.manageBtn:hover {
+  text-decoration: underline;
+}
+
+.compactBody {
+  display: grid;
+  gap: 10px;
+  padding: 12px 16px;
+  color: #6b7280;
+  font-size: 12px;
+}
+
+.compactSummary strong {
+  color: #111827;
+  font-variant-numeric: tabular-nums;
+}
+
+.compactSummary .compactAttention {
+  color: #b45309;
+}
+
+.compactProviders {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+}
+
+.compactProvider {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #4b5563;
+  font-size: 11px;
+}
+
+.compactOverflow {
+  color: #9ca3af;
+  font-size: 11px;
 }
 
 .loginBtn {
@@ -278,6 +343,28 @@
 
 :global(html[data-theme="dark"]) .modelCount {
   color: #4b5563;
+}
+
+:global(html[data-theme="dark"]) .statusLabel,
+:global(html[data-theme="dark"]) .compactBody,
+:global(html[data-theme="dark"]) .compactOverflow {
+  color: #6b7280;
+}
+
+:global(html[data-theme="dark"]) .manageBtn {
+  color: #a5b4fc;
+}
+
+:global(html[data-theme="dark"]) .compactSummary strong {
+  color: #e5edf7;
+}
+
+:global(html[data-theme="dark"]) .compactSummary .compactAttention {
+  color: #fbbf24;
+}
+
+:global(html[data-theme="dark"]) .compactProvider {
+  color: #9ca3af;
 }
 
 :global(html[data-theme="dark"]) .loginBtn {

--- a/console/src/components/provider-health.test.tsx
+++ b/console/src/components/provider-health.test.tsx
@@ -32,6 +32,28 @@ describe('ProviderHealth', () => {
     expect(screen.getByText('not running locally')).toBeTruthy();
   });
 
+  it('keeps the complete provider diagnostic available for long status rows', () => {
+    const diagnostic =
+      'Mistral is disabled. Enable it: config set mistral.enabled true';
+    render(
+      <ProviderHealth
+        title="Provider health"
+        entries={[
+          [
+            'mistral',
+            {
+              kind: 'remote',
+              reachable: false,
+              error: diagnostic,
+            },
+          ],
+        ]}
+      />,
+    );
+
+    expect(screen.getByText(diagnostic).getAttribute('title')).toBe(diagnostic);
+  });
+
   it('summarizes health and invokes the compact manage action', () => {
     const onManage = vi.fn();
     render(

--- a/console/src/components/provider-health.test.tsx
+++ b/console/src/components/provider-health.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { type ProviderEntry, ProviderHealth } from './provider-health';
+
+const ENTRIES: Array<[string, ProviderEntry]> = [
+  [
+    'hybridai',
+    {
+      kind: 'remote' as const,
+      reachable: true,
+      latencyMs: 12,
+      modelCount: 3,
+    },
+  ],
+  [
+    'ollama',
+    {
+      kind: 'local' as const,
+      reachable: false,
+      modelCount: 0,
+    },
+  ],
+];
+
+describe('ProviderHealth', () => {
+  it('renders detailed provider rows in the full variant', () => {
+    render(<ProviderHealth title="Provider health" entries={ENTRIES} />);
+
+    expect(screen.getByText('hybridai')).toBeTruthy();
+    expect(screen.getByText('12ms')).toBeTruthy();
+    expect(screen.getByText('ollama')).toBeTruthy();
+    expect(screen.getByText('not running locally')).toBeTruthy();
+  });
+
+  it('summarizes health and invokes the compact manage action', () => {
+    const onManage = vi.fn();
+    render(
+      <ProviderHealth
+        title="Backend health"
+        entries={ENTRIES}
+        variant="compact"
+        onManage={onManage}
+      />,
+    );
+
+    expect(
+      screen.getByText('Backend health').closest('section')?.textContent,
+    ).toContain('1 healthy · 1 inactive');
+    fireEvent.click(screen.getByRole('button', { name: 'Manage providers →' }));
+    expect(onManage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/console/src/components/provider-health.test.tsx
+++ b/console/src/components/provider-health.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
 import { type ProviderEntry, ProviderHealth } from './provider-health';
 
 const ENTRIES: Array<[string, ProviderEntry]> = [
@@ -52,23 +52,5 @@ describe('ProviderHealth', () => {
     );
 
     expect(screen.getByText(diagnostic).getAttribute('title')).toBe(diagnostic);
-  });
-
-  it('summarizes health and invokes the compact manage action', () => {
-    const onManage = vi.fn();
-    render(
-      <ProviderHealth
-        title="Backend health"
-        entries={ENTRIES}
-        variant="compact"
-        onManage={onManage}
-      />,
-    );
-
-    expect(
-      screen.getByText('Backend health').closest('section')?.textContent,
-    ).toContain('1 healthy · 1 inactive');
-    fireEvent.click(screen.getByRole('button', { name: 'Manage providers →' }));
-    expect(onManage).toHaveBeenCalledTimes(1);
   });
 });

--- a/console/src/components/provider-health.tsx
+++ b/console/src/components/provider-health.tsx
@@ -7,7 +7,7 @@ const LOCAL_PROVIDER_NAMES = new Set([
   'vllm',
 ]);
 
-type HealthStatus = 'healthy' | 'warning' | 'inactive' | 'down';
+type HealthStatus = 'healthy' | 'warning' | 'catalog' | 'inactive' | 'down';
 
 export interface ProviderEntry {
   kind?: 'local' | 'remote';
@@ -17,9 +17,11 @@ export interface ProviderEntry {
   modelCount?: number;
   detail?: string;
   loginRequired?: boolean;
+  catalogOnly?: boolean;
 }
 
 function resolveStatus(name: string, provider: ProviderEntry): HealthStatus {
+  if (provider.catalogOnly) return 'catalog';
   if (provider.loginRequired) return 'warning';
   if (!provider.reachable) {
     const isLocal = provider.kind === 'local' || LOCAL_PROVIDER_NAMES.has(name);
@@ -35,6 +37,7 @@ function isLocalProvider(name: string, provider: ProviderEntry): boolean {
 const DOT_CLASS: Record<HealthStatus, string> = {
   healthy: styles.dotHealthy,
   warning: styles.dotWarning,
+  catalog: styles.dotCatalog,
   down: styles.dotDown,
   inactive: styles.dotInactive,
 };
@@ -42,7 +45,7 @@ const DOT_CLASS: Record<HealthStatus, string> = {
 interface ProviderRowProps {
   name: string;
   provider: ProviderEntry;
-  onLogin: () => void;
+  onLogin?: () => void;
 }
 
 function ProviderRow({ name, provider, onLogin }: ProviderRowProps) {
@@ -81,28 +84,33 @@ function ProviderRow({ name, provider, onLogin }: ProviderRowProps) {
           <span className={styles.modelCount}>
             {modelCount} {modelCount === 1 ? 'model' : 'models'}
           </span>
-          {provider.loginRequired && (
+          <span className={styles.statusLabel}>{status}</span>
+          {provider.loginRequired && onLogin ? (
             <button type="button" className={styles.loginBtn} onClick={onLogin}>
               Log in →
             </button>
-          )}
+          ) : null}
         </div>
       </div>
     </div>
   );
 }
 
-interface ProviderHealthPanelProps {
+export interface ProviderHealthProps {
   title: string;
   entries: Array<[string, ProviderEntry]>;
-  onLogin: () => void;
+  variant?: 'full' | 'compact';
+  onLogin?: () => void;
+  onManage?: () => void;
 }
 
-export function ProviderHealthPanel({
+export function ProviderHealth({
   title,
   entries,
+  variant = 'full',
   onLogin,
-}: ProviderHealthPanelProps) {
+  onManage,
+}: ProviderHealthProps) {
   // Split into active (visible rows) and inactive (collapsed footer)
   const activeEntries = entries.filter(([name, p]) => {
     const status = resolveStatus(name, p);
@@ -113,6 +121,78 @@ export function ProviderHealthPanel({
     const status = resolveStatus(name, p);
     return status === 'inactive';
   });
+  const healthyCount = entries.filter(
+    ([name, provider]) => resolveStatus(name, provider) === 'healthy',
+  ).length;
+  const attentionCount = entries.filter(([name, provider]) => {
+    const status = resolveStatus(name, provider);
+    return status === 'warning' || status === 'down';
+  }).length;
+  const catalogCount = entries.filter(
+    ([name, provider]) => resolveStatus(name, provider) === 'catalog',
+  ).length;
+
+  if (variant === 'compact') {
+    return (
+      <section className={`${styles.panel} ${styles.panelCompact}`}>
+        <div className={styles.panelHeader}>
+          <span className={styles.panelTitle}>{title}</span>
+          {onManage ? (
+            <button
+              type="button"
+              className={styles.manageBtn}
+              onClick={onManage}
+            >
+              Manage providers →
+            </button>
+          ) : null}
+        </div>
+        <div className={styles.compactBody}>
+          {entries.length === 0 ? (
+            <span>No provider health data available.</span>
+          ) : (
+            <>
+              <span className={styles.compactSummary}>
+                <strong>{healthyCount}</strong> healthy
+                {attentionCount > 0 ? (
+                  <>
+                    {' · '}
+                    <strong className={styles.compactAttention}>
+                      {attentionCount}
+                    </strong>{' '}
+                    need attention
+                  </>
+                ) : null}
+                {catalogCount > 0 ? ` · ${catalogCount} catalog only` : ''}
+                {inactiveEntries.length > 0
+                  ? ` · ${inactiveEntries.length} inactive`
+                  : ''}
+              </span>
+              <div className={styles.compactProviders}>
+                {activeEntries.slice(0, 6).map(([name, provider]) => {
+                  const status = resolveStatus(name, provider);
+                  return (
+                    <span className={styles.compactProvider} key={name}>
+                      <span
+                        className={`${styles.dot} ${DOT_CLASS[status]}`}
+                        aria-hidden="true"
+                      />
+                      {name}
+                    </span>
+                  );
+                })}
+                {activeEntries.length > 6 ? (
+                  <span className={styles.compactOverflow}>
+                    +{activeEntries.length - 6}
+                  </span>
+                ) : null}
+              </div>
+            </>
+          )}
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className={styles.panel}>

--- a/console/src/components/provider-health.tsx
+++ b/console/src/components/provider-health.tsx
@@ -45,10 +45,9 @@ const DOT_CLASS: Record<HealthStatus, string> = {
 interface ProviderRowProps {
   name: string;
   provider: ProviderEntry;
-  onLogin?: () => void;
 }
 
-function ProviderRow({ name, provider, onLogin }: ProviderRowProps) {
+function ProviderRow({ name, provider }: ProviderRowProps) {
   const status = resolveStatus(name, provider);
   const isLocal = isLocalProvider(name, provider);
   const modelCount = provider.modelCount ?? 0;
@@ -90,11 +89,6 @@ function ProviderRow({ name, provider, onLogin }: ProviderRowProps) {
             {modelCount} {modelCount === 1 ? 'model' : 'models'}
           </span>
           <span className={styles.statusLabel}>{status}</span>
-          {provider.loginRequired && onLogin ? (
-            <button type="button" className={styles.loginBtn} onClick={onLogin}>
-              Log in →
-            </button>
-          ) : null}
         </div>
       </div>
     </div>
@@ -104,18 +98,9 @@ function ProviderRow({ name, provider, onLogin }: ProviderRowProps) {
 export interface ProviderHealthProps {
   title: string;
   entries: Array<[string, ProviderEntry]>;
-  variant?: 'full' | 'compact';
-  onLogin?: () => void;
-  onManage?: () => void;
 }
 
-export function ProviderHealth({
-  title,
-  entries,
-  variant = 'full',
-  onLogin,
-  onManage,
-}: ProviderHealthProps) {
+export function ProviderHealth({ title, entries }: ProviderHealthProps) {
   // Split into active (visible rows) and inactive (collapsed footer)
   const activeEntries = entries.filter(([name, p]) => {
     const status = resolveStatus(name, p);
@@ -126,79 +111,6 @@ export function ProviderHealth({
     const status = resolveStatus(name, p);
     return status === 'inactive';
   });
-  const healthyCount = entries.filter(
-    ([name, provider]) => resolveStatus(name, provider) === 'healthy',
-  ).length;
-  const attentionCount = entries.filter(([name, provider]) => {
-    const status = resolveStatus(name, provider);
-    return status === 'warning' || status === 'down';
-  }).length;
-  const catalogCount = entries.filter(
-    ([name, provider]) => resolveStatus(name, provider) === 'catalog',
-  ).length;
-
-  if (variant === 'compact') {
-    return (
-      <section className={`${styles.panel} ${styles.panelCompact}`}>
-        <div className={styles.panelHeader}>
-          <span className={styles.panelTitle}>{title}</span>
-          {onManage ? (
-            <button
-              type="button"
-              className={styles.manageBtn}
-              onClick={onManage}
-            >
-              Manage providers →
-            </button>
-          ) : null}
-        </div>
-        <div className={styles.compactBody}>
-          {entries.length === 0 ? (
-            <span>No provider health data available.</span>
-          ) : (
-            <>
-              <span className={styles.compactSummary}>
-                <strong>{healthyCount}</strong> healthy
-                {attentionCount > 0 ? (
-                  <>
-                    {' · '}
-                    <strong className={styles.compactAttention}>
-                      {attentionCount}
-                    </strong>{' '}
-                    need attention
-                  </>
-                ) : null}
-                {catalogCount > 0 ? ` · ${catalogCount} catalog only` : ''}
-                {inactiveEntries.length > 0
-                  ? ` · ${inactiveEntries.length} inactive`
-                  : ''}
-              </span>
-              <div className={styles.compactProviders}>
-                {activeEntries.slice(0, 6).map(([name, provider]) => {
-                  const status = resolveStatus(name, provider);
-                  return (
-                    <span className={styles.compactProvider} key={name}>
-                      <span
-                        className={`${styles.dot} ${DOT_CLASS[status]}`}
-                        aria-hidden="true"
-                      />
-                      {name}
-                    </span>
-                  );
-                })}
-                {activeEntries.length > 6 ? (
-                  <span className={styles.compactOverflow}>
-                    +{activeEntries.length - 6}
-                  </span>
-                ) : null}
-              </div>
-            </>
-          )}
-        </div>
-      </section>
-    );
-  }
-
   return (
     <section className={styles.panel}>
       <div className={styles.panelHeader}>
@@ -210,12 +122,7 @@ export function ProviderHealth({
       ) : (
         <>
           {activeEntries.map(([name, provider]) => (
-            <ProviderRow
-              key={name}
-              name={name}
-              provider={provider}
-              onLogin={onLogin}
-            />
+            <ProviderRow key={name} name={name} provider={provider} />
           ))}
           {inactiveEntries.length > 0 && (
             <div className={styles.inactiveFooter}>
@@ -233,5 +140,3 @@ export function ProviderHealth({
     </section>
   );
 }
-
-export { ProviderRow as ProviderHealthRow };

--- a/console/src/components/provider-health.tsx
+++ b/console/src/components/provider-health.tsx
@@ -71,7 +71,10 @@ function ProviderRow({ name, provider, onLogin }: ProviderRowProps) {
     <div className={rowClass}>
       <div className={styles.rowTop}>
         <div className={styles.nameGroup}>
-          <span className={`${styles.dot} ${DOT_CLASS[status]}`} />
+          <span
+            className={`${styles.dot} ${DOT_CLASS[status]}`}
+            aria-hidden="true"
+          />
           <span className={styles.name}>{name}</span>
           <span
             className={`${styles.badge} ${isLocal ? styles.badgeLocal : styles.badgeRemote}`}
@@ -80,7 +83,9 @@ function ProviderRow({ name, provider, onLogin }: ProviderRowProps) {
           </span>
         </div>
         <div className={styles.meta}>
-          <span className={styles.detail}>{detail}</span>
+          <span className={styles.detail} title={detail}>
+            {detail}
+          </span>
           <span className={styles.modelCount}>
             {modelCount} {modelCount === 1 ? 'model' : 'models'}
           </span>

--- a/console/src/components/secret-ref-picker.module.css
+++ b/console/src/components/secret-ref-picker.module.css
@@ -1,0 +1,28 @@
+.picker {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+}
+
+.meta a {
+  color: var(--primary);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .meta {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
+  }
+}

--- a/console/src/components/secret-ref-picker.test.tsx
+++ b/console/src/components/secret-ref-picker.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AdminSecretsResponse } from '../api/types';
+import { renderWithProviders } from '../test-utils';
+import { Field, FieldLabel } from './field';
+import { SecretRefPicker } from './secret-ref-picker';
+
+const fetchAdminSecretsMock = vi.fn<() => Promise<AdminSecretsResponse>>();
+const useAuthMock = vi.fn();
+
+vi.mock('../api/client', () => ({
+  fetchAdminSecrets: () => fetchAdminSecretsMock(),
+}));
+
+vi.mock('../auth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+function renderPicker(value = '', onValueChange = vi.fn()) {
+  renderWithProviders(
+    <Field>
+      <FieldLabel>API key secret</FieldLabel>
+      <SecretRefPicker value={value} onValueChange={onValueChange} />
+    </Field>,
+  );
+}
+
+describe('SecretRefPicker', () => {
+  beforeEach(() => {
+    fetchAdminSecretsMock.mockReset();
+    useAuthMock.mockReset();
+    useAuthMock.mockReturnValue({ token: 'test-token' });
+    fetchAdminSecretsMock.mockResolvedValue({
+      secrets: [
+        {
+          name: 'ZETA_KEY',
+          state: 'unset',
+          created_at: null,
+          last_rotated_at: null,
+          length: null,
+          fingerprint: null,
+        },
+        {
+          name: 'ALPHA_KEY',
+          state: 'set',
+          created_at: '2026-07-18T10:00:00.000Z',
+          last_rotated_at: '2026-07-18T10:00:00.000Z',
+          length: 32,
+          fingerprint: { length: 32, sha256_prefix: 'not-rendered' },
+        },
+      ],
+      total: 2,
+      actions: ['secret.list_metadata'],
+    });
+  });
+
+  it('renders sorted secret names without exposing secret metadata', async () => {
+    renderPicker();
+
+    const select = (await screen.findByLabelText(
+      'API key secret',
+    )) as HTMLSelectElement;
+    await screen.findByRole('option', { name: 'ALPHA_KEY' });
+    expect(Array.from(select.options).map((option) => option.text)).toEqual([
+      'Select secret',
+      'ALPHA_KEY',
+      'ZETA_KEY (unset)',
+    ]);
+    expect(document.body.textContent).not.toContain('not-rendered');
+    expect(document.body.textContent).not.toContain('32');
+    expect(
+      screen
+        .getByRole('link', { name: 'Create new secret →' })
+        .getAttribute('href'),
+    ).toBe('/admin/secrets');
+  });
+
+  it('selects a stored secret name and preserves a missing current reference', async () => {
+    const onValueChange = vi.fn();
+    renderPicker('LEGACY_KEY', onValueChange);
+
+    const select = (await screen.findByLabelText(
+      'API key secret',
+    )) as HTMLSelectElement;
+    await screen.findByRole('option', { name: 'ALPHA_KEY' });
+    expect(select.value).toBe('LEGACY_KEY');
+    expect(screen.getByRole('option', { name: 'LEGACY_KEY' })).toBeTruthy();
+
+    fireEvent.change(select, { target: { value: 'ALPHA_KEY' } });
+    expect(onValueChange).toHaveBeenCalledWith('ALPHA_KEY');
+  });
+});

--- a/console/src/components/secret-ref-picker.tsx
+++ b/console/src/components/secret-ref-picker.tsx
@@ -1,0 +1,62 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchAdminSecrets } from '../api/client';
+import { useAuth } from '../auth';
+import { NativeSelect, NativeSelectOption } from './native-select';
+import styles from './secret-ref-picker.module.css';
+
+export interface SecretRefPickerProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export function SecretRefPicker({
+  value,
+  onValueChange,
+  placeholder = 'Select secret',
+  disabled = false,
+}: SecretRefPickerProps) {
+  const { token } = useAuth();
+  const secretsQuery = useQuery({
+    queryKey: ['admin', 'secrets', token],
+    queryFn: () => fetchAdminSecrets(token),
+    retry: false,
+  });
+  const entries = [...(secretsQuery.data?.secrets ?? [])].sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+  const currentIsMissing =
+    Boolean(value) && !entries.some((entry) => entry.name === value);
+
+  return (
+    <div className={styles.picker}>
+      <NativeSelect
+        value={value}
+        disabled={disabled || secretsQuery.isPending}
+        onChange={(event) => onValueChange(event.target.value)}
+      >
+        <NativeSelectOption value="">
+          {secretsQuery.isPending ? 'Loading secrets…' : placeholder}
+        </NativeSelectOption>
+        {currentIsMissing ? (
+          <NativeSelectOption value={value}>{value}</NativeSelectOption>
+        ) : null}
+        {entries.map((entry) => (
+          <NativeSelectOption key={entry.name} value={entry.name}>
+            {entry.name}
+            {entry.state === 'unset' ? ' (unset)' : ''}
+          </NativeSelectOption>
+        ))}
+      </NativeSelect>
+      <div className={styles.meta}>
+        {secretsQuery.isError ? (
+          <span role="alert">Secret names are unavailable.</span>
+        ) : (
+          <span>Values stay in the runtime secret store.</span>
+        )}
+        <a href="/admin/secrets">Create new secret →</a>
+      </div>
+    </div>
+  );
+}

--- a/console/src/components/sidebar/navigation.test.ts
+++ b/console/src/components/sidebar/navigation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { SIDEBAR_NAV_GROUPS } from './navigation';
+import { ADMIN_CONFIG_SECTION_OWNERS, SIDEBAR_NAV_GROUPS } from './navigation';
 
 describe('SIDEBAR_NAV_GROUPS', () => {
   it('uses the task-oriented Phase 1 information architecture', () => {
@@ -80,5 +80,20 @@ describe('SIDEBAR_NAV_GROUPS', () => {
     );
 
     expect(new Set(routes).size).toBe(routes.length);
+  });
+
+  it('keeps JSON section ownership next to the canonical navigation map', () => {
+    expect(ADMIN_CONFIG_SECTION_OWNERS.discord).toEqual({
+      label: 'Channels',
+      to: '/admin/channels',
+    });
+    expect(ADMIN_CONFIG_SECTION_OWNERS.mcpServers).toEqual({
+      label: 'MCP Servers',
+      to: '/admin/mcp',
+    });
+    expect(ADMIN_CONFIG_SECTION_OWNERS.scheduler).toEqual({
+      label: 'Schedules',
+      to: '/admin/scheduler',
+    });
   });
 });

--- a/console/src/components/sidebar/navigation.ts
+++ b/console/src/components/sidebar/navigation.ts
@@ -39,6 +39,39 @@ export type SidebarNavGroup = {
   items: ReadonlyArray<SidebarNavItem>;
 };
 
+export type AdminConfigSectionOwner = {
+  label: string;
+  to: string;
+};
+
+const CHANNELS_OWNER: AdminConfigSectionOwner = {
+  label: 'Channels',
+  to: '/admin/channels',
+};
+
+export const ADMIN_CONFIG_SECTION_OWNERS: Readonly<
+  Partial<Record<string, AdminConfigSectionOwner>>
+> = {
+  channels: CHANNELS_OWNER,
+  channelInstructions: CHANNELS_OWNER,
+  discord: CHANNELS_OWNER,
+  discordWebhook: CHANNELS_OWNER,
+  email: CHANNELS_OWNER,
+  imessage: CHANNELS_OWNER,
+  line: CHANNELS_OWNER,
+  msteams: CHANNELS_OWNER,
+  signal: CHANNELS_OWNER,
+  slack: CHANNELS_OWNER,
+  slackWebhook: CHANNELS_OWNER,
+  telegram: CHANNELS_OWNER,
+  threema: CHANNELS_OWNER,
+  voice: CHANNELS_OWNER,
+  whatsapp: CHANNELS_OWNER,
+  mcpServers: { label: 'MCP Servers', to: '/admin/mcp' },
+  outputGuard: { label: 'Output Guard', to: '/admin/output-guard' },
+  scheduler: { label: 'Schedules', to: '/admin/scheduler' },
+};
+
 export const SIDEBAR_NAV_GROUPS: ReadonlyArray<SidebarNavGroup> = [
   {
     label: 'Overview',

--- a/console/src/lib/json-cursor-section.test.ts
+++ b/console/src/lib/json-cursor-section.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { findTopLevelJsonSection } from './json-cursor-section';
+
+const JSON_TEXT = JSON.stringify(
+  {
+    version: 1,
+    discord: { enabled: true, nested: { value: 1 } },
+    scheduler: { jobs: [] },
+  },
+  null,
+  2,
+);
+
+describe('findTopLevelJsonSection', () => {
+  it('returns the top-level section containing the cursor', () => {
+    expect(
+      findTopLevelJsonSection(JSON_TEXT, JSON_TEXT.indexOf('"enabled"')),
+    ).toBe('discord');
+    expect(
+      findTopLevelJsonSection(JSON_TEXT, JSON_TEXT.indexOf('"jobs"')),
+    ).toBe('scheduler');
+  });
+
+  it('does not mistake nested object keys for sections', () => {
+    expect(
+      findTopLevelJsonSection(JSON_TEXT, JSON_TEXT.indexOf('"value"')),
+    ).toBe('discord');
+  });
+
+  it('returns null before the first top-level key', () => {
+    expect(findTopLevelJsonSection(JSON_TEXT, 0)).toBeNull();
+  });
+});

--- a/console/src/lib/json-cursor-section.ts
+++ b/console/src/lib/json-cursor-section.ts
@@ -1,0 +1,76 @@
+type JsonSection = {
+  name: string;
+  start: number;
+};
+
+function readJsonStringEnd(value: string, start: number): number {
+  let escaped = false;
+  for (let index = start + 1; index < value.length; index += 1) {
+    const char = value[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === '"') return index;
+  }
+  return value.length - 1;
+}
+
+function readTopLevelSections(value: string): JsonSection[] {
+  const sections: JsonSection[] = [];
+  let depth = 0;
+  let expectingTopLevelKey = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === '"') {
+      const end = readJsonStringEnd(value, index);
+      if (depth === 1 && expectingTopLevelKey) {
+        let colon = end + 1;
+        while (/\s/u.test(value[colon] ?? '')) colon += 1;
+        if (value[colon] === ':') {
+          try {
+            const name = JSON.parse(value.slice(index, end + 1)) as string;
+            sections.push({ name, start: index });
+            expectingTopLevelKey = false;
+          } catch {
+            // Keep scanning malformed draft JSON; the editor owns parse errors.
+          }
+        }
+      }
+      index = end;
+      continue;
+    }
+    if (char === '{' || char === '[') {
+      depth += 1;
+      if (depth === 1 && char === '{') expectingTopLevelKey = true;
+      continue;
+    }
+    if (char === '}' || char === ']') {
+      if (depth === 1) expectingTopLevelKey = false;
+      depth = Math.max(0, depth - 1);
+      continue;
+    }
+    if (char === ',' && depth === 1) expectingTopLevelKey = true;
+  }
+
+  return sections;
+}
+
+export function findTopLevelJsonSection(
+  value: string,
+  cursorOffset: number,
+): string | null {
+  const offset = Math.max(0, Math.min(cursorOffset, value.length));
+  const sections = readTopLevelSections(value);
+  let current: JsonSection | null = null;
+  for (const section of sections) {
+    if (section.start > offset) break;
+    current = section;
+  }
+  return current?.name ?? null;
+}

--- a/console/src/routes/config.test.tsx
+++ b/console/src/routes/config.test.tsx
@@ -4,6 +4,7 @@ import type {
   AdminBrowserPoolHealthResponse,
   AdminConfig,
   AdminConfigResponse,
+  AdminSecretsResponse,
 } from '../api/types';
 import {
   blockerStateMock,
@@ -17,11 +18,13 @@ vi.mock('@tanstack/react-router', () => mockRouterBlocker());
 const fetchConfigMock = vi.fn<() => Promise<AdminConfigResponse>>();
 const fetchBrowserPoolHealthMock =
   vi.fn<() => Promise<AdminBrowserPoolHealthResponse>>();
+const fetchAdminSecretsMock = vi.fn<() => Promise<AdminSecretsResponse>>();
 const saveConfigMock = vi.fn();
 const startBrowserPoolMock = vi.fn();
 const useAuthMock = vi.fn();
 
 vi.mock('../api/client', () => ({
+  fetchAdminSecrets: () => fetchAdminSecretsMock(),
   fetchBrowserPoolHealth: () => fetchBrowserPoolHealthMock(),
   fetchConfig: () => fetchConfigMock(),
   saveConfig: (...args: unknown[]) => saveConfigMock(...args),
@@ -157,6 +160,28 @@ beforeEach(() => {
     message:
       'Managed browser pool health check failed at http://127.0.0.1:8787: fetch failed',
   });
+  fetchAdminSecretsMock.mockResolvedValue({
+    secrets: [
+      {
+        name: 'BROWSER_USE_API_KEY',
+        state: 'set',
+        created_at: '2026-07-18T10:00:00.000Z',
+        last_rotated_at: '2026-07-18T10:00:00.000Z',
+        length: 24,
+        fingerprint: { length: 24, sha256_prefix: 'browser-use' },
+      },
+      {
+        name: 'MANAGED_BROWSER_POOL_TOKEN',
+        state: 'set',
+        created_at: '2026-07-18T10:00:00.000Z',
+        last_rotated_at: '2026-07-18T10:00:00.000Z',
+        length: 24,
+        fingerprint: { length: 24, sha256_prefix: 'browser-pool' },
+      },
+    ],
+    total: 2,
+    actions: ['secret.list_metadata'],
+  });
   saveConfigMock.mockResolvedValue({
     path: '/tmp/config.json',
     config,
@@ -193,12 +218,9 @@ describe('ConfigPage', () => {
     fireEvent.change(screen.getByDisplayValue('http://127.0.0.1:8787'), {
       target: { value: 'https://browser.example' },
     });
-    fireEvent.change(
-      screen.getByPlaceholderText('MANAGED_BROWSER_POOL_TOKEN'),
-      {
-        target: { value: 'MANAGED_BROWSER_POOL_TOKEN' },
-      },
-    );
+    fireEvent.change(screen.getByLabelText('Pool token secret'), {
+      target: { value: 'MANAGED_BROWSER_POOL_TOKEN' },
+    });
     fireEvent.change(screen.getByLabelText('Default tenant id (optional)'), {
       target: { value: 'tenant-a' },
     });
@@ -406,6 +428,62 @@ describe('ConfigPage', () => {
         }) as HTMLButtonElement
       ).disabled,
     ).toBe(false);
+  });
+
+  it('links page-owned settings instead of rendering duplicate form controls', async () => {
+    renderConfigPage();
+
+    await screen.findByLabelText('Health host');
+
+    expect(screen.queryByRole('combobox', { name: 'Log level' })).toBeNull();
+    expect(screen.queryByRole('textbox', { name: 'Default model' })).toBeNull();
+    expect(
+      screen.getByRole('link', { name: 'Open Logs' }).getAttribute('href'),
+    ).toBe('/admin/logs');
+    expect(
+      screen.getByRole('link', { name: 'Open Providers' }).getAttribute('href'),
+    ).toBe('/admin/models');
+  });
+
+  it('links page-owned sections from JSON mode based on the cursor position', async () => {
+    renderConfigPage();
+
+    await screen.findByLabelText('Health host');
+    fireEvent.click(screen.getByRole('button', { name: 'JSON' }));
+
+    const editor = (await screen.findByLabelText(
+      'config.json',
+    )) as HTMLTextAreaElement;
+    const rawJson = JSON.stringify(
+      {
+        ...makeConfig(),
+        discord: { enabled: true },
+      },
+      null,
+      2,
+    );
+    fireEvent.change(editor, { target: { value: rawJson } });
+
+    const discordCursor = rawJson.indexOf('"discord"') + '"discord"'.length;
+    editor.setSelectionRange(discordCursor, discordCursor);
+    fireEvent.select(editor);
+
+    expect(screen.getByLabelText('Managed elsewhere')).toBeTruthy();
+    expect(
+      screen.getByText('This section is managed on the Channels page.'),
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByRole('link', { name: 'Open Channels →' })
+        .getAttribute('href'),
+    ).toBe('/admin/channels');
+
+    const containerCursor =
+      rawJson.indexOf('"container"') + '"container"'.length;
+    editor.setSelectionRange(containerCursor, containerCursor);
+    fireEvent.select(editor);
+
+    expect(screen.queryByLabelText('Managed elsewhere')).toBeNull();
   });
 
   it('surfaces a FieldError for malformed JSON in raw mode and blocks saving', async () => {

--- a/console/src/routes/config.test.tsx
+++ b/console/src/routes/config.test.tsx
@@ -430,19 +430,17 @@ describe('ConfigPage', () => {
     ).toBe(false);
   });
 
-  it('links page-owned settings instead of rendering duplicate form controls', async () => {
+  it('omits settings managed by dedicated pages', async () => {
     renderConfigPage();
 
     await screen.findByLabelText('Health host');
 
+    expect(screen.queryByText('Log level')).toBeNull();
+    expect(screen.queryByText('Default model')).toBeNull();
     expect(screen.queryByRole('combobox', { name: 'Log level' })).toBeNull();
     expect(screen.queryByRole('textbox', { name: 'Default model' })).toBeNull();
-    expect(
-      screen.getByRole('link', { name: 'Open Logs' }).getAttribute('href'),
-    ).toBe('/admin/logs');
-    expect(
-      screen.getByRole('link', { name: 'Open Providers' }).getAttribute('href'),
-    ).toBe('/admin/models');
+    expect(screen.queryByRole('link', { name: 'Open Logs' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Open Providers' })).toBeNull();
   });
 
   it('links page-owned sections from JSON mode based on the cursor position', async () => {

--- a/console/src/routes/config.tsx
+++ b/console/src/routes/config.tsx
@@ -15,7 +15,6 @@ import {
   startBrowserPool,
 } from '../api/client';
 import type { AdminBrowserPoolHealthResponse, AdminConfig } from '../api/types';
-import { LOG_LEVELS } from '../api/types';
 import { useAuth } from '../auth';
 import { Button } from '../components/button';
 import { Card } from '../components/card';
@@ -28,14 +27,18 @@ import {
   FieldLabel,
   FieldLegend,
   FieldSet,
+  FieldTitle,
   pattern,
   required,
 } from '../components/field';
 import { Form, FormField, useForm } from '../components/form';
 import { Trash } from '../components/icons';
 import { Input } from '../components/input';
+import { ManagedElsewhereBanner } from '../components/managed-elsewhere-banner';
 import { NativeSelect, NativeSelectOption } from '../components/native-select';
 import { NumberField } from '../components/number-field';
+import { SecretRefPicker } from '../components/secret-ref-picker';
+import { ADMIN_CONFIG_SECTION_OWNERS } from '../components/sidebar/navigation';
 import { Switch } from '../components/switch';
 import { Textarea } from '../components/textarea';
 import { useToast } from '../components/toast';
@@ -45,7 +48,7 @@ import { DEFAULT_VIEW_SWITCH_ITEMS } from '../components/view-switch';
 import { useFormMutation } from '../hooks/use-form-mutation';
 import { useUnsavedChangesGuard } from '../hooks/use-unsaved-changes-guard';
 import { getErrorMessage } from '../lib/error-message';
-import { isOneOf } from '../lib/oneof';
+import { findTopLevelJsonSection } from '../lib/json-cursor-section';
 import styles from './config.module.css';
 
 function serialize(config: AdminConfig): string {
@@ -541,6 +544,9 @@ export function ConfigPage() {
   const [viewMode, setViewMode] = useState<'form' | 'json'>('form');
   const [rawJson, setRawJson] = useState('');
   const [jsonError, setJsonError] = useState<string | null>(null);
+  const [jsonCursorSection, setJsonCursorSection] = useState<string | null>(
+    null,
+  );
 
   const configQuery = useQuery({
     queryKey: ['config', auth.token],
@@ -634,15 +640,19 @@ export function ConfigPage() {
     },
   });
 
-  const handleRawJsonChange = useCallback((next: string) => {
-    setRawJson(next);
-    try {
-      JSON.parse(next);
-      setJsonError(null);
-    } catch (error) {
-      setJsonError(getErrorMessage(error));
-    }
-  }, []);
+  const handleRawJsonChange = useCallback(
+    (next: string, cursorOffset: number) => {
+      setRawJson(next);
+      setJsonCursorSection(findTopLevelJsonSection(next, cursorOffset));
+      try {
+        JSON.parse(next);
+        setJsonError(null);
+      } catch (error) {
+        setJsonError(getErrorMessage(error));
+      }
+    },
+    [],
+  );
 
   const { dialog: unsavedChangesDialog } = useUnsavedChangesGuard({
     isDirty,
@@ -680,6 +690,7 @@ export function ConfigPage() {
         const parsed = JSON.parse(rawJson) as AdminConfig;
         setDraft(parsed);
         setJsonError(null);
+        setJsonCursorSection(null);
         setViewMode('form');
       } catch (error) {
         setJsonError(getErrorMessage(error));
@@ -688,6 +699,7 @@ export function ConfigPage() {
     }
     setRawJson(serialize(draft));
     setJsonError(null);
+    setJsonCursorSection(null);
     setViewMode('json');
   };
 
@@ -715,6 +727,9 @@ export function ConfigPage() {
   const saveDisabled =
     saveMutation.isPending ||
     (viewMode === 'json' ? Boolean(jsonError) : !form.isValid);
+  const jsonSectionOwner = jsonCursorSection
+    ? ADMIN_CONFIG_SECTION_OWNERS[jsonCursorSection]
+    : undefined;
 
   return (
     <Form form={form} className={styles.page} onSubmit={save}>
@@ -768,26 +783,44 @@ export function ConfigPage() {
 
       <div className={styles.content}>
         {viewMode === 'json' ? (
-          <Field className={styles.jsonField} invalid={Boolean(jsonError)}>
-            <FieldLabel>config.json</FieldLabel>
-            <Textarea
-              className={`code-editor ${styles.jsonEditor}`}
-              spellCheck={false}
-              autoComplete="off"
-              autoCorrect="off"
-              autoCapitalize="off"
-              value={rawJson}
-              onChange={(event) => handleRawJsonChange(event.target.value)}
-            />
-            <FieldError>{jsonError}</FieldError>
-          </Field>
+          <>
+            {jsonSectionOwner ? (
+              <ManagedElsewhereBanner owner={jsonSectionOwner} />
+            ) : null}
+            <Field className={styles.jsonField} invalid={Boolean(jsonError)}>
+              <FieldLabel>config.json</FieldLabel>
+              <Textarea
+                className={`code-editor ${styles.jsonEditor}`}
+                spellCheck={false}
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                value={rawJson}
+                onChange={(event) =>
+                  handleRawJsonChange(
+                    event.target.value,
+                    event.target.selectionStart,
+                  )
+                }
+                onSelect={(event) =>
+                  setJsonCursorSection(
+                    findTopLevelJsonSection(
+                      rawJson,
+                      event.currentTarget.selectionStart,
+                    ),
+                  )
+                }
+              />
+              <FieldError>{jsonError}</FieldError>
+            </Field>
+          </>
         ) : (
           <>
             <Card className={styles.sectionCard}>
               <FieldSet>
                 <FieldLegend>Operations</FieldLegend>
                 <FieldDescription className={styles.sectionDescription}>
-                  Gateway listener and log verbosity.
+                  Gateway listener and public URLs.
                 </FieldDescription>
                 <FieldGroup>
                   <FormField
@@ -819,29 +852,17 @@ export function ConfigPage() {
                       </Field>
                     )}
                   />
-                  <FormField
-                    name="ops.logLevel"
-                    render={({ field }) => (
-                      <Field>
-                        <FieldLabel>Log level</FieldLabel>
-                        <NativeSelect
-                          value={field.value as string}
-                          onChange={(event) => {
-                            const next = event.target.value;
-                            if (isOneOf(LOG_LEVELS, next)) {
-                              field.onChange(next);
-                            }
-                          }}
-                        >
-                          {LOG_LEVELS.map((level) => (
-                            <NativeSelectOption key={level} value={level}>
-                              {level}
-                            </NativeSelectOption>
-                          ))}
-                        </NativeSelect>
-                      </Field>
-                    )}
-                  />
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <FieldTitle>Log level</FieldTitle>
+                      <FieldDescription>
+                        Runtime logging controls are managed on the Logs page.
+                      </FieldDescription>
+                    </FieldContent>
+                    <Link to="/admin/logs" className="ghost-button">
+                      Open Logs
+                    </Link>
+                  </Field>
                   <FormField
                     name="ops.gatewayBaseUrl"
                     render={({ field }) => (
@@ -929,15 +950,18 @@ export function ConfigPage() {
                       </Field>
                     )}
                   />
-                  <FormField
-                    name="hybridai.defaultModel"
-                    render={({ field }) => (
-                      <Field>
-                        <FieldLabel>Default model</FieldLabel>
-                        <Input {...field} />
-                      </Field>
-                    )}
-                  />
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <FieldTitle>Default model</FieldTitle>
+                      <FieldDescription>
+                        Model selection and routing are managed on the Providers
+                        page.
+                      </FieldDescription>
+                    </FieldContent>
+                    <Link to="/admin/models" className="ghost-button">
+                      Open Providers
+                    </Link>
+                  </Field>
                   <FormField
                     name="hybridai.enableRag"
                     render={({ field }) => (
@@ -1142,12 +1166,11 @@ export function ConfigPage() {
                         />
                       </Field>
                       <Field>
-                        <FieldLabel>Pool token SecretRef id</FieldLabel>
-                        <Input
+                        <FieldLabel>Pool token secret</FieldLabel>
+                        <SecretRefPicker
                           value={managedPoolTokenId}
                           placeholder="MANAGED_BROWSER_POOL_TOKEN"
-                          onChange={(event) => {
-                            const id = event.target.value.trim();
+                          onValueChange={(id) => {
                             setBrowserSection(setDraft, 'managedCloud', {
                               poolTokenRef: id
                                 ? { source: 'store', id }
@@ -1197,11 +1220,11 @@ export function ConfigPage() {
                   {browser.provider === 'browser-use-cloud' ? (
                     <>
                       <Field>
-                        <FieldLabel>API key SecretRef id</FieldLabel>
-                        <Input
+                        <FieldLabel>API key secret</FieldLabel>
+                        <SecretRefPicker
                           value={browserUseApiKeyId}
-                          onChange={(event) => {
-                            const id = event.target.value.trim();
+                          placeholder="BROWSER_USE_API_KEY"
+                          onValueChange={(id) => {
                             setBrowserSection(setDraft, 'browserUseCloud', {
                               apiKeyRef: id
                                 ? { source: 'store', id }

--- a/console/src/routes/config.tsx
+++ b/console/src/routes/config.tsx
@@ -27,7 +27,6 @@ import {
   FieldLabel,
   FieldLegend,
   FieldSet,
-  FieldTitle,
   pattern,
   required,
 } from '../components/field';
@@ -852,17 +851,6 @@ export function ConfigPage() {
                       </Field>
                     )}
                   />
-                  <Field orientation="horizontal">
-                    <FieldContent>
-                      <FieldTitle>Log level</FieldTitle>
-                      <FieldDescription>
-                        Runtime logging controls are managed on the Logs page.
-                      </FieldDescription>
-                    </FieldContent>
-                    <Link to="/admin/logs" className="ghost-button">
-                      Open Logs
-                    </Link>
-                  </Field>
                   <FormField
                     name="ops.gatewayBaseUrl"
                     render={({ field }) => (
@@ -950,18 +938,6 @@ export function ConfigPage() {
                       </Field>
                     )}
                   />
-                  <Field orientation="horizontal">
-                    <FieldContent>
-                      <FieldTitle>Default model</FieldTitle>
-                      <FieldDescription>
-                        Model selection and routing are managed on the Providers
-                        page.
-                      </FieldDescription>
-                    </FieldContent>
-                    <Link to="/admin/models" className="ghost-button">
-                      Open Providers
-                    </Link>
-                  </Field>
                   <FormField
                     name="hybridai.enableRag"
                     render={({ field }) => (

--- a/console/src/routes/dashboard.test.tsx
+++ b/console/src/routes/dashboard.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AdminOverview, AdminTunnelStatus } from '../api/types';
 import { renderWithProviders } from '../test-utils';
@@ -150,6 +150,28 @@ describe('DashboardPage', () => {
       await screen.findByRole('heading', { name: 'Recent sessions' }),
     ).toBeTruthy();
     expect(screen.queryByRole('heading', { name: 'Public tunnel' })).toBeNull();
+  });
+
+  it('links compact backend health to the Providers page', async () => {
+    const overview = makeOverview();
+    overview.status.providerHealth = {
+      hybridai: {
+        kind: 'remote',
+        reachable: true,
+        latencyMs: 12,
+        modelCount: 3,
+      },
+    };
+    fetchOverviewMock.mockResolvedValue(overview);
+
+    renderDashboardPage();
+
+    expect(await screen.findByText('Backend health')).toBeTruthy();
+    expect(
+      screen.getByText('Backend health').closest('section')?.textContent,
+    ).toContain('1 healthy');
+    fireEvent.click(screen.getByRole('button', { name: 'Manage providers →' }));
+    expect(navigateMock).toHaveBeenCalledWith({ to: '/admin/models' });
   });
 
   it('keeps zero daily usage and per-day chart labels visible', async () => {

--- a/console/src/routes/dashboard.test.tsx
+++ b/console/src/routes/dashboard.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AdminOverview, AdminTunnelStatus } from '../api/types';
 import { renderWithProviders } from '../test-utils';
@@ -6,7 +6,6 @@ import { DashboardPage } from './dashboard';
 
 const fetchOverviewMock = vi.fn();
 const fetchStatisticsMock = vi.fn();
-const navigateMock = vi.fn();
 const useAuthMock = vi.fn();
 const useLiveEventsMock = vi.fn();
 
@@ -18,16 +17,6 @@ vi.mock('../api/client', () => ({
 vi.mock('../auth', () => ({
   useAuth: () => useAuthMock(),
 }));
-
-vi.mock('@tanstack/react-router', async () => {
-  const actual = await vi.importActual<typeof import('@tanstack/react-router')>(
-    '@tanstack/react-router',
-  );
-  return {
-    ...actual,
-    useNavigate: () => navigateMock,
-  };
-});
 
 vi.mock('../hooks/use-live-events', () => ({
   useLiveEvents: (...args: unknown[]) => useLiveEventsMock(...args),
@@ -121,7 +110,6 @@ describe('DashboardPage', () => {
       trend: [],
       channels: [],
     });
-    navigateMock.mockReset();
     useAuthMock.mockReset();
     useLiveEventsMock.mockReset();
 
@@ -150,28 +138,7 @@ describe('DashboardPage', () => {
       await screen.findByRole('heading', { name: 'Recent sessions' }),
     ).toBeTruthy();
     expect(screen.queryByRole('heading', { name: 'Public tunnel' })).toBeNull();
-  });
-
-  it('links compact backend health to the Providers page', async () => {
-    const overview = makeOverview();
-    overview.status.providerHealth = {
-      hybridai: {
-        kind: 'remote',
-        reachable: true,
-        latencyMs: 12,
-        modelCount: 3,
-      },
-    };
-    fetchOverviewMock.mockResolvedValue(overview);
-
-    renderDashboardPage();
-
-    expect(await screen.findByText('Backend health')).toBeTruthy();
-    expect(
-      screen.getByText('Backend health').closest('section')?.textContent,
-    ).toContain('1 healthy');
-    fireEvent.click(screen.getByRole('button', { name: 'Manage providers →' }));
-    expect(navigateMock).toHaveBeenCalledWith({ to: '/admin/models' });
+    expect(screen.queryByText('Backend health')).toBeNull();
   });
 
   it('keeps zero daily usage and per-day chart labels visible', async () => {

--- a/console/src/routes/dashboard.tsx
+++ b/console/src/routes/dashboard.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { fetchOverview, fetchStatistics } from '../api/client';
 import { useAuth } from '../auth';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/card';
-import { ProviderHealthPanel } from '../components/provider-health';
+import { ProviderHealth } from '../components/provider-health';
 import {
   MetricCard,
   PageHeader,
@@ -175,10 +175,11 @@ export function DashboardPage() {
           </CardContent>
         </Card>
 
-        <ProviderHealthPanel
+        <ProviderHealth
           title="Backend health"
           entries={backendEntries}
-          onLogin={() => void navigate({ to: '/admin/config' })}
+          variant="compact"
+          onManage={() => void navigate({ to: '/admin/models' })}
         />
       </div>
 

--- a/console/src/routes/dashboard.tsx
+++ b/console/src/routes/dashboard.tsx
@@ -1,9 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
 import { fetchOverview, fetchStatistics } from '../api/client';
 import { useAuth } from '../auth';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/card';
-import { ProviderHealth } from '../components/provider-health';
 import {
   MetricCard,
   PageHeader,
@@ -71,7 +69,6 @@ function formatTrendDate(isoDate: string): string {
 
 export function DashboardPage() {
   const auth = useAuth();
-  const navigate = useNavigate();
   const live = useLiveEvents(auth.token);
   useLiveConnectionToasts(live.connection);
   const overviewQuery = useQuery({
@@ -119,20 +116,6 @@ export function DashboardPage() {
   }
 
   const schedulerJobs = status.scheduler?.jobs.length || 0;
-  const backendEntries = Object.entries(
-    status.providerHealth || status.localBackends || {},
-  ) as Array<
-    [
-      string,
-      {
-        reachable: boolean;
-        latencyMs?: number;
-        error?: string;
-        modelCount?: number;
-        detail?: string;
-      },
-    ]
-  >;
 
   return (
     <div className="page-stack">
@@ -161,27 +144,18 @@ export function DashboardPage() {
         />
       </div>
 
-      <div className="two-column-grid">
-        <Card variant="muted">
-          <CardHeader>
-            <CardTitle>Usage rollup</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <UsageRollup
-              usage={overview.usage}
-              trend={usageTrendQuery.data?.trend ?? null}
-              formatTrendDate={formatTrendDate}
-            />
-          </CardContent>
-        </Card>
-
-        <ProviderHealth
-          title="Backend health"
-          entries={backendEntries}
-          variant="compact"
-          onManage={() => void navigate({ to: '/admin/models' })}
-        />
-      </div>
+      <Card variant="muted">
+        <CardHeader>
+          <CardTitle>Usage rollup</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <UsageRollup
+            usage={overview.usage}
+            trend={usageTrendQuery.data?.trend ?? null}
+            formatTrendDate={formatTrendDate}
+          />
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader>

--- a/console/src/routes/fleet-topology.test.tsx
+++ b/console/src/routes/fleet-topology.test.tsx
@@ -1,0 +1,75 @@
+import { screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AdminFleetTopologyResponse } from '../api/types';
+import { renderWithProviders } from '../test-utils';
+import { FleetTopologyPage } from './fleet-topology';
+
+const fetchFleetTopologyMock =
+  vi.fn<() => Promise<AdminFleetTopologyResponse>>();
+const useAuthMock = vi.fn();
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ to, children }: { to: string; children: ReactNode }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+vi.mock('../api/client', () => ({
+  fetchFleetTopology: () => fetchFleetTopologyMock(),
+}));
+
+vi.mock('../auth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+describe('FleetTopologyPage', () => {
+  beforeEach(() => {
+    fetchFleetTopologyMock.mockReset();
+    useAuthMock.mockReset();
+    useAuthMock.mockReturnValue({ token: 'test-token' });
+    fetchFleetTopologyMock.mockResolvedValue({
+      hq: {
+        instanceId: 'hq-1',
+        publicKeyFingerprint: 'hq-fingerprint',
+        version: '0.12.6',
+        status: 'local',
+        latencyMs: 0,
+        lastSeenAt: '2026-07-18T10:00:00.000Z',
+      },
+      instances: [
+        {
+          peerId: 'peer-1',
+          agentCardUrl: 'https://peer.example/.well-known/agent-card.json',
+          deliveryUrl: 'https://peer.example/a2a',
+          publicKeyFingerprint: 'peer-fingerprint',
+          trustStatus: 'trusted',
+          status: 'online',
+          version: '0.12.6',
+          latencyMs: 18,
+          error: null,
+          trustedAt: '2026-07-17T10:00:00.000Z',
+          createdAt: '2026-07-17T10:00:00.000Z',
+          updatedAt: '2026-07-18T10:00:00.000Z',
+          lastSeenAt: '2026-07-18T10:00:00.000Z',
+          revokedAt: null,
+          revokedReason: null,
+        },
+      ],
+    });
+  });
+
+  it('keeps topology read-only and links peer mutations to A2A Trust', async () => {
+    renderWithProviders(<FleetTopologyPage />);
+
+    expect(await screen.findAllByText('peer-1')).toHaveLength(2);
+    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Remove' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Trust instance' })).toBeNull();
+    expect(
+      screen
+        .getByRole('link', { name: 'Manage peer trust' })
+        .getAttribute('href'),
+    ).toBe('/admin/a2a-trust');
+  });
+});

--- a/console/src/routes/fleet-topology.tsx
+++ b/console/src/routes/fleet-topology.tsx
@@ -1,14 +1,7 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
-import {
-  deleteFleetTopologyInstance,
-  fetchFleetTopology,
-  upsertFleetTopologyInstance,
-} from '../api/client';
-import type {
-  AdminFleetTopologyInstance,
-  AdminFleetTopologyInstanceStatus,
-} from '../api/types';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import { fetchFleetTopology } from '../api/client';
+import type { AdminFleetTopologyInstanceStatus } from '../api/types';
 import { useAuth } from '../auth';
 import {
   Card,
@@ -17,9 +10,6 @@ import {
   CardHeader,
   CardTitle,
 } from '../components/card';
-import { Field, FieldLabel } from '../components/field';
-import { Input } from '../components/input';
-import { Textarea } from '../components/textarea';
 import { BooleanPill, PageHeader } from '../components/ui';
 import { formatDateTime, formatRelativeTime } from '../lib/format';
 
@@ -49,65 +39,14 @@ function formatLatency(value: number | null): string {
 
 export function FleetTopologyPage() {
   const auth = useAuth();
-  const queryClient = useQueryClient();
-  const [peerId, setPeerId] = useState('');
-  const [agentCardUrl, setAgentCardUrl] = useState('');
-  const [deliveryUrl, setDeliveryUrl] = useState('');
-  const [fingerprint, setFingerprint] = useState('');
-  const [publicKeyJwk, setPublicKeyJwk] = useState('');
-  const [reason, setReason] = useState('');
 
   const topologyQuery = useQuery({
     queryKey: ['fleet-topology', auth.token],
     queryFn: () => fetchFleetTopology(auth.token),
   });
 
-  const upsertMutation = useMutation({
-    mutationFn: () => {
-      const parsedPublicKeyJwk = publicKeyJwk.trim()
-        ? JSON.parse(publicKeyJwk)
-        : undefined;
-      return upsertFleetTopologyInstance(auth.token, {
-        peerId,
-        agentCardUrl: agentCardUrl || undefined,
-        deliveryUrl: deliveryUrl || undefined,
-        publicKeyFingerprint: fingerprint || undefined,
-        publicKeyJwk: parsedPublicKeyJwk,
-        reason: reason || undefined,
-      });
-    },
-    onSuccess: (data) => {
-      queryClient.setQueryData(['fleet-topology', auth.token], data);
-      setPeerId('');
-      setAgentCardUrl('');
-      setDeliveryUrl('');
-      setFingerprint('');
-      setPublicKeyJwk('');
-      setReason('');
-    },
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (instance: AdminFleetTopologyInstance) =>
-      deleteFleetTopologyInstance(auth.token, instance.peerId),
-    onSuccess: (data) => {
-      queryClient.setQueryData(['fleet-topology', auth.token], data);
-    },
-  });
-
   const topology = topologyQuery.data;
   const instances = topology?.instances || [];
-  const canSubmit =
-    peerId.trim() && (fingerprint.trim() || publicKeyJwk.trim());
-
-  function fillInstance(instance: AdminFleetTopologyInstance): void {
-    setPeerId(instance.peerId);
-    setAgentCardUrl(instance.agentCardUrl);
-    setDeliveryUrl(instance.deliveryUrl);
-    setFingerprint(instance.publicKeyFingerprint);
-    setPublicKeyJwk('');
-    setReason('');
-  }
 
   return (
     <div className="page-stack">
@@ -193,21 +132,6 @@ export function FleetTopologyPage() {
                     </div>
                     <div className="row-actions">
                       {statusPill(instance.status)}
-                      <button
-                        className="ghost-button"
-                        type="button"
-                        onClick={() => fillInstance(instance)}
-                      >
-                        Edit
-                      </button>
-                      <button
-                        className="danger-button"
-                        type="button"
-                        disabled={deleteMutation.isPending}
-                        onClick={() => deleteMutation.mutate(instance)}
-                      >
-                        Remove
-                      </button>
                     </div>
                   </div>
                 ))}
@@ -215,88 +139,33 @@ export function FleetTopologyPage() {
             ) : (
               <div className="empty-state">No child instances configured.</div>
             )}
-            {deleteMutation.error ? (
+            {topologyQuery.error ? (
               <small className="row-status-note-danger">
-                {deleteMutation.error instanceof Error
-                  ? deleteMutation.error.message
-                  : 'Remove failed.'}
+                {topologyQuery.error instanceof Error
+                  ? topologyQuery.error.message
+                  : 'Fleet topology load failed.'}
               </small>
             ) : null}
           </CardContent>
         </Card>
 
-        <Card>
+        <Card variant="muted">
           <CardHeader>
-            <CardTitle>Add instance</CardTitle>
-            <CardDescription>A2A trust ledger</CardDescription>
+            <CardTitle>Peer trust</CardTitle>
+            <CardDescription>Managed on the A2A Trust page</CardDescription>
           </CardHeader>
           <CardContent>
             <div className="detail-stack">
-              <Field>
-                <FieldLabel>Instance</FieldLabel>
-                <Input
-                  value={peerId}
-                  onChange={(event) => setPeerId(event.target.value)}
-                />
-              </Field>
-              <Field>
-                <FieldLabel>Agent Card</FieldLabel>
-                <Input
-                  value={agentCardUrl}
-                  onChange={(event) => setAgentCardUrl(event.target.value)}
-                />
-              </Field>
-              <Field>
-                <FieldLabel>Delivery URL</FieldLabel>
-                <Input
-                  value={deliveryUrl}
-                  onChange={(event) => setDeliveryUrl(event.target.value)}
-                />
-              </Field>
-              <Field>
-                <FieldLabel>Fingerprint</FieldLabel>
-                <Input
-                  value={fingerprint}
-                  onChange={(event) => setFingerprint(event.target.value)}
-                />
-              </Field>
-              <Field>
-                <FieldLabel>Public JWK</FieldLabel>
-                <Textarea
-                  rows={5}
-                  value={publicKeyJwk}
-                  onChange={(event) => setPublicKeyJwk(event.target.value)}
-                />
-              </Field>
-              <Field>
-                <FieldLabel>Reason</FieldLabel>
-                <Input
-                  value={reason}
-                  onChange={(event) => setReason(event.target.value)}
-                />
-              </Field>
-              <button
-                className="primary-button"
-                type="button"
-                disabled={!canSubmit || upsertMutation.isPending}
-                onClick={() => upsertMutation.mutate()}
-              >
-                Trust instance
-              </button>
-              {upsertMutation.error ? (
-                <small className="row-status-note-danger">
-                  {upsertMutation.error instanceof Error
-                    ? upsertMutation.error.message
-                    : 'Trust update failed.'}
-                </small>
-              ) : null}
-              {topologyQuery.error ? (
-                <small className="row-status-note-danger">
-                  {topologyQuery.error instanceof Error
-                    ? topologyQuery.error.message
-                    : 'Fleet topology load failed.'}
-                </small>
-              ) : null}
+              <p className="supporting-text">
+                Add, edit, revoke, or remove trusted peers in one place. Fleet
+                topology remains a read-only view of reachability and runtime
+                status.
+              </p>
+              <div className="button-row">
+                <Link to="/admin/a2a-trust" className="primary-button">
+                  Manage peer trust
+                </Link>
+              </div>
             </div>
           </CardContent>
         </Card>

--- a/console/src/routes/gateway.test.tsx
+++ b/console/src/routes/gateway.test.tsx
@@ -14,7 +14,6 @@ const fetchAdminHybridAIBotsMock =
 const fetchAdminSecretsMock = vi.fn<() => Promise<AdminSecretsResponse>>();
 const reloadGatewayMock = vi.fn();
 const updateAdminAgentMock = vi.fn();
-const navigateMock = vi.fn();
 const useAuthMock = vi.fn();
 const useLiveEventsMock = vi.fn();
 
@@ -30,16 +29,6 @@ vi.mock('../api/client', () => ({
 vi.mock('../auth', () => ({
   useAuth: () => useAuthMock(),
 }));
-
-vi.mock('@tanstack/react-router', async () => {
-  const actual = await vi.importActual<typeof import('@tanstack/react-router')>(
-    '@tanstack/react-router',
-  );
-  return {
-    ...actual,
-    useNavigate: () => navigateMock,
-  };
-});
 
 vi.mock('../hooks/use-live-events', () => ({
   useLiveEvents: (...args: unknown[]) => useLiveEventsMock(...args),
@@ -125,7 +114,6 @@ describe('GatewayPage', () => {
     fetchAdminSecretsMock.mockReset();
     reloadGatewayMock.mockReset();
     updateAdminAgentMock.mockReset();
-    navigateMock.mockReset();
     useAuthMock.mockReset();
     useLiveEventsMock.mockReset();
 
@@ -175,30 +163,7 @@ describe('GatewayPage', () => {
     renderGatewayPage();
 
     expect(screen.getByText('Public tunnel settings')).toBeTruthy();
-  });
-
-  it('uses compact provider health that opens the Providers page', () => {
-    useAuthMock.mockReturnValue({
-      token: 'test-token',
-      gatewayStatus: makeStatus({
-        providerHealth: {
-          hybridai: {
-            kind: 'remote',
-            reachable: true,
-            latencyMs: 12,
-            modelCount: 3,
-          },
-        },
-      }),
-    });
-
-    renderGatewayPage();
-
-    expect(
-      screen.getByText('Provider health').closest('section')?.textContent,
-    ).toContain('1 healthy');
-    fireEvent.click(screen.getByRole('button', { name: 'Manage providers →' }));
-    expect(navigateMock).toHaveBeenCalledWith({ to: '/admin/models' });
+    expect(screen.queryByText('Provider health')).toBeNull();
   });
 
   it('opens a reload confirmation dialog and calls the reload endpoint', async () => {

--- a/console/src/routes/gateway.test.tsx
+++ b/console/src/routes/gateway.test.tsx
@@ -1,12 +1,17 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { AdminAgent, AdminHybridAIBot } from '../api/types';
+import type {
+  AdminAgent,
+  AdminHybridAIBot,
+  AdminSecretsResponse,
+} from '../api/types';
 import { renderWithProviders } from '../test-utils';
 import { GatewayPage } from './gateway';
 
 const fetchAdminAgentsMock = vi.fn<() => Promise<AdminAgent[]>>();
 const fetchAdminHybridAIBotsMock =
   vi.fn<(token: string, baseUrl?: string) => Promise<AdminHybridAIBot[]>>();
+const fetchAdminSecretsMock = vi.fn<() => Promise<AdminSecretsResponse>>();
 const reloadGatewayMock = vi.fn();
 const updateAdminAgentMock = vi.fn();
 const navigateMock = vi.fn();
@@ -17,6 +22,7 @@ vi.mock('../api/client', () => ({
   fetchAdminAgents: () => fetchAdminAgentsMock(),
   fetchAdminHybridAIBots: (...args: [string, string?]) =>
     fetchAdminHybridAIBotsMock(...args),
+  fetchAdminSecrets: () => fetchAdminSecretsMock(),
   reloadGateway: (...args: unknown[]) => reloadGatewayMock(...args),
   updateAdminAgent: (...args: unknown[]) => updateAdminAgentMock(...args),
 }));
@@ -116,6 +122,7 @@ describe('GatewayPage', () => {
   beforeEach(() => {
     fetchAdminAgentsMock.mockReset();
     fetchAdminHybridAIBotsMock.mockReset();
+    fetchAdminSecretsMock.mockReset();
     reloadGatewayMock.mockReset();
     updateAdminAgentMock.mockReset();
     navigateMock.mockReset();
@@ -144,6 +151,20 @@ describe('GatewayPage', () => {
         name: 'Research Bot',
       },
     ]);
+    fetchAdminSecretsMock.mockResolvedValue({
+      secrets: [
+        {
+          name: 'HYBRIDAI_PROXY_KEY',
+          state: 'set',
+          created_at: '2026-07-18T10:00:00.000Z',
+          last_rotated_at: '2026-07-18T10:00:00.000Z',
+          length: 24,
+          fingerprint: { length: 24, sha256_prefix: 'proxy-key' },
+        },
+      ],
+      total: 1,
+      actions: ['secret.list_metadata'],
+    });
   });
 
   afterEach(() => {
@@ -154,6 +175,30 @@ describe('GatewayPage', () => {
     renderGatewayPage();
 
     expect(screen.getByText('Public tunnel settings')).toBeTruthy();
+  });
+
+  it('uses compact provider health that opens the Providers page', () => {
+    useAuthMock.mockReturnValue({
+      token: 'test-token',
+      gatewayStatus: makeStatus({
+        providerHealth: {
+          hybridai: {
+            kind: 'remote',
+            reachable: true,
+            latencyMs: 12,
+            modelCount: 3,
+          },
+        },
+      }),
+    });
+
+    renderGatewayPage();
+
+    expect(
+      screen.getByText('Provider health').closest('section')?.textContent,
+    ).toContain('1 healthy');
+    fireEvent.click(screen.getByRole('button', { name: 'Manage providers →' }));
+    expect(navigateMock).toHaveBeenCalledWith({ to: '/admin/models' });
   });
 
   it('opens a reload confirmation dialog and calls the reload endpoint', async () => {
@@ -208,7 +253,7 @@ describe('GatewayPage', () => {
     fireEvent.change(screen.getByLabelText('Chatbot id'), {
       target: { value: 'bot-research' },
     });
-    fireEvent.change(screen.getByLabelText('API key SecretRef id'), {
+    fireEvent.change(screen.getByLabelText('API key secret'), {
       target: { value: 'HYBRIDAI_PROXY_KEY' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Save Proxy Mode' }));
@@ -252,7 +297,7 @@ describe('GatewayPage', () => {
     fireEvent.change(screen.getByLabelText('Chatbot id'), {
       target: { value: 'upstream-chatbot' },
     });
-    fireEvent.change(screen.getByLabelText('API key SecretRef id'), {
+    fireEvent.change(screen.getByLabelText('API key secret'), {
       target: { value: 'HYBRIDAI_PROXY_KEY' },
     });
     fireEvent.change(screen.getByLabelText('Conversation scope'), {
@@ -288,7 +333,7 @@ describe('GatewayPage', () => {
     fireEvent.change(screen.getByLabelText('Chatbot id'), {
       target: { value: 'upstream-chatbot' },
     });
-    fireEvent.change(screen.getByLabelText('API key SecretRef id'), {
+    fireEvent.change(screen.getByLabelText('API key secret'), {
       target: { value: 'HYBRIDAI_PROXY_KEY' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Save Proxy Mode' }));

--- a/console/src/routes/gateway.tsx
+++ b/console/src/routes/gateway.tsx
@@ -1,5 +1,4 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
 import { useEffect, useRef, useState } from 'react';
 import {
   fetchAdminAgents,
@@ -27,7 +26,6 @@ import {
 import { Field, FieldLabel } from '../components/field';
 import { Input } from '../components/input';
 import { NativeSelect, NativeSelectOption } from '../components/native-select';
-import { ProviderHealth } from '../components/provider-health';
 import { SecretRefPicker } from '../components/secret-ref-picker';
 import { Switch } from '../components/switch';
 import { useToast } from '../components/toast';
@@ -105,9 +103,9 @@ export function GatewayPage() {
     useState<AdminAgentProxyConversationScope>('channel');
   const lastProxyAgentFormSyncKeyRef = useRef('');
   const status = live.status || auth.gatewayStatus;
-  const providerEntries = Object.entries(
+  const providerCount = Object.keys(
     status?.providerHealth || status?.localBackends || {},
-  );
+  ).length;
   const schedulerJobs = status?.scheduler?.jobs || [];
   const agentsQuery = useQuery({
     queryKey: ['admin-agents', auth.token],
@@ -132,7 +130,6 @@ export function GatewayPage() {
     },
   });
 
-  const navigate = useNavigate();
   const adminAgents = agentsQuery.data || [];
   const selectedProxyAgent =
     adminAgents.find((agent) => agent.id === selectedProxyAgentId) ||
@@ -246,7 +243,7 @@ export function GatewayPage() {
       <div className="metric-grid">
         <MetricCard label="Uptime" value={formatUptime(status.uptime)} />
         <MetricCard label="Sessions" value={String(status.sessions)} />
-        <MetricCard label="Providers" value={String(providerEntries.length)} />
+        <MetricCard label="Providers" value={String(providerCount)} />
         <MetricCard
           label="Scheduler jobs"
           value={String(schedulerJobs.length)}
@@ -346,13 +343,6 @@ export function GatewayPage() {
       <TunnelSettings />
 
       <div className="two-column-grid">
-        <ProviderHealth
-          title="Provider health"
-          entries={providerEntries}
-          variant="compact"
-          onManage={() => void navigate({ to: '/admin/models' })}
-        />
-
         <Card>
           <CardHeader>
             <CardTitle>Agent proxy mode</CardTitle>

--- a/console/src/routes/gateway.tsx
+++ b/console/src/routes/gateway.tsx
@@ -27,7 +27,8 @@ import {
 import { Field, FieldLabel } from '../components/field';
 import { Input } from '../components/input';
 import { NativeSelect, NativeSelectOption } from '../components/native-select';
-import { ProviderHealthPanel } from '../components/provider-health';
+import { ProviderHealth } from '../components/provider-health';
+import { SecretRefPicker } from '../components/secret-ref-picker';
 import { Switch } from '../components/switch';
 import { useToast } from '../components/toast';
 import { BooleanPill, MetricCard, PageHeader } from '../components/ui';
@@ -345,10 +346,11 @@ export function GatewayPage() {
       <TunnelSettings />
 
       <div className="two-column-grid">
-        <ProviderHealthPanel
+        <ProviderHealth
           title="Provider health"
           entries={providerEntries}
-          onLogin={() => void navigate({ to: '/admin/config' })}
+          variant="compact"
+          onManage={() => void navigate({ to: '/admin/models' })}
         />
 
         <Card>
@@ -450,13 +452,11 @@ export function GatewayPage() {
                         )}
                       </Field>
                       <Field>
-                        <FieldLabel>API key SecretRef id</FieldLabel>
-                        <Input
+                        <FieldLabel>API key secret</FieldLabel>
+                        <SecretRefPicker
                           value={proxyApiKeySecretId}
                           placeholder={DEFAULT_PROXY_SECRET_ID}
-                          onChange={(event) =>
-                            setProxyApiKeySecretId(event.target.value)
-                          }
+                          onValueChange={setProxyApiKeySecretId}
                         />
                       </Field>
                       <Field>

--- a/console/src/routes/models.test.tsx
+++ b/console/src/routes/models.test.tsx
@@ -103,6 +103,7 @@ describe('ModelsPage', () => {
 
     renderModelsPage();
 
+    expect(await screen.findByText('Provider health')).not.toBeNull();
     expect(await screen.findByText('openrouter')).not.toBeNull();
     expect(
       screen.getByText('Visible in catalog · no live health data'),

--- a/console/src/routes/models.tsx
+++ b/console/src/routes/models.tsx
@@ -12,6 +12,10 @@ import {
 import { Field, FieldLabel } from '../components/field';
 import { Input } from '../components/input';
 import { NativeSelect, NativeSelectOption } from '../components/native-select';
+import {
+  type ProviderEntry,
+  ProviderHealth,
+} from '../components/provider-health';
 import { useToast } from '../components/toast';
 import { PageHeader, SortableHeader, useSortableRows } from '../components/ui';
 import { getErrorMessage } from '../lib/error-message';
@@ -50,14 +54,6 @@ function compareModelsByUsage(left: ModelEntry, right: ModelEntry): number {
 }
 
 type ModelSortKey = 'model' | 'backend' | 'context' | 'monthlyUsage';
-type ProviderStatusEntry = NonNullable<
-  Awaited<ReturnType<typeof fetchModels>>['providerStatus']
->[string];
-type ProviderSummary = {
-  name: string;
-  status: ProviderStatusEntry | null;
-};
-
 const PROVIDER_DISPLAY_ORDER = [
   'hybridai',
   'codex',
@@ -97,19 +93,33 @@ function compareProviderNames(left: string, right: string): number {
   return left.localeCompare(right);
 }
 
-function buildProviderSummaries(
+function buildProviderEntries(
   payload?: Awaited<ReturnType<typeof fetchModels>>,
-): ProviderSummary[] {
+): Array<[string, ProviderEntry]> {
   const providerNames = new Set(Object.keys(payload?.providerStatus || {}));
+  const catalogModelCounts = new Map<string, number>();
   for (const model of payload?.models || []) {
     const provider = inferProviderName(model);
-    if (provider) providerNames.add(provider);
+    if (!provider) continue;
+    providerNames.add(provider);
+    catalogModelCounts.set(
+      provider,
+      (catalogModelCounts.get(provider) ?? 0) + 1,
+    );
   }
 
-  return [...providerNames].sort(compareProviderNames).map((name) => ({
-    name,
-    status: payload?.providerStatus?.[name] || null,
-  }));
+  return [...providerNames].sort(compareProviderNames).map((name) => {
+    const status = payload?.providerStatus?.[name];
+    return [
+      name,
+      status || {
+        reachable: false,
+        catalogOnly: true,
+        modelCount: catalogModelCounts.get(name) ?? 0,
+        detail: 'Visible in catalog · no live health data',
+      },
+    ];
+  });
 }
 
 const MODEL_SORTERS: Record<
@@ -208,7 +218,7 @@ export function ModelsPage() {
     defaultDirections: MODEL_DEFAULT_DIRECTIONS,
   });
 
-  const providerEntries = buildProviderSummaries(modelsQuery.data);
+  const providerEntries = buildProviderEntries(modelsQuery.data);
   const modelsWithDailyUsage = (modelsQuery.data?.models || []).filter(
     hasDailyUsage,
   );
@@ -227,58 +237,11 @@ export function ModelsPage() {
       />
 
       <div className="two-column-grid">
-        <Card>
-          <CardHeader>
-            <CardTitle>Provider status</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="list-stack">
-              {providerEntries.map(({ name, status }) => (
-                <div className="list-row" key={name}>
-                  <div>
-                    <strong>{name}</strong>
-                    <small>
-                      {status?.reachable
-                        ? `${status.detail || (typeof status.latencyMs === 'number' ? `${status.latencyMs}ms` : 'ready')} · ${status.modelCount ?? 0} models`
-                        : status
-                          ? status.error || 'unreachable'
-                          : 'Visible in catalog · no live health data'}
-                    </small>
-                  </div>
-                  <span
-                    className={
-                      status?.reachable
-                        ? 'list-status list-status-success'
-                        : status
-                          ? 'list-status list-status-danger'
-                          : 'list-status'
-                    }
-                  >
-                    <span
-                      className={
-                        status?.reachable
-                          ? 'status-dot status-dot-success'
-                          : status
-                            ? 'status-dot status-dot-danger'
-                            : 'status-dot'
-                      }
-                    />
-                    {status?.reachable
-                      ? 'healthy'
-                      : status
-                        ? 'down'
-                        : 'catalog'}
-                  </span>
-                </div>
-              ))}
-              {providerEntries.length === 0 ? (
-                <div className="empty-state">
-                  No provider health checks available.
-                </div>
-              ) : null}
-            </div>
-          </CardContent>
-        </Card>
+        <ProviderHealth
+          title="Provider health"
+          entries={providerEntries}
+          variant="full"
+        />
 
         <Card variant="muted">
           <CardHeader>

--- a/console/src/routes/models.tsx
+++ b/console/src/routes/models.tsx
@@ -237,11 +237,7 @@ export function ModelsPage() {
       />
 
       <div className="two-column-grid">
-        <ProviderHealth
-          title="Provider health"
-          entries={providerEntries}
-          variant="full"
-        />
+        <ProviderHealth title="Provider health" entries={providerEntries} />
 
         <Card variant="muted">
           <CardHeader>


### PR DESCRIPTION
## Summary

- keep provider health in one canonical location on Providers and remove duplicate Dashboard/Gateway summaries
- replace free-text SecretRef inputs with a metadata-only secret picker and a shortcut to Secrets
- remove duplicate Config rows for log level and default model
- make Fleet Topology read-only for trust management and link operators to A2A Trust
- add cursor-aware “Managed elsewhere” guidance in Config JSON mode using a canonical section-owner registry

## Why

Phase 1 made the admin navigation task-oriented. Phase 2 establishes one mutating home per setting and one canonical provider-health view so operators do not encounter conflicting or repeated controls and status.

## User-facing changes

- **Providers:** provider health appears only here, in the detailed view including catalog-only providers.
- **Dashboard and Gateway:** duplicate provider-health summaries have been removed.
- **Settings:** Log level and Default model rows have been removed; those controls remain on **Logs** and **Providers**.
- **Secrets:** managed browser pool, Browser Use, and Gateway proxy credentials are selected by stored secret name; secret values never render in the picker. A **Create new secret** shortcut opens Secrets.
- **Fleet Topology:** topology and reachability remain visible, while add/edit/revoke/remove trust actions live exclusively on **A2A Trust**.
- **Config JSON:** moving the cursor into a page-owned section shows a **Managed elsewhere** banner with a direct link to the owning page.

## Scope

Console-only change. No gateway APIs, persistence, config schema, or runtime behavior changed.

## Validation

- `npm run format`
- `npm run lint`
- `npm --prefix console run build`
- `npm --prefix console test` — 89 files, 845 tests passed
- `git diff --check`
