### PR TITLE
docs: prepare patch release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,27 @@
   reads both OpenAI-style (`prompt_tokens_details.cached_tokens`) and
   Anthropic-style (`cache_read_input_tokens`) spellings.
 
-  `Manifesto: Principle IX - A coworker thinks before they spend.`
+- **Cloud and Docker sandbox tool execution**: The gateway host-sandbox image
+  and standalone agent image include Python, pip, `openpyxl`, `unzip`, `file`,
+  and compatible XLSX libraries with resolvable Node module paths, restoring
+  spreadsheet inspection and manipulation in cloud deployments. Prompts that
+  mention versions or commands such as `python3 --version` also reach the agent
+  instead of being intercepted by the former HybridClaw-version shortcut.
+- **Admin console reliability**: Tab bars keep a stable, pinned layout with
+  contextual controls in the tab row; provider health appears only on the
+  Providers page with readable rows; generated settings replace build-host
+  home directories with portable `~/` paths; and redundant owned settings no
+  longer appear as editable duplicates.
+- **Agent archive migration**: Existing databases whose schema version `52`
+  came from the parallel agent-sharing migration still add the archived-agent
+  column through a collision-free version `53` migration.
+- **Install-on-demand channel plugins**: The Channels page offers to install a
+  missing WhatsApp transport, package-name resolution finds locally installed
+  plugins, and the generalized channel-plugin path preserves setup and doctor
+  behavior after the transport is removed from core.
+- **Release metadata walks**: Dependency-policy, SBOM, and third-party-notice
+  generators skip every dot-directory, preventing auxiliary Git worktrees from
+  being scanned as duplicate or partially updated package trees.
 
 ### Added
 
@@ -24,28 +44,45 @@
   (`ECDH-ES` and `A256GCM`), bind encrypted envelopes to Ed25519-signed
   delegation tokens, reject per-peer plaintext downgrades, and expose an admin
   switch that requires E2EE for every A2A trust entry.
+- **Deterministic model-tier routing**: Operators can define an ordered
+  `routing.tiers[]` ladder across hosted and named local models. Unpinned agent
+  turns start from the agent's configured rung or `routing.defaultStart`, while
+  heartbeat, scheduler, and full-auto turns begin at the lowest rung. Provider
+  auth, rate-limit, and server failures, malformed tool calls, and persistently
+  empty or narrate-only answers escalate safely; successful escalation can stay
+  sticky for subsequent turns, `/escalate` raises the next unpinned turn by one
+  rung, and request/session model pins remain hard overrides. Routing attempts
+  and escalation reasons are recorded in the audit trail.
+- **Local model privacy and pricing metadata**: Named local endpoints can
+  declare a `local`, `hai`, `region`, or `cloud` zone plus input/output EUR
+  prices per million tokens. Model info, usage accounting, and the admin Models
+  page preserve unknown prices instead of silently treating unpriced endpoints
+  as free.
+- **Searchable admin configuration**: The admin shell exposes page and setting
+  search from the sidebar or `Cmd/Ctrl+K`. A generated registry makes every
+  runtime setting discoverable by label, description, and dotted path; results
+  open the exact setting or its canonical owner page, and the Providers page
+  owns provider enablement, endpoint, auth method, and SecretRef setup.
 - **Model latency benchmark**: `scripts/benchmark-model-latency.mjs` measures
   time-to-headers, time-to-first-token, total duration, and tokens/sec for the
   same model across three paths — the local gateway's OpenAI-compatible API
   (full agent turn), the HybridAI API called directly, and the model vendor
-  (Anthropic) called directly — each with streaming on and off. Request bodies
-  mirror the exact shapes HybridClaw sends, so latency deltas attribute slow
-  responses to the HybridClaw layer, the HybridAI backend, or the upstream
-  vendor. A connection preflight separates DNS/TCP/TLS handshake cost per
-  origin.
+  (Anthropic or OpenAI) called directly — each with streaming on and off.
+  Request bodies mirror the exact shapes HybridClaw sends, so latency deltas
+  attribute slow responses to the HybridClaw layer, the HybridAI backend, or
+  the upstream vendor. Connection preflight separates DNS/TCP/TLS handshake
+  cost per origin; cache-hit reporting distinguishes unavailable data from a
+  real zero; multiple gateway provider arms can be compared side by side; and
+  long prompts can be loaded from a file for meaningful throughput tests.
 - **Direct OpenAI API provider**: `openai/...` models use the OpenAI Responses
   API with encrypted `OPENAI_API_KEY` storage, streaming, function calling,
   stateless encrypted reasoning-item replay, model catalog metadata, CLI auth,
   gateway health, and doctor diagnostics. Codex OAuth remains available under
   the separate `openai-codex/...` provider.
