### PR TITLE
feat(console): add Microsoft Teams app password field to Channels workspace

### DIFF
--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -157,6 +157,10 @@ export interface GatewayStatus {
     passwordConfigured: boolean;
     passwordSource: 'config' | 'env' | 'runtime-secrets' | null;
   };
+  msteams?: {
+    appPasswordConfigured: boolean;
+    appPasswordSource: 'env' | 'runtime-secrets' | null;
+  };
   voice?: {
     enabled: boolean;
     accountSidConfigured: boolean;

--- a/console/src/routes/channels-catalog.ts
+++ b/console/src/routes/channels-catalog.ts
@@ -41,6 +41,7 @@ interface ChannelCatalogOptions {
   lineLinked?: boolean;
   emailPasswordConfigured?: boolean;
   imessagePasswordConfigured?: boolean;
+  msteamsAppPasswordConfigured?: boolean;
   channelPlugins?: GatewayChannelPluginStatus[];
 }
 
@@ -484,13 +485,17 @@ function describeEmail(
   };
 }
 
-function describeMSTeams(config: AdminConfig): ChannelCatalogItem {
+function describeMSTeams(
+  config: AdminConfig,
+  options: ChannelCatalogOptions,
+): ChannelCatalogItem {
   const teamCount = countTeams(config);
   const overrideCount = countTeamsOverrides(config);
   const active =
     config.msteams.enabled &&
     !!config.msteams.appId &&
-    !!config.msteams.tenantId;
+    !!config.msteams.tenantId &&
+    options.msteamsAppPasswordConfigured === true;
   const configured =
     active ||
     config.msteams.enabled ||
@@ -586,7 +591,7 @@ export function buildChannelCatalog(
     describeWhatsApp(config, options),
     describeLine(config, options),
     describeEmail(config, options),
-    describeMSTeams(config),
+    describeMSTeams(config, options),
     describeIMessage(config, options),
   ]
     .map((item) => applyChannelPluginStatus(item, options))

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -2253,6 +2253,93 @@ describe('ChannelsPage', () => {
     screen.getByText('Bot token updated in encrypted runtime secrets.');
   });
 
+  it('updates the Microsoft Teams app password through encrypted runtime secrets', async () => {
+    fetchConfigMock.mockResolvedValue({
+      path: '/tmp/config.json',
+      config: makeConfig(),
+    });
+    setRuntimeSecretMock.mockResolvedValue({
+      kind: 'plain',
+      text: 'stored',
+    });
+    validateTokenMock.mockResolvedValue({
+      status: 'ok',
+      webAuthConfigured: true,
+      version: 'test',
+      imageTag: null,
+      uptime: 1,
+      sessions: 0,
+      activeContainers: 0,
+      defaultModel: 'gpt-5',
+      ragDefault: true,
+      timestamp: new Date().toISOString(),
+      msteams: {
+        appPasswordConfigured: false,
+        appPasswordSource: null,
+      },
+      email: {
+        passwordConfigured: false,
+        passwordSource: null,
+      },
+      imessage: {
+        passwordConfigured: false,
+        passwordSource: null,
+      },
+      whatsapp: {
+        linked: false,
+        jid: null,
+        pairingQrText: null,
+        pairingUpdatedAt: null,
+      },
+    });
+    useAuthMock.mockReturnValue({
+      token: 'test-token',
+      gatewayStatus: {
+        msteams: {
+          appPasswordConfigured: false,
+          appPasswordSource: null,
+        },
+        email: {
+          passwordConfigured: false,
+          passwordSource: null,
+        },
+        imessage: {
+          passwordConfigured: false,
+          passwordSource: null,
+        },
+        whatsapp: {
+          linked: false,
+          jid: null,
+          pairingQrText: null,
+          pairingUpdatedAt: null,
+        },
+      },
+    });
+
+    renderChannelsPage();
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /Microsoft Teams/i }),
+    );
+    expect(screen.queryByLabelText('New password')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set password' }));
+    fireEvent.change(screen.getByLabelText('New password'), {
+      target: { value: 'test-app-password' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save password' }));
+
+    await waitFor(() => {
+      expect(setRuntimeSecretMock).toHaveBeenCalledWith(
+        'test-token',
+        'MSTEAMS_APP_PASSWORD',
+        'test-app-password',
+      );
+    });
+
+    screen.getByText('App password updated in encrypted runtime secrets.');
+  });
+
   it('shows change password when passwordConfigured is true without a source', async () => {
     fetchConfigMock.mockResolvedValue({
       path: '/tmp/config.json',

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -346,7 +346,8 @@ function ManagedSecretField(props: {
     | 'THREEMA_GATEWAY_SECRET'
     | 'TWILIO_AUTH_TOKEN'
     | 'EMAIL_PASSWORD'
-    | 'IMESSAGE_PASSWORD';
+    | 'IMESSAGE_PASSWORD'
+    | 'MSTEAMS_APP_PASSWORD';
   secretLabel: 'token' | 'password' | 'secret';
   configValue?: string;
   configured: boolean;
@@ -2512,9 +2513,13 @@ function VoiceChannelEditor(props: {
   );
 }
 
-function TeamsChannelEditor(_props: {
+function TeamsChannelEditor(props: {
   draft: AdminConfig;
   form: UseFormControllerReturn<AdminConfig>;
+  appPasswordConfigured: boolean;
+  appPasswordSource: SecretSource;
+  token: string;
+  onSecretSaved: () => void;
 }) {
   return (
     <>
@@ -2535,7 +2540,8 @@ function TeamsChannelEditor(_props: {
 
       <p className="muted-copy">
         Paste values from Microsoft Entra Admin Center. Use the app
-        registration's Application (client) ID and Directory (tenant) ID.
+        registration's Application (client) ID and Directory (tenant) ID, plus a
+        client secret value stored as the app password.
       </p>
 
       <div className="field-grid">
@@ -2565,6 +2571,16 @@ function TeamsChannelEditor(_props: {
         />
       </div>
 
+      <ManagedSecretField
+        label="App password"
+        secretName="MSTEAMS_APP_PASSWORD"
+        secretLabel="password"
+        configured={props.appPasswordConfigured}
+        source={props.appPasswordSource}
+        token={props.token}
+        onSecretSaved={props.onSecretSaved}
+      />
+
       <div className="button-row">
         <Button
           variant="outline"
@@ -2591,6 +2607,12 @@ function TeamsChannelEditor(_props: {
               Paste those two values here in Microsoft Teams settings, then save
               channel settings. This lets App Setup detect the tenant and derive
               the correct Teams SSO values.
+            </li>
+            <li>
+              In Entra's Certificates &amp; secrets, create a client secret and
+              copy its value. Store it here as the app password; it is kept in
+              encrypted runtime secrets and required before Teams messages are
+              accepted.
             </li>
             <li>
               In App Setup, copy the App ID URI and Browser redirect URI. In
@@ -3520,6 +3542,10 @@ function renderSelectedEditor(
       configured: boolean;
       source: SecretSource;
     };
+    msteams: {
+      configured: boolean;
+      source: SecretSource;
+    };
   },
   hybridaiApiKeyConfigured: boolean,
   whatsappStatus: {
@@ -3667,7 +3693,16 @@ function renderSelectedEditor(
         />
       );
     case 'msteams':
-      return <TeamsChannelEditor draft={draft} form={form} />;
+      return (
+        <TeamsChannelEditor
+          draft={draft}
+          form={form}
+          appPasswordConfigured={secretStatus.msteams.configured}
+          appPasswordSource={secretStatus.msteams.source}
+          token={token}
+          onSecretSaved={onSecretSaved}
+        />
+      );
     case 'imessage':
       return (
         <IMessageChannelEditor
@@ -3827,6 +3862,10 @@ export function ChannelsPage() {
     imessage: {
       configured: statusQuery.data?.imessage?.passwordConfigured ?? false,
       source: statusQuery.data?.imessage?.passwordSource ?? null,
+    },
+    msteams: {
+      configured: statusQuery.data?.msteams?.appPasswordConfigured ?? false,
+      source: statusQuery.data?.msteams?.appPasswordSource ?? null,
     },
   };
   const whatsappPlugin = statusQuery.data?.channelPlugins?.find(

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -4862,6 +4862,15 @@ export async function getGatewayStatus(
     configValue: runtimeConfig.imessage.password,
     storedValue: storedSecrets.IMESSAGE_PASSWORD,
   });
+  const msteamsCredential = resolveRuntimeCredentialStatus(
+    'MSTEAMS_APP_PASSWORD',
+    [MSTEAMS_APP_PASSWORD],
+    storedSecrets.MSTEAMS_APP_PASSWORD,
+  );
+  const msteams = {
+    appPasswordConfigured: Boolean(msteamsCredential.value),
+    appPasswordSource: msteamsCredential.source,
+  } as NonNullable<GatewayStatus['msteams']>;
   const voiceAuth = resolveGatewayVoiceAuthStatus({
     envValues: [TWILIO_AUTH_TOKEN],
     configValue: runtimeConfig.voice.twilio.authToken,
@@ -4924,6 +4933,7 @@ export async function getGatewayStatus(
     email,
     emailEnabled: runtimeConfig.email.enabled === true,
     imessage,
+    msteams,
     voice: {
       enabled: runtimeConfig.voice.enabled,
       accountSidConfigured: Boolean(

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -533,6 +533,10 @@ export interface GatewayStatus {
     passwordConfigured: boolean;
     passwordSource: 'config' | 'env' | 'runtime-secrets' | null;
   };
+  msteams?: {
+    appPasswordConfigured: boolean;
+    appPasswordSource: 'env' | 'runtime-secrets' | null;
+  };
   voice?: {
     enabled: boolean;
     accountSidConfigured: boolean;


### PR DESCRIPTION
## Problem

The /admin Channels workspace's Microsoft Teams editor collects **App ID** and **Tenant ID**, but the gateway also hard-requires the `MSTEAMS_APP_PASSWORD` runtime secret (the Entra client secret) before it accepts Teams webhooks (`ensureTeamsRuntimeReady` in `src/channels/msteams/runtime.ts`). Every other credentialed channel (Discord, Slack, Telegram, Threema, Twilio voice, Email, iMessage) exposes its secret via `ManagedSecretField`; Teams had no field and the console has no generic secrets page, so a console-only setup always dead-ends with:

```
Teams webhook rejected: channel not configured
{"reason":"Microsoft Teams app password is required. Store MSTEAMS_APP_PASSWORD ..."}
```

The catalog badge also showed the channel as `active` in this state, so nothing in the UI hinted that a credential was still missing.

## Changes

- **console/channels.tsx**: add an `App password` `ManagedSecretField` (secret `MSTEAMS_APP_PASSWORD`, already in the runtime-secrets allowlist) to `TeamsChannelEditor`, wire configured/source state through `secretStatus`, and document the Entra *Certificates & secrets* step in the setup instructions.
- **gateway status** (`gateway-types.ts`, `gateway-service.ts`): report `msteams.appPasswordConfigured` / `appPasswordSource`, mirroring the other channels, so the console can show Set vs Change and badge the channel correctly.
- **channels-catalog.ts**: the catalog badge only shows Teams as `active` when the app password is configured (previously enabled+appId+tenantId looked "active" while the gateway was rejecting every webhook).

## Tests

- New console test: sets the Teams app password through the managed secret field and asserts `setRuntimeSecret('MSTEAMS_APP_PASSWORD', ...)` is called (channels.test.tsx, 40/40 passing).
- `npm run typecheck`, `npm run lint`, `npx biome check` clean on touched files (root + console).

## Note / possible follow-up

`/secret set MSTEAMS_APP_PASSWORD` alone does not re-run `startMSTeamsIntegration`, so after storing the secret the channel only comes up on the next msteams config save (or gateway restart). The console flow ends with *Save channel settings*, which triggers the refresh — but the TUI flow leaves the integration down until something touches the config. Worth a follow-up if we want secret writes to refresh dependent channels.