### PR TITLE
fix: enforce web fetch timeout

### DIFF
--- a/container/src/web-fetch.ts
+++ b/container/src/web-fetch.ts
@@ -43,6 +43,39 @@ const BROWSER_USER_AGENT =
 export const BOT_USER_AGENT =
   'hybridclaw/1.0 (+https://github.com/hybridaione/hybridclaw; AI assistant bot)';
 
+function createWebFetchTimeoutError(): Error {
+  const error = new Error(`Web fetch timed out after ${TIMEOUT_MS}ms`);
+  error.name = 'TimeoutError';
+  return error;
+}
+
+function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : createWebFetchTimeoutError();
+}
+
+function rejectOnAbort<T>(
+  operation: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(abortError(signal));
+    signal.addEventListener('abort', onAbort, { once: true });
+    operation.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      },
+    );
+    if (signal.aborted) onAbort();
+  });
+}
+
 interface CacheEntry {
   value: WebFetchResult;
   expiresAt: number;
@@ -225,6 +258,7 @@ async function extractReadableContent(
 async function readResponseText(
   res: Response,
   maxBytes: number,
+  signal: AbortSignal,
 ): Promise<{ text: string; truncated: boolean }> {
   const body = res.body;
   if (body && typeof body === 'object' && 'getReader' in body) {
@@ -233,10 +267,16 @@ async function readResponseText(
     let bytesRead = 0;
     let truncated = false;
     const parts: string[] = [];
+    const cancelOnAbort = () => {
+      void reader.cancel(abortError(signal)).catch(() => {});
+    };
+    signal.addEventListener('abort', cancelOnAbort, { once: true });
+    if (signal.aborted) cancelOnAbort();
 
     try {
       while (true) {
         const { value, done } = await reader.read();
+        if (signal.aborted) throw abortError(signal);
         if (done) break;
         if (!value || value.byteLength === 0) continue;
 
@@ -259,8 +299,10 @@ async function readResponseText(
         }
       }
     } catch {
+      if (signal.aborted) throw abortError(signal);
       /* return what we have */
     } finally {
+      signal.removeEventListener('abort', cancelOnAbort);
       if (truncated) {
         try {
           await reader.cancel();
@@ -274,7 +316,7 @@ async function readResponseText(
     return { text: parts.join(''), truncated };
   }
 
-  const text = await res.text();
+  const text = await rejectOnAbort(res.text(), signal);
   return { text, truncated: false };
 }
 
@@ -550,9 +592,11 @@ export async function webFetch(params: {
 
   const start = Date.now();
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
-
-  try {
+  const timer = setTimeout(
+    () => controller.abort(createWebFetchTimeoutError()),
+    TIMEOUT_MS,
+  );
+  const operation = (async (): Promise<WebFetchResult> => {
     // The initial fetch and optional Cloudflare retry share one overall timeout
     // budget; we intentionally do not reset the timer per attempt.
     const doFetch = (userAgent: string) =>
@@ -573,7 +617,11 @@ export async function webFetch(params: {
       res.headers.get('content-type') ?? 'application/octet-stream';
     const normalizedContentType =
       contentType.split(';')[0]?.trim() || 'application/octet-stream';
-    const bodyResult = await readResponseText(res, MAX_RESPONSE_BYTES);
+    const bodyResult = await readResponseText(
+      res,
+      MAX_RESPONSE_BYTES,
+      controller.signal,
+    );
     const body = bodyResult.text;
 
     let title: string | undefined;
@@ -644,6 +692,10 @@ export async function webFetch(params: {
 
     writeCache(cacheKey, result);
     return result;
+  })();
+
+  try {
+    return await rejectOnAbort(operation, controller.signal);
   } finally {
     clearTimeout(timer);
   }

--- a/tests/unit/web-fetch.test.ts
+++ b/tests/unit/web-fetch.test.ts
@@ -1,10 +1,74 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.resetModules();
   vi.doUnmock('node:dns/promises');
   vi.unstubAllGlobals();
+});
+
+describe('web fetch timeout', () => {
+  it('rejects and cancels a response body that stalls after headers', async () => {
+    vi.useFakeTimers();
+    const cancelMock = vi.fn();
+    const stalledBody = new ReadableStream<Uint8Array>({
+      cancel: cancelMock,
+    });
+    const fetchMock = vi.fn(async () => {
+      return new Response(stalledBody, {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { webFetch } = await import('../../container/src/web-fetch.js');
+    const outcome = webFetch({
+      url: 'https://93.184.216.34/stalled-body',
+      extractMode: 'text',
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(await outcome).toMatchObject({
+      name: 'TimeoutError',
+      message: 'Web fetch timed out after 30000ms',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(cancelMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when the SSRF DNS lookup does not settle', async () => {
+    vi.useFakeTimers();
+    const lookupMock = vi.fn(
+      () => new Promise<never>(() => undefined),
+    );
+    vi.doMock('node:dns/promises', () => ({ lookup: lookupMock }));
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { webFetch } = await import('../../container/src/web-fetch.js');
+    const outcome = webFetch({
+      url: 'https://stalled.example/resource',
+      extractMode: 'text',
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(await outcome).toMatchObject({
+      name: 'TimeoutError',
+      message: 'Web fetch timed out after 30000ms',
+    });
+    expect(lookupMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('web fetch Cloudflare challenge retry', () => {


### PR DESCRIPTION
## Summary

- enforce the existing 30-second `web_fetch` deadline across DNS checks, redirects, response headers, and response-body reads
- explicitly cancel a stalled response reader when the deadline expires
- return a typed `TimeoutError` instead of leaving the agent turn pending
- add regression tests for stalled response bodies and stalled SSRF DNS lookups

## Root cause

The timeout callback only called `AbortController.abort()`. Once Node's `fetch()` had resolved with response headers, `readResponseText()` awaited `reader.read()` without a deadline. On the affected response, aborting the original fetch signal did not settle that body-read promise. The SSRF DNS lookup was also outside the abortable boundary.

As a result, `web_fetch` could remain pending until the user interrupted the entire agent process.

## Impact

Stalled fetches now reject after 30 seconds, release the response reader, and return an error that existing timeout/retry classification can understand. Normal response extraction, caching, redirects, and SSRF policy are unchanged.

## Validation

- `npm run format`
- `npm run lint`
- `npm --prefix container run lint`
- `npm run build`
- `vitest run tests/unit/web-fetch.test.ts tests/ipc.test.ts tests/container.auxiliary-task-tools.test.ts` — 13 tests passed
- `git diff --check`
- reproduced against `https://www.hybridclaw.io/docs/reference/commands`: `TimeoutError` returned after 30,002 ms instead of hanging