-  `Manifesto: Principle IV - Model freedom without lock-in.`
 - **Codex 5.6 models**: `openai-codex/gpt-5.6-sol`, `openai-codex/gpt-5.6-terra`,
   and `openai-codex/gpt-5.6-luna` are now recognised as forward-compatible Codex
   models, so they are selectable as soon as the Codex account offers them
   instead of waiting for the discovery endpoint to list them.
-
-  `Manifesto: Principle VIII - A coworker doesn't break overnight.`
-
 - **Dependency license gate**: `scripts/check-dependency-policy.mjs` now scans
   every tracked `package-lock.json` and fails on GPL, AGPL, and SSPL-family
   licenses unless the exact `name@version` and license pair is approved under
@@ -55,16 +92,32 @@
   most permissive option. The gate runs in every existing dependency-policy
   entry point: the pre-commit hook, the CI lint job, `npm run deps:policy`,
   and `npm run release:check`.
-  `Manifesto: Principle VII - A coworker you can trust with real responsibility.`
+- **Release IP and provenance artifacts**: Distributed components declare MIT
+  license metadata; `THIRD_PARTY_NOTICES.md` inventories production packages,
+  deduplicated license texts, and required NOTICE content; release CI generates
+  per-component CycloneDX and SPDX SBOMs; and pull requests enforce Developer
+  Certificate of Origin sign-offs. A public provenance statement documents the
+  project's independent history, contributor ownership, third-party intake,
+  and relationship to OpenClaw.
 
 ### Changed
 
+- **Admin workflows and navigation**: The console groups related work into
+  Activity, Agents, Automation, Federation, Credentials, and Extensions tabbed
+  pages; settings live on one canonical owner surface; legacy admin URLs
+  redirect to the matching tab; contextual controls stay attached to their
+  active tab; and non-default agents can be archived without deleting their
+  files or history.
 - **Install-on-demand WhatsApp transport**: WhatsApp ships as the separate
   `@hybridaione/hybridclaw-whatsapp` plugin so Baileys and its GPL-3.0
   `libsignal` dependency are excluded from core npm, Docker, desktop, and
   Homebrew artifacts. Existing linked sessions remain in
   `~/.hybridclaw/credentials/whatsapp`; install the transport with
   `hybridclaw plugin install @hybridaione/hybridclaw-whatsapp`.
+- **Secret inspection terminology**: `hybridclaw secret status <NAME>` and
+  `/secret status <NAME>` replace the misleading `secret show` spelling. The
+  command reports only whether a secret exists and never decrypts or prints its
+  value.
 - **AGPL removed from the dependency tree**: `camoufox-js` now resolves
   `ua-parser-js` 1.0.41 (MIT) through a scoped npm override instead of 2.0.10
   (AGPL-3.0-or-later), retiring the `ua-parser-js@2.0.10` AGPL exception from
@@ -73,7 +126,6 @@
   fingerprint is treated as Linux and receives Linux fonts, WebGL strings, and
   environment variables. Camofox stealth is degraded for macOS fingerprints
   until `determineUAOS` is patched.
-  `Manifesto: Principle VII - A coworker you can trust with real responsibility.`
 
 ## [0.28.2](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.2) - 2026-07-17
 
@@ -231,8 +283,6 @@
   When the gateway's watcher does fail (for example `EMFILE: too many open
   files`), config hot-reload now falls back to descriptor-free stat polling
   instead of going dark after ten failed watcher restarts.
-
-  `Manifesto: Principle VIII - A coworker doesn't break overnight.`
 - **A2A chat delivery stability**: Remote A2A replies now appear in the origin
   chat, local A2A smoke replies are stable, inbound audience resolution works
   behind public tunnels, and the delivery chip remains coherent across history
@@ -301,9 +351,6 @@
   gateway already emits on `/api/chat`, gated by the session `/show` mode.
   The ordered trace is persisted per assistant message (schema v46), so a page
   reload replays the same activity instead of dropping it.
