### PR TITLE
fix(approvals): stop collapsing newlines before bash inspection

### DIFF
--- a/container/src/approval-policy.ts
+++ b/container/src/approval-policy.ts
@@ -3522,7 +3522,13 @@ export class TrustedAgentApprovalRuntime {
   }
 
   private classifyBashAction(args: Record<string, unknown>): ClassifiedAction {
-    const command = normalizeText(args.command);
+    // Newlines must survive here: buildBashInspectionSurface() strips heredoc
+    // bodies line by line, and CRITICAL_BASH_RE's [^\n] classes assume
+    // multi-line input. normalizeText() collapses newlines, which fed whole
+    // heredoc bodies into path extraction — e.g. PDF object keys like
+    // `/Type` inside a python heredoc classified as write-outside-workspace
+    // paths. Human-facing previews still collapse via normalizePreview().
+    const command = String(args.command || '').trim();
     const inspectionSurface = buildBashInspectionSurface(command);
     const lower = command.toLowerCase();
     const hosts = extractHostsFromUrlLikeText(command);

--- a/tests/approval-policy.test.ts
+++ b/tests/approval-policy.test.ts
@@ -2166,6 +2166,42 @@ browser:
     expect(evaluation.tier).toBe('yellow');
   });
 
+  test('python heredocs writing PDF syntax are not fenced on PDF object keys', () => {
+    // Regression: the classifier collapsed newlines before heredoc stripping,
+    // so multi-line heredoc bodies leaked into path extraction and PDF object
+    // keys like `/Type` were classified as write-outside-workspace paths
+    // (observed live: an agent hand-writing a minimal PDF was blocked with
+    // "write outside workspace (`/Type`)").
+    const runtime = new TrustedAgentApprovalRuntime(
+      '/tmp/hybridclaw-missing-policy.yaml',
+    );
+
+    const evaluation = runtime.evaluateToolCall({
+      toolName: 'bash',
+      argsJson: JSON.stringify({
+        command: [
+          "python3 - <<'PY'",
+          'from pathlib import Path',
+          "text='pdf artifact check'",
+          '# Minimal valid PDF with one page and one text object.',
+          'objects=[]',
+          'def obj(n, body):',
+          '    objects.append((n, body))',
+          "obj(1, '<< /Type /Catalog /Pages 2 0 R >>')",
+          "obj(2, '<< /Type /Pages /Kids [3 0 R] /Count 1 >>')",
+          "obj(5, '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>')",
+          "Path('out.pdf').write_bytes(b'%PDF-1.4')",
+          'PY',
+        ].join('\n'),
+      }),
+      latestUserPrompt: 'Create a PDF file',
+    });
+
+    expect(evaluation.actionKey).not.toBe('bash:workspace-fence');
+    expect(evaluation.decision).toBe('implicit');
+    expect(evaluation.tier).toBe('yellow');
+  });
+
   test('outer-shell redirections in heredoc commands still trigger workspace-fence approvals', () => {
     const runtime = new TrustedAgentApprovalRuntime(
       '/tmp/hybridclaw-missing-policy.yaml',


### PR DESCRIPTION
Found by a live staging capability check: an agent asked to produce a PDF was blocked mid-turn with the nonsense approval intent **"write outside workspace (`/Type`)"**.

## Root cause

`classifyBashAction` ran the command through `normalizeText()`, which collapses **all** whitespace — including newlines — into single spaces. `buildBashInspectionSurface()`'s heredoc stripping (ff76531a) is line-based, so every multi-line heredoc arrived as a single line and the stripper never removed anything. Entire heredoc bodies leaked into path extraction and write-intent detection:

- PDF object keys (`/Type`, `/Catalog`, `/Pages`, …) inside a `python3 - <<'PY'` heredoc parsed as absolute filesystem paths;
- the `>>` tokens in PDF dictionary syntax satisfied `WRITE_INTENT_RE`;
- the workspace fence then red-tiered the command and the agent turn stalled on an approval no user can make sense of.

Reproduced with the exact live command against the extracted v0.28.3 helpers: surface contains the full body, `absPaths` starts with `/Type`. With newlines preserved, the surface reduces to `python3 - <<'PY'` and nothing fences.

## Fix

Preserve newlines for classification (`CRITICAL_BASH_RE`'s `[^\n]` classes always assumed multi-line input). Human-facing previews are unaffected — every preview path already collapses via `normalizePreview()`.

## Tests

- New regression test mirroring the live incident (python heredoc writing PDF syntax → not fenced). Verified it fails on the previous code and passes with the fix.
- Existing guards still hold: outer-shell redirection on the heredoc opening line (`node - <<'NODE' > /outside/path`) still fences; node-heredoc-body test still passes.
- `tests/approval-policy.test.ts`: 84/84 pass; `npm run lint` (tsc strict) clean.