### PR TITLE
fix(email): seed poll cursors at channel setup so early mail is not skipped

### DIFF
--- a/src/channels/email/connection.ts
+++ b/src/channels/email/connection.ts
@@ -13,6 +13,10 @@ const INITIAL_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 60_000;
 const EMAIL_CURSOR_STATE_DIR = path.join(DATA_DIR, 'email');
 const EMAIL_CURSOR_STATE_VERSION = 1;
+// Cursor seeding runs inside `channels email setup`, which platforms exec with
+// their own deadline (e.g. sandbox provisioning) — fail fast rather than
+// eating the caller's whole budget on an unreachable IMAP host.
+const SEED_CONNECT_TIMEOUT_MS = 10_000;
 
 export interface EmailFetchedMessage {
   folder: string;
@@ -169,6 +173,78 @@ async function savePersistedFolderCursorState(
   };
   await fs.mkdir(path.dirname(statePath), { recursive: true });
   await fs.writeFile(statePath, JSON.stringify(serialized, null, 2));
+}
+
+export interface EmailCursorBaseline {
+  folder: string;
+  lastProcessedUid: number;
+  seeded: boolean;
+}
+
+/**
+ * Persist the current mailbox head as each folder's initial poll cursor.
+ *
+ * The poll loop only processes UIDs above its stored cursor, and when no
+ * cursor exists it seeds one from the mailbox head on its own first poll — so
+ * mail delivered between channel setup and that first poll was silently and
+ * permanently skipped. Seeding at setup time moves the baseline to the moment
+ * the channel is configured: everything delivered afterwards is processed no
+ * matter when the gateway's poller comes up, while a reused mailbox's
+ * pre-setup backlog stays unanswered. Folders that already have a cursor for
+ * the mailbox's current UIDVALIDITY are left untouched so re-running setup
+ * neither skips nor re-processes mail.
+ */
+export async function seedEmailFolderCursors(
+  config: Pick<
+    RuntimeEmailConfig,
+    'address' | 'folders' | 'imapHost' | 'imapPort' | 'imapSecure'
+  >,
+  password: string,
+): Promise<EmailCursorBaseline[]> {
+  const folders = resolveFolders(config.folders);
+  const client = new ImapFlow({
+    host: config.imapHost,
+    port: config.imapPort,
+    secure: config.imapSecure,
+    auth: {
+      user: config.address,
+      pass: password,
+    },
+    logger: false,
+    connectionTimeout: SEED_CONNECT_TIMEOUT_MS,
+    greetingTimeout: SEED_CONNECT_TIMEOUT_MS,
+  });
+  await client.connect();
+  try {
+    const persisted = await loadPersistedFolderCursorState(config.address);
+    const baselines: EmailCursorBaseline[] = [];
+    let changed = false;
+    for (const folder of folders) {
+      const mailboxStatus = await resolveMailboxStatus(client, folder);
+      const existing = persisted.get(folder);
+      if (existing && existing.uidValidity === mailboxStatus.uidValidity) {
+        baselines.push({
+          folder,
+          lastProcessedUid: existing.lastProcessedUid,
+          seeded: false,
+        });
+        continue;
+      }
+      const lastProcessedUid = mailboxStatus.uidNext - 1;
+      persisted.set(folder, {
+        uidValidity: mailboxStatus.uidValidity,
+        lastProcessedUid,
+      });
+      changed = true;
+      baselines.push({ folder, lastProcessedUid, seeded: true });
+    }
+    if (changed) {
+      await savePersistedFolderCursorState(config.address, persisted);
+    }
+    return baselines;
+  } finally {
+    await client.logout().catch(() => {});
+  }
 }
 
 export function createEmailConnectionManager(

--- a/src/cli/channels-command.ts
+++ b/src/cli/channels-command.ts
@@ -11,6 +11,10 @@ import {
   normalizeEmailAddress,
   normalizeEmailAllowEntry,
 } from '../channels/email/allowlist.js';
+import {
+  type EmailCursorBaseline,
+  seedEmailFolderCursors,
+} from '../channels/email/connection.js';
 import { normalizeIMessageHandle } from '../channels/imessage/handle.js';
 import { normalizeSignalDaemonUrl } from '../channels/signal/api.js';
 import { normalizeSignalRecipient } from '../channels/signal/target.js';
@@ -1753,6 +1757,28 @@ async function configureEmailChannel(args: string[]): Promise<void> {
     smtpSecure: parsed.smtpSecure ?? currentConfig.smtpSecure,
   });
 
