### PR TITLE
feat(console): add What's New release dialog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,6 +390,8 @@ When the user says "bump release":
    - `container/package-lock.json` and `container/npm-shrinkwrap.json` (root
      `version` and `packages[""]`)
    - any user-facing version text (for example `src/tui.ts` banner)
+   - `console/src/release-notes.ts` with up to four ultra-short highlights for
+     the What's New dialog
 3. Review the generated lockfile diff. Even a version-only release changes the
    lockfile bytes, so update the matching SHA-256 entries in
    `scripts/dependency-policy-baseline.json` after confirming that no dependency

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,21 +390,22 @@ When the user says "bump release":
    - `container/package-lock.json` and `container/npm-shrinkwrap.json` (root
      `version` and `packages[""]`)
    - any user-facing version text (for example `src/tui.ts` banner)
-   - `console/src/release-notes.ts` with up to four ultra-short highlights for
-     the What's New dialog
-3. Review the generated lockfile diff. Even a version-only release changes the
+3. **Always** update `console/src/release-notes.ts` for the new version with up
+   to four ultra-short highlights for the What's New dialog. Do not carry the
+   previous release's version or highlights forward.
+4. Review the generated lockfile diff. Even a version-only release changes the
    lockfile bytes, so update the matching SHA-256 entries in
    `scripts/dependency-policy-baseline.json` after confirming that no dependency
    versions or lifecycle scripts changed. Run `npm run deps:policy` before the
    release commit; the pre-commit override does not approve stale baseline
    hashes in CI.
-4. Move `CHANGELOG.md` release notes from `Unreleased` to the new version
+5. Move `CHANGELOG.md` release notes from `Unreleased` to the new version
    heading (or create one).
-5. Update `README.md` "latest tag" link/text if present.
-6. Commit with `chore: release vX.Y.Z`.
-7. Create an annotated git tag `vX.Y.Z`.
-8. Push the commit and tag.
-9. Create or publish a GitHub Release entry for the tag using the same curated
+6. Update `README.md` "latest tag" link/text if present.
+7. Commit with `chore: release vX.Y.Z`.
+8. Create an annotated git tag `vX.Y.Z`.
+9. Push the commit and tag.
+10. Create or publish a GitHub Release entry for the tag using the same curated
    format as `v0.9.2`:
    - title: `HybridClaw vX.Y.Z`
    - `Release Date:` line with the calendar date

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+- **Once-per-release console updates**: The admin console shows an ultra-short
+  What's New dialog once for each release, and the sidebar version number
+  reopens it on demand.
+
 ## [0.28.3](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.3) - 2026-07-22
 
 ### Fixed

--- a/console/src/components/sidebar/app-sidebar.tsx
+++ b/console/src/components/sidebar/app-sidebar.tsx
@@ -13,6 +13,7 @@ import {
 } from '../dialog';
 import { ChevronDown, HybridClaw, LogOut } from '../icons';
 import { ThemeToggle } from '../theme-toggle';
+import { WhatsNew } from '../whats-new';
 import {
   Sidebar,
   SidebarContent,
@@ -157,7 +158,10 @@ export function SidebarMeta(props: { version?: string }) {
   if (!props.version) return null;
   return (
     <div className={styles.footerMeta}>
-      <span className={styles.footerValue}>v{props.version}</span>
+      <WhatsNew
+        version={props.version}
+        triggerClassName={styles.footerVersionButton}
+      />
     </div>
   );
 }

--- a/console/src/components/sidebar/index.module.css
+++ b/console/src/components/sidebar/index.module.css
@@ -299,12 +299,26 @@
   align-items: center;
 }
 