-
-  `Manifesto: Principle IV - A coworker is a colleague, not a chatbot.`
-
 - **Apps gallery**: Web chat includes an `/apps` gallery and `/app <description>`
   flow for building self-contained HTML apps, documents, games, dashboards, and
   tools, then saving captured HTML artifacts with search, category filtering,
@@ -788,8 +835,7 @@
   persona, work module, runs, and revision snapshots as one identifier set.
   Includes a leakage/fidelity eval (`coworker eval`), conversational
   corrections (`coworker correct`), and one-bundle multi-host export/install
-  for Claude Code, Codex, OpenClaw, and HybridClaw. Manifesto: Principle VII -
-  A coworker you can trust with real responsibility.
+  for Claude Code, Codex, OpenClaw, and HybridClaw.
 - **Cloud memory sync**: Agents now sync local memory files (`MEMORY.md`,
   `USER.md`, and recent daily memory notes) with the HybridAI cloud and receive
   shared installation- and company-scoped memory back for prompt context. Sync

--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ rails instead of fragile free-form prompting.
 
 HybridClaw also treats agents as networked coworkers. Local agents, hosted
 HybridAI proxy agents, and trusted peer HybridClaw instances can address one
-another, exchange A2A envelopes, and route work through approval-aware
-channels. An A2A local mode keeps peer delivery and authenticated administration
-reachable while disabling other external gateway and channel surfaces.
+another, exchange end-to-end encrypted A2A envelopes, and route work through
+approval-aware channels. An A2A local mode keeps peer delivery and authenticated
+administration reachable while disabling other external gateway and channel
+surfaces.
 
 First-run onboarding is built around hatching: a new agent asks about the
 user's work, records useful context, keeps setup links visible in chat, and can
@@ -61,13 +62,13 @@ HybridClaw on HybridAI Cloud in a few minutes at
 | A first run that becomes useful quickly | Guided hatching with setup links, tailored first-job suggestions, optional onboarding-specific model routing, welcome-email handoff, and structured audit events |
 | Business workflows that survive real use | Production skill helpers with fixtures, eval scenarios, targeted tests, approval tiers, and a `Qwen/Qwen3.6-27B-FP8` validation baseline |
 | Generated work artifacts you can reuse | An Apps gallery for self-contained HTML apps, dashboards, documents, games, tools, live connector-backed views, sharing links, and Teams tabs |
-| Multi-agent workflows across installations | Local agents, hosted proxy agents, A2A trust, explicit addressing, inbound envelopes, reply-back delivery, admin-visible peer pairing, and an A2A-only deployment mode |
+| Multi-agent workflows across installations | Local agents, hosted proxy agents, encrypted A2A trust, explicit addressing, inbound envelopes, reply-back delivery, admin-visible peer pairing, and an A2A-only deployment mode |
 | Credentials the model cannot read | Encrypted runtime secrets, SecretRef-backed execution paths, and scoped gateway API tokens that keep raw keys and passwords out of prompts and tool results |
 | Assistants that can act, not just chat | A gateway, web chat, Apps gallery, TUI, admin console, scheduler, tools, and OpenAI-compatible API behind one local service |
 | Control over sensitive work | Approval policy, sandbox boundaries, output guardrails, and hash-chained audit trails |
-| Agents that fit existing teams | Discord, Slack, Teams, Telegram, WhatsApp, email, voice, web, and more through the same runtime |
+| Agents that fit existing teams | Discord, Slack, Teams, Telegram, email, voice, web, and more through the same runtime, with WhatsApp available as an install-on-demand plugin |
 | Operational memory | Local files, SQLite state, semantic recall, session compaction, and optional HybridAI cloud memory |
-| Repeatable expert workflows | Per-agent workspaces, budgets, model routing, A2A trust, proxy agents, `.claw` archives, and human-distillation workflows |
+| Repeatable expert workflows | Per-agent workspaces, budgets, deterministic model-tier routing, A2A trust, proxy agents, `.claw` archives, and human-distillation workflows |
 
 ## Install
 
@@ -106,7 +107,7 @@ After the gateway starts, open:
 | --- | --- | --- |
 | Web Chat | `http://127.0.0.1:9090/chat` | Chat, slash commands, model and agent switching |
 | Apps Gallery | `http://127.0.0.1:9090/apps` | Generated web apps, documents, games, tools, live connector-backed views, and sharing |
