### PR TITLE
fix: let agents pip install Python packages at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates \
       python3 \
       python3-pip \
+      python3-venv \
       python-is-python3 \
       unzip \
       file \
     && rm -rf /var/lib/apt/lists/*
+
+# Debian's PEP 668 marker makes bare `pip install` fail with
+# externally-managed-environment. This image is a disposable sandbox whose
+# agent runs as root, so the marker only blocks agents from installing the
+# Python packages they need at runtime; python3-venv above keeps the venv
+# route working too.
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 RUN python3 -m pip install --break-system-packages \
       openpyxl==3.1.5

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -31,7 +31,13 @@ RUN --mount=type=cache,target=/root/.npm \
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    ripgrep git curl python3 python3-pip python-is-python3 unzip file poppler-utils qpdf pandoc
+    ripgrep git curl python3 python3-pip python3-venv python-is-python3 unzip file poppler-utils qpdf pandoc
+
+# Debian's PEP 668 marker makes bare `pip install` fail with
+# externally-managed-environment. This image is a disposable sandbox, so the
+# marker only blocks agents from installing the Python packages they need at
+# runtime; python3-venv above keeps the venv route working too.
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install --break-system-packages \

--- a/tests/dockerfile-runtime-tools.test.ts
+++ b/tests/dockerfile-runtime-tools.test.ts
@@ -25,10 +25,19 @@ function expectSpreadsheetRuntimeTools(runtime: string): void {
   expect(runtime).toContain('openpyxl==3.1.5');
 }
 
+function expectRuntimePipInstallable(runtime: string): void {
+  // Agents must be able to `pip install` at runtime: Debian's PEP 668 marker
+  // otherwise rejects bare installs, and without python3-venv the venv escape
+  // hatch fails too (no ensurepip).
+  expect(runtime).toMatch(/\bpython3-venv\b/);
+  expect(runtime).toContain('PIP_BREAK_SYSTEM_PACKAGES=1');
+}
+
 describe('Docker runtime tool parity', () => {
   test('gateway host-sandbox runtime includes spreadsheet inspection tools', () => {
     const runtime = runtimeStage(readRepoFile('Dockerfile'), 'runtime');
     expectSpreadsheetRuntimeTools(runtime);
+    expectRuntimePipInstallable(runtime);
     expect(runtime).toContain(
       'NODE_PATH=/usr/local/lib/node_modules:/app/node_modules:/app/container/node_modules',
     );
@@ -48,6 +57,7 @@ describe('Docker runtime tool parity', () => {
       'runtime-lite',
     );
     expectSpreadsheetRuntimeTools(runtime);
+    expectRuntimePipInstallable(runtime);
     expect(runtime).toContain('@e965/xlsx@0.20.3');
     expect(runtime).toContain('xlsx-populate@1.21.0');
     expect(runtime).toContain(


### PR DESCRIPTION
## Problem

Agents in both sandbox images cannot install Python packages at runtime. The images are Debian bookworm, whose PEP 668 `EXTERNALLY-MANAGED` marker rejects every bare `pip install` with `externally-managed-environment` — and the venv escape hatch fails too, because `python3-venv` (`ensurepip`) is not installed.

Observed in the staging e2e2 PDF-artifact test (2026-07-24, 06:00 UTC monitor run): the agent needed `reportlab`, tried `pip install` (PEP 668 refusal), then `python3 -m venv` (no ensurepip), and was left hand-rolling a raw PDF with no install path at all.

## Fix

For the gateway host-sandbox runtime (`Dockerfile`) and the standalone agent runtime (`container/Dockerfile`):

- `ENV PIP_BREAK_SYSTEM_PACKAGES=1` — bare `pip install` works again. These are disposable sandboxes where the agent runs as root; the Debian marker protects an OS install that doesn't need protecting here, while blocking the libraries agents legitimately need. The images' own build steps already install with `--break-system-packages`.
- `python3-venv` — the isolated-environment route works for agents that prefer it.
- Extended `tests/dockerfile-runtime-tools.test.ts` so both images keep runtime pip installability (parity guard, same pattern as the spreadsheet-tools check).

## Testing

- `npx vitest run tests/dockerfile-runtime-tools.test.ts` — 2 passed
- `npx vitest run tests/container-setup.test.ts` — 23 passed