+  // Seed the poll cursors BEFORE enabling the channel: once the config write
+  // lands, the (hot-reloading) gateway may start polling at any moment, and
+  // its first poll seeds missing cursors from the mailbox head — silently
+  // skipping everything delivered since setup. Seeding first closes that
+  // window. Best-effort: an unreachable IMAP host must not break setup.
+  let cursorBaselines: EmailCursorBaseline[] | null = null;
+  try {
+    cursorBaselines = await seedEmailFolderCursors(
+      {
+        address: resolved.address,
+        folders:
+          parsed.folders.length > 0 ? parsed.folders : currentConfig.folders,
+        imapHost: resolved.imapHost,
+        imapPort: resolved.imapPort,
+        imapSecure: resolved.imapSecure,
+      },
+      resolved.password,
+    );
+  } catch {
+    cursorBaselines = null;
+  }
+
   const nextConfig = updateRuntimeConfig((draft) => {
     draft.email.enabled = true;
     draft.email.address = resolved.address;
@@ -1809,6 +1835,18 @@ async function configureEmailChannel(args: string[]): Promise<void> {
   );
   console.log(`SMTP secure: ${nextConfig.email.smtpSecure}`);
   console.log(`Folders: ${nextConfig.email.folders.join(', ')}`);
+  if (cursorBaselines) {
+    for (const baseline of cursorBaselines) {
+      console.log(
+        `Mailbox cursor: ${baseline.folder} @ UID ${baseline.lastProcessedUid}` +
+          `${baseline.seeded ? ' (seeded at setup; only newer mail is processed)' : ' (existing cursor kept)'}`,
+      );
+    }
+  } else {
+    console.log(
+      'Warning: could not reach the mailbox to seed poll cursors; mail that arrives before the gateway first polls may be skipped.',
+    );
+  }
   if (nextConfig.email.allowFrom.length > 0) {
     console.log(`Allowed senders: ${nextConfig.email.allowFrom.join(', ')}`);
   } else {

--- a/tests/email.connection.test.ts
+++ b/tests/email.connection.test.ts
@@ -640,3 +640,213 @@ describe('email connection manager', () => {
     );
   });
 });