-| Admin Console | `http://127.0.0.1:9090/admin` | Channels, connectors, agents, approvals, audit, config, secrets, tokens, skills, distillation |
+| Admin Console | `http://127.0.0.1:9090/admin` | Searchable settings plus agents, automation, activity, connectivity, security, and federation workflows |
 | Agents UI | `http://127.0.0.1:9090/agents` | Agent fleet overview and prompt-file editing |
 | TUI | `hybridclaw tui` | Terminal chat, approvals, status, resume |
 | OpenAI-compatible API | `http://127.0.0.1:9090/v1/chat/completions` | Local evals and compatible clients |
@@ -127,12 +128,12 @@ npm run desktop
 | Area | Built in |
 | --- | --- |
 | Skills | 79 bundled skills, production business helpers, eval fixtures, packaged skill lifecycle, and human-distillation workflows |
-| Channels | Discord, Slack, Signal, WhatsApp, LINE self-chat, Telegram, Microsoft Teams, email, iMessage, fax, Twilio voice, web, and incoming webhooks |
-| Runtime | Gateway service, TUI client, web chat, Apps gallery, admin console, loopback OpenAI-compatible API, Docker or host execution |
-| Governance | Encrypted runtime secrets, scoped API tokens, SecretRef credential isolation, approval policies, sandbox controls, audit trails with hash-chain integrity |
+| Channels | Discord, Slack, Signal, LINE self-chat, Telegram, Microsoft Teams, email, iMessage, fax, Twilio voice, web, incoming webhooks, and an install-on-demand WhatsApp plugin |
+| Runtime | Gateway service, TUI client, web chat, Apps gallery, searchable admin console, loopback OpenAI-compatible API, and Docker or host execution with document and spreadsheet tooling |
+| Governance | Encrypted runtime secrets, scoped API tokens, SecretRef credential isolation, approval policies, sandbox controls, hash-chained audit trails, dependency license gates, SBOMs, and third-party notices |
 | Memory | Local memory files, SQLite persistence, semantic recall, session compaction, optional HybridAI cloud memory sync |
-| Agents | Guided hatching, per-agent workspaces, models, budgets, prompt files, explicit addressing, proxy agents, A2A trust, peer-instance communication, reply delivery status |
-| Extensibility | Packaged business skills, plugins, MCP servers, admin connector flows, SecretRef-backed HTTP tools |
+| Agents | Guided hatching, per-agent workspaces, models, budgets, prompt files, deterministic tier routing, explicit addressing, proxy agents, encrypted A2A trust, peer-instance communication, and reply delivery status |
+| Extensibility | Packaged business skills, install-on-demand channel plugins, MCP servers, admin connector flows, and SecretRef-backed HTTP tools |
 
 ## Product Strengths
 
@@ -145,9 +146,9 @@ npm run desktop
   normal default. Its lifecycle is searchable in audit as onboarding events.
 - **Multi-agent operations**: agents can coordinate across local workspaces,
   hosted HybridAI proxies, and trusted peer HybridClaw instances with A2A
-  pairing, explicit addressing, inbound envelopes, reply-back delivery status,
-  admin-visible trust, and an A2A local mode that closes unrelated external
-  surfaces.
+  pairing, pinned X25519 keys, encrypted envelopes, explicit addressing,
+  inbound messages, reply-back delivery status, admin-visible trust, and an A2A
+  local mode that closes unrelated external surfaces.
 - **Prompt-level credential isolation**: encrypted secrets and SecretRefs keep
   credential values out of model context while tools receive only the scoped
   credential material needed at execution time.
@@ -161,13 +162,15 @@ npm run desktop
 - **Secure by default**: LLM output is treated as untrusted, risky actions
   route through approval policy, and every sensitive boundary is visible in
   audit.
-- **Model freedom**: use HybridAI, major hosted providers, local engines, or
-  named OpenAI-compatible endpoints from the same model picker and config
-  surface.
-- **Operator visibility**: `/admin` covers channels, connectors, approvals,
-  audit, statistics, output guard, secrets, scoped tokens, fleet topology, A2A
-  inbox/trust, tunnel configuration and health, distillation, and browser PDF
-  previews without requiring shell access.
+- **Model freedom**: use HybridAI, the direct OpenAI Responses API, Codex OAuth,
+  other hosted providers, local engines, or named OpenAI-compatible endpoints
+  from the same model picker and config surface. Ordered routing tiers can start
+  routine work cheaply and escalate retry-safe failures while explicit model
+  pins remain authoritative.
+- **Operator visibility**: `/admin` groups Activity, Agents, Automation,
+  Connectivity, Models, Security, System, and Labs workflows. Page and setting
+  search opens with `Cmd/Ctrl+K`, settings link to one canonical owner, and
+  legacy admin URLs redirect to their corresponding tab.
 - **Business-ready extension model**: packaged skills, plugins, MCP servers,
   and SecretRef-backed HTTP tools share the same approval and credential
   boundaries.

