### PR TITLE
fix(console): allow inline PDF blob previews

### DIFF
--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -3121,10 +3121,13 @@ function serveConsoleFile(
     'X-Content-Type-Options': 'nosniff',
     'Referrer-Policy': 'no-referrer',
     'Cross-Origin-Opener-Policy': 'same-origin',
+    // Some browsers apply frame-ancestors to PDF blob previews created here.
+    // X-Frame-Options keeps the console unframeable without blocking its blobs.
+    'X-Frame-Options': 'DENY',
     ...(isIndex
       ? {
           'Content-Security-Policy':
-            "default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data: blob:; media-src 'self' blob:; frame-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ws: wss:",
+            "default-src 'self'; base-uri 'none'; object-src 'none'; form-action 'self'; img-src 'self' data: blob:; media-src 'self' blob:; frame-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ws: wss:",
         }
       : {}),
   });

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -3173,11 +3173,15 @@ describe('gateway HTTP server', () => {
       expect(res.body).not.toContain('web-token');
       expect(res.headers['X-Content-Type-Options']).toBe('nosniff');
       expect(res.headers['Referrer-Policy']).toBe('no-referrer');
+      expect(res.headers['X-Frame-Options']).toBe('DENY');
       expect(res.headers['Content-Security-Policy']).toContain(
         "default-src 'self'",
       );
       expect(res.headers['Content-Security-Policy']).toContain(
         "frame-src 'self' blob:",
+      );
+      expect(res.headers['Content-Security-Policy']).not.toContain(
+        'frame-ancestors',
       );
     }
   });


### PR DESCRIPTION
## Summary

- allow authenticated PDF blob previews to render inline in `/chat`
- keep the console protected from framing with `X-Frame-Options: DENY`
- add regression coverage for the console framing headers

## Root cause

The console response combined `frame-src 'self' blob:` with `frame-ancestors 'none'`. Some browsers apply the console CSP to PDF blob documents created by the page, causing the blob to reject its own preview iframe even though the parent permits `blob:` frame sources.

## Impact

Generated PDF artifacts display inline again. Clickjacking protection remains deny-by-default through `X-Frame-Options: DENY`; artifact authentication and MIME-type pinning are unchanged.

## Validation

- `npm run format` (completed; existing advisory warnings only)
- `npm run lint`
- `./node_modules/.bin/vitest run tests/gateway-http-server.test.ts` — 378 passed
- `npm --prefix console test -- src/routes/chat/message-block.test.tsx` — 32 passed
- generated PDF visually verified inside the preview frame in Google Chrome with no console errors
