### PR TITLE
Attach user prompts to HybridAI activity metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Fixed
 
+- **HybridAI activity notifications now show the actual user prompt**:
+  interactive agent turns send the raw user text as transient request metadata,
+  separately from the compiled model context. Background turns omit the field,
+  and confidential values are redacted before the prompt crosses the sandbox
+  boundary.
+
 - **Prompt-cache usage is now visible through the OpenAI-compatible API**: the
   gateway parsed upstream cache reads and writes internally but dropped them
   when building the response, so clients could not tell a cold cache from a

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -759,6 +759,7 @@ async function executePreparedToolCall(
 
 async function callHybridAIWithRetry(params: {
   sessionId?: string;
+  activityUserPrompt?: string;
   provider?: ContainerInput['provider'];
   providerMethod?: string;
   baseUrl: string;
@@ -782,6 +783,7 @@ async function callHybridAIWithRetry(params: {
 }): Promise<ChatCompletionResponse> {
   const {
     sessionId,
+    activityUserPrompt,
     provider,
     providerMethod,
     baseUrl,
@@ -832,6 +834,7 @@ async function callHybridAIWithRetry(params: {
             provider,
             providerMethod,
             sessionId,
+            activityUserPrompt,
             baseUrl,
             apiKey,
             model,
@@ -868,6 +871,7 @@ async function callHybridAIWithRetry(params: {
             provider,
             providerMethod,
             sessionId,
+            activityUserPrompt,
             baseUrl,
             apiKey,
             model,
@@ -889,6 +893,7 @@ async function callHybridAIWithRetry(params: {
           provider,
           providerMethod,
           sessionId,
+          activityUserPrompt,
           baseUrl,
           apiKey,
           model,
@@ -950,6 +955,7 @@ async function callHybridAIWithRetry(params: {
 interface ProcessRequestParams {
   sessionId: string;
   messages: ChatMessage[];
+  activityUserPrompt?: string;
   apiKey: string;
   baseUrl: string;
   provider: ContainerInput['provider'];
@@ -1013,6 +1019,7 @@ async function processRequest(
   const {
     sessionId,
     messages,
+    activityUserPrompt,
     apiKey,
     baseUrl,
     provider,
@@ -1354,6 +1361,7 @@ async function processRequest(
     try {
       response = await callHybridAIWithRetry({
         sessionId,
+        activityUserPrompt,
         provider,
         providerMethod,
         baseUrl,
@@ -2046,6 +2054,7 @@ async function main(): Promise<void> {
     firstOutput = await processRequest({
       sessionId: firstInput.sessionId,
       messages: firstMessagesForRequest,
+      activityUserPrompt: firstInput.activityUserPrompt,
       apiKey: storedApiKey,
       baseUrl: firstInput.baseUrl,
       provider: firstInput.provider,
@@ -2089,6 +2098,7 @@ async function main(): Promise<void> {
       firstOutput = await processRequest({
         sessionId: firstInput.sessionId,
         messages: firstRetryMessagesWithSkillCache,
+        activityUserPrompt: firstInput.activityUserPrompt,
         apiKey: storedApiKey,
         baseUrl: firstInput.baseUrl,
         provider: firstInput.provider,
@@ -2240,6 +2250,7 @@ async function main(): Promise<void> {
     let output = await processRequest({
       sessionId: input.sessionId,
       messages: messagesForRequestWithSkillCache,
+      activityUserPrompt: input.activityUserPrompt,
       apiKey,
       baseUrl: input.baseUrl,
       provider: input.provider,
@@ -2282,6 +2293,7 @@ async function main(): Promise<void> {
       output = await processRequest({
         sessionId: input.sessionId,
         messages: retryMessagesWithSkillCache,
+        activityUserPrompt: input.activityUserPrompt,
         apiKey,
         baseUrl: input.baseUrl,
         provider: input.provider,

--- a/container/src/providers/hybridai.ts
+++ b/container/src/providers/hybridai.ts
@@ -63,6 +63,11 @@ function buildHybridAIRequestBody(
     messages: args.messages,
     enable_rag: args.enableRag,
   };
+  if (args.activityUserPrompt?.trim()) {
+    request.metadata = {
+      hybridclawUserPrompt: args.activityUserPrompt,
+    };
+  }
   if (args.tools.length > 0) {
     request.tools = args.tools;
     request.tool_choice = 'auto';

--- a/container/src/providers/router.ts
+++ b/container/src/providers/router.ts
@@ -45,6 +45,7 @@ const DEFAULT_VISION_INSTRUCTIONS =
 
 export interface RoutedModelContext {
   sessionId?: string;
+  activityUserPrompt?: string;
   provider: RuntimeProvider | undefined;
   providerMethod?: string;
   baseUrl: string;
@@ -87,6 +88,7 @@ export interface RoutedVisionCallParams extends RoutedModelContext {
 function buildCallArgs(params: RoutedModelCallParams): NormalizedCallArgs {
   return {
     sessionId: params.sessionId,
+    activityUserPrompt: params.activityUserPrompt,
     provider: params.provider,
     providerMethod: params.providerMethod,
     baseUrl: params.baseUrl.trim(),

--- a/container/src/providers/shared.ts
+++ b/container/src/providers/shared.ts
@@ -15,6 +15,7 @@ export type { RuntimeProvider } from './provider-ids.js';
 
 export interface NormalizedCallArgs {
   sessionId?: string;
+  activityUserPrompt?: string;
   provider: RuntimeProvider | undefined;
   providerMethod?: string;
   baseUrl: string;

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -230,6 +230,7 @@ export interface ContainerInput {
   sessionId: string;
   agentId?: string;
   messages: ChatMessage[];
+  activityUserPrompt?: string;
   chatbotId: string;
   enableRag: boolean;
   apiKey: string;

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -169,10 +169,19 @@ async function runAgentInner(
     preparedMessages,
     'agent.messages',
   );
+  const activityUserPrompt = params.activityUserPrompt
+    ? getLatestUserTextContent(
+        confidential.dehydrate(
+          [{ role: 'user', content: params.activityUserPrompt }],
+          'agent.activity_user_prompt',
+        ),
+      )
+    : undefined;
   const output = await executor.exec({
     ...params,
     sessionId,
     messages: dehydratedMessages,
+    activityUserPrompt,
     chatbotId,
     model,
     agentId,

--- a/src/agent/executor-types.ts
+++ b/src/agent/executor-types.ts
@@ -15,6 +15,7 @@ import type { ScheduledTask } from '../types/scheduler.js';
 export interface ExecutorRequest {
   sessionId: string;
   messages: ChatMessage[];
+  activityUserPrompt?: string;
   chatbotId: string;
   enableRag: boolean;
   executorModeOverride?: 'host' | 'container';

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -1287,6 +1287,10 @@ async function handleGatewayMessageInner(
     source !== 'fullauto' &&
     channelType !== 'scheduler' &&
     channelType !== 'heartbeat';
+  const activityUserPrompt =
+    isInteractiveSource && !isGoalContinuationSource(source)
+      ? userTurnContent
+      : undefined;
   // Each success path returns after scheduling title work, so one turn enqueues
   // at most one title request.
   const autoTitleParams = () => ({
@@ -2028,6 +2032,7 @@ async function handleGatewayMessageInner(
       runAgent({
         sessionId: req.executionSessionId || req.sessionId,
         messages,
+        activityUserPrompt,
         chatbotId: params.chatbotId,
         enableRag,
         executorModeOverride: req.executorModeOverride,
@@ -2131,6 +2136,7 @@ async function handleGatewayMessageInner(
       output = await runAgent({
         sessionId: req.executionSessionId || req.sessionId,
         messages,
+        activityUserPrompt,
         chatbotId,
         enableRag,
         executorModeOverride: req.executorModeOverride,

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -1015,6 +1015,7 @@ async function runContainerInner(
   const {
     sessionId,
     messages,
+    activityUserPrompt,
     chatbotId,
     enableRag,
     model = HYBRIDAI_MODEL,
@@ -1112,6 +1113,7 @@ async function runContainerInner(
     sessionId,
     agentId,
     messages,
+    activityUserPrompt,
     chatbotId: modelRuntime.chatbotId,
     enableRag: modelRuntime.enableRag,
     apiKey: modelRuntime.apiKey,

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -873,6 +873,7 @@ async function runHostProcessInner(
   const {
     sessionId,
     messages,
+    activityUserPrompt,
     chatbotId,
     enableRag,
     model = HYBRIDAI_MODEL,
@@ -959,6 +960,7 @@ async function runHostProcessInner(
     sessionId,
     agentId,
     messages,
+    activityUserPrompt,
     chatbotId: modelRuntime.chatbotId,
     enableRag: modelRuntime.enableRag,
     apiKey: modelRuntime.apiKey,

--- a/src/types/container.ts
+++ b/src/types/container.ts
@@ -67,6 +67,7 @@ export interface ContainerInput {
   sessionId: string;
   agentId?: string;
   messages: ChatMessage[];
+  activityUserPrompt?: string;
   chatbotId: string;
   enableRag: boolean;
   apiKey: string;

--- a/tests/container.model-router.test.ts
+++ b/tests/container.model-router.test.ts
@@ -94,6 +94,7 @@ describe('container model router', () => {
         >;
         expect(body.model).toBe('anthropic/claude-sonnet-4');
         expect(body.messages).toEqual(baseMessages);
+        expect(body.metadata).toBeUndefined();
         return new Response(
           JSON.stringify({
             id: 'resp_1',
@@ -131,10 +132,59 @@ describe('container model router', () => {
       messages: baseMessages,
       tools: [],
       maxTokens: 128,
+      activityUserPrompt: 'This must not reach OpenRouter metadata',
     });
 
     expect(response.choices[0]?.message.content).toBe('ok');
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('sends raw activity prompts only on HybridAI chat callbacks', async () => {
+    const requestBodies: Array<Record<string, unknown>> = [];
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        requestBodies.push(
+          JSON.parse(String(init?.body || '{}')) as Record<string, unknown>,
+        );
+        return new Response(
+          JSON.stringify({
+            id: 'resp_hybridai',
+            model: 'gpt-5.4',
+            choices: [
+              {
+                message: { role: 'assistant', content: 'ok' },
+                finish_reason: 'stop',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+      },
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const request = {
+      provider: 'hybridai' as const,
+      baseUrl: 'https://hybridai.one',
+      apiKey: 'hybridai-test-key',
+      model: 'gpt-5.4',
+      chatbotId: 'bot_123',
+      messages: baseMessages,
+      tools: [],
+    };
+    await callRoutedModel({
+      ...request,
+      activityUserPrompt: 'Please summarize my invoices',
+    });
+    await callRoutedModel(request);
+
+    expect(requestBodies[0]?.metadata).toEqual({
+      hybridclawUserPrompt: 'Please summarize my invoices',
+    });
+    expect(requestBodies[1]?.metadata).toBeUndefined();
   });
 
   test('routes Codex vision calls through the shared router', async () => {

--- a/tests/gateway-service.context-references.test.ts
+++ b/tests/gateway-service.context-references.test.ts
@@ -72,6 +72,7 @@ test('handleGatewayMessage expands context references only for llm-facing paths'
 
   const request = runAgentMock.mock.calls[0]?.[0] as
     | {
+        activityUserPrompt?: string;
         messages?: Array<{ content: string; role: string }>;
       }
     | undefined;
@@ -82,6 +83,7 @@ test('handleGatewayMessage expands context references only for llm-facing paths'
   expect(userMessage?.content).toContain('File: src/app.ts');
   expect(userMessage?.content).toContain('export const answer = 42;');
   expect(userMessage?.content).not.toContain('@file:src/app.ts');
+  expect(request?.activityUserPrompt).toBe(content);
 
   const history = memoryService.getConversationHistory(sessionId, 10);
   expect(history.find((message) => message.role === 'user')?.content).toBe(


### PR DESCRIPTION
## What changed

- Capture the original interactive user input before HybridClaw expands context references or compiles model context.
- Carry it through host/container execution as transient activity metadata.
- Attach it only to HybridAI chat-completion callbacks as `metadata.hybridclawUserPrompt`.
- Omit it for scheduler, heartbeat, full-auto, goal-continuation, and non-HybridAI provider requests.
- Apply the existing confidential-value redaction before the prompt crosses the sandbox boundary.
- Add gateway and provider-boundary coverage and document the behavior.

## Why

The HybridAI usage observer currently sees only the compiled model-facing `messages` payload. That payload can contain bootstrap instructions, memory, and other constructed context, so Discord notifications can display internal agent prompts rather than the text entered by the user.

This preserves the UI input as telemetry without adding a second copy to the LLM input.

## Companion receiver

- https://github.com/snoller/chat/pull/2049

Deploy the receiver first or deploy both together. Older receivers ignore the metadata safely.

## Risk notes

- The field is scoped to interactive turns and the HybridAI provider.
- Confidential rules are applied before transport.
- External model providers do not receive this metadata.
- Repeated callbacks for one turn are deduplicated by the receiver's observer.

## Validation

- `npx vitest run --configLoader runner --project unit tests/container.model-router.test.ts tests/gateway-service.context-references.test.ts` — 17 passed on Node 22
- `./node_modules/.bin/tsc --noEmit`
- `npm --prefix container run lint`
- Commit hooks passed (existing optional-chain and license-metadata warnings only)
- `git diff --check`
