### PR TITLE
fix: remove HybridAI prompt metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
+- **HybridAI requests omit duplicate prompt metadata**: Agent turns no longer
+  copy raw user text into a separate provider request field, preventing
+  OpenAI-compatible backends from forwarding it as completion metadata.
+
 ## [0.28.4](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.4) - 2026-07-24
 
 ### Added

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -759,7 +759,6 @@ async function executePreparedToolCall(
 
 async function callHybridAIWithRetry(params: {
   sessionId?: string;
-  activityUserPrompt?: string;
   provider?: ContainerInput['provider'];
   providerMethod?: string;
   baseUrl: string;
@@ -783,7 +782,6 @@ async function callHybridAIWithRetry(params: {
 }): Promise<ChatCompletionResponse> {
   const {
     sessionId,
-    activityUserPrompt,
     provider,
     providerMethod,
     baseUrl,
@@ -834,7 +832,6 @@ async function callHybridAIWithRetry(params: {
             provider,
             providerMethod,
             sessionId,
-            activityUserPrompt,
             baseUrl,
             apiKey,
             model,
@@ -871,7 +868,6 @@ async function callHybridAIWithRetry(params: {
             provider,
             providerMethod,
             sessionId,
-            activityUserPrompt,
             baseUrl,
             apiKey,
             model,
@@ -893,7 +889,6 @@ async function callHybridAIWithRetry(params: {
           provider,
           providerMethod,
           sessionId,
-          activityUserPrompt,
           baseUrl,
           apiKey,
           model,
@@ -955,7 +950,6 @@ async function callHybridAIWithRetry(params: {
 interface ProcessRequestParams {
   sessionId: string;
   messages: ChatMessage[];
-  activityUserPrompt?: string;
   apiKey: string;
   baseUrl: string;
   provider: ContainerInput['provider'];
@@ -1019,7 +1013,6 @@ async function processRequest(
   const {
     sessionId,
     messages,
-    activityUserPrompt,
     apiKey,
     baseUrl,
     provider,
@@ -1361,7 +1354,6 @@ async function processRequest(
     try {
       response = await callHybridAIWithRetry({
         sessionId,
-        activityUserPrompt,
         provider,
         providerMethod,
         baseUrl,
@@ -2054,7 +2046,6 @@ async function main(): Promise<void> {
     firstOutput = await processRequest({
       sessionId: firstInput.sessionId,
       messages: firstMessagesForRequest,
-      activityUserPrompt: firstInput.activityUserPrompt,
       apiKey: storedApiKey,
       baseUrl: firstInput.baseUrl,
       provider: firstInput.provider,
@@ -2098,7 +2089,6 @@ async function main(): Promise<void> {
       firstOutput = await processRequest({
         sessionId: firstInput.sessionId,
         messages: firstRetryMessagesWithSkillCache,
-        activityUserPrompt: firstInput.activityUserPrompt,
         apiKey: storedApiKey,
         baseUrl: firstInput.baseUrl,
         provider: firstInput.provider,
@@ -2250,7 +2240,6 @@ async function main(): Promise<void> {
     let output = await processRequest({
       sessionId: input.sessionId,
       messages: messagesForRequestWithSkillCache,
-      activityUserPrompt: input.activityUserPrompt,
       apiKey,
       baseUrl: input.baseUrl,
       provider: input.provider,
@@ -2293,7 +2282,6 @@ async function main(): Promise<void> {
       output = await processRequest({
         sessionId: input.sessionId,
         messages: retryMessagesWithSkillCache,
-        activityUserPrompt: input.activityUserPrompt,
         apiKey,
         baseUrl: input.baseUrl,
         provider: input.provider,

--- a/container/src/providers/hybridai.ts
+++ b/container/src/providers/hybridai.ts
@@ -63,11 +63,6 @@ function buildHybridAIRequestBody(
     messages: args.messages,
     enable_rag: args.enableRag,
   };
-  if (args.activityUserPrompt?.trim()) {
-    request.metadata = {
-      hybridclawUserPrompt: args.activityUserPrompt,
-    };
-  }
   if (args.tools.length > 0) {
     request.tools = args.tools;
     request.tool_choice = 'auto';

--- a/container/src/providers/router.ts
+++ b/container/src/providers/router.ts
@@ -45,7 +45,6 @@ const DEFAULT_VISION_INSTRUCTIONS =
 
 export interface RoutedModelContext {
   sessionId?: string;
-  activityUserPrompt?: string;
   provider: RuntimeProvider | undefined;
   providerMethod?: string;
   baseUrl: string;
@@ -88,7 +87,6 @@ export interface RoutedVisionCallParams extends RoutedModelContext {
 function buildCallArgs(params: RoutedModelCallParams): NormalizedCallArgs {
   return {
     sessionId: params.sessionId,
-    activityUserPrompt: params.activityUserPrompt,
     provider: params.provider,
     providerMethod: params.providerMethod,
     baseUrl: params.baseUrl.trim(),

--- a/container/src/providers/shared.ts
+++ b/container/src/providers/shared.ts
@@ -15,7 +15,6 @@ export type { RuntimeProvider } from './provider-ids.js';
 
 export interface NormalizedCallArgs {
   sessionId?: string;
-  activityUserPrompt?: string;
   provider: RuntimeProvider | undefined;
   providerMethod?: string;
   baseUrl: string;

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -230,7 +230,6 @@ export interface ContainerInput {
   sessionId: string;
   agentId?: string;
   messages: ChatMessage[];
-  activityUserPrompt?: string;
   chatbotId: string;
   enableRag: boolean;
   apiKey: string;

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -169,19 +169,10 @@ async function runAgentInner(
     preparedMessages,
     'agent.messages',
   );
-  const activityUserPrompt = params.activityUserPrompt
-    ? getLatestUserTextContent(
-        confidential.dehydrate(
-          [{ role: 'user', content: params.activityUserPrompt }],
-          'agent.activity_user_prompt',
-        ),
-      )
-    : undefined;
   const output = await executor.exec({
     ...params,
     sessionId,
     messages: dehydratedMessages,
-    activityUserPrompt,
     chatbotId,
     model,
     agentId,

--- a/src/agent/executor-types.ts
+++ b/src/agent/executor-types.ts
@@ -15,7 +15,6 @@ import type { ScheduledTask } from '../types/scheduler.js';
 export interface ExecutorRequest {
   sessionId: string;
   messages: ChatMessage[];
-  activityUserPrompt?: string;
   chatbotId: string;
   enableRag: boolean;
   executorModeOverride?: 'host' | 'container';

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -1287,10 +1287,6 @@ async function handleGatewayMessageInner(
     source !== 'fullauto' &&
     channelType !== 'scheduler' &&
     channelType !== 'heartbeat';
-  const activityUserPrompt =
-    isInteractiveSource && !isGoalContinuationSource(source)
-      ? userTurnContent
-      : undefined;
   // Each success path returns after scheduling title work, so one turn enqueues
   // at most one title request.
   const autoTitleParams = () => ({
@@ -2032,7 +2028,6 @@ async function handleGatewayMessageInner(
       runAgent({
         sessionId: req.executionSessionId || req.sessionId,
         messages,
-        activityUserPrompt,
         chatbotId: params.chatbotId,
         enableRag,
         executorModeOverride: req.executorModeOverride,
@@ -2136,7 +2131,6 @@ async function handleGatewayMessageInner(
       output = await runAgent({
         sessionId: req.executionSessionId || req.sessionId,
         messages,
-        activityUserPrompt,
         chatbotId,
         enableRag,
         executorModeOverride: req.executorModeOverride,

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -1015,7 +1015,6 @@ async function runContainerInner(
   const {
     sessionId,
     messages,
-    activityUserPrompt,
     chatbotId,
     enableRag,
     model = HYBRIDAI_MODEL,
@@ -1113,7 +1112,6 @@ async function runContainerInner(
     sessionId,
     agentId,
     messages,
-    activityUserPrompt,
     chatbotId: modelRuntime.chatbotId,
     enableRag: modelRuntime.enableRag,
     apiKey: modelRuntime.apiKey,

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -873,7 +873,6 @@ async function runHostProcessInner(
   const {
     sessionId,
     messages,
-    activityUserPrompt,
     chatbotId,
     enableRag,
     model = HYBRIDAI_MODEL,
@@ -960,7 +959,6 @@ async function runHostProcessInner(
     sessionId,
     agentId,
     messages,
-    activityUserPrompt,
     chatbotId: modelRuntime.chatbotId,
     enableRag: modelRuntime.enableRag,
     apiKey: modelRuntime.apiKey,

--- a/src/types/container.ts
+++ b/src/types/container.ts
@@ -67,7 +67,6 @@ export interface ContainerInput {
   sessionId: string;
   agentId?: string;
   messages: ChatMessage[];
-  activityUserPrompt?: string;
   chatbotId: string;
   enableRag: boolean;
   apiKey: string;

--- a/tests/container.model-router.test.ts
+++ b/tests/container.model-router.test.ts
@@ -94,7 +94,6 @@ describe('container model router', () => {
         >;
         expect(body.model).toBe('anthropic/claude-sonnet-4');
         expect(body.messages).toEqual(baseMessages);
-        expect(body.metadata).toBeUndefined();
         return new Response(
           JSON.stringify({
             id: 'resp_1',
@@ -132,59 +131,10 @@ describe('container model router', () => {
       messages: baseMessages,
       tools: [],
       maxTokens: 128,
-      activityUserPrompt: 'This must not reach OpenRouter metadata',
     });
 
     expect(response.choices[0]?.message.content).toBe('ok');
     expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  test('sends raw activity prompts only on HybridAI chat callbacks', async () => {
-    const requestBodies: Array<Record<string, unknown>> = [];
-    const fetchMock = vi.fn(
-      async (_input: RequestInfo | URL, init?: RequestInit) => {
-        requestBodies.push(
-          JSON.parse(String(init?.body || '{}')) as Record<string, unknown>,
-        );
-        return new Response(
-          JSON.stringify({
-            id: 'resp_hybridai',
-            model: 'gpt-5.4',
-            choices: [
-              {
-                message: { role: 'assistant', content: 'ok' },
-                finish_reason: 'stop',
-              },
-            ],
-          }),
-          {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          },
-        );
-      },
-    );
-    vi.stubGlobal('fetch', fetchMock);
-
-    const request = {
-      provider: 'hybridai' as const,
-      baseUrl: 'https://hybridai.one',
-      apiKey: 'hybridai-test-key',
-      model: 'gpt-5.4',
-      chatbotId: 'bot_123',
-      messages: baseMessages,
-      tools: [],
-    };
-    await callRoutedModel({
-      ...request,
-      activityUserPrompt: 'Please summarize my invoices',
-    });
-    await callRoutedModel(request);
-
-    expect(requestBodies[0]?.metadata).toEqual({
-      hybridclawUserPrompt: 'Please summarize my invoices',
-    });
-    expect(requestBodies[1]?.metadata).toBeUndefined();
   });
 
   test('routes Codex vision calls through the shared router', async () => {

--- a/tests/gateway-service.context-references.test.ts
+++ b/tests/gateway-service.context-references.test.ts
@@ -72,7 +72,6 @@ test('handleGatewayMessage expands context references only for llm-facing paths'
 
   const request = runAgentMock.mock.calls[0]?.[0] as
     | {
-        activityUserPrompt?: string;
         messages?: Array<{ content: string; role: string }>;
       }
     | undefined;
@@ -83,7 +82,6 @@ test('handleGatewayMessage expands context references only for llm-facing paths'
   expect(userMessage?.content).toContain('File: src/app.ts');
   expect(userMessage?.content).toContain('export const answer = 42;');
   expect(userMessage?.content).not.toContain('@file:src/app.ts');
-  expect(request?.activityUserPrompt).toBe(content);
 
   const history = memoryService.getConversationHistory(sessionId, 10);
   expect(history.find((message) => message.role === 'user')?.content).toBe(


### PR DESCRIPTION
## Summary

- remove the `activityUserPrompt` field from the gateway, agent executor, host/container IPC, and provider routing path
- stop attaching `hybridclawUserPrompt` as HybridAI request metadata
- remove the feature-specific tests and document the correction in the changelog

## Root cause

HybridClaw 0.28.4 added the raw user prompt to the outbound HybridAI `/v1/chat/completions` request as `metadata` so Discord activity notifications could display it. Although intended for internal HybridAI use, the field crossed the provider boundary and could be forwarded to OpenAI. OpenAI rejects completion metadata when storage is not enabled, breaking OpenAI-backed HybridAI models with HTTP 400 responses.

## Impact

OpenAI-backed HybridAI requests no longer include the duplicate metadata field and resume using the existing non-stored request behavior. Discord activity notifications will no longer receive the raw prompt through this mechanism.

## Validation

- `npm run typecheck` (Node 22)
- `npm run lint` (Node 22)
- `npm --prefix container run lint`
- `npm run build` (Node 22)
- `vitest run tests/container.model-router.test.ts tests/gateway-service.context-references.test.ts` — 16 passed
- `git diff --check`