+
+describe('setup-time cursor seeding', () => {
+  const SEED_CONFIG = {
+    address: BASE_EMAIL_CONFIG.address,
+    folders: BASE_EMAIL_CONFIG.folders,
+    imapHost: BASE_EMAIL_CONFIG.imapHost,
+    imapPort: BASE_EMAIL_CONFIG.imapPort,
+    imapSecure: BASE_EMAIL_CONFIG.imapSecure,
+  };
+
+  function cursorStatePathFor(dataDir: string): string {
+    return path.join(
+      dataDir,
+      'email',
+      `${Buffer.from(BASE_EMAIL_CONFIG.address).toString('base64url').replace(/=+$/g, '')}-cursor-state.json`,
+    );
+  }
+
+  test('seeded cursor makes the poller process mail that arrived before its first poll', async () => {
+    const dataDir = makeTempDir('hybridclaw-email-connection-');
+
+    let mailboxUids = [1, 2];
+    let uidNext = 3;
+    const processedUids: number[] = [];
+    const search = vi.fn(async () => [...mailboxUids]);
+    const status = vi.fn(async (folder: string) => ({
+      path: folder,
+      uidNext,
+      uidValidity: 1n,
+    }));
+    const messageFlagsAdd = vi.fn(async () => true);
+    const fetch = vi.fn(async function* (uids: number[]) {
+      for (const uid of uids) {
+        yield {
+          uid,
+          source: Buffer.from(`raw-${uid}`, 'utf8'),
+        };
+      }
+    });
+
+    vi.doMock('../src/config/config.js', () => ({
+      DATA_DIR: dataDir,
+    }));
+    vi.doMock('imapflow', () => ({
+      ImapFlow: class {
+        mailbox = {
+          path: 'INBOX',
+          uidNext,
+          uidValidity: 1n,
+        };
+        connect = vi.fn(async () => {});
+        logout = vi.fn(async () => {});
+        close = vi.fn(() => {});
+        removeAllListeners = vi.fn(() => {});
+        on = vi.fn(() => this);
+        getMailboxLock = vi.fn(async (folder: string) => {
+          this.mailbox = {
+            path: folder,
+            uidNext,
+            uidValidity: 1n,
+          };
+          return {
+            release: vi.fn(),
+          };
+        });
+        status = status;
+        search = search;
+        fetch = fetch;
+        messageFlagsAdd = messageFlagsAdd;
+      },
+    }));
+
+    const { createEmailConnectionManager, seedEmailFolderCursors } =
+      await import('../src/channels/email/connection.js');
+
+    const baselines = await seedEmailFolderCursors(SEED_CONFIG, 'secret');
+    expect(baselines).toEqual([
+      { folder: 'INBOX', lastProcessedUid: 2, seeded: true },
+    ]);
+
+    // Mail lands after setup but before the gateway's poller has ever run —
+    // without the seeded cursor, the first poll would baseline past it.
+    mailboxUids = [1, 2, 3];
+    uidNext = 4;
+
+    const manager = createEmailConnectionManager(
+      BASE_EMAIL_CONFIG,
+      'secret',
+      async (messages) => {
+        for (const message of messages) {
+          processedUids.push(message.uid);
+        }
+      },
+    );
+    await manager.start();
+    await manager.stop();
+
+    expect(processedUids).toEqual([3]);
+    expect(search).toHaveBeenCalledWith({ uid: '3:*' }, { uid: true });
+  });
+
+  test('re-running setup keeps an existing compatible cursor', async () => {
+    const dataDir = makeTempDir('hybridclaw-email-connection-');
+    const cursorStatePath = cursorStatePathFor(dataDir);
+    fs.mkdirSync(path.dirname(cursorStatePath), { recursive: true });
+    fs.writeFileSync(
+      cursorStatePath,
+      JSON.stringify(
+        {
+          version: 1,
+          folders: {
+            INBOX: {
+              uidValidity: '1',
+              lastProcessedUid: 1,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const status = vi.fn(async (folder: string) => ({
+      path: folder,
+      uidNext: 5,
+      uidValidity: 1n,
+    }));
+
+    vi.doMock('../src/config/config.js', () => ({
+      DATA_DIR: dataDir,
+    }));
+    vi.doMock('imapflow', () => ({
+      ImapFlow: class {
+        connect = vi.fn(async () => {});
+        logout = vi.fn(async () => {});
+        status = status;
+      },
+    }));
+
+    const { seedEmailFolderCursors } = await import(
+      '../src/channels/email/connection.js'
+    );
+
+    const baselines = await seedEmailFolderCursors(SEED_CONFIG, 'secret');
+    expect(baselines).toEqual([
+      { folder: 'INBOX', lastProcessedUid: 1, seeded: false },
+    ]);
+
+    const persisted = JSON.parse(fs.readFileSync(cursorStatePath, 'utf8')) as {
+      folders: Record<string, { lastProcessedUid: number }>;
+    };
+    expect(persisted.folders.INBOX.lastProcessedUid).toBe(1);
+  });
+
+  test('reseeds from the mailbox head when UIDVALIDITY changed', async () => {
+    const dataDir = makeTempDir('hybridclaw-email-connection-');
+    const cursorStatePath = cursorStatePathFor(dataDir);
+    fs.mkdirSync(path.dirname(cursorStatePath), { recursive: true });
+    fs.writeFileSync(
+      cursorStatePath,
+      JSON.stringify(
+        {
+          version: 1,
+          folders: {
+            INBOX: {
+              uidValidity: '1',
+              lastProcessedUid: 7,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const status = vi.fn(async (folder: string) => ({
+      path: folder,
+      uidNext: 5,
+      uidValidity: 2n,
+    }));
+
+    vi.doMock('../src/config/config.js', () => ({
+      DATA_DIR: dataDir,
+    }));
+    vi.doMock('imapflow', () => ({
+      ImapFlow: class {
+        connect = vi.fn(async () => {});
+        logout = vi.fn(async () => {});
+        status = status;
+      },
+    }));
+
+    const { seedEmailFolderCursors } = await import(
+      '../src/channels/email/connection.js'
+    );
+
+    const baselines = await seedEmailFolderCursors(SEED_CONFIG, 'secret');
+    expect(baselines).toEqual([
+      { folder: 'INBOX', lastProcessedUid: 4, seeded: true },
+    ]);
+
+    const persisted = JSON.parse(fs.readFileSync(cursorStatePath, 'utf8')) as {
+      folders: Record<string, { uidValidity: string; lastProcessedUid: number }>;
+    };
+    expect(persisted.folders.INBOX).toEqual({
+      uidValidity: '2',
+      lastProcessedUid: 4,
+    });
+  });
+});

--- a/tests/local-cli.test.ts
+++ b/tests/local-cli.test.ts
@@ -20,11 +20,25 @@ function makeTempHome(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'hybridclaw-local-cli-'));
 }
 
-async function importFreshCli(homeDir: string) {
+async function importFreshCli(
+  homeDir: string,
+  options: { emailSeedError?: boolean } = {},
+) {
   process.env.HOME = homeDir;
   process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
   process.env.HYBRIDCLAW_WHATSAPP_SETUP_SETTLE_MS = '0';
   vi.resetModules();
+  vi.doMock('../src/channels/email/connection.ts', async (importOriginal) => ({
+    ...(await importOriginal<Record<string, unknown>>()),
+    // `channels email setup` seeds poll cursors over a real IMAP connection;
+    // these tests configure unreachable example.com hosts, so stub it.
+    seedEmailFolderCursors: async () => {
+      if (options.emailSeedError) {
+        throw new Error('IMAP unreachable');
+      }
+      return [{ folder: 'INBOX', lastProcessedUid: 41, seeded: true }];
+    },
+  }));
   vi.doMock('../src/channels/whatsapp/runtime.ts', () => ({
     createWhatsAppPairingSession: async () => ({
       start: async () => {},
@@ -875,6 +889,35 @@ test('channels email setup writes config and stores EMAIL_PASSWORD', async () =>
   );
   expect(logSpy).toHaveBeenCalledWith(
     `Saved email password to ${path.join(homeDir, '.hybridclaw', 'credentials.json')}`,
+  );
+  expect(logSpy).toHaveBeenCalledWith(
+    'Mailbox cursor: INBOX @ UID 41 (seeded at setup; only newer mail is processed)',
+  );
+});
+
+test('channels email setup still succeeds when cursor seeding cannot reach IMAP', async () => {
+  const homeDir = makeTempHome();
+  const cli = await importFreshCli(homeDir, { emailSeedError: true });
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  await cli.main([
+    'channels',
+    'email',
+    'setup',
+    '--address',
+    'agent@example.com',
+    '--password',
+    'email-app-password',
+    '--imap-host',
+    'imap.example.com',
+    '--smtp-host',
+    'smtp.example.com',
+  ]);
+
+  const config = readRuntimeConfig(homeDir);
+  expect(config.email.enabled).toBe(true);
+  expect(logSpy).toHaveBeenCalledWith(
+    'Warning: could not reach the mailbox to seed poll cursors; mail that arrives before the gateway first polls may be skipped.',
   );
 });
 


### PR DESCRIPTION
## Problem

The IMAP poll loop only processes UIDs above its stored cursor, and when no cursor exists it seeds one from the mailbox head on its **own first poll** (`pollFolder` in `src/channels/email/connection.ts`). Mail delivered between `channels email setup` and that first poll is therefore silently and permanently skipped — there's no log line, no reply, no trace.

On cloud provisions this is a real window: platform onboarding execs `channels email setup` and reports the channel configured, but the gateway's poller starts tens of seconds later. Observed on staging 2026-07-24 (e2e2 monitor): mail delivered to the agent mailbox 06:03:56, poller demonstrably up 06:04:31, message never processed. Any user who emails their agent right after onboarding hits the same silent drop. It's also the root cause of the flaky `test_hybridclaw_email_round_trip` in the chat repo.

## Fix

`channels email setup` now connects once (10s connect budget), reads each configured folder's `UIDNEXT`/`UIDVALIDITY`, and persists that as the initial cursor (`seedEmailFolderCursors`) — **before** enabling the channel in the runtime config, so a hot-reloading gateway can never start polling without the seeded state.

This moves the baseline from first-poll time to setup time:

- everything delivered **after setup** is processed no matter when the poller comes up;
- a reused mailbox's **pre-setup backlog** stays unanswered (unchanged protection);
- folders that already have a cursor for the current `UIDVALIDITY` are left untouched, so re-running setup neither skips nor re-processes mail; a changed `UIDVALIDITY` reseeds from the head.

Seeding is best-effort: if IMAP is unreachable, setup completes as before and prints a warning that mail arriving before the first poll may be skipped.

## Testing

- `tests/email.connection.test.ts`: 3 new tests — the regression case (message arrives after seeding but before the poller's first run → processed; without the seed the first poll baselines past it), re-run keeps an existing compatible cursor, `UIDVALIDITY` change reseeds. 10/10 pass.
- `tests/local-cli.test.ts`: setup prints the seeded cursor; setup still succeeds (with warning) when seeding can't reach IMAP. 39/39 pass.
- `tsc --noEmit --noUnusedLocals --noUnusedParameters` and `biome check` clean.