--- a/docs/content/README.md
+++ b/docs/content/README.md
@@ -27,6 +27,42 @@ doc at once, start from [For Agents](./agents.md).
 
 ## Latest Highlights
 
+- The next patch release adds deterministic model-tier routing for unpinned
+  turns: agents can start on a configured rung, system work starts at the
+  lowest rung, retry-safe provider and output failures escalate with audit
+  telemetry, successful escalation stays sticky, and `/escalate` raises one
+  upcoming turn without overriding explicit model pins. Named local endpoints
+  can also declare privacy zones and EUR-denominated input/output pricing.
+- The admin console groups related work into Activity, Agents, Automation,
+  Federation, Credentials, and Extensions tabs. Page and setting search opens
+  from the sidebar or `Cmd/Ctrl+K`, links each result to its exact field or
+  canonical owner, and keeps provider configuration with provider health.
+- Paired HybridClaw gateways pin X25519 keys and protect A2A envelopes with
+  signed, compact JWE payloads. Operators can also require encryption for every
+  trust entry to prevent plaintext interoperability fallbacks.
+- Direct `openai/...` models use the OpenAI Responses API with encrypted key
+  storage, streaming, tools, and encrypted reasoning replay, while Codex OAuth
+  remains under `openai-codex/...` and recognises the 5.6 Sol, Terra, and Luna
+  model line.
+- The model latency benchmark compares gateway, HybridAI, and direct Anthropic
+  or OpenAI paths with streaming on and off, connection timing, prompt-cache
+  visibility, multi-provider gateway arms, long prompt files, and optional raw
+  JSON output.
+- WhatsApp is an install-on-demand channel plugin, keeping Baileys and its GPL
+  dependency outside core distributions. The core dependency tree is AGPL-free,
+  and dependency policy rejects unapproved GPL, AGPL, and SSPL packages.
+- Release artifacts include MIT package metadata, comprehensive third-party
+  notices, per-component CycloneDX and SPDX SBOMs, DCO enforcement, and a public
+  code-provenance statement covering authorship and the project's independent
+  relationship to OpenClaw.
+- Cloud gateway and standalone sandbox images carry the Python and XLSX tools
+  needed for spreadsheet work. Version-related prompts reach the agent, agent
+  archive migrations avoid the schema-52 collision, generated settings use
+  portable home paths, and release metadata generators ignore dot-directory
+  worktrees.
+- Secret existence checks use `secret status` rather than the misleading
+  `secret show` spelling and continue to return metadata without decrypting or
+  displaying stored values.
 - HybridClaw v0.28.2 adds A2A local mode for keeping peer Agent Card and
   delivery routes reachable while disabling unrelated external chat, APIs,
   webhooks, channel runtimes, and channel delivery; tunnel configuration and

--- a/docs/content/channels/admin-console.md
+++ b/docs/content/channels/admin-console.md
@@ -23,6 +23,31 @@ the rest of `/admin`: `WEB_API_TOKEN` when configured, or loopback-only local
 web access. The Credentials page at `/admin/credentials` combines write-only
 secret management with scoped gateway API tokens.
 
+## Navigation And Settings Search
+
+The sidebar groups the operator surface by job: Overview, Agents,
+Connectivity, Models, Security, System, and Labs. Related workflows share a
+tabbed page instead of competing for separate sidebar entries:
+
+- Activity combines usage, sessions, and audit
+- Agents combines the scoreboard and workspace files
+- Automation combines the work queue and schedules
+- Federation combines the A2A inbox, peer trust, and fleet topology
+- Credentials combines secrets and scoped API tokens
+- Extensions combines plugins and tools
+
+Legacy URLs such as `/admin/audit`, `/admin/scheduler`, `/admin/a2a-trust`,
+`/admin/secrets`, and `/admin/plugins` redirect to their matching tab, so saved
+links continue to land on the intended workflow.
+
+Use the Search control in the sidebar, `Cmd+K` on macOS, or `Ctrl+K` on other
+platforms to find both pages and individual runtime settings. Search accepts
+labels, descriptions, and dotted config paths. Selecting a result opens the
+exact setting on `/admin/config`, or the canonical owner page when a focused
+surface such as Channels, Providers, Automation, or Output Guard manages it.
+The Settings page also supports section and text filters and protects unsaved
+changes before navigation.
+
 ## What The Admin Console Can Do
 
 - `/admin/channels` shows each transport as `active`, `configured`, or
