### PR TITLE
chore: release v0.28.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,20 @@
 
 ## Unreleased
 
+## [0.28.5](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.5) - 2026-07-24
+
 ### Fixed
 
-- **HybridAI requests omit duplicate prompt metadata**: Agent turns no longer
-  copy raw user text into a separate provider request field, preventing
-  OpenAI-compatible backends from forwarding it as completion metadata.
+- **Email sent immediately after setup is processed**: Email channel setup
+  seeds each mailbox folder's polling cursor before enabling the channel, so
+  messages arriving before the gateway's first poll are not skipped. Existing
+  compatible cursors remain intact when setup is rerun.
+- **Agents can install Python packages in sandbox images**: Gateway and
+  standalone container runtimes support both direct `pip install` commands and
+  isolated virtual environments.
+- **GPT models no longer trigger Provider API error 500 on HybridAI**: Agent
+  turns no longer copy raw user text into duplicate provider metadata that
+  caused the provider request to fail.
 
 ## [0.28.4](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.4) - 2026-07-24
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Core pieces:
 | Build desktop releases | [Desktop Release Builds](https://hybridaione.github.io/hybridclaw/docs/developer-guide/desktop-release) |
 | Contribute | [CONTRIBUTING.md](./CONTRIBUTING.md), [docs/content/README.md](./docs/content/README.md) |
 
-Latest release: [v0.28.4](https://github.com/HybridAIOne/hybridclaw/releases/tag/v0.28.4).
+Latest release: [v0.28.5](https://github.com/HybridAIOne/hybridclaw/releases/tag/v0.28.5).
 Release notes: [CHANGELOG.md](./CHANGELOG.md)
 
 ## Development

--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hybridaione/hybridclaw-console",
   "private": true,
-  "version": "0.28.4",
+  "version": "0.28.5",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/console/src/release-notes.ts
+++ b/console/src/release-notes.ts
@@ -1,10 +1,9 @@
 export const LATEST_RELEASE_NOTES = {
-  version: '0.28.4',
+  version: '0.28.5',
   highlights: [
-    'Stable conversation prompt caching.',
-    'Refined admin navigation and design.',
-    'Guided Microsoft Teams setup.',
-    'Security and dependency hardening.',
+    'Reliable email delivery immediately after setup.',
+    'Runtime Python package installation.',
+    'Fix Provider API error 500 with GPT models.',
   ],
 } as const;
 

--- a/container/npm-shrinkwrap.json
+++ b/container/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/container/package-lock.json
+++ b/container/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/container/package.json
+++ b/container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@hybridaione/hybridclaw-desktop",
   "productName": "HybridClaw",
   "private": true,
-  "version": "0.28.4",
+  "version": "0.28.5",
   "license": "MIT",
   "type": "module",
   "description": "macOS wrapper for the HybridClaw chat and admin web surfaces",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -85,7 +85,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "5.101.2",
@@ -111,7 +111,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -139,7 +139,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "license": "MIT",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -85,7 +85,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "5.101.2",
@@ -111,7 +111,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -139,7 +139,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "license": "MIT",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "type": "module",
   "description": "Enterprise-ready self-hosted AI assistant runtime with sandboxed execution, secure credentials, approvals, and memory",
   "license": "MIT",

--- a/scripts/dependency-policy-baseline.json
+++ b/scripts/dependency-policy-baseline.json
@@ -1,9 +1,9 @@
 {
   "lockfiles": {
-    "package-lock.json": "fa929eaa1a8a7a2373fdde74aa194e5a68c994c140d56efaa61f1ff8f8cfbb62",
-    "npm-shrinkwrap.json": "fa929eaa1a8a7a2373fdde74aa194e5a68c994c140d56efaa61f1ff8f8cfbb62",
-    "container/package-lock.json": "35807746f66699475cc7bb271d2589f654e350b413abecd5e99417ad1809e0e0",
-    "container/npm-shrinkwrap.json": "35807746f66699475cc7bb271d2589f654e350b413abecd5e99417ad1809e0e0",
+    "package-lock.json": "637adabcb0f623b82caddd396f787f9df89ef6722789056b965bc36fec36629c",
+    "npm-shrinkwrap.json": "637adabcb0f623b82caddd396f787f9df89ef6722789056b965bc36fec36629c",
+    "container/package-lock.json": "039db00d11ddb222076b0ba061f7d561d11ca1ba5af4d5d66aa2f8fd3c0de415",
+    "container/npm-shrinkwrap.json": "039db00d11ddb222076b0ba061f7d561d11ca1ba5af4d5d66aa2f8fd3c0de415",
     "plugins/brevo-email/package-lock.json": "3377225eb3bdbb252eaa28ad420b9a725ea1da533417388557aa1984730229b5",
     "plugins/whatsapp/package-lock.json": "a80140f6687804addf0416a443c1c578fed6d89771f6a03eee5adeccdd9bae86",
     "plugins/whatsapp/npm-shrinkwrap.json": "a80140f6687804addf0416a443c1c578fed6d89771f6a03eee5adeccdd9bae86"


### PR DESCRIPTION
## Summary

- bump root, console, desktop, and container package metadata to `0.28.5`
- publish the three post-`0.28.4` fixes in the changelog and refresh the console What's New copy
- update the README release link, lockfile/shrinkwrap version metadata, and dependency-policy hashes

## Why

This packages the fixes already merged since `v0.28.4`: email setup now preserves messages arriving before the first poll, sandbox images support runtime Python package installation, and GPT requests no longer trigger HybridAI Provider API error 500 from duplicate provider metadata.

Users receive consistent `0.28.5` versioning across distributed components and concise release notes describing the fixes.

## Validation

- `npm run format`
- `npm run lint`
- `npm run release:check`
- `npm --prefix container run release:check`
- console release-notes and What's New tests under Node.js 22: 5 passed
- `git diff --check`