### PR TITLE
docs: expand Microsoft Teams channel setup

### DIFF
--- a/docs/content/channels/msteams.md
+++ b/docs/content/channels/msteams.md
@@ -61,7 +61,8 @@ is not required.
    prompted.
 3. Enter the **Application (client) ID** from Step 1. If Azure asks for a tenant
    ID, enter the **Directory (tenant) ID** from the same app registration.
-4. Set the bot's messaging endpoint to:
+4. Set the bot's messaging endpoint. For a HybridClaw Cloud instance, replace
+   the placeholder with the cloud hostname assigned to your instance:
 
    ```text
    https://u-xxxxxxxxxxxx.sbx.hybridai.one/api/msteams/messages
@@ -70,18 +71,19 @@ is not required.
 5. In the Azure Bot resource, open **Settings** -> **Channels** and enable the
    **Microsoft Teams** channel.
 
-The endpoint above is for the hosted HybridClaw environment used by this guide.
-For a different cloud or self-hosted deployment, use its public HTTPS origin
-with the same path:
+The `u-xxxxxxxxxxxx.sbx.hybridai.one` pattern applies only to HybridClaw Cloud
+instances. For a local HybridClaw instance, first open a public HTTPS tunnel
+using ngrok or Tailscale Funnel. Follow
+[Configure Local With A Public Tunnel](../getting-started/local-vs-cloud.md#configure-local-with-a-public-tunnel),
+then use the tunnel's public hostname with the same path:
 
 ```text
-https://<your-public-host>/api/msteams/messages
+https://<your-tunnel-host>/api/msteams/messages
 ```
 
-For local testing, expose the gateway's HTTP port through an HTTPS tunnel or
-reverse proxy first. The local endpoint is
-`http://127.0.0.1:9090/api/msteams/messages`, but Azure Bot must be configured
-with the public HTTPS URL.
+The local gateway endpoint is
+`http://127.0.0.1:9090/api/msteams/messages`, but Azure Bot cannot call that
+loopback address and must be configured with the public tunnel URL.
 
 ## Step 5: Create and download the Teams app
 

--- a/docs/content/channels/msteams.md
+++ b/docs/content/channels/msteams.md
@@ -1,137 +1,165 @@
 ---
 title: Microsoft Teams
-description: Configure Microsoft Teams with Entra credentials, Azure Bot setup, and the HybridClaw webhook endpoint.
+description: Configure Microsoft Teams with an Entra app, Azure Bot resource, Teams app package, and HybridClaw credentials.
 sidebar_position: 9
 ---
 
 # Microsoft Teams
 
-HybridClaw uses the Microsoft Bot Framework webhook flow for Teams. You need
-three things before it can receive messages:
-
-1. A Microsoft Entra app registration for the bot
-2. An Azure Bot resource with the Microsoft Teams channel enabled
-3. A public HTTPS endpoint that forwards to your local gateway
+HybridClaw uses the Microsoft Bot Framework webhook flow for Teams. The same
+single-tenant Microsoft Entra application ID connects the Entra app
+registration, HybridClaw channel, Azure Bot resource, and Teams app.
 
 For shared browser and local config surfaces, also see
 [Admin Console](./admin-console.md), [Local Config And Secrets](./local-config-and-secrets.md),
 and [Policies And Allowlists](./policies-and-allowlists.md).
 
-## 1. Get the bot credentials
+## Step 1: Create the Entra app registration
 
-In the Azure portal:
+1. Open the
+   [Microsoft Entra app registration form](https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/CreateApplicationBlade/quickStartType~/null/isMSAApp~/false).
+2. Enter a name for the app.
+3. For **Supported account types**, select **Accounts in this organizational
+   directory only (Single tenant)**.
+4. Leave **Redirect URI** empty. The Teams bot channel does not need one.
+5. Register the app.
+6. From the app's **Overview** page, copy both:
+   - **Application (client) ID**
+   - **Directory (tenant) ID**
 
-1. Open `Microsoft Entra ID` -> `App registrations`
-2. Create or open the app registration used by your bot
-3. Copy:
-   - `Application (client) ID` -> use as `--app-id`
-   - `Directory (tenant) ID` -> use as `--tenant-id`
-4. Open `Certificates & secrets` -> `New client secret`
-5. Copy the secret `Value` immediately -> use as `--app-password`
+Keep the app page open. You need it again when creating the client secret.
 