@@ -77,6 +102,12 @@ secret management with scoped gateway API tokens.
 - `/admin/config` edits runtime settings through structured controls for
   booleans, numbers, one-of selections, arrays, and nested config paths, with
   unsaved-change protection and validation before save
+- `/admin/config` is generated from the runtime setting registry, supports
+  section and free-text filtering, and links settings owned by focused pages to
+  those canonical workflows instead of rendering a second editor
+- `/admin/models` combines provider health and default-model selection with
+  enablement, endpoint, auth method, and SecretRef configuration for hosted and
+  local providers
 - `/admin/credentials?tab=secrets` lists stored and declared-but-empty secrets by metadata
   only, supports overwrite and unset actions, and never returns cleartext
   secret values to the browser

--- a/docs/content/guides/a2a-peer-pairing.md
+++ b/docs/content/guides/a2a-peer-pairing.md
@@ -67,7 +67,8 @@ Agent Card whose encryption fingerprint has changed.
 
 HybridClaw pairings require an E2EE-capable peer. Manually trusted or
 third-party A2A peers without this HybridClaw extension can use plaintext only
-while **Require A2A E2EE** is disabled on `/admin/a2a-trust`. Enable that switch
+while **Require A2A E2EE** is disabled on
+`/admin/federation?tab=peers`. Enable that switch
 after pairing every HybridClaw peer to make the entire A2A boundary fail closed.
 
 This is transport E2EE between HybridClaw instances. Messages are plaintext on

--- a/docs/content/guides/office-dependencies.md
+++ b/docs/content/guides/office-dependencies.md
@@ -10,8 +10,18 @@ The default container sandbox already includes the main office tooling. These
 installs matter primarily for `--sandbox=host` workflows or when you want the
 same capabilities on your local machine.
 
+Packaged Linux runtimes include the spreadsheet-inspection baseline: Python 3,
+pip, `openpyxl`, `unzip`, `file`, `@e965/xlsx` (available through the compatible
+`xlsx` module name), and `xlsx-populate`. The standalone agent image also
+includes Poppler, QPDF, and Pandoc; its full default target adds LibreOffice.
+The gateway Docker image used for cloud host-sandbox execution carries the same
+Python and XLSX baseline, so spreadsheet tasks do not depend on packages left
+behind in the build stage.
+
 What they unlock:
 
+- Python `openpyxl` and Node XLSX libraries for workbook inspection, editing,
+  and formula-preserving transformations
 - LibreOffice (`soffice`) for Office-to-PDF export, PPTX visual QA, and XLSX
   recalculation
 - Poppler (`pdftoppm`) for slide and page thumbnail rendering
@@ -38,6 +48,15 @@ sudo dnf install -y libreoffice poppler-utils pandoc
 ```
 
 ## Verify Availability
+
+Inside a packaged Docker runtime, verify the spreadsheet baseline with:
+
+```bash
+python3 -c 'import openpyxl; print(openpyxl.__version__)'
+node -e "console.log(require('xlsx').version)"
+```
+
+Verify optional host-side conversion tools with:
 
 ```bash
 sh -lc 'command -v soffice >/dev/null 2>&1 || command -v libreoffice >/dev/null 2>&1 && echo soffice_ok'

--- a/docs/content/guides/skills/productivity.md
+++ b/docs/content/guides/skills/productivity.md
@@ -168,7 +168,8 @@ hybridclaw secret set MIRO_DISCOVERY_ACCESS_TOKEN "<enterprise-discovery-token>"
 
 **Troubleshooting**
 
-- **Missing `MIRO_ACCESS_TOKEN`** — set it in `/admin/secrets`, with
+- **Missing `MIRO_ACCESS_TOKEN`** — set it in
+  `/admin/credentials?tab=secrets`, with
   `/secret set`, or with `hybridclaw secret set` in a local console.
 - **401 or 403** — Miro rejected the token or the token lacks the required
   board, organization, Enterprise, or OAuth scope.

