### PR TITLE
feat: improve admin navigation and command palette

### DIFF
--- a/console/src/components/command-palette.test.tsx
+++ b/console/src/components/command-palette.test.tsx
@@ -44,4 +44,57 @@ describe('CommandPalette', () => {
       '#setting-container-warmPool-memoryPressureRssMb',
     );
   });
+
+  it.each([
+    ['teams', 'msteams.appId', '#teams'],
+    ['discordwebhook', 'discordWebhook.enabled', '#discord_webhook'],
+  ])('deep-links %s to its Channels subpage', (query, settingPath, expectedHash) => {
+    render(<CommandPalette />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Search pages and settings' }),
+    );
+    fireEvent.change(
+      screen.getByRole('combobox', { name: 'Search pages and settings' }),
+      { target: { value: query } },
+    );
+    const option = screen
+      .getAllByRole('option')
+      .find((entry) => entry.textContent?.includes(settingPath));
+    expect(option).toBeDefined();
+    fireEvent.click(option as HTMLElement);
+
+    expect(window.location.pathname).toBe('/admin/channels');
+    expect(window.location.hash).toBe(expectedHash);
+  });
+
+  it.each([
+    ['work queue', 'Work queue', '/admin/automation', 'work-queue'],
+    ['job board', 'Work queue', '/admin/automation', 'work-queue'],
+    ['schedules', 'Schedules', '/admin/automation', 'schedules'],
+    ['fleet topology', 'Fleet topology', '/admin/federation', 'topology'],
+    ['api tokens', 'API tokens', '/admin/credentials', 'api-tokens'],
+  ])('finds the %s tab and links directly to it', (query, label, pathname, tab) => {
+    render(<CommandPalette />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Search pages and settings' }),
+    );
+    fireEvent.change(
+      screen.getByRole('combobox', { name: 'Search pages and settings' }),
+      { target: { value: query } },
+    );
+    const option = screen
+      .getAllByRole('option')
+      .find(
+        (entry) =>
+          entry.textContent?.includes(label) &&
+          entry.textContent.includes('Pages'),
+      );
+    expect(option).toBeDefined();
+    fireEvent.click(option as HTMLElement);
+
+    expect(window.location.pathname).toBe(pathname);
+    expect(new URLSearchParams(window.location.search).get('tab')).toBe(tab);
+  });
 });

--- a/console/src/components/command-palette.tsx
+++ b/console/src/components/command-palette.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { ADMIN_TAB_GROUPS } from '../lib/admin-tabs';
 import {
   SETTINGS_REGISTRY,
   settingAnchor,
@@ -42,6 +43,22 @@ const PAGE_COMMANDS: ReadonlyArray<CommandEntry> = SIDEBAR_NAV_GROUPS.flatMap(
     })),
 );
 