-If you do not already have a bot resource, create an `Azure Bot` resource and
-connect it to that app registration, then enable the Microsoft Teams channel on
-that bot.
+## Step 2: Enable the channel in HybridClaw
 
-## 2. Save the credentials in HybridClaw
+1. Open `/admin/channels#msteams`.
+2. Open the **Microsoft Teams** channel.
+3. Turn on **Enabled**.
+4. Paste the **Application (client) ID** into **App ID**.
+5. Paste the **Directory (tenant) ID** into **Tenant ID**.
+6. Save the channel settings.
+
+## Step 3: Create and save the client secret
+
+1. Return to the Entra app registration.
+2. Open **Certificates & secrets** -> **Client secrets**.
+3. Create a client secret and copy its **Value** immediately. Microsoft only
+   displays that value once.
+4. Open `/admin/credentials?tab=secrets` in HybridClaw.
+5. Create or update the secret named `MSTEAMS_APP_PASSWORD` and use the copied
+   client secret value as its password.
+
+Use the client secret **Value**, not its **Secret ID**. On a running gateway,
+setting or rotating `MSTEAMS_APP_PASSWORD` from the Credentials page refreshes
+the Teams credential and Bot Framework adapter in process. A container restart
+is not required.
+
+## Step 4: Create the Azure Bot resource
+
+1. Open the [Azure portal](https://portal.azure.com/) and create an **Azure
+   Bot** resource.
+2. Select **Single Tenant** and **Use existing app registration** when
+   prompted.
+3. Enter the **Application (client) ID** from Step 1. If Azure asks for a tenant
+   ID, enter the **Directory (tenant) ID** from the same app registration.
+4. Set the bot's messaging endpoint to:
+
+   ```text
+   https://u-sp57rprd6kv7akzh.sbx.hybridai.one/api/msteams/messages
+   ```
+
+5. In the Azure Bot resource, open **Settings** -> **Channels** and enable the
+   **Microsoft Teams** channel.
+
+The endpoint above is for the hosted HybridClaw environment used by this guide.
+For a different cloud or self-hosted deployment, use its public HTTPS origin
+with the same path:
+
+```text
+https://<your-public-host>/api/msteams/messages
+```
+
+For local testing, expose the gateway's HTTP port through an HTTPS tunnel or
+reverse proxy first. The local endpoint is
+`http://127.0.0.1:9090/api/msteams/messages`, but Azure Bot must be configured
+with the public HTTPS URL.
+
+## Step 5: Create and download the Teams app
+
+1. Open the [Teams Developer Portal](https://dev.teams.cloud.microsoft/) and
+   create a Teams app.
+2. Use the **Application (client) ID** from Step 1 as the app ID.
+3. Under **Features**, add or enable **Bot**.
+4. Use the same **Application (client) ID** for the bot and enable these scopes:
+   - **Personal**
+   - **Team**
+5. Save the app, open **Publish**, and download the app package.
+
+Keep the downloaded `.zip` file intact. It is the package uploaded in the next
+step.
+
+## Step 6: Upload the app for your organization
+
+1. Open the [Teams admin center](https://admin.teams.microsoft.com/).
+2. Go to **Teams apps** -> **Manage apps**.
+3. Select **Upload new app** and upload the `.zip` package downloaded from the
+   Teams Developer Portal.
+4. Make the app available to the intended users through your organization's
+   Teams app policies.
+
+The app can take some time to appear in the organization's Teams app catalog.
+
+## Step 7: Verify the setup
+
+1. Install the app from your organization's Teams app catalog.
+2. Open a direct message with the bot and send `hello`.
+3. Add the app to a team and send `@BotName hello` in a channel.
+4. Confirm the bot replies in both places.
+
+Team channel messages require a mention by default. A plain `hello` in a team
+channel does not trigger a reply unless you change the Teams policy in
+HybridClaw.
+
+## Troubleshooting: the bot does not respond
+
+The default DM policy is `allowlist`, so the bot does not respond to a direct
+message until the sender is allowed.
+
+1. Open `/admin/channels#msteams` and select the **Microsoft Teams** channel.
+2. Expand **Advanced delivery settings**.
+3. Either:
+   - add your Microsoft Entra user object ID to **Allowed AAD object IDs**, or
+   - temporarily change **DM policy** from `allowlist` to `open`
+4. Save the channel settings and send another direct message to the bot.
+
+Using `open` allows any user who can reach the bot to send it direct messages.
+Prefer adding stable AAD object IDs before wider use. Do not use display names
+unless there is no alternative: display names are mutable and not guaranteed
+to be unique.
+
+If direct messages work but team channel messages do not, check **Group policy**
+in the same section, verify the app was added to that team, and mention the bot
+in the message.
+
+If authentication fails, confirm that `MSTEAMS_APP_PASSWORD` contains the
+client secret **Value**, that the secret has not expired, and that all four
+resources use the same Application (client) ID.
+
+## CLI alternative
+
+You can save the same three HybridClaw values from the command line instead of
+Steps 2 and 3:
 
 ```bash
 hybridclaw auth login msteams --app-id <APP_ID> --tenant-id <TENANT_ID> --app-password <APP_PASSWORD>
 ```
 
-If you want interactive prompts instead:
+For interactive prompts, run:
 
 ```bash
 hybridclaw auth login msteams
 ```
 
-That interactive flow prompts for:
-- app id
-- app password
-- tenant id (optional)
-
-Check what HybridClaw saved:
-
-```bash
-hybridclaw auth status msteams
-```
-
-On a running gateway, setting or rotating `MSTEAMS_APP_PASSWORD` from
-`/admin/credentials?tab=secrets` refreshes the Teams credential and Bot Framework adapter in
-process. A container restart is not required.
-
-By default, Teams DMs and group channels start in `allowlist` mode. That means
-the bot will not answer anyone until you explicitly allow AAD object IDs in
-config or open a specific team/channel policy for testing.
-
-Do not rely on display names in `allowFrom` unless you have no alternative.
-`msteams.dangerouslyAllowNameMatching` is intentionally dangerous:
-- Teams display names are mutable
-- display names are not guaranteed to be unique
-- a name-based allowlist grant is logged with a warning so you can find and
-  remove it later
-
-Prefer stable AAD object IDs in `msteams.allowFrom`.
-
-## 3. Start the gateway
-
-```bash
-hybridclaw gateway restart --foreground
-```
-
-If the gateway is already running and you have the admin UI open, you can also
-go to `/admin/gateway` and click `Reload Gateway`.
-
-By default, Teams messages are served from the gateway HTTP port at:
-
-```text
-http://127.0.0.1:9090/api/msteams/messages
-```
-
-## 4. Expose the webhook on HTTPS
-
-Teams needs a public HTTPS URL. For local testing, expose the gateway with a
-tunnel such as `ngrok`:
-
-```bash
-ngrok http 9090
-```
-
-Take the public HTTPS URL and use this as your Teams messaging endpoint:
-
-```text
-https://<your-public-host>/api/msteams/messages
-```
-
-## 5. Register the webhook in Azure
-
-In your Azure Bot resource, set the bot messaging endpoint to:
-
-```text
-https://<your-public-host>/api/msteams/messages
-```
-
-Then confirm the Microsoft Teams channel is enabled for that bot.
-
-## 6. Verify the setup
-
-For a quick test, either:
-
-1. temporarily set `msteams.dmPolicy` / `msteams.groupPolicy` to `open`, or
-2. add your own AAD object ID to `msteams.allowFrom`
-
-1. Open a DM with the bot in Microsoft Teams and send `hello`
-2. Confirm the bot replies
-3. Add the bot to a Team/channel and send `@BotName hello`
-4. Confirm the bot replies in-channel
-
-Channel messages require a mention by default, so a plain `hello` in a Team
-channel should not trigger a reply unless you change the Teams policy in
-runtime config.
-
-## 7. Clean up or reset
-
-Use these commands when you need to inspect or remove the setup:
+Inspect or remove the saved setup with:
 
 ```bash
 hybridclaw help msteams

--- a/docs/content/channels/msteams.md
+++ b/docs/content/channels/msteams.md
@@ -64,7 +64,7 @@ is not required.
 4. Set the bot's messaging endpoint to:
 
    ```text
-   https://u-sp57rprd6kv7akzh.sbx.hybridai.one/api/msteams/messages
+   https://u-xxxxxxxxxxxx.sbx.hybridai.one/api/msteams/messages
    ```
 
 5. In the Azure Bot resource, open **Settings** -> **Channels** and enable the

--- a/docs/msteams.md
+++ b/docs/msteams.md
@@ -54,7 +54,7 @@ is not required.
 4. Set the bot's messaging endpoint to:
 
    ```text
-   https://u-sp57rprd6kv7akzh.sbx.hybridai.one/api/msteams/messages
+   https://u-xxxxxxxxxxxx.sbx.hybridai.one/api/msteams/messages
    ```
 
 5. In the Azure Bot resource, open **Settings** -> **Channels** and enable the

--- a/docs/msteams.md
+++ b/docs/msteams.md
@@ -51,7 +51,8 @@ is not required.
    prompted.
 3. Enter the **Application (client) ID** from Step 1. If Azure asks for a tenant
    ID, enter the **Directory (tenant) ID** from the same app registration.
-4. Set the bot's messaging endpoint to:
+4. Set the bot's messaging endpoint. For a HybridClaw Cloud instance, replace
+   the placeholder with the cloud hostname assigned to your instance:
 
    ```text
    https://u-xxxxxxxxxxxx.sbx.hybridai.one/api/msteams/messages
@@ -60,18 +61,19 @@ is not required.
 5. In the Azure Bot resource, open **Settings** -> **Channels** and enable the
    **Microsoft Teams** channel.
 
-The endpoint above is for the hosted HybridClaw environment used by this guide.
-For a different cloud or self-hosted deployment, use its public HTTPS origin
-with the same path:
+The `u-xxxxxxxxxxxx.sbx.hybridai.one` pattern applies only to HybridClaw Cloud
+instances. For a local HybridClaw instance, first open a public HTTPS tunnel
+using ngrok or Tailscale Funnel. Follow
+[Configure Local With A Public Tunnel](./content/getting-started/local-vs-cloud.md#configure-local-with-a-public-tunnel),
+then use the tunnel's public hostname with the same path:
 
 ```text
-https://<your-public-host>/api/msteams/messages
+https://<your-tunnel-host>/api/msteams/messages
 ```
 
-For local testing, expose the gateway's HTTP port through an HTTPS tunnel or
-reverse proxy first. The local endpoint is
-`http://127.0.0.1:9090/api/msteams/messages`, but Azure Bot must be configured
-with the public HTTPS URL.
+The local gateway endpoint is
+`http://127.0.0.1:9090/api/msteams/messages`, but Azure Bot cannot call that
+loopback address and must be configured with the public tunnel URL.
 
 ## Step 5: Create and download the Teams app
 

--- a/docs/msteams.md
+++ b/docs/msteams.md
@@ -1,124 +1,155 @@
-# Setting Up MS Teams
+# Setting Up Microsoft Teams
 
-HybridClaw uses the Microsoft Bot Framework webhook flow for Teams. You need
-three things before it can receive messages:
+HybridClaw uses the Microsoft Bot Framework webhook flow for Teams. The same
+single-tenant Microsoft Entra application ID connects the Entra app
+registration, HybridClaw channel, Azure Bot resource, and Teams app.
 
-1. A Microsoft Entra app registration for the bot
-2. An Azure Bot resource with the Microsoft Teams channel enabled
-3. A public HTTPS endpoint that forwards to your local gateway
+## Step 1: Create the Entra app registration
 
-## 1. Get the bot credentials
+1. Open the
+   [Microsoft Entra app registration form](https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/CreateApplicationBlade/quickStartType~/null/isMSAApp~/false).
+2. Enter a name for the app.
+3. For **Supported account types**, select **Accounts in this organizational
+   directory only (Single tenant)**.
+4. Leave **Redirect URI** empty. The Teams bot channel does not need one.
+5. Register the app.
+6. From the app's **Overview** page, copy both:
+   - **Application (client) ID**
+   - **Directory (tenant) ID**
 
-In the Azure portal:
+Keep the app page open. You need it again when creating the client secret.
 
-1. Open `Microsoft Entra ID` -> `App registrations`
-2. Create or open the app registration used by your bot
-3. Copy:
-   - `Application (client) ID` -> use as `--app-id`
-   - `Directory (tenant) ID` -> use as `--tenant-id`
-4. Open `Certificates & secrets` -> `New client secret`
-5. Copy the secret `Value` immediately -> use as `--app-password`
+## Step 2: Enable the channel in HybridClaw
 
-If you do not already have a bot resource, create an `Azure Bot` resource and
-connect it to that app registration, then enable the Microsoft Teams channel on
-that bot.
+1. Open `/admin/channels#msteams`.
+2. Open the **Microsoft Teams** channel.
+3. Turn on **Enabled**.
+4. Paste the **Application (client) ID** into **App ID**.
+5. Paste the **Directory (tenant) ID** into **Tenant ID**.
+6. Save the channel settings.
 
-## 2. Save the credentials in HybridClaw
+## Step 3: Create and save the client secret
+
+1. Return to the Entra app registration.
+2. Open **Certificates & secrets** -> **Client secrets**.
+3. Create a client secret and copy its **Value** immediately. Microsoft only
+   displays that value once.
+4. Open `/admin/credentials?tab=secrets` in HybridClaw.
+5. Create or update the secret named `MSTEAMS_APP_PASSWORD` and use the copied
+   client secret value as its password.
+
+Use the client secret **Value**, not its **Secret ID**. On a running gateway,
+setting or rotating `MSTEAMS_APP_PASSWORD` from the Credentials page refreshes
+the Teams credential and Bot Framework adapter in process. A container restart
+is not required.
+
+## Step 4: Create the Azure Bot resource
+
+1. Open the [Azure portal](https://portal.azure.com/) and create an **Azure
+   Bot** resource.
+2. Select **Single Tenant** and **Use existing app registration** when
+   prompted.
+3. Enter the **Application (client) ID** from Step 1. If Azure asks for a tenant
+   ID, enter the **Directory (tenant) ID** from the same app registration.
+4. Set the bot's messaging endpoint to:
+
+   ```text
+   https://u-sp57rprd6kv7akzh.sbx.hybridai.one/api/msteams/messages
+   ```
+
+5. In the Azure Bot resource, open **Settings** -> **Channels** and enable the
+   **Microsoft Teams** channel.
+
+The endpoint above is for the hosted HybridClaw environment used by this guide.
+For a different cloud or self-hosted deployment, use its public HTTPS origin
+with the same path:
+
+```text
+https://<your-public-host>/api/msteams/messages
+```
+
+For local testing, expose the gateway's HTTP port through an HTTPS tunnel or
+reverse proxy first. The local endpoint is
+`http://127.0.0.1:9090/api/msteams/messages`, but Azure Bot must be configured
+with the public HTTPS URL.
+
+## Step 5: Create and download the Teams app
+
+1. Open the [Teams Developer Portal](https://dev.teams.cloud.microsoft/) and
+   create a Teams app.
+2. Use the **Application (client) ID** from Step 1 as the app ID.
+3. Under **Features**, add or enable **Bot**.
+4. Use the same **Application (client) ID** for the bot and enable these scopes:
+   - **Personal**
+   - **Team**
+5. Save the app, open **Publish**, and download the app package.
+
+Keep the downloaded `.zip` file intact. It is the package uploaded in the next
+step.
+
+## Step 6: Upload the app for your organization
+
+1. Open the [Teams admin center](https://admin.teams.microsoft.com/).
+2. Go to **Teams apps** -> **Manage apps**.
+3. Select **Upload new app** and upload the `.zip` package downloaded from the
+   Teams Developer Portal.
+4. Make the app available to the intended users through your organization's
+   Teams app policies.
+
+The app can take some time to appear in the organization's Teams app catalog.
+
+## Step 7: Verify the setup
+
+1. Install the app from your organization's Teams app catalog.
+2. Open a direct message with the bot and send `hello`.
+3. Add the app to a team and send `@BotName hello` in a channel.
+4. Confirm the bot replies in both places.
+
+Team channel messages require a mention by default. A plain `hello` in a team
+channel does not trigger a reply unless you change the Teams policy in
+HybridClaw.
+
+## Troubleshooting: the bot does not respond
+
+The default DM policy is `allowlist`, so the bot does not respond to a direct
+message until the sender is allowed.
+
+1. Open `/admin/channels#msteams` and select the **Microsoft Teams** channel.
+2. Expand **Advanced delivery settings**.
+3. Either:
+   - add your Microsoft Entra user object ID to **Allowed AAD object IDs**, or
+   - temporarily change **DM policy** from `allowlist` to `open`
+4. Save the channel settings and send another direct message to the bot.
+
+Using `open` allows any user who can reach the bot to send it direct messages.
+Prefer adding stable AAD object IDs before wider use. Do not use display names
+unless there is no alternative: display names are mutable and not guaranteed
+to be unique.
+
+If direct messages work but team channel messages do not, check **Group policy**
+in the same section, verify the app was added to that team, and mention the bot
+in the message.
+
+If authentication fails, confirm that `MSTEAMS_APP_PASSWORD` contains the
+client secret **Value**, that the secret has not expired, and that all four
+resources use the same Application (client) ID.
+
+## CLI alternative
+
+You can save the same three HybridClaw values from the command line instead of
+Steps 2 and 3:
 
 ```bash
 hybridclaw auth login msteams --app-id <APP_ID> --tenant-id <TENANT_ID> --app-password <APP_PASSWORD>
 ```
 
-If you want interactive prompts instead:
+For interactive prompts, run:
 
 ```bash
 hybridclaw auth login msteams
 ```
 
-That interactive flow prompts for:
-- app id
-- app password
-- tenant id (optional)
-
-Check what HybridClaw saved:
-
-```bash
-hybridclaw auth status msteams
-```
-
-On a running gateway, setting or rotating `MSTEAMS_APP_PASSWORD` from
-`/admin/credentials?tab=secrets` refreshes the Teams credential and Bot Framework adapter in
-process. A container restart is not required.
-
-By default, Teams DMs and group channels start in `allowlist` mode. That means
-the bot will not answer anyone until you explicitly allow AAD object IDs in
-config or open a specific team/channel policy for testing.
-
-Do not rely on display names in `allowFrom` unless you have no alternative.
-`msteams.dangerouslyAllowNameMatching` is intentionally dangerous:
-- Teams display names are mutable
-- display names are not guaranteed to be unique
-- a name-based allowlist grant is logged with a warning so you can find and
-  remove it later
-
-Prefer stable AAD object IDs in `msteams.allowFrom`.
-
-## 3. Start the gateway
-
-```bash
-hybridclaw gateway restart --foreground
-```
-
-By default, Teams messages are served from the gateway HTTP port at:
-
-```text
-http://127.0.0.1:9090/api/msteams/messages
-```
-
-## 4. Expose the webhook on HTTPS
-
-Teams needs a public HTTPS URL. For local testing, expose the gateway with a
-tunnel such as `ngrok`:
-
-```bash
-ngrok http 9090
-```
-
-Take the public HTTPS URL and use this as your Teams messaging endpoint:
-
-```text
-https://<your-public-host>/api/msteams/messages
-```
-
-## 5. Register the webhook in Azure
-
-In your Azure Bot resource, set the bot messaging endpoint to:
-
-```text
-https://<your-public-host>/api/msteams/messages
-```
-
-Then confirm the Microsoft Teams channel is enabled for that bot.
-
-## 6. Verify the setup
-
-For a quick test, either:
-
-1. temporarily set `msteams.dmPolicy` / `msteams.groupPolicy` to `open`, or
-2. add your own AAD object ID to `msteams.allowFrom`
-
-1. Open a DM with the bot in Microsoft Teams and send `hello`
-2. Confirm the bot replies
-3. Add the bot to a Team/channel and send `@BotName hello`
-4. Confirm the bot replies in-channel
-
-Channel messages require a mention by default, so a plain `hello` in a Team
-channel should not trigger a reply unless you change the Teams policy in
-runtime config.
-
-## 7. Clean up or reset
-
-Use these commands when you need to inspect or remove the setup:
+Inspect or remove the saved setup with:
 
 ```bash
 hybridclaw help msteams


### PR DESCRIPTION
## Summary

- document the complete single-tenant Entra app registration and HybridClaw admin setup
- add client-secret, Azure Bot, Teams Developer Portal, and organization app-upload steps
- show an anonymized cloud messaging-endpoint pattern and clearly mark it as cloud-only
- link local operators to the ngrok and Tailscale Funnel setup before configuring the Azure Bot endpoint
- add DM allowlist and group-channel troubleshooting
- keep the canonical and legacy Teams guides aligned

## Why

The existing guide covered credentials and the Azure webhook but omitted the Teams app package and organization distribution workflow. It also did not show the browser-based HybridClaw configuration path or explain the default DM allowlist behavior that can make a correctly configured bot appear unresponsive. Cloud and local endpoint requirements also needed to be distinguished: local gateways require a public HTTPS tunnel before Azure Bot can deliver messages.

## Impact

Operators now have an end-to-end setup path from Entra registration through installing and testing the Teams app, including the most common no-response remediation. Concrete sandbox deployment hostnames are not exposed, and local operators are directed to the existing ngrok and Tailscale Funnel instructions.

## Validation

- `npm run format`
- `npm run lint`
- `./node_modules/.bin/vitest run tests/docs-viewer.test.ts tests/gateway-http-docs.integration.test.ts` (47 tests passed)
- `git diff --check`
- verified the local tunnel guide link and heading anchor
- scanned the tracked repository to confirm the real sandbox hostname is absent; remaining sandbox hosts are anonymized documentation or synthetic test fixtures