-.footerValue {
-  padding: 0 8px;
+.footerVersionButton {
+  border: 0;
+  border-radius: var(--radius-sm);
+  padding: 4px 8px;
+  background: transparent;
   color: var(--sidebar-fg);
+  cursor: pointer;
   font-size: 0.75rem;
   font-weight: 500;
   line-height: 1;
+}
+
+.footerVersionButton:hover {
+  background: var(--accent-soft);
+  color: var(--text);
+}
+
+.footerVersionButton:focus-visible {
+  outline: 2px solid var(--accent-foreground);
+  outline-offset: 2px;
 }
 
 .footerBlock {

--- a/console/src/components/whats-new.module.css
+++ b/console/src/components/whats-new.module.css
@@ -1,0 +1,19 @@
+.highlights {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding-left: 20px;
+  color: var(--text);
+  line-height: 1.45;
+}
+
+.releaseLink {
+  color: var(--accent-foreground);
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.releaseLink:hover {
+  text-decoration: underline;
+}

--- a/console/src/components/whats-new.module.css
+++ b/console/src/components/whats-new.module.css
@@ -1,3 +1,53 @@
+.header {
+  grid-template-columns: 56px minmax(0, 1fr);
+  align-items: center;
+  gap: 14px;
+}
+
+.markWrap {
+  display: grid;
+  place-items: center;
+  width: 56px;
+  height: 56px;
+  border: 1px solid color-mix(in srgb, var(--primary) 22%, var(--line));
+  border-radius: 50%;
+  background: linear-gradient(
+    145deg,
+    color-mix(in srgb, var(--primary) 16%, var(--panel-bg)),
+    color-mix(in srgb, var(--success) 10%, var(--panel-bg))
+  );
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 42%, transparent),
+    0 10px 24px color-mix(in srgb, var(--primary) 16%, transparent);
+}
+
+.mark {
+  width: 31px;
+  height: 35px;
+  color: color-mix(in srgb, var(--primary) 76%, var(--text));
+  filter: drop-shadow(
+    0 5px 9px color-mix(in srgb, var(--primary) 20%, transparent)
+  );
+}
+
+.heading {
+  display: grid;
+  gap: 4px;
+}
+
+.eyebrow {
+  color: var(--muted-foreground);
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.srOnly {
+  composes: srOnly from "../lib/a11y.module.css";
+}
+
 .highlights {
   display: grid;
   gap: 10px;

--- a/console/src/components/whats-new.test.tsx
+++ b/console/src/components/whats-new.test.tsx
@@ -1,0 +1,72 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LATEST_RELEASE_NOTES } from '../release-notes';
+import { WhatsNew } from './whats-new';
+
+const SEEN_VERSION_STORAGE_KEY = 'hybridclaw_whats_new_seen_version';
+
+describe('WhatsNew', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(cleanup);
+
+  it('automatically opens once for the current release', () => {
+    const { unmount } = render(
+      <WhatsNew version={LATEST_RELEASE_NOTES.version} />,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(
+      within(dialog).getByText(
+        `What's new in v${LATEST_RELEASE_NOTES.version}`,
+      ),
+    ).toBeDefined();
+    expect(localStorage.getItem(SEEN_VERSION_STORAGE_KEY)).toBe(
+      LATEST_RELEASE_NOTES.version,
+    );
+
+    unmount();
+    render(<WhatsNew version={LATEST_RELEASE_NOTES.version} />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('reopens when the version number is clicked', () => {
+    localStorage.setItem(
+      SEEN_VERSION_STORAGE_KEY,
+      LATEST_RELEASE_NOTES.version,
+    );
+    render(<WhatsNew version={LATEST_RELEASE_NOTES.version} />);
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: `What's new in v${LATEST_RELEASE_NOTES.version}`,
+      }),
+    );
+
+    expect(screen.getByRole('dialog')).toBeDefined();
+    for (const highlight of LATEST_RELEASE_NOTES.highlights) {
+      expect(screen.getByText(highlight)).toBeDefined();
+    }
+  });
+
+  it('does not automatically open for an unmatched runtime version', () => {
+    render(<WhatsNew version="0.0.0-dev" />);
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+    fireEvent.click(
+      screen.getByRole('button', { name: "What's new in v0.0.0-dev" }),
+    );
+    expect(screen.getByRole('dialog')).toBeDefined();
+    expect(
+      screen.getByRole('link', { name: 'Full release notes' }),
+    ).toBeDefined();
+  });
+});

--- a/console/src/components/whats-new.test.tsx
+++ b/console/src/components/whats-new.test.tsx
@@ -52,6 +52,10 @@ describe('WhatsNew', () => {
     );
 
     expect(screen.getByRole('dialog')).toBeDefined();
+    expect(screen.getByText('HybridClaw update')).toBeDefined();
+    expect(
+      screen.queryByText('A quick look at this HybridClaw release.'),
+    ).toBeNull();
     for (const highlight of LATEST_RELEASE_NOTES.highlights) {
       expect(screen.getByText(highlight)).toBeDefined();
     }

--- a/console/src/components/whats-new.tsx
+++ b/console/src/components/whats-new.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import { getReleaseHighlights, LATEST_RELEASE_NOTES } from '../release-notes';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from './dialog';
+import styles from './whats-new.module.css';
+
+const SEEN_VERSION_STORAGE_KEY = 'hybridclaw_whats_new_seen_version';
+
+function hasSeenVersion(version: string): boolean {
+  try {
+    return window.localStorage.getItem(SEEN_VERSION_STORAGE_KEY) === version;
+  } catch {
+    return false;
+  }
+}
+
+function markVersionSeen(version: string): void {
+  try {
+    window.localStorage.setItem(SEEN_VERSION_STORAGE_KEY, version);
+  } catch {
+    // The popup still works when browser storage is unavailable.
+  }
+}
+
+export function WhatsNew(props: {
+  version: string;
+  triggerClassName?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const highlights = getReleaseHighlights(props.version);
+
+  useEffect(() => {
+    if (
+      props.version !== LATEST_RELEASE_NOTES.version ||
+      hasSeenVersion(props.version)
+    ) {
+      return;
+    }
+    markVersionSeen(props.version);
+    setOpen(true);
+  }, [props.version]);
+
+  const releaseUrl = `https://github.com/HybridAIOne/hybridclaw/releases/tag/v${encodeURIComponent(props.version)}`;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger
+        className={props.triggerClassName}
+        aria-label={`What's new in v${props.version}`}
+      >
+        v{props.version}
+      </DialogTrigger>
+      <DialogContent size="sm">
+        <DialogHeader>
+          <DialogTitle>What&apos;s new in v{props.version}</DialogTitle>
+          <DialogDescription>
+            A quick look at this HybridClaw release.
+          </DialogDescription>
+        </DialogHeader>
+        {highlights.length > 0 ? (
+          <ul className={styles.highlights}>
+            {highlights.map((highlight) => (
+              <li key={highlight}>{highlight}</li>
+            ))}
+          </ul>
+        ) : null}
+        <a
+          className={styles.releaseLink}
+          href={releaseUrl}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Full release notes
+        </a>
+        <DialogFooter>
+          <DialogClose className="primary-button">Got it</DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/console/src/components/whats-new.tsx
+++ b/console/src/components/whats-new.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { getReleaseHighlights, LATEST_RELEASE_NOTES } from '../release-notes';
+import { Button } from './button';
 import {
   Dialog,
   DialogClose,
@@ -81,7 +82,7 @@ export function WhatsNew(props: {
           Full release notes
         </a>
         <DialogFooter>
-          <DialogClose className="primary-button">Got it</DialogClose>
+          <Button render={<DialogClose>Got it</DialogClose>} />
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/console/src/components/whats-new.tsx
+++ b/console/src/components/whats-new.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from './dialog';
+import { HybridClaw } from './icons';
 import styles from './whats-new.module.css';
 
 const SEEN_VERSION_STORAGE_KEY = 'hybridclaw_whats_new_seen_version';
@@ -60,10 +61,16 @@ export function WhatsNew(props: {
         v{props.version}
       </DialogTrigger>
       <DialogContent size="sm">
-        <DialogHeader>
-          <DialogTitle>What&apos;s new in v{props.version}</DialogTitle>
-          <DialogDescription>
-            A quick look at this HybridClaw release.
+        <DialogHeader className={styles.header}>
+          <div className={styles.markWrap} aria-hidden="true">
+            <HybridClaw className={styles.mark} />
+          </div>
+          <div className={styles.heading}>
+            <span className={styles.eyebrow}>HybridClaw update</span>
+            <DialogTitle>What&apos;s new in v{props.version}</DialogTitle>
+          </div>
+          <DialogDescription className={styles.srOnly}>
+            Release highlights for HybridClaw v{props.version}.
           </DialogDescription>
         </DialogHeader>
         {highlights.length > 0 ? (

--- a/console/src/release-notes.test.ts
+++ b/console/src/release-notes.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import consolePackage from '../package.json';
+import { LATEST_RELEASE_NOTES } from './release-notes';
+
+describe('release notes', () => {
+  it('describes the current console release', () => {
+    expect(LATEST_RELEASE_NOTES.version).toBe(consolePackage.version);
+  });
+
+  it('keeps the popup copy ultra short', () => {
+    expect(LATEST_RELEASE_NOTES.highlights.length).toBeLessThanOrEqual(4);
+    for (const highlight of LATEST_RELEASE_NOTES.highlights) {
+      expect(highlight.length).toBeLessThanOrEqual(48);
+    }
+  });
+});

--- a/console/src/release-notes.ts
+++ b/console/src/release-notes.ts
@@ -1,0 +1,15 @@
+export const LATEST_RELEASE_NOTES = {
+  version: '0.28.3',
+  highlights: [
+    'Encrypted A2A gateway messaging.',
+    'Automatic model-tier failover.',
+    'Direct OpenAI API support.',
+    'Searchable admin settings.',
+  ],
+} as const;
+
+export function getReleaseHighlights(version: string): readonly string[] {
+  return version === LATEST_RELEASE_NOTES.version
+    ? LATEST_RELEASE_NOTES.highlights
+    : [];
+}

--- a/docs/content/developer-guide/desktop-release.md
+++ b/docs/content/developer-guide/desktop-release.md
@@ -59,6 +59,12 @@ manifest and generated lockfile entry:
 npm run version:sync
 ```
 
+Always update `console/src/release-notes.ts` in the same release commit. Set its
+version to the new product version and replace the previous release copy with
+up to four ultra-short highlights for the console's What's New dialog. The
+console test suite rejects release notes whose version does not match
+`console/package.json`.
+
 Review the four generated lockfile diffs before approving them. A normal
 version-only release changes only the product `version` fields; dependency
 versions, resolved artifacts, integrity values, and lifecycle-script entries
@@ -94,7 +100,8 @@ baseline, and CI rejects stale hashes.
 Do not publish the public GitHub Release first and then start building the
 desktop app. The safer order is:
 
-1. Finalize the release commit with version, changelog, README, and docs.
+1. Finalize the release commit with version, What's New highlights, changelog,
+   README, and docs.
 2. Create the annotated version tag and make sure the desktop build host is
    building from that exact tag or commit.
 3. Build, sign, notarize, staple, and verify the macOS artifacts.


### PR DESCRIPTION
## Summary

- show an ultra-short What's New dialog once per console release
- reopen the dialog whenever the sidebar version number is clicked
- share the behavior across the admin and chat sidebars
- keep release highlights version-aligned and capped at four short bullets
- document the release-maintenance step and add an Unreleased changelog entry

## Why

Users currently have no lightweight in-product way to discover what changed after upgrading. This adds a small, release-scoped update surface without repeatedly interrupting returning users.

## User impact

The current release dialog opens automatically once per browser profile. Its seen state is stored locally per version, while clicking the version footer always opens it again. A full GitHub release-notes link remains available for details.

## Validation

- `npm run format`
- `npm run lint`
- `npm --workspace console run test` — 95 files, 871 tests passed
- `npm --workspace console run build`
- `git diff --check`