### PR TITLE
chore: release v0.28.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ HybridClaw is a personal AI assistant bot for Discord, powered by HybridAI.
 Enterprise-grade Node.js 22 application with gateway service, TUI client, and
 Docker-sandboxed container runtime.
 
-**Version:** 0.12.6 &ensp;|&ensp; **Package:** `@hybridaione/hybridclaw`
+**Version:** 0.28.4 &ensp;|&ensp; **Package:** `@hybridaione/hybridclaw`
 &ensp;|&ensp; **License:** see `LICENSE`
 
 Architecture: gateway (core runtime, SQLite persistence, REST API, Discord

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,68 @@
 
 ## Unreleased
 
+## [0.28.4](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.4) - 2026-07-24
+
 ### Added
 
 - **Once-per-release console updates**: The admin console shows an ultra-short
   What's New dialog once for each release, and the sidebar version number
   reopens it on demand.
+- **Complete Microsoft Teams setup in the console**: The Channels workspace can
+  store the required Teams app password in encrypted runtime secrets, reports
+  whether it is configured, and does not mark Teams active until the app ID,
+  tenant ID, and password are all ready.
+
+### Changed
+
+- **Stable conversation prompt caching**: Static core instructions, workspace
+  memory, and skills use stable prompt segments; turn-local context sits beside
+  the latest user turn; and history trimming preserves complete messages.
+  Anthropic requests add cache breakpoints across stable prompt blocks and the
+  retained conversation prefix, improving reuse across tool loops and later
+  turns.
+- **Refined admin navigation and design system**: Admin tabs are searchable
+  from the command palette, clearer labels and icons make grouped workflows
+  easier to scan, Labs starts collapsed, and shared components plus visual
+  contract tests keep console surfaces consistent.
+- **Expanded Microsoft Teams guidance**: The channel documentation covers local
+  tunnel setup, Entra registration, client secrets, SSO values, manifest
+  packaging, installation, and troubleshooting as one end-to-end workflow.
+- **Age-eligible dependency refresh**: Pinned runtime and development packages
+  move to releases that satisfy the repository's minimum-age policy. Generated
+  metadata drops stale workspace lock entries and keeps Electron's newer
+  `undici` override scoped to its download helper.
+
+### Fixed
+
+- **HybridAI activity notifications show the actual user prompt**: Interactive
+  agent turns send the raw user text as transient request metadata, separately
+  from the compiled model context. Background turns omit the field, and
+  confidential values are redacted before the prompt crosses the sandbox
+  boundary.
+- **Shell approval inspection preserves heredoc boundaries**: Bash
+  classification keeps newlines while removing heredoc bodies, preventing
+  content such as PDF object keys from being misread as writes outside the
+  workspace.
+- **Web fetches respect their deadline**: DNS resolution, redirects, response
+  headers, and body streaming share an enforced timeout instead of allowing a
+  stalled phase to run indefinitely.
+- **Inline PDF previews work under the console CSP**: Blob-backed PDF artifacts
+  can render in the sandboxed preview while retaining their pinned PDF content
+  type.
+- **Microsoft Teams app icon visibility**: The manifest's outline icon uses a
+  white glyph on transparency so it remains visible in the Teams app rail.
+- **Release provenance audit setup**: The publish workflow installs every
+  component's dependencies before verifying npm registry signatures.
+- **CodeQL security hardening**: Managed-browser proxy connections resolve and
+  pin policy-checked addresses while rejecting private-network targets; docs
+  and static-file serving validate filesystem boundaries; channel and plugin
+  errors avoid exposing internal details; URL, hostname, and HTML parsing use
+  stricter validation; and non-credential content fingerprints use SHA-256.
 
 ## [0.28.3](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.3) - 2026-07-22
 
 ### Fixed
-
-- **HybridAI activity notifications now show the actual user prompt**:
-  interactive agent turns send the raw user text as transient request metadata,
-  separately from the compiled model context. Background turns omit the field,
-  and confidential values are redacted before the prompt crosses the sandbox
-  boundary.
 
 - **Prompt-cache usage is now visible through the OpenAI-compatible API**: the
   gateway parsed upstream cache reads and writes internally but dropped them

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Core pieces:
 | Build desktop releases | [Desktop Release Builds](https://hybridaione.github.io/hybridclaw/docs/developer-guide/desktop-release) |
 | Contribute | [CONTRIBUTING.md](./CONTRIBUTING.md), [docs/content/README.md](./docs/content/README.md) |
 
-Latest release: [v0.28.3](https://github.com/HybridAIOne/hybridclaw/releases/tag/v0.28.3).
+Latest release: [v0.28.4](https://github.com/HybridAIOne/hybridclaw/releases/tag/v0.28.4).
 Release notes: [CHANGELOG.md](./CHANGELOG.md)
 
 ## Development

--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hybridaione/hybridclaw-console",
   "private": true,
-  "version": "0.28.3",
+  "version": "0.28.4",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/console/src/release-notes.ts
+++ b/console/src/release-notes.ts
@@ -1,10 +1,10 @@
 export const LATEST_RELEASE_NOTES = {
-  version: '0.28.3',
+  version: '0.28.4',
   highlights: [
-    'Encrypted A2A gateway messaging.',
-    'Automatic model-tier failover.',
-    'Direct OpenAI API support.',
-    'Searchable admin settings.',
+    'Stable conversation prompt caching.',
+    'Refined admin navigation and design.',
+    'Guided Microsoft Teams setup.',
+    'Security and dependency hardening.',
   ],
 } as const;
 

--- a/container/npm-shrinkwrap.json
+++ b/container/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.28.3",
+      "version": "0.28.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/container/package-lock.json
+++ b/container/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.28.3",
+      "version": "0.28.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/container/package.json
+++ b/container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@hybridaione/hybridclaw-desktop",
   "productName": "HybridClaw",
   "private": true,
-  "version": "0.28.3",
+  "version": "0.28.4",
   "license": "MIT",
   "type": "module",
   "description": "macOS wrapper for the HybridClaw chat and admin web surfaces",

--- a/docs/content/README.md
+++ b/docs/content/README.md
@@ -27,7 +27,24 @@ doc at once, start from [For Agents](./agents.md).
 
 ## Latest Highlights
 
-- The next patch release adds deterministic model-tier routing for unpinned
+- HybridClaw v0.28.4 keeps conversation prefixes cache-stable across turns and
+  tool loops by separating static instructions, workspace memory, skills, and
+  turn-local context while preserving complete retained messages.
+- The console shows a short What's New dialog once per release, makes grouped
+  admin tabs searchable from the command palette, and applies shared components
+  and visual contracts consistently across admin workflows.
+- Microsoft Teams setup in Channels includes encrypted app-password storage,
+  complete readiness status, end-to-end Entra and tunnel guidance, and a
+  manifest icon that remains visible in the Teams app rail.
+- Security hardening pins policy-checked browser proxy addresses, validates
+  filesystem and hostname boundaries, avoids leaking internal channel errors,
+  and strengthens non-secret fingerprints. Shell approvals preserve heredoc
+  boundaries, web fetches enforce a shared deadline, and inline PDF previews
+  work under the console CSP.
+- Age-eligible dependency updates refresh pinned packages, remove stale
+  workspace lock entries, scope Electron's newer HTTP client override, and keep
+  third-party notices and signature audits aligned with every component.
+- HybridClaw v0.28.3 adds deterministic model-tier routing for unpinned
   turns: agents can start on a configured rung, system work starts at the
   lowest rung, retry-safe provider and output failures escalate with audit
   telemetry, successful escalation stays sticky, and `/escalate` raises one

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.28.3",
+      "version": "0.28.4",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -85,7 +85,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.28.3",
+      "version": "0.28.4",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "5.101.2",
@@ -111,7 +111,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.28.3",
+      "version": "0.28.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -139,7 +139,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.28.3",
+      "version": "0.28.4",
       "license": "MIT",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.28.3",
+      "version": "0.28.4",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -85,7 +85,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.28.3",
+      "version": "0.28.4",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "5.101.2",
@@ -111,7 +111,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.28.3",
+      "version": "0.28.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -139,7 +139,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.28.3",
+      "version": "0.28.4",
       "license": "MIT",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "type": "module",
   "description": "Enterprise-ready self-hosted AI assistant runtime with sandboxed execution, secure credentials, approvals, and memory",
   "license": "MIT",

--- a/scripts/dependency-policy-baseline.json
+++ b/scripts/dependency-policy-baseline.json
@@ -1,9 +1,9 @@
 {
   "lockfiles": {
-    "package-lock.json": "e10e167e473c87357891080df2253a4965ca8215a15578fd7d11ce8fc7fa6986",
-    "npm-shrinkwrap.json": "e10e167e473c87357891080df2253a4965ca8215a15578fd7d11ce8fc7fa6986",
-    "container/package-lock.json": "4cd51bce035c58ba708ae7e3642fffdd94d9cbda1c7a8dbdea756728aef12be1",
-    "container/npm-shrinkwrap.json": "4cd51bce035c58ba708ae7e3642fffdd94d9cbda1c7a8dbdea756728aef12be1",
+    "package-lock.json": "fa929eaa1a8a7a2373fdde74aa194e5a68c994c140d56efaa61f1ff8f8cfbb62",
+    "npm-shrinkwrap.json": "fa929eaa1a8a7a2373fdde74aa194e5a68c994c140d56efaa61f1ff8f8cfbb62",
+    "container/package-lock.json": "35807746f66699475cc7bb271d2589f654e350b413abecd5e99417ad1809e0e0",
+    "container/npm-shrinkwrap.json": "35807746f66699475cc7bb271d2589f654e350b413abecd5e99417ad1809e0e0",
     "plugins/brevo-email/package-lock.json": "3377225eb3bdbb252eaa28ad420b9a725ea1da533417388557aa1984730229b5",
     "plugins/whatsapp/package-lock.json": "a80140f6687804addf0416a443c1c578fed6d89771f6a03eee5adeccdd9bae86",
     "plugins/whatsapp/npm-shrinkwrap.json": "a80140f6687804addf0416a443c1c578fed6d89771f6a03eee5adeccdd9bae86"


### PR DESCRIPTION
## Summary

- bump HybridClaw and all synchronized product package metadata to `0.28.4`
- publish curated `0.28.4` changelog notes for every change since `v0.28.3`
- refresh the console What's New highlights and current-release README links
- update version-only lockfile hashes while preserving the dependency and CodeQL hardening already merged to `main`

## Why

This prepares the next patch release with consistent package versions, release documentation, lockfile policy approvals, and user-facing update notes.

## Impact

The PR contains release metadata and documentation only. It does not add another runtime behavior change on top of `main`; the changelog and popup describe the changes already merged since `v0.28.3`.

## Validation

- `npm run format`
- `npm run lint`
- `npm run build`
- `npm run deps:verify`
- `npm run release:check`
- `npm --prefix container run release:check`
- `npm run notices:check`
- `npm --workspace console run test -- src/release-notes.test.ts src/components/whats-new.test.tsx` (5 tests passed)

Full unit, integration, end-to-end, visual, and live suites were not rerun because this PR changes only release metadata and documentation.