--- a/docs/content/reference/commands.md
+++ b/docs/content/reference/commands.md
@@ -677,6 +677,8 @@ context-window accounting.
   demand and prints the provider/model that answered
 - `/second-opinion` compares a question or validates the last answer with a
   stronger configured model; `fact-check` adds bounded web-search evidence
+- `/escalate` is registered by the bundled tier router when `routing.enabled`
+  is true and raises exactly the next unpinned agent turn by one tier
 
 ### Slash Command Inventory
 
@@ -705,6 +707,7 @@ plugins and explicit skill invocations can add dynamic slash commands; use
 | `/dream [status|on|off|now]` | local TUI/web | Configure or run memory consolidation |
 | `/env [list|set|show|unset]` | local TUI/web | Manage plaintext runtime env values for agents and helpers |
 | `/eval [list|env|<suite>|<command...>]` | local TUI/web | Run local eval helpers or detached benchmark commands |
+| `/escalate` | local and chat channels | Start the next unpinned agent turn one configured routing tier higher |
 | `/export session [sessionId]` | local and chat channels | Export a session snapshot |
 | `/export trace [sessionId|all]` | local and chat channels | Export trace JSONL |
 | `/fullauto [status|off|on [prompt]|prompt]` | local and chat channels | Inspect or control full-auto mode for the session |

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -136,10 +136,20 @@ saved revision history directly.
   `modelBehavior` currently supports `thinkingFormat: "qwen"`.
 - `routing.enabled`, ordered `routing.tiers[]`, `routing.defaultStart`, and
   `routing.escalationStickyTurns` define the model-routing ladder. Each tier
-  has a unique `name` and an ordered, non-empty `models` list. Remote model
-  references must exist in the configured provider catalogs; named local
-  endpoint references use `<endpoint>/<model-id>`. Phase 1 validates and
-  exposes this substrate without changing live turn selection.
+  has a unique `name` and an ordered, non-empty `models` list; models later in
+  one tier are provider fallbacks, while later tiers are stronger escalation
+  rungs. Remote model references must exist in the configured provider
+  catalogs; named local endpoint references use `<endpoint>/<model-id>`.
+  Unpinned agent turns start from the tier containing the agent model or from
+  `routing.defaultStart`; heartbeat, scheduler, and full-auto turns start at
+  the lowest tier. Retry-safe auth, rate-limit, server, malformed-tool-call,
+  empty-output, and narrate-only failures can move to the next tier. A
+  successful escalation remains the session floor for
+  `routing.escalationStickyTurns` interactive turns (`0` disables stickiness),
+  and `/escalate` raises the next unpinned agent turn by one tier. Explicit
+  request and session model selections bypass the ladder. Enabling routing
+  also enables the bundled `tier-router` middleware and rejects attempts to
+  replace it with a custom path.
 - `codex.baseUrl`, `codex.turnRuntime`, and `codex.models` for first-class
   Codex provider behavior. `codex.turnRuntime` accepts `hybridclaw` for the
   standard HybridClaw tool loop or `app-server` for the native Codex app-server

--- a/docs/content/reference/diagnostics.md
+++ b/docs/content/reference/diagnostics.md
@@ -46,6 +46,46 @@ HybridAI discovery and bot-health calls. Auth failures, missing chatbot
 configuration, and upstream service errors are reported separately so setup
 problems do not look like generic provider outages.
 
+## Model Latency Benchmark
+
+Use the cross-stack benchmark when a model is healthy but responses are slower
+than expected:
+
+```bash
+node scripts/benchmark-model-latency.mjs --help
+node scripts/benchmark-model-latency.mjs \
+  --model gpt-5.6-luna \
+  --gateway-models hybridai/gpt-5.6-luna,openai-codex/gpt-5.6-luna \
+  --stream both \
+  --runs 3
+```
+
+The script sends equivalent requests through the local HybridClaw gateway, the
+HybridAI API directly, and the upstream Anthropic or OpenAI API directly. Arms
+without their required credentials are skipped:
+
+- create a narrow gateway credential with
+  `hybridclaw token create --label latency-bench --actions openai.api`, then
+  provide the one-time token as `WEB_API_TOKEN`; `GATEWAY_API_TOKEN` is also
+  accepted
+- set `HYBRIDAI_API_KEY` for the direct HybridAI arm
+- set `ANTHROPIC_API_KEY` for direct Claude models or `OPENAI_API_KEY` for
+  direct GPT and o-series models
+
+Use `--prompt-file <path>` with a prompt that requests a few hundred output
+tokens when measuring generation throughput. `--max-tokens` applies only to
+the direct HybridAI and vendor arms because the gateway's OpenAI-compatible
+request parser does not accept that field; gateway output length follows the
+prompt. `--json <path>` preserves raw per-run results.
+
+The connection preflight separates DNS, TCP, and TLS setup time. Per-request
+tables show time to headers, first event, first thinking delta, first visible
+text, total time, input/output tokens, prompt-cache tokens, and streaming
+tokens per second. A cache value of `-` means the backend did not report cache
+data, while `0` is an explicit cache miss. Compare `gateway - HybridAI` for
+HybridClaw overhead and `HybridAI - vendor` for backend proxy or queueing
+overhead.
+
 ## Resource Hygiene
 
 `doctor` includes a resource hygiene maintenance pass that detects stale

--- a/docs/content/reference/model-selection.md
+++ b/docs/content/reference/model-selection.md
@@ -98,6 +98,65 @@ The admin Models page combines the same metadata with daily and monthly usage
 rollups, so operators can sort by context window or monthly usage and compare
 spend across active models.
 
+## Deterministic Tier Routing
+
+`routing.enabled` lets unpinned turns use an ordered model ladder instead of
+one fixed default. Tier order expresses escalation strength; model order inside
+one tier expresses provider fallback order.
+
+```json
+{
+  "routing": {
+    "enabled": true,
+    "tiers": [
+      {
+        "name": "economy",
+        "models": ["openai/gpt-5.6-luna"]
+      },
+      {
+        "name": "general",
+        "models": [
+          "openai/gpt-5.6-terra",
+          "anthropic/claude-sonnet-4-6"
+        ]
+      },
+      {
+        "name": "advanced",
+        "models": ["openai/gpt-5.6-sol"]
+      }
+    ],
+    "defaultStart": "economy",
+    "escalationStickyTurns": 3
+  }
+}
+```
+
+Every referenced provider must be configured with its required credential.
+Remote models must exist in the configured provider catalogs; named local
+models use `<endpoint>/<model-id>`.
+
+Routing follows these rules:
+
+- an explicit request model or `/model set` session override remains a hard pin
+  and bypasses the ladder
+- an agent's configured model chooses its starting tier when that model appears
+  in the ladder; otherwise `routing.defaultStart` applies
+- heartbeat, scheduler, and full-auto turns start at the lowest tier
+- models later in one tier handle eligible provider fallback before HybridClaw
+  moves to the next tier
+- provider authentication, rate-limit, or server errors and malformed tool
+  calls can escalate to the next tier
+- empty or narrate-only output receives one retry on the same rung before
+  escalation; buffered deltas from a failed attempt are not shown to the user
+- after a successful escalation, that tier remains the floor for
+  `routing.escalationStickyTurns` interactive turns; set the value to `0` to
+  disable stickiness
+- `/escalate` raises exactly the next unpinned agent turn by one tier
+
+Audit output records `route.escalated` events and adds the route tier, reason,
+and escalation state to each model-usage attempt. Enabling routing activates
+the bundled `tier-router` middleware automatically.
+
 ## Codex Turn Runtime
 
 `codex.turnRuntime` controls how turns run when the selected model starts with


### PR DESCRIPTION
## Summary

- curate all user-facing changes since v0.28.2 under `Unreleased`
- refresh the README and documentation for model-tier routing, local pricing/privacy metadata, admin configuration search, A2A encryption, latency diagnostics, and office tooling
- update renamed commands and stale admin-console routes
- remove manifesto references from the full changelog; manifesto language remains roadmap-only

## Release state

This prepares the documentation for the next patch release without bumping package metadata or presenting an unreleased version as published. The README latest-release link remains v0.28.2.

## Validation

- `npm run format`
- `npm run lint`
- `npm run build`
- `npm run release:check`
- `npm --prefix container run release:check`
- local Markdown-target validation for all touched documents
- `node scripts/benchmark-model-latency.mjs --help`
- `git diff --check`

## Release follow-up

The bundled tier-router implementation is not currently included by the npm `files` whitelist, and `plugins/` is excluded from the Docker build context. This docs-only PR intentionally leaves packaging unchanged; address that separately before publishing the patch release.