+const TAB_COMMANDS: ReadonlyArray<CommandEntry> = ADMIN_TAB_GROUPS.flatMap(
+  (group) =>
+    group.tabs.map((tab) => {
+      const aliases = 'aliases' in tab ? tab.aliases.join(' ') : '';
+      return {
+        id: `tab:${group.to}:${tab.id}`,
+        label: tab.label,
+        detail: `${group.label} tab`,
+        group: 'Pages' as const,
+        href: `${group.to}?tab=${encodeURIComponent(tab.id)}`,
+        searchText:
+          `${tab.label} ${group.label} ${aliases} ${group.to} ${tab.id}`.toLowerCase(),
+      };
+    }),
+);
+
 const SETTING_COMMANDS: ReadonlyArray<CommandEntry> = SETTINGS_REGISTRY.map(
   (entry) => ({
     id: `setting:${entry.path}`,
@@ -55,7 +72,7 @@ const SETTING_COMMANDS: ReadonlyArray<CommandEntry> = SETTINGS_REGISTRY.map(
   }),
 );
 
-const COMMANDS = [...PAGE_COMMANDS, ...SETTING_COMMANDS];
+const COMMANDS = [...PAGE_COMMANDS, ...TAB_COMMANDS, ...SETTING_COMMANDS];
 
 function fuzzyScore(haystack: string, query: string): number | null {
   const directIndex = haystack.indexOf(query);

--- a/console/src/components/icons/Network.tsx
+++ b/console/src/components/icons/Network.tsx
@@ -1,0 +1,12 @@
+import { Icon, type IconProps } from './base';
+
+export function Network(props: IconProps) {
+  return (
+    <Icon strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <rect x="9" y="2" width="6" height="6" rx="1" />
+      <rect x="2" y="16" width="6" height="6" rx="1" />
+      <rect x="16" y="16" width="6" height="6" rx="1" />
+      <path d="M12 8v4M5 16v-4h14v4" />
+    </Icon>
+  );
+}

--- a/console/src/components/icons/index.ts
+++ b/console/src/components/icons/index.ts
@@ -29,6 +29,7 @@ export { Logs } from './Logs';
 export { Menu } from './Menu';
 export { Minus } from './Minus';
 export { Models } from './Models';
+export { Network } from './Network';
 export { PanelLeft } from './PanelLeft';
 export { Plugins } from './Plugins';
 export { Policy } from './Policy';

--- a/console/src/components/sidebar/app-sidebar.tsx
+++ b/console/src/components/sidebar/app-sidebar.tsx
@@ -10,7 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../dialog';
-import { HybridClaw, LogOut } from '../icons';
+import { ChevronDown, HybridClaw, LogOut } from '../icons';
 import { ThemeToggle } from '../theme-toggle';
 import {
   Sidebar,
@@ -47,18 +47,7 @@ export function AppSidebar(props: {
       </SidebarHeader>
       <SidebarContent>
         {props.groups.map((group) => (
-          <SidebarGroup key={group.label}>
-            <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
-            <SidebarGroupContent>
-              <SidebarMenu ariaLabel={group.label}>
-                {group.items.map((item) => (
-                  <SidebarMenuItem key={item.to}>
-                    <SidebarNavLink item={item} />
-                  </SidebarMenuItem>
-                ))}
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
+          <AppSidebarGroup key={group.label} group={group} />
         ))}
       </SidebarContent>
       <SidebarFooter>
@@ -77,6 +66,45 @@ export function AppSidebar(props: {
         ) : null}
       </SidebarFooter>
     </Sidebar>
+  );
+}
+
+function AppSidebarGroup(props: { group: SidebarNavGroup }) {
+  const [open, setOpen] = useState(!props.group.defaultCollapsed);
+
+  return (
+    <SidebarGroup>
+      {props.group.defaultCollapsed === undefined ? (
+        <SidebarGroupLabel>{props.group.label}</SidebarGroupLabel>
+      ) : (
+        <button
+          className={styles.groupToggle}
+          type="button"
+          aria-expanded={open}
+          onClick={() => setOpen((value) => !value)}
+        >
+          <span>{props.group.label}</span>
+          <span className={styles.groupToggleDivider} />
+          <ChevronDown
+            className={cx(
+              styles.groupToggleIcon,
+              open && styles.groupToggleIconOpen,
+            )}
+          />
+        </button>
+      )}
+      {open ? (
+        <SidebarGroupContent>
+          <SidebarMenu ariaLabel={props.group.label}>
+            {props.group.items.map((item) => (
+              <SidebarMenuItem key={item.to}>
+                <SidebarNavLink item={item} />
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      ) : null}
+    </SidebarGroup>
   );
 }
 

--- a/console/src/components/sidebar/index.module.css
+++ b/console/src/components/sidebar/index.module.css
@@ -138,6 +138,37 @@
   background: var(--sidebar-border);
 }
 
+.groupToggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  border: 0;
+  padding: 0 8px;
+  background: transparent;
+  color: var(--muted-foreground);
+  font: inherit;
+  font-size: 0.64rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.groupToggleDivider {
+  flex: 1;
+  height: 1px;
+  background: var(--sidebar-border);
+}
+
+.groupToggleIcon {
+  width: 12px;
+  height: 12px;
+  transition: transform 120ms ease;
+}
+
+.groupToggleIconOpen {
+  transform: rotate(180deg);
+}
+
 .menu {
   display: grid;
   gap: 2px;
@@ -338,6 +369,7 @@
 }
 
 .root[data-state="collapsed"] .groupLabel,
+.root[data-state="collapsed"] .groupToggle,
 .root[data-state="collapsed"] .brandText,
 .root[data-state="collapsed"] .footerMeta,
 .root[data-state="collapsed"] .footerDivider,

--- a/console/src/components/sidebar/navigation.test.ts
+++ b/console/src/components/sidebar/navigation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { Network, Share } from '../icons';
 import { ADMIN_CONFIG_SECTION_OWNERS, SIDEBAR_NAV_GROUPS } from './navigation';
 
 describe('SIDEBAR_NAV_GROUPS', () => {
@@ -6,6 +7,9 @@ describe('SIDEBAR_NAV_GROUPS', () => {
     expect(
       SIDEBAR_NAV_GROUPS.map((group) => ({
         label: group.label,
+        ...(group.defaultCollapsed === undefined
+          ? {}
+          : { defaultCollapsed: group.defaultCollapsed }),
         items: group.items.map(({ to, label }) => ({ to, label })),
       })),
     ).toEqual([
@@ -21,7 +25,7 @@ describe('SIDEBAR_NAV_GROUPS', () => {
         items: [
           { to: '/admin/agents', label: 'Agents' },
           { to: '/admin/skills', label: 'Skills' },
-          { to: '/admin/automation', label: 'Automation' },
+          { to: '/admin/automation', label: 'Jobs' },
         ],
       },
       {
@@ -30,7 +34,7 @@ describe('SIDEBAR_NAV_GROUPS', () => {
           { to: '/admin/channels', label: 'Channels' },
           { to: '/admin/connectors', label: 'Connectors' },
           { to: '/admin/mcp', label: 'MCP Servers' },
-          { to: '/admin/federation', label: 'Federation' },
+          { to: '/admin/federation', label: 'Agent2Agent' },
         ],
       },
       {
@@ -51,12 +55,13 @@ describe('SIDEBAR_NAV_GROUPS', () => {
           { to: '/admin/gateway', label: 'Gateway' },
           { to: '/admin/config', label: 'Settings' },
           { to: '/admin/logs', label: 'Logs' },
-          { to: '/admin/extensions', label: 'Extensions' },
+          { to: '/admin/extensions', label: 'Plugins & Tools' },
           { to: '/admin/terminal', label: 'Terminal' },
         ],
       },
       {
         label: 'Labs',
+        defaultCollapsed: true,
         items: [
           { to: '/admin/harness-evolution', label: 'Harness Evolution' },
           { to: '/admin/distill', label: 'Distill' },
@@ -78,18 +83,33 @@ describe('SIDEBAR_NAV_GROUPS', () => {
     ).toHaveLength(18);
   });
 
+  it('uses network-oriented icons for network policy and Agent2Agent', () => {
+    const items = SIDEBAR_NAV_GROUPS.flatMap((group) => group.items);
+
+    expect(
+      items.find((item) => item.to === '/admin/network-policy')?.icon,
+    ).toBe(Network);
+    expect(items.find((item) => item.to === '/admin/federation')?.icon).toBe(
+      Share,
+    );
+  });
+
   it('keeps JSON section ownership next to the canonical navigation map', () => {
     expect(ADMIN_CONFIG_SECTION_OWNERS.discord).toEqual({
       label: 'Channels',
-      to: '/admin/channels',
+      to: '/admin/channels#discord',
+    });
+    expect(ADMIN_CONFIG_SECTION_OWNERS.msteams).toEqual({
+      label: 'Channels',
+      to: '/admin/channels#teams',
     });
     expect(ADMIN_CONFIG_SECTION_OWNERS.mcpServers).toEqual({
       label: 'MCP Servers',
       to: '/admin/mcp',
     });
     expect(ADMIN_CONFIG_SECTION_OWNERS.scheduler).toEqual({
-      label: 'Automation',
-      to: '/admin/automation',
+      label: 'Jobs',
+      to: '/admin/automation?tab=schedules',
     });
   });
 });

--- a/console/src/components/sidebar/navigation.ts
+++ b/console/src/components/sidebar/navigation.ts
@@ -16,10 +16,11 @@ import {
   Lightbulb,
   Logs,
   Models,
+  Network,
   Plugins,
   Policy,
   Secrets,
-  Server,
+  Share,
   Statistics,
   Terminal,
 } from '../icons';
@@ -34,6 +35,7 @@ export type SidebarNavItem = {
 export type SidebarNavGroup = {
   label: string;
   items: ReadonlyArray<SidebarNavItem>;
+  defaultCollapsed?: boolean;
 };
 
 export type { AdminConfigSectionOwner };
@@ -56,7 +58,7 @@ export const SIDEBAR_NAV_GROUPS: ReadonlyArray<SidebarNavGroup> = [
         icon: AgentGroup,
       },
       { to: '/admin/skills', label: 'Skills', icon: Lightbulb },
-      { to: '/admin/automation', label: 'Automation', icon: Jobs },
+      { to: '/admin/automation', label: 'Jobs', icon: Jobs },
     ],
   },
   {
@@ -67,8 +69,8 @@ export const SIDEBAR_NAV_GROUPS: ReadonlyArray<SidebarNavGroup> = [
       { to: '/admin/mcp', label: 'MCP Servers', icon: Cog },
       {
         to: '/admin/federation',
-        label: 'Federation',
-        icon: Server,
+        label: 'Agent2Agent',
+        icon: Share,
       },
     ],
   },
@@ -82,7 +84,7 @@ export const SIDEBAR_NAV_GROUPS: ReadonlyArray<SidebarNavGroup> = [
       {
         to: '/admin/network-policy',
         label: 'Network Policy',
-        icon: Policy,
+        icon: Network,
       },
       { to: '/admin/output-guard', label: 'Output Guard', icon: Policy },
       { to: '/admin/credentials', label: 'Credentials', icon: Secrets },
@@ -94,12 +96,17 @@ export const SIDEBAR_NAV_GROUPS: ReadonlyArray<SidebarNavGroup> = [
       { to: '/admin/gateway', label: 'Gateway', icon: Gateway },
       { to: '/admin/config', label: 'Settings', icon: Config },
       { to: '/admin/logs', label: 'Logs', icon: Logs },
-      { to: '/admin/extensions', label: 'Extensions', icon: Plugins },
+      {
+        to: '/admin/extensions',
+        label: 'Plugins & Tools',
+        icon: Plugins,
+      },
       { to: '/admin/terminal', label: 'Terminal', icon: Terminal },
     ],
   },
   {
     label: 'Labs',
+    defaultCollapsed: true,
     items: [
       {
         to: '/admin/harness-evolution',

--- a/console/src/components/sidebar/sidebar.test.tsx
+++ b/console/src/components/sidebar/sidebar.test.tsx
@@ -517,9 +517,34 @@ describe('AppSidebar', () => {
         />
       </SidebarProvider>,
     );
-    for (const item of SIDEBAR_NAV_GROUPS.flatMap((g) => g.items)) {
+    for (const item of SIDEBAR_NAV_GROUPS.filter(
+      (group) => !group.defaultCollapsed,
+    ).flatMap((group) => group.items)) {
       expect(screen.getAllByText(item.label).length).toBeGreaterThan(0);
     }
+  });
+
+  it('starts Labs collapsed and expands it on request', () => {
+    render(
+      <SidebarProvider>
+        <AppSidebar
+          groups={SIDEBAR_NAV_GROUPS}
+          showLogout={false}
+          onLogout={vi.fn()}
+        />
+      </SidebarProvider>,
+    );
+
+    const labsToggle = screen.getByRole('button', { name: 'Labs' });
+    expect(labsToggle.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByRole('navigation', { name: 'Labs' })).toBeNull();
+
+    fireEvent.click(labsToggle);
+
+    expect(labsToggle.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByRole('navigation', { name: 'Labs' })).toBeDefined();
+    expect(screen.getByText('Harness Evolution')).toBeDefined();
+    expect(screen.getByText('Distill')).toBeDefined();
   });
 
   it('renders version when provided', () => {

--- a/console/src/lib/admin-config-owners.ts
+++ b/console/src/lib/admin-config-owners.ts
@@ -8,25 +8,32 @@ const CHANNELS_OWNER: AdminConfigSectionOwner = {
   to: '/admin/channels',
 };
 
+export function adminChannelOwner(fragment: string): AdminConfigSectionOwner {
+  return {
+    label: 'Channels',
+    to: `/admin/channels#${fragment}`,
+  };
+}
+
 export const ADMIN_CONFIG_SECTION_OWNERS: Readonly<
   Partial<Record<string, AdminConfigSectionOwner>>
 > = {
   channels: CHANNELS_OWNER,
   channelInstructions: CHANNELS_OWNER,
-  discord: CHANNELS_OWNER,
-  discordWebhook: CHANNELS_OWNER,
-  email: CHANNELS_OWNER,
-  imessage: CHANNELS_OWNER,
-  line: CHANNELS_OWNER,
-  msteams: CHANNELS_OWNER,
-  signal: CHANNELS_OWNER,
-  slack: CHANNELS_OWNER,
-  slackWebhook: CHANNELS_OWNER,
-  telegram: CHANNELS_OWNER,
-  threema: CHANNELS_OWNER,
-  voice: CHANNELS_OWNER,
-  whatsapp: CHANNELS_OWNER,
+  discord: adminChannelOwner('discord'),
+  discordWebhook: adminChannelOwner('discord_webhook'),
+  email: adminChannelOwner('email'),
+  imessage: adminChannelOwner('imessage'),
+  line: adminChannelOwner('line'),
+  msteams: adminChannelOwner('teams'),
+  signal: adminChannelOwner('signal'),
+  slack: adminChannelOwner('slack'),
+  slackWebhook: adminChannelOwner('slack_webhook'),
+  telegram: adminChannelOwner('telegram'),
+  threema: adminChannelOwner('threema'),
+  voice: adminChannelOwner('voice'),
+  whatsapp: adminChannelOwner('whatsapp'),
   mcpServers: { label: 'MCP Servers', to: '/admin/mcp' },
   outputGuard: { label: 'Output Guard', to: '/admin/output-guard' },
-  scheduler: { label: 'Automation', to: '/admin/automation' },
+  scheduler: { label: 'Jobs', to: '/admin/automation?tab=schedules' },
 };

--- a/console/src/lib/admin-tabs.ts
+++ b/console/src/lib/admin-tabs.ts
@@ -1,0 +1,56 @@
+export const ACTIVITY_TABS = [
+  { id: 'usage', label: 'Usage' },
+  { id: 'sessions', label: 'Sessions' },
+  { id: 'audit', label: 'Audit log' },
+] as const;
+
+export const AGENT_TABS = [
+  { id: 'scoreboard', label: 'Scoreboard' },
+  { id: 'files', label: 'Workspace files' },
+] as const;
+
+export const AUTOMATION_TABS = [
+  {
+    id: 'work-queue',
+    label: 'Work queue',
+    aliases: ['job board', 'jobs board'],
+  },
+  { id: 'schedules', label: 'Schedules' },
+] as const;
+
+export const CREDENTIAL_TABS = [
+  { id: 'secrets', label: 'Secrets' },
+  { id: 'api-tokens', label: 'API tokens' },
+] as const;
+
+export const EXTENSION_TABS = [
+  { id: 'plugins', label: 'Plugins' },
+  { id: 'tools', label: 'Tool catalog' },
+] as const;
+
+export const FEDERATION_TABS = [
+  { id: 'peers', label: 'Peers & trust' },
+  { id: 'topology', label: 'Fleet topology' },
+  { id: 'inbox', label: 'A2A inbox' },
+] as const;
+
+export const ADMIN_TAB_GROUPS = [
+  { label: 'Activity', to: '/admin/activity', tabs: ACTIVITY_TABS },
+  { label: 'Agents', to: '/admin/agents', tabs: AGENT_TABS },
+  { label: 'Jobs', to: '/admin/automation', tabs: AUTOMATION_TABS },
+  {
+    label: 'Agent2Agent',
+    to: '/admin/federation',
+    tabs: FEDERATION_TABS,
+  },
+  {
+    label: 'Credentials',
+    to: '/admin/credentials',
+    tabs: CREDENTIAL_TABS,
+  },
+  {
+    label: 'Plugins & Tools',
+    to: '/admin/extensions',
+    tabs: EXTENSION_TABS,
+  },
+] as const;

--- a/console/src/lib/settings-registry.ts
+++ b/console/src/lib/settings-registry.ts
@@ -7,6 +7,7 @@ import {
 import {
   ADMIN_CONFIG_SECTION_OWNERS,
   type AdminConfigSectionOwner,
+  adminChannelOwner,
 } from './admin-config-owners';
 
 export interface SettingsRegistryEntry extends GeneratedSettingEntry {
@@ -34,8 +35,8 @@ const SECTION_OWNERS: Readonly<
   ...ADMIN_CONFIG_SECTION_OWNERS,
   agents: { label: 'Agents', to: '/admin/agents' },
   skills: { label: 'Skills', to: '/admin/skills' },
-  tools: { label: 'Extensions', to: '/admin/extensions?tab=tools' },
-  plugins: { label: 'Extensions', to: '/admin/extensions?tab=plugins' },
+  tools: { label: 'Plugins & Tools', to: '/admin/extensions?tab=tools' },
+  plugins: { label: 'Plugins & Tools', to: '/admin/extensions?tab=plugins' },
   adaptiveSkills: {
     label: 'Harness Evolution',
     to: '/admin/harness-evolution',
@@ -205,7 +206,11 @@ function fieldDescription(entry: GeneratedSettingEntry): string {
 export function settingsOwnerForPath(
   path: string,
 ): AdminConfigSectionOwner | undefined {
-  return FIELD_OWNERS[path] ?? SECTION_OWNERS[path.split('.')[0] ?? ''];
+  const [section, subpage] = path.split('.');
+  if (section === 'channelInstructions' && subpage) {
+    return adminChannelOwner(subpage === 'msteams' ? 'teams' : subpage);
+  }
+  return FIELD_OWNERS[path] ?? SECTION_OWNERS[section ?? ''];
 }
 
 export const SETTINGS_REGISTRY: ReadonlyArray<SettingsRegistryEntry> =

--- a/console/src/routes/activity.tsx
+++ b/console/src/routes/activity.tsx
@@ -1,17 +1,12 @@
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { TabbedPage } from '../components/tabbed-page';
+import { ACTIVITY_TABS } from '../lib/admin-tabs';
 import { logNavigationError } from '../lib/navigation';
 import { AuditPage } from './audit';
 import type { TimeRange } from './audit-filters';
 import { SessionsPage } from './sessions';
 import { StatisticsPage } from './statistics';
 import { mergeRouteSearch, readRouteTab } from './tabbed-route';
-
-const ACTIVITY_TABS = [
-  { id: 'usage', label: 'Usage' },
-  { id: 'sessions', label: 'Sessions' },
-  { id: 'audit', label: 'Audit log' },
-] as const;
 
 const ACTIVITY_RANGES = [
   { value: '7d', label: 'Last 7 days', days: 7 },

--- a/console/src/routes/agents-hub.tsx
+++ b/console/src/routes/agents-hub.tsx
@@ -14,17 +14,13 @@ import {
 } from '../components/dialog';
 import { TabbedPage } from '../components/tabbed-page';
 import { useToast } from '../components/toast';
+import { AGENT_TABS } from '../lib/admin-tabs';
 import { DEFAULT_AGENT_ID } from '../lib/chat-helpers';
 import { getErrorMessage } from '../lib/error-message';
 import { logNavigationError } from '../lib/navigation';
 import { AgentsPage } from './agent-scoreboard';
 import { AgentFilesPage } from './agents';
 import { mergeRouteSearch, readRouteTab } from './tabbed-route';
-
-const AGENT_TABS = [
-  { id: 'scoreboard', label: 'Scoreboard' },
-  { id: 'files', label: 'Workspace files' },
-] as const;
 
 type AgentTab = (typeof AGENT_TABS)[number]['id'];
 

--- a/console/src/routes/automation.tsx
+++ b/console/src/routes/automation.tsx
@@ -1,14 +1,10 @@
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { TabbedPage } from '../components/tabbed-page';
+import { AUTOMATION_TABS } from '../lib/admin-tabs';
 import { logNavigationError } from '../lib/navigation';
 import { JobsPage } from './jobs';
 import { SchedulerPage } from './scheduler';
 import { mergeRouteSearch, readRouteTab } from './tabbed-route';
-
-const AUTOMATION_TABS = [
-  { id: 'work-queue', label: 'Work queue' },
-  { id: 'schedules', label: 'Schedules' },
-] as const;
 
 type AutomationTab = (typeof AUTOMATION_TABS)[number]['id'];
 

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -1769,6 +1769,23 @@ describe('ChannelsPage', () => {
     });
   });
 
+  it('selects Microsoft Teams settings from the teams hash fragment', async () => {
+    window.history.replaceState(null, '', '/admin/channels#teams');
+    fetchConfigMock.mockResolvedValue({
+      path: '/tmp/config.json',
+      config: makeConfig(),
+    });
+
+    renderChannelsPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'Microsoft Teams settings' }),
+      ).toBeTruthy();
+    });
+    expect(document.getElementById('teams')).toBeTruthy();
+  });
+
   it('selects Discord settings from the discord hash fragment', async () => {
     window.history.replaceState(null, '', '/admin/channels#discord');
     fetchConfigMock.mockResolvedValue({

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -49,6 +49,14 @@ import { buildChannelCatalog, type ChannelKind } from './channels-catalog';
 type SecretSource = 'config' | 'env' | 'runtime-secrets' | null;
 type ChannelInstructionKind = keyof AdminConfig['channelInstructions'];
 
+function channelFragment(kind: ChannelKind): string {
+  return kind === 'msteams' ? 'teams' : kind;
+}
+
+function channelKindFromFragment(fragment: string): string {
+  return fragment === 'teams' ? 'msteams' : fragment;
+}
+
 function isDiscordEnabled(config: AdminConfig): boolean {
   return (
     config.discord.commandsOnly || config.discord.groupPolicy !== 'disabled'
@@ -3751,7 +3759,9 @@ export function ChannelsPage() {
     const firstCatalogEntry = catalog[0];
     if (!firstCatalogEntry) return;
     setSelectedKind((current) => {
-      const hashKind = window.location.hash.replace(/^#/, '');
+      const hashKind = channelKindFromFragment(
+        window.location.hash.replace(/^#/, ''),
+      );
       const hashEntry = catalog.find((entry) => entry.kind === hashKind);
       if (hashEntry) return hashEntry.kind;
       if (current && catalog.some((entry) => entry.kind === current)) {
@@ -3762,10 +3772,12 @@ export function ChannelsPage() {
   }, [catalog]);
 
   useEffect(() => {
-    const hashKind = window.location.hash.replace(/^#/, '');
+    const hashKind = channelKindFromFragment(
+      window.location.hash.replace(/^#/, ''),
+    );
     if (!selectedKind || selectedKind !== hashKind) return;
     window.setTimeout(() => {
-      const target = document.getElementById(selectedKind);
+      const target = document.getElementById(channelFragment(selectedKind));
       if (typeof target?.scrollIntoView === 'function') {
         target.scrollIntoView({ block: 'start' });
       }
@@ -3897,7 +3909,14 @@ export function ChannelsPage() {
         </Card>
 
         <Form form={form} onSubmit={() => saveMutation.mutate(draft)}>
-          <Card id={selectedChannel?.kind} variant="muted">
+          <Card
+            id={
+              selectedChannel
+                ? channelFragment(selectedChannel.kind)
+                : undefined
+            }
+            variant="muted"
+          >
             <CardHeader>
               <CardTitle>
                 {selectedChannel

--- a/console/src/routes/credentials.tsx
+++ b/console/src/routes/credentials.tsx
@@ -1,14 +1,10 @@
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { TabbedPage } from '../components/tabbed-page';
+import { CREDENTIAL_TABS } from '../lib/admin-tabs';
 import { logNavigationError } from '../lib/navigation';
 import { SecretsPage } from './secrets';
 import { mergeRouteSearch, readRouteTab } from './tabbed-route';
 import { TokensPage } from './tokens';
-
-const CREDENTIAL_TABS = [
-  { id: 'secrets', label: 'Secrets' },
-  { id: 'api-tokens', label: 'API tokens' },
-] as const;
 
 type CredentialTab = (typeof CREDENTIAL_TABS)[number]['id'];
 

--- a/console/src/routes/extensions.tsx
+++ b/console/src/routes/extensions.tsx
@@ -1,14 +1,10 @@
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { TabbedPage } from '../components/tabbed-page';
+import { EXTENSION_TABS } from '../lib/admin-tabs';
 import { logNavigationError } from '../lib/navigation';
 import { PluginsPage } from './plugins';
 import { mergeRouteSearch, readRouteTab } from './tabbed-route';
 import { ToolsPage } from './tools';
-
-const EXTENSION_TABS = [
-  { id: 'plugins', label: 'Plugins' },
-  { id: 'tools', label: 'Tool catalog' },
-] as const;
 
 type ExtensionTab = (typeof EXTENSION_TABS)[number]['id'];
 

--- a/console/src/routes/federation.tsx
+++ b/console/src/routes/federation.tsx
@@ -1,16 +1,11 @@
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { TabbedPage } from '../components/tabbed-page';
+import { FEDERATION_TABS } from '../lib/admin-tabs';
 import { logNavigationError } from '../lib/navigation';
 import { A2AInboxPage } from './a2a-inbox';
 import { A2ATrustPage } from './a2a-trust';
 import { FleetTopologyPage } from './fleet-topology';
 import { mergeRouteSearch, readRouteTab } from './tabbed-route';
-
-const FEDERATION_TABS = [
-  { id: 'peers', label: 'Peers & trust' },
-  { id: 'topology', label: 'Fleet topology' },
-  { id: 'inbox', label: 'A2A inbox' },
-] as const;
 
 type FederationTab = (typeof FEDERATION_TABS)[number]['id'];
 


### PR DESCRIPTION
## Summary

- refresh the admin sidebar labels and network-oriented icons, and collapse Labs by default
- deep-link channel-owned settings to their matching subpages, including Microsoft Teams at `#teams`
- index all merged admin tabs in the command palette, including a `job board` alias for Work queue
- centralize tab metadata so rendered tabs and command-palette destinations stay synchronized

## Why

The admin navigation used outdated labels and generic icons. Command-palette results for channel settings discarded their subpage fragment, while tab destinations such as Work queue and Schedules were not searchable at all.

## Impact

Users can navigate directly from ⌘K to channel editors and admin tabs instead of landing on the parent page and selecting the subpage manually. Existing route paths remain compatible.

## Validation

- `npm run format`
- `npm run lint`
- full console test suite: 93 files, 876 tests passed
