### PR TITLE
fix: exclude dot-directories from repo lockfile walks

### DIFF
--- a/scripts/check-dependency-policy.mjs
+++ b/scripts/check-dependency-policy.mjs
@@ -99,8 +99,10 @@ function readJsonFile(filePath) {
 
 function isIgnoredDir(name) {
   return (
-    name === '.git' ||
-    name === '.worktrees' ||
+    // All dot-directories: .git, and the git worktrees under .claude/worktrees/
+    // (and legacy .worktrees/) contain full repo checkouts with their own
+    // lockfiles that must not be scanned.
+    name.startsWith('.') ||
     name === 'coverage' ||
     name === 'dist' ||
     name === 'node_modules' ||

--- a/scripts/generate-sbom.mjs
+++ b/scripts/generate-sbom.mjs
@@ -27,8 +27,10 @@ function fail(message) {
 
 function isIgnoredDir(name) {
   return (
-    name === '.git' ||
-    name === '.worktrees' ||
+    // All dot-directories: .git, and the git worktrees under .claude/worktrees/
+    // (and legacy .worktrees/) contain full repo checkouts with their own
+    // lockfiles that must not be scanned.
+    name.startsWith('.') ||
     name === 'coverage' ||
     name === 'dist' ||
     name === 'node_modules' ||

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -37,8 +37,10 @@ function fail(message) {
 
 function isIgnoredDir(name) {
   return (
-    name === '.git' ||
-    name === '.worktrees' ||
+    // All dot-directories: .git, and the git worktrees under .claude/worktrees/
+    // (and legacy .worktrees/) contain full repo checkouts with their own
+    // lockfiles that must not be scanned.
+    name.startsWith('.') ||
     name === 'coverage' ||
     name === 'dist' ||
     name === 'node_modules' ||


### PR DESCRIPTION
## Summary

- Problem: `npm run sbom` in a checkout with active Claude Code worktrees wrote duplicate, mutually overwriting SBOM files and failed with `ESBOMPROBLEMS` on a worktree containing a mid-work inconsistent lockfile. Cause: the repo walkers ignore `.worktrees/` but not `.claude/`, where the worktrees actually live — every worktree is a full checkout with its own lockfiles.
- Why it matters: `npm run sbom`, `npm run notices:check`, and `npm run deps:policy` must be runnable locally (the SBOM/notices artifacts feed the IP due diligence folder); the same blind spot in check-dependency-policy would also surface worktree lockfiles in local policy runs.
- What changed: the shared `isIgnoredDir` in all three walker scripts now skips every dot-directory.
- What did not change: CI behavior (runners have no worktrees), scanned component set (root, container, both plugins).

## Change Type

- [x] Bug fix

## Licensing

- [x] All commits are signed off (`git commit -s`) to certify the
      [DCO](https://developercertificate.org/); the contribution is licensed
      under the repository's MIT license.

## Validation

```bash
npm run sbom            # with a dummy .claude/worktrees/zz-dummy lockfile present
npm run notices:check
npm run deps:policy
npx biome check scripts/*.mjs
```

- Verified manually: with a simulated nested worktree lockfile, `npm run sbom` writes exactly 8 files (4 components × 2 formats, no duplicates) and the dummy is not scanned by any of the three scripts.
- Edge cases checked: no legitimate component lockfile lives under a dot-directory (`.github`, `.husky`, `.claude` checked).

## Risk Notes

- Security-sensitive paths touched? No
- Gateway, audit, approval, or container boundaries touched? No

🤖 Generated with [Claude Code](https://claude.com/claude-code)