### PR TITLE
fix: improve Teams streaming and artifact delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
   setup, build, lint, typecheck, test, audit, and release workflows never fetch
   or compile it. Explicitly enabling WhatsApp installs a pinned release through
   the approved plugin installer.
+- **Microsoft Teams shows live agent activity in direct messages**: One-on-one
+  chats use Teams native streaming for Thinking, tool activity, and incremental
+  response updates, with standard typing and message delivery retained as the
+  fallback for unsupported scopes or clients.
+- **Microsoft Teams generated files no longer degrade into dead links**:
+  Referenced PDF, Office, image, audio, and video outputs are recovered as
+  artifacts, local-only Markdown links are removed, personal chats use Teams
+  file-consent cards, and unsupported channel/group-chat delivery is reported
+  explicitly.
 
 ## [0.28.5](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.5) - 2026-07-24
 

--- a/docs/content/channels/msteams.md
+++ b/docs/content/channels/msteams.md
@@ -94,7 +94,9 @@ loopback address and must be configured with the public tunnel URL.
 4. Use the same **Application (client) ID** for the bot and enable these scopes:
    - **Personal**
    - **Team**
-5. Save the app, open **Publish**, and download the app package.
+5. Enable file upload/download support for the bot. In the downloaded
+   manifest, verify that the bot entry contains `"supportsFiles": true`.
+6. Save the app, open **Publish**, and download the app package.
 
 Keep the downloaded `.zip` file intact. It is the package uploaded in the next
 step.
@@ -120,6 +122,18 @@ The app can take some time to appear in the organization's Teams app catalog.
 Team channel messages require a mention by default. A plain `hello` in a team
 channel does not trigger a reply unless you change the Teams policy in
 HybridClaw.
+
+Direct messages use Teams native streaming: the chat shows an informative
+progress bar such as **Thinking…** or **Searching…**, then replaces it with the
+incremental response. Teams supports this streaming experience only in
+one-on-one chats. Group chats and team channels use the standard typing and
+message-update fallback.
+
+Generated files are delivered in direct messages through a Teams file-consent
+card. Select **Accept** on that card to upload the file to OneDrive and receive
+an openable file card. The Teams bot file API supports this flow only in
+one-on-one chats; channel and group-chat file delivery requires a separate
+Microsoft Graph and SharePoint/OneDrive integration.
 
 ## Troubleshooting: the bot does not respond
 

--- a/src/channels/msteams/attachments.ts
+++ b/src/channels/msteams/attachments.ts
@@ -292,12 +292,26 @@ function estimateDataUrlSize(url: string): number {
   return payload ? Buffer.from(payload, 'base64').length : 0;
 }
 
+function isPersonalFileConversation(activity: Partial<Activity>): boolean {
+  const conversationType = normalizeValue(
+    activity.conversation?.conversationType,
+  ).toLowerCase();
+  if (conversationType === 'personal') return true;
+  if (conversationType === 'groupchat') return false;
+  const channelData = isRecord(activity.channelData)
+    ? activity.channelData
+    : null;
+  const team =
+    channelData && isRecord(channelData.team) ? channelData.team : null;
+  return !normalizeValue(team?.id);
+}
+
 function shouldUseFileConsent(params: {
-  conversationType: string;
+  personalConversation: boolean;
   contentType: string;
   sizeBytes: number;
 }): boolean {
-  if (params.conversationType !== 'personal') {
+  if (!params.personalConversation) {
     return false;
   }
   if (!params.contentType.startsWith('image/')) {
@@ -917,6 +931,9 @@ export async function buildTeamsUploadedFileAttachment(params: {
   const conversationType = normalizeValue(
     params.turnContext.activity.conversation?.conversationType,
   ).toLowerCase();
+  const personalConversation = isPersonalFileConversation(
+    params.turnContext.activity,
+  );
   if (
     shouldInlinePersonalImageAttachment({
       conversationType,
@@ -933,7 +950,7 @@ export async function buildTeamsUploadedFileAttachment(params: {
 
   if (
     shouldUseFileConsent({
-      conversationType,
+      personalConversation,
       contentType,
       sizeBytes: fileBuffer.byteLength,
     })
@@ -951,9 +968,15 @@ export async function buildTeamsUploadedFileAttachment(params: {
     });
   }
 
+  if (!contentType.startsWith('image/')) {
+    throw new Error(
+      'Teams bot file delivery is supported only in personal chats. Channel and group-chat file delivery requires Microsoft Graph with OneDrive or SharePoint.',
+    );
+  }
+
   if (fileBuffer.byteLength >= FILE_CONSENT_THRESHOLD_BYTES) {
     throw new Error(
-      'Teams file uploads larger than 4 MB in channels or group chats require SharePoint/OneDrive fallback, which is not implemented yet.',
+      'Teams image uploads larger than 4 MB in channels or group chats require SharePoint/OneDrive fallback, which is not implemented yet.',
     );
   }
 

--- a/src/channels/msteams/delivery.ts
+++ b/src/channels/msteams/delivery.ts
@@ -34,6 +34,24 @@ export function buildResponseText(text: string, toolsUsed?: string[]): string {
   return body;
 }
 
+export function stripUnusableMSTeamsArtifactLinks(text: string): string {
+  return text.replace(
+    /\[([^\]\n]+)\]\(([^)\n]+)\)/g,
+    (link, label: string, rawTarget: string) => {
+      const target = rawTarget.trim().replace(/^<|>$/g, '');
+      const isLocalTarget =
+        /^(?:file|sandbox):/i.test(target) ||
+        /^\/?api\/artifact\?/i.test(target) ||
+        /^(?:\/workspace\/|\.\/)/i.test(target) ||
+        (!/^[a-z][a-z0-9+.-]*:/i.test(target) &&
+          /\.(?:docx|gif|jpe?g|m4a|m4v|mov|mp3|mp4|ogg|pdf|png|pptx|svg|wav|webm|webp|xlsx)(?:[?#].*)?$/i.test(
+            target,
+          ));
+      return isLocalTarget ? label : link;
+    },
+  );
+}
+
 export function buildAdaptiveCardAttachment(
   card: Record<string, unknown>,
 ): Attachment {

--- a/src/channels/msteams/runtime.ts
+++ b/src/channels/msteams/runtime.ts
@@ -643,9 +643,18 @@ async function handleIncomingMessage(turnContext: TurnContext): Promise<void> {
     const stream = new MSTeamsStreamManager(turnContext, {
       replyStyle: policy.replyStyle,
       replyToId: activity.id,
+      nativeStreaming: isDm,
+      onNativeCancellation: () => abortController.abort(),
     });
     const typingController = createMSTeamsTypingController(turnContext);
-    typingController.start();
+    let legacyTypingStarted = false;
+    if (isDm) {
+      await stream.updateInformative();
+    }
+    if (!stream.isNativeStreamingActive()) {
+      typingController.start();
+      legacyTypingStarted = true;
+    }
     try {
       await messageHandler(
         sessionId,
@@ -665,7 +674,9 @@ async function handleIncomingMessage(turnContext: TurnContext): Promise<void> {
         },
       );
     } finally {
-      typingController.stop();
+      if (legacyTypingStarted) {
+        typingController.stop();
+      }
     }
   } finally {
     releaseActiveSession();

--- a/src/channels/msteams/stream.ts
+++ b/src/channels/msteams/stream.ts
@@ -1,5 +1,9 @@
 import type { TurnContext } from 'botbuilder-core';
-import type { Attachment } from 'botframework-schema';
+import {
+  type Activity,
+  ActivityTypes,
+  type Attachment,
+} from 'botframework-schema';
 import type { MSTeamsReplyStyle } from '../../config/runtime-config.js';
 import { logger } from '../../logger.js';
 import {
@@ -12,18 +16,24 @@ import {
 } from './retry.js';
 
 const DEFAULT_EDIT_INTERVAL_MS = 1_200;
+const DEFAULT_NATIVE_STREAM_INTERVAL_MS = 1_500;
 const STREAM_FAILURE_TEXT =
   'Teams streaming was interrupted while sending the reply. Please retry.';
+const INITIAL_INFORMATIVE_TEXT = 'Thinking…';
 
 interface SentActivityRef {
   id: string;
   text: string;
 }
 
+type MSTeamsNativeStreamType = 'informative' | 'streaming' | 'final';
+
 export interface MSTeamsStreamOptions {
   replyStyle: MSTeamsReplyStyle;
   replyToId?: string | null;
   editIntervalMs?: number;
+  nativeStreaming?: boolean;
+  onNativeCancellation?: () => void;
 }
 
 export class MSTeamsStreamManager {
@@ -31,6 +41,8 @@ export class MSTeamsStreamManager {
   private readonly replyStyle: MSTeamsReplyStyle;
   private readonly replyToId?: string | null;
   private readonly editIntervalMs: number;
+  private readonly nativeStreaming: boolean;
+  private readonly onNativeCancellation?: () => void;
 
   private readonly sent: SentActivityRef[] = [];
   private content = '';
@@ -38,15 +50,59 @@ export class MSTeamsStreamManager {
   private lastFlushAt = 0;
   private opQueue = Promise.resolve();
   private closed = false;
+  private nativeCancelled = false;
+  private nativeFailed = false;
+  private nativeStreamId: string | null = null;
+  private nativeSequence = 0;
+  private nativeLastText = '';
+  private nativeLastInformativeText = '';
 
   constructor(turnContext: TurnContext, options: MSTeamsStreamOptions) {
     this.turnContext = turnContext;
     this.replyStyle = options.replyStyle;
     this.replyToId = options.replyToId;
+    this.nativeStreaming = options.nativeStreaming === true;
+    this.onNativeCancellation = options.onNativeCancellation;
     this.editIntervalMs = Math.max(
       250,
-      options.editIntervalMs ?? DEFAULT_EDIT_INTERVAL_MS,
+      options.editIntervalMs ??
+        (this.nativeStreaming
+          ? DEFAULT_NATIVE_STREAM_INTERVAL_MS
+          : DEFAULT_EDIT_INTERVAL_MS),
     );
+  }
+
+  isNativeStreamingActive(): boolean {
+    return this.nativeStreaming && !this.nativeCancelled && !this.nativeFailed;
+  }
+
+  updateInformative(text = INITIAL_INFORMATIVE_TEXT): Promise<void> {
+    const normalized = text.replace(/\s+/g, ' ').trim();
+    if (
+      !this.isNativeStreamingActive() ||
+      this.closed ||
+      this.content ||
+      !normalized ||
+      normalized === this.nativeLastInformativeText
+    ) {
+      return Promise.resolve();
+    }
+    return this.enqueue(async () => {
+      if (
+        !this.isNativeStreamingActive() ||
+        this.closed ||
+        this.content ||
+        normalized === this.nativeLastInformativeText
+      ) {
+        return;
+      }
+      try {
+        await this.sendNativeUpdate(normalized, 'informative');
+        this.nativeLastInformativeText = normalized;
+      } catch (error) {
+        await this.disableNativeStreaming(error);
+      }
+    });
   }
 
   append(delta: string): Promise<void> {
@@ -77,6 +133,17 @@ export class MSTeamsStreamManager {
     this.clearFlushTimer();
     this.closed = true;
     return this.enqueue(async () => {
+      if (this.nativeStreamId) {
+        try {
+          await this.turnContext.deleteActivity(this.nativeStreamId);
+        } catch (error) {
+          logger.debug(
+            { error, streamId: this.nativeStreamId },
+            'Failed to delete streamed Teams preview',
+          );
+        }
+        this.nativeStreamId = null;
+      }
       for (const entry of this.sent) {
         try {
           await this.turnContext.deleteActivity(entry.id);
@@ -149,6 +216,22 @@ export class MSTeamsStreamManager {
     force: boolean,
     attachments?: Attachment[],
   ): Promise<void> {
+    if (this.isNativeStreamingActive()) {
+      try {
+        await this.syncNative(force, attachments);
+        return;
+      } catch (error) {
+        await this.disableNativeStreaming(error);
+      }
+    }
+    if (this.nativeCancelled) return;
+    await this.syncLegacy(force, attachments);
+  }
+
+  private async syncLegacy(
+    force: boolean,
+    attachments?: Attachment[],
+  ): Promise<void> {
     const chunks = prepareChunkedActivities({
       text: this.content,
       attachments,
@@ -204,4 +287,186 @@ export class MSTeamsStreamManager {
 
     this.lastFlushAt = Date.now();
   }
+
+  private async syncNative(
+    force: boolean,
+    attachments?: Attachment[],
+  ): Promise<void> {
+    const chunks = prepareChunkedActivities({
+      text: this.content,
+      attachments,
+    });
+    const first = chunks[0];
+    if (!first) return;
+
+    if (!force) {
+      if (!first.text || first.text === this.nativeLastText) return;
+      if (this.nativeLastText && !first.text.startsWith(this.nativeLastText)) {
+        return;
+      }
+      await this.sendNativeUpdate(first.text, 'streaming');
+      this.nativeLastText = first.text;
+      this.lastFlushAt = Date.now();
+      return;
+    }
+
+    if (!first.text) {
+      await this.disableNativeStreaming(
+        new Error('Teams native streaming requires final text.'),
+      );
+      await this.syncLegacy(true, attachments);
+      return;
+    }
+
+    let finalText = first.text;
+    let remaining = chunks.slice(1);
+    if (this.nativeLastText && !finalText.startsWith(this.nativeLastText)) {
+      finalText = this.nativeLastText;
+      const fallbackText = this.content.startsWith(this.nativeLastText)
+        ? this.content.slice(this.nativeLastText.length)
+        : this.content;
+      remaining = prepareChunkedActivities({
+        text: fallbackText,
+        attachments,
+      });
+    }
+
+    await this.sendNativeFinal(
+      finalText,
+      remaining.length === 0 ? first.attachments : undefined,
+    );
+    for (const chunk of remaining) {
+      await sendMSTeamsActivityWithRetry(
+        this.turnContext,
+        buildMSTeamsMessageActivity({
+          text: chunk.text,
+          attachments: chunk.attachments,
+          replyStyle: 'top-level',
+        }),
+        'msteams.stream.native.remainder',
+      );
+    }
+    this.lastFlushAt = Date.now();
+  }
+
+  private async sendNativeUpdate(
+    text: string,
+    streamType: Exclude<MSTeamsNativeStreamType, 'final'>,
+  ): Promise<void> {
+    const streamSequence = this.nativeSequence + 1;
+    const response = await sendMSTeamsActivityWithRetry(
+      this.turnContext,
+      {
+        type: ActivityTypes.Typing,
+        text,
+        entities: [
+          buildNativeStreamEntity({
+            streamId: this.nativeStreamId,
+            streamSequence,
+            streamType,
+          }),
+        ],
+      },
+      `msteams.stream.native.${streamType}`,
+    );
+    if (!this.nativeStreamId) {
+      const streamId = String(response?.id || '').trim();
+      if (!streamId) {
+        throw new Error(
+          'Teams native streaming did not return a stream identifier.',
+        );
+      }
+      this.nativeStreamId = streamId;
+    }
+    this.nativeSequence = streamSequence;
+  }
+
+  private async sendNativeFinal(
+    text: string,
+    attachments?: Attachment[],
+  ): Promise<void> {
+    if (!this.nativeStreamId) {
+      throw new Error('Teams native streaming was not initialized.');
+    }
+    await sendMSTeamsActivityWithRetry(
+      this.turnContext,
+      {
+        type: ActivityTypes.Message,
+        text,
+        ...(attachments?.length ? { attachments } : {}),
+        entities: [
+          buildNativeStreamEntity({
+            streamId: this.nativeStreamId,
+            streamType: 'final',
+          }),
+        ],
+      },
+      'msteams.stream.native.final',
+    );
+  }
+
+  private async disableNativeStreaming(error: unknown): Promise<void> {
+    if (this.nativeStreamId && isMSTeamsNativeStreamCancellation(error)) {
+      this.nativeCancelled = true;
+      this.closed = true;
+      this.clearFlushTimer();
+      try {
+        this.onNativeCancellation?.();
+      } catch (callbackError) {
+        logger.debug(
+          { error: callbackError },
+          'Teams native stream cancellation callback failed',
+        );
+      }
+      return;
+    }
+    if (this.nativeFailed) return;
+    this.nativeFailed = true;
+    logger.debug(
+      { error, streamId: this.nativeStreamId },
+      'Teams native streaming unavailable; falling back to message updates',
+    );
+    if (!this.nativeStreamId) return;
+    try {
+      await this.turnContext.deleteActivity(this.nativeStreamId);
+    } catch (deleteError) {
+      logger.debug(
+        { error: deleteError, streamId: this.nativeStreamId },
+        'Failed to remove Teams native streaming preview during fallback',
+      );
+    }
+    this.nativeStreamId = null;
+  }
+}
+
+function buildNativeStreamEntity(params: {
+  streamId: string | null;
+  streamType: MSTeamsNativeStreamType;
+  streamSequence?: number;
+}): NonNullable<Activity['entities']>[number] {
+  return {
+    type: 'streaminfo',
+    ...(params.streamId ? { streamId: params.streamId } : {}),
+    streamType: params.streamType,
+    ...(typeof params.streamSequence === 'number'
+      ? { streamSequence: params.streamSequence }
+      : {}),
+  };
+}
+
+function isMSTeamsNativeStreamCancellation(error: unknown): boolean {
+  const details: string[] = [];
+  if (typeof error === 'string') details.push(error);
+  if (error instanceof Error) details.push(error.message);
+  try {
+    details.push(JSON.stringify(error));
+  } catch {
+    // The explicit string or Error message can still identify cancellation.
+  }
+  const normalized = details.join(' ').toLowerCase();
+  return (
+    normalized.includes('contentstreamnotallowed') &&
+    (normalized.includes('canceled by user') ||
+      normalized.includes('cancelled by user'))
+  );
 }

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -412,6 +412,8 @@ export function buildEmptyAgentResponseFallback(
 
 const GENERATED_MEDIA_ARTIFACT_RE =
   /(?:\/workspace\/|\.\/)?(\.generated-(?:images|videos)\/[A-Za-z0-9._@%+=-]+\.(?:png|jpe?g|gif|webp|svg|mp4|m4v|mov|webm))/gi;
+const REFERENCED_WORKSPACE_ARTIFACT_RE =
+  /(?:\/workspace\/|\.\/)?([\p{L}\p{N}._@%+=-]+(?:\/[\p{L}\p{N}._@%+= -]+)*\.(?:docx|gif|jpe?g|m4a|m4v|mov|mp3|mp4|ogg|pdf|png|pptx|svg|wav|webm|webp|xlsx))/giu;
 
 function isGeneratedMediaPath(filePath: string): boolean {
   const parts = filePath.replace(/\\/g, '/').split('/');
@@ -448,6 +450,33 @@ function extractGeneratedMediaReferences(params: {
   const seen = new Set<string>();
   for (const textVariant of decodeArtifactTextVariants(params.resultText)) {
     for (const match of textVariant.matchAll(GENERATED_MEDIA_ARTIFACT_RE)) {
+      const relativePath = match[1];
+      if (!relativePath) continue;
+      const filePath = resolveWorkspaceRelativePath(
+        params.workspacePath,
+        relativePath,
+      );
+      if (!filePath || seen.has(filePath)) continue;
+      seen.add(filePath);
+      references.push({
+        filePath,
+        filename: path.basename(filePath),
+      });
+    }
+  }
+  return references;
+}
+
+function extractReferencedWorkspaceArtifacts(params: {
+  resultText: string;
+  workspacePath: string;
+}): Array<{ filePath: string; filename: string }> {
+  const references: Array<{ filePath: string; filename: string }> = [];
+  const seen = new Set<string>();
+  for (const textVariant of decodeArtifactTextVariants(params.resultText)) {
+    for (const match of textVariant.matchAll(
+      REFERENCED_WORKSPACE_ARTIFACT_RE,
+    )) {
       const relativePath = match[1];
       if (!relativePath) continue;
       const filePath = resolveWorkspaceRelativePath(
@@ -507,10 +536,16 @@ export function recoverGeneratedMediaArtifactsFromResultText(params: {
   const existing = Array.isArray(params.artifacts) ? params.artifacts : [];
   const recovered = [...existing];
   const seen = new Set(existing.map((artifact) => artifact.path));
-  const references = extractGeneratedMediaReferences({
-    resultText: params.resultText,
-    workspacePath: params.workspacePath,
-  });
+  const references = [
+    ...extractGeneratedMediaReferences({
+      resultText: params.resultText,
+      workspacePath: params.workspacePath,
+    }),
+    ...extractReferencedWorkspaceArtifacts({
+      resultText: params.resultText,
+      workspacePath: params.workspacePath,
+    }),
+  ];
   for (const reference of references) {
     if (seen.has(reference.filePath)) continue;
     seen.add(reference.filePath);

--- a/src/gateway/gateway-utils.ts
+++ b/src/gateway/gateway-utils.ts
@@ -5,16 +5,26 @@ import { parseJsonObject } from '../utils/json-object.js';
 import { finiteNumberOrNull } from '../utils/number-normalization.js';
 
 const COMMON_EXTENSION_MIME_TYPES: Record<string, string> = {
+  '.docx':
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
   '.gif': 'image/gif',
   '.jpeg': 'image/jpeg',
   '.jpg': 'image/jpeg',
+  '.m4a': 'audio/mp4',
   '.m4v': 'video/mp4',
+  '.mp3': 'audio/mpeg',
   '.mov': 'video/quicktime',
   '.mp4': 'video/mp4',
+  '.ogg': 'audio/ogg',
+  '.pdf': 'application/pdf',
   '.png': 'image/png',
+  '.pptx':
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
   '.svg': 'image/svg+xml',
+  '.wav': 'audio/wav',
   '.webm': 'video/webm',
   '.webp': 'image/webp',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 };
 
 export function extensionToMimeType(

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -73,6 +73,7 @@ import {
   shutdownLine,
 } from '../channels/line/runtime.js';
 import { isLineChannelId } from '../channels/line/target.js';
+import { stripUnusableMSTeamsArtifactLinks } from '../channels/msteams/delivery.js';
 import {
   initSignal,
   type SignalReplyFn,
@@ -1628,6 +1629,19 @@ async function startDiscordIntegration(): Promise<boolean> {
   return true;
 }
 
+function formatMSTeamsActivityVerb(toolName: string): string {
+  const action = toolName.trim().toLowerCase().split('__').at(-1) || '';
+  if (/search|query|find|lookup/.test(action)) return 'Searching…';
+  if (/read|open|fetch|get|list|browse/.test(action)) return 'Reading…';
+  if (/create|generate|render|image/.test(action)) return 'Creating…';
+  if (/write|edit|update|apply|patch/.test(action)) return 'Updating…';
+  if (/exec|run|test|build|bash|shell|command/.test(action)) {
+    return 'Running…';
+  }
+  if (/send|post|message|email|notify/.test(action)) return 'Sending…';
+  return 'Working…';
+}
+
 async function startMSTeamsIntegration(): Promise<boolean> {
   const teamsConfig = getConfigSnapshot().msteams;
   const hasCredentials =
@@ -1707,6 +1721,14 @@ async function startMSTeamsIntegration(): Promise<boolean> {
                 if (!filteredDelta) return;
                 void appendStreamText(filteredDelta);
               },
+              onToolProgress: (event) => {
+                if (sawTextDelta) return;
+                void context.stream.updateInformative(
+                  event.phase === 'start'
+                    ? formatMSTeamsActivityVerb(event.toolName)
+                    : 'Thinking…',
+                );
+              },
               abortSignal: context.abortSignal,
             }),
           ),
@@ -1735,9 +1757,9 @@ async function startMSTeamsIntegration(): Promise<boolean> {
         const showMode = normalizeSessionShowMode(
           memoryService.getSessionById(effectiveSessionId)?.show_mode,
         );
-        const responseText = renderedText.trim()
+        let responseText = renderedText.trim()
           ? buildResponseText(
-              renderedText,
+              stripUnusableMSTeamsArtifactLinks(renderedText),
               sessionShowModeShowsTools(showMode)
                 ? result.toolsUsed
                 : undefined,
@@ -1790,6 +1812,11 @@ async function startMSTeamsIntegration(): Promise<boolean> {
             },
             'Failed to build Teams artifact attachments',
           );
+          const deliveryNotice =
+            'The artifact was created, but Teams could not deliver the file. Try the bot’s direct chat; if this already is a direct chat, enable file support (`supportsFiles`) in the Teams app manifest.';
+          responseText = responseText
+            ? `${responseText}\n\n${deliveryNotice}`
+            : deliveryNotice;
         }
 
         if (attachments?.length && sawTextDelta) {

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -1950,6 +1950,58 @@ describe('gateway bootstrap', () => {
     );
   });
 
+  test('updates the Teams informative activity while tools run', async () => {
+    const state = await importFreshGatewayMain();
+    state.handleGatewayMessage.mockImplementation(
+      async ({
+        onToolProgress,
+      }: {
+        onToolProgress?: (event: {
+          phase: 'start' | 'finish';
+          toolName: string;
+        }) => void;
+      }) => {
+        onToolProgress?.({ phase: 'start', toolName: 'web_search' });
+        onToolProgress?.({ phase: 'finish', toolName: 'web_search' });
+        return {
+          status: 'success' as const,
+          result: 'Found it.',
+          toolsUsed: ['web_search'],
+          artifacts: [],
+        };
+      },
+    );
+    const stream = {
+      append: vi.fn(async () => {}),
+      discard: vi.fn(async () => {}),
+      fail: vi.fn(async () => {}),
+      finalize: vi.fn(async () => {}),
+      updateInformative: vi.fn(async () => {}),
+    };
+    const context = {
+      abortSignal: new AbortController().signal,
+      activity: { id: 'activity-1' },
+      policy: { replyStyle: 'thread' },
+      stream,
+      turnContext: { sendActivities: vi.fn() },
+    };
+
+    await state.teamsMessageHandler?.(
+      'teams:dm:user-aad-id',
+      null,
+      'a:teams-current-conversation',
+      'user-aad-id',
+      'alice',
+      'find it',
+      [],
+      vi.fn(async () => {}),
+      context,
+    );
+
+    expect(stream.updateInformative).toHaveBeenNthCalledWith(1, 'Searching…');
+    expect(stream.updateInformative).toHaveBeenNthCalledWith(2, 'Thinking…');
+  });
+
   test('keeps attachment-only Teams replies instead of discarding them', async () => {
     const state = await importFreshGatewayMain();
     state.buildTeamsArtifactAttachments.mockResolvedValue([
@@ -2070,6 +2122,57 @@ describe('gateway bootstrap', () => {
         name: 'attachment.png',
       },
     ]);
+  });
+
+  test('reports Teams artifact delivery failures instead of leaving only a dead link', async () => {
+    const state = await importFreshGatewayMain();
+    state.buildTeamsArtifactAttachments.mockRejectedValue(
+      new Error('Teams bot file delivery is supported only in personal chats.'),
+    );
+    state.handleGatewayMessage.mockResolvedValue({
+      status: 'success',
+      result:
+        'Created [dog_with_image.pdf](sandbox:/workspace/dog_with_image.pdf).',
+      toolsUsed: ['bash'],
+      artifacts: [
+        {
+          filename: 'dog_with_image.pdf',
+          mimeType: 'application/pdf',
+          path: '/tmp/dog_with_image.pdf',
+        },
+      ],
+    });
+    const stream = {
+      append: vi.fn(async () => {}),
+      discard: vi.fn(async () => {}),
+      fail: vi.fn(async () => {}),
+      finalize: vi.fn(async () => {}),
+      updateInformative: vi.fn(async () => {}),
+    };
+    const context = {
+      abortSignal: new AbortController().signal,
+      activity: { id: 'activity-1' },
+      policy: { replyStyle: 'thread' },
+      stream,
+      turnContext: { sendActivities: vi.fn() },
+    };
+
+    await state.teamsMessageHandler?.(
+      'teams:channel:conversation-1',
+      'team-1',
+      'conversation-1',
+      'user-aad-id',
+      'alice',
+      'create a PDF',
+      [],
+      vi.fn(async () => {}),
+      context,
+    );
+
+    expect(stream.finalize).toHaveBeenCalledWith(
+      'Created dog_with_image.pdf.\n*Tools: bash*\n\nThe artifact was created, but Teams could not deliver the file. Try the bot’s direct chat; if this already is a direct chat, enable file support (`supportsFiles`) in the Teams app manifest.',
+      undefined,
+    );
   });
 
   test('stores rendered fallback text for Discord pending approvals', async () => {

--- a/tests/gateway-prompt-env-defaults.test.ts
+++ b/tests/gateway-prompt-env-defaults.test.ts
@@ -132,6 +132,54 @@ describe('generated media artifact recovery', () => {
     ).toEqual([existing]);
   });
 
+  test('recovers a referenced PDF from the workspace root', () => {
+    const workspacePath = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'hybridclaw-generated-artifacts-'),
+    );
+    tempDirs.push(workspacePath);
+    const pdfPath = path.join(workspacePath, 'dog_with_image.pdf');
+    fs.writeFileSync(pdfPath, '%PDF-1.7');
+
+    expect(
+      recoverGeneratedMediaArtifactsFromResultText({
+        workspacePath,
+        resultText:
+          'Erledigt: [dog_with_image.pdf](sandbox:/workspace/dog_with_image.pdf)',
+      }),
+    ).toEqual([
+      {
+        path: pdfPath,
+        filename: 'dog_with_image.pdf',
+        mimeType: 'application/pdf',
+      },
+    ]);
+  });
+
+  test('recovers a referenced Office artifact from a nested workspace path', () => {
+    const workspacePath = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'hybridclaw-generated-artifacts-'),
+    );
+    tempDirs.push(workspacePath);
+    const outputDir = path.join(workspacePath, 'outputs');
+    fs.mkdirSync(outputDir);
+    const documentPath = path.join(outputDir, 'Überblick.docx');
+    fs.writeFileSync(documentPath, 'docx');
+
+    expect(
+      recoverGeneratedMediaArtifactsFromResultText({
+        workspacePath,
+        resultText: 'The document is `outputs/Überblick.docx`.',
+      }),
+    ).toEqual([
+      {
+        path: documentPath,
+        filename: 'Überblick.docx',
+        mimeType:
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      },
+    ]);
+  });
+
   test('recovers generated media artifacts without replacing assistant text', () => {
     const workspacePath = fs.mkdtempSync(
       path.join(os.tmpdir(), 'hybridclaw-generated-artifacts-'),

--- a/tests/msteams.attachments.test.ts
+++ b/tests/msteams.attachments.test.ts
@@ -247,11 +247,11 @@ test('buildTeamsUploadedFileAttachment uses a file consent card for personal non
   });
 });
 
-test('buildTeamsUploadedFileAttachment rejects large non-personal uploads without a storage fallback', async () => {
+test('buildTeamsUploadedFileAttachment rejects non-image files outside personal chats', async () => {
   const { buildTeamsUploadedFileAttachment } = await importAttachmentsModule();
   const tempDir = makeTempDir('hybridclaw-msteams-');
-  const filePath = path.join(tempDir, 'large.zip');
-  fs.writeFileSync(filePath, Buffer.alloc(4_300_000, 1));
+  const filePath = path.join(tempDir, 'report.pdf');
+  fs.writeFileSync(filePath, Buffer.from('%PDF-1.7'));
 
   const connectorKey = Symbol('ConnectorClientKey');
   const turnContext = {
@@ -281,11 +281,60 @@ test('buildTeamsUploadedFileAttachment rejects large non-personal uploads withou
     buildTeamsUploadedFileAttachment({
       turnContext: turnContext as never,
       filePath,
-      mimeType: 'application/zip',
+      mimeType: 'application/pdf',
     }),
   ).rejects.toThrow(
-    'Teams file uploads larger than 4 MB in channels or group chats require SharePoint/OneDrive fallback, which is not implemented yet.',
+    'Teams bot file delivery is supported only in personal chats.',
   );
+  expect(
+    (
+      turnContext.turnState.get(connectorKey) as {
+        conversations: { uploadAttachment: ReturnType<typeof vi.fn> };
+      }
+    ).conversations.uploadAttachment,
+  ).not.toHaveBeenCalled();
+});
+
+test('buildTeamsUploadedFileAttachment infers personal chat when Teams omits conversationType', async () => {
+  const { buildTeamsUploadedFileAttachment } = await importAttachmentsModule();
+  const tempDir = makeTempDir('hybridclaw-msteams-');
+  const filePath = path.join(tempDir, 'report.pdf');
+  fs.writeFileSync(filePath, Buffer.from('%PDF-1.7'));
+
+  const uploadAttachment = vi.fn(async () => ({ id: 'attachment-123' }));
+  const connectorKey = Symbol('ConnectorClientKey');
+  const turnContext = {
+    activity: {
+      conversation: { id: 'conversation-123' },
+      channelData: {},
+      serviceUrl: 'https://smba.trafficmanager.net/de/tenant-id/',
+    },
+    adapter: {
+      ConnectorClientKey: connectorKey,
+    },
+    turnState: new Map([
+      [
+        connectorKey,
+        {
+          conversations: {
+            uploadAttachment,
+          },
+        },
+      ],
+    ]),
+  };
+
+  const attachment = await buildTeamsUploadedFileAttachment({
+    turnContext: turnContext as never,
+    filePath,
+    mimeType: 'application/pdf',
+  });
+
+  expect(uploadAttachment).not.toHaveBeenCalled();
+  expect(attachment).toMatchObject({
+    contentType: 'application/vnd.microsoft.teams.card.file.consent',
+    name: 'report.pdf',
+  });
 });
 
 test('maybeHandleMSTeamsFileConsentInvoke uploads the pending file and sends a file info card', async () => {

--- a/tests/msteams.delivery.test.ts
+++ b/tests/msteams.delivery.test.ts
@@ -3,7 +3,18 @@ import { expect, test, vi } from 'vitest';
 import {
   prepareChunkedActivities,
   sendChunkedReply,
+  stripUnusableMSTeamsArtifactLinks,
 } from '../src/channels/msteams/delivery.js';
+
+test('stripUnusableMSTeamsArtifactLinks keeps artifact names but removes local URLs', () => {
+  expect(
+    stripUnusableMSTeamsArtifactLinks(
+      'Created [dog_with_image.pdf](sandbox:/workspace/dog_with_image.pdf) and [docs](https://example.com/docs).',
+    ),
+  ).toBe(
+    'Created dog_with_image.pdf and [docs](https://example.com/docs).',
+  );
+});
 
 test('prepareChunkedActivities keeps attachment-only Teams sends empty', () => {
   const attachments = [

--- a/tests/msteams.runtime.test.ts
+++ b/tests/msteams.runtime.test.ts
@@ -8,6 +8,8 @@ const credentialsFactoryMock = vi.fn();
 const authConfigMock = vi.fn();
 const typingStartMock = vi.fn();
 const typingStopMock = vi.fn();
+const streamUpdateInformativeMock = vi.fn(async () => {});
+const streamIsNativeStreamingActiveMock = vi.fn(() => true);
 const sendChunkedReplyMock = vi.fn(async () => {});
 const continueConversationAsyncMock = vi.fn();
 const buildTeamsAttachmentContextMock = vi.fn(async () => []);
@@ -200,7 +202,10 @@ async function importRuntime() {
     })),
   }));
   vi.doMock('../src/channels/msteams/stream.js', () => ({
-    MSTeamsStreamManager: class {},
+    MSTeamsStreamManager: class {
+      updateInformative = streamUpdateInformativeMock;
+      isNativeStreamingActive = streamIsNativeStreamingActiveMock;
+    },
   }));
   vi.doMock('../src/channels/msteams/typing.js', () => ({
     createMSTeamsTypingController: vi.fn(() => ({
@@ -218,6 +223,10 @@ afterEach(() => {
   authConfigMock.mockReset();
   typingStartMock.mockReset();
   typingStopMock.mockReset();
+  streamUpdateInformativeMock.mockReset();
+  streamUpdateInformativeMock.mockResolvedValue(undefined);
+  streamIsNativeStreamingActiveMock.mockReset();
+  streamIsNativeStreamingActiveMock.mockReturnValue(true);
   sendChunkedReplyMock.mockReset();
   continueConversationAsyncMock.mockReset();
   buildTeamsAttachmentContextMock.mockReset();
@@ -532,6 +541,38 @@ describe('Microsoft Teams runtime webhook adapter', () => {
       ['clear'],
       expect.any(Function),
     );
+    expect(typingStartMock).not.toHaveBeenCalled();
+    expect(typingStopMock).not.toHaveBeenCalled();
+  });
+
+  test('starts a native Teams informative stream for direct messages', async () => {
+    processMock.mockImplementation(
+      async (_req, _res, logic: (context: unknown) => Promise<void>) => {
+        await logic({
+          activity: {
+            type: 'message',
+            text: 'Hello',
+            conversation: {
+              id: 'conversation-123',
+              conversationType: 'personal',
+            },
+            recipient: { id: 'bot-id' },
+          },
+          sendActivity: vi.fn(async () => ({ id: 'reply-1' })),
+          turnState: new Map(),
+        });
+      },
+    );
+
+    const runtime = await importRuntime();
+    runtime.initMSTeams(vi.fn(async () => {}), vi.fn(async () => {}));
+
+    await runtime.handleMSTeamsWebhook(
+      makeRequest({ type: 'message', text: 'Hello' }),
+      makeResponse(),
+    );
+
+    expect(streamUpdateInformativeMock).toHaveBeenCalledWith();
     expect(typingStartMock).not.toHaveBeenCalled();
     expect(typingStopMock).not.toHaveBeenCalled();
   });

--- a/tests/msteams.stream.test.ts
+++ b/tests/msteams.stream.test.ts
@@ -2,6 +2,177 @@ import { expect, test, vi } from 'vitest';
 
 import { MSTeamsStreamManager } from '../src/channels/msteams/stream.js';
 
+test('uses the Teams streaminfo protocol for direct-message progress and text', async () => {
+  vi.useFakeTimers();
+  try {
+    const sendActivity = vi
+      .fn()
+      .mockResolvedValueOnce({ id: 'stream-1' })
+      .mockResolvedValue(undefined);
+    const turnContext = {
+      sendActivity,
+      updateActivity: vi.fn(async () => {}),
+      deleteActivity: vi.fn(async () => {}),
+    };
+    const stream = new MSTeamsStreamManager(turnContext as never, {
+      replyStyle: 'thread',
+      replyToId: 'incoming-1',
+      editIntervalMs: 500,
+      nativeStreaming: true,
+    });
+
+    await stream.updateInformative();
+    expect(sendActivity).toHaveBeenNthCalledWith(1, {
+      type: 'typing',
+      text: 'Thinking…',
+      entities: [
+        {
+          type: 'streaminfo',
+          streamType: 'informative',
+          streamSequence: 1,
+        },
+      ],
+    });
+
+    await stream.updateInformative('Searching…');
+    expect(sendActivity).toHaveBeenNthCalledWith(2, {
+      type: 'typing',
+      text: 'Searching…',
+      entities: [
+        {
+          type: 'streaminfo',
+          streamId: 'stream-1',
+          streamType: 'informative',
+          streamSequence: 2,
+        },
+      ],
+    });
+
+    await stream.append('Hello');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sendActivity).toHaveBeenNthCalledWith(3, {
+      type: 'typing',
+      text: 'Hello',
+      entities: [
+        {
+          type: 'streaminfo',
+          streamId: 'stream-1',
+          streamType: 'streaming',
+          streamSequence: 3,
+        },
+      ],
+    });
+
+    await stream.finalize('Hello world');
+    expect(sendActivity).toHaveBeenNthCalledWith(4, {
+      type: 'message',
+      text: 'Hello world',
+      entities: [
+        {
+          type: 'streaminfo',
+          streamId: 'stream-1',
+          streamType: 'final',
+        },
+      ],
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('falls back to normal Teams messages when native streaming is unavailable', async () => {
+  const sendActivity = vi
+    .fn()
+    .mockRejectedValueOnce({ statusCode: 403 })
+    .mockResolvedValueOnce({ id: 'activity-1' });
+  const turnContext = {
+    sendActivity,
+    updateActivity: vi.fn(async () => {}),
+    deleteActivity: vi.fn(async () => {}),
+  };
+  const stream = new MSTeamsStreamManager(turnContext as never, {
+    replyStyle: 'thread',
+    replyToId: 'incoming-1',
+    nativeStreaming: true,
+  });
+
+  await stream.updateInformative();
+  expect(stream.isNativeStreamingActive()).toBe(false);
+
+  await stream.finalize('Fallback reply');
+  expect(sendActivity).toHaveBeenNthCalledWith(2, {
+    type: 'message',
+    text: 'Fallback reply',
+    replyToId: 'incoming-1',
+  });
+});
+
+test('delivers the full reply when Teams rejects native stream finalization', async () => {
+  const sendActivity = vi
+    .fn()
+    .mockResolvedValueOnce({ id: 'stream-1' })
+    .mockRejectedValueOnce({ statusCode: 403 })
+    .mockResolvedValueOnce({ id: 'activity-1' });
+  const deleteActivity = vi.fn(async () => {});
+  const turnContext = {
+    sendActivity,
+    updateActivity: vi.fn(async () => {}),
+    deleteActivity,
+  };
+  const stream = new MSTeamsStreamManager(turnContext as never, {
+    replyStyle: 'thread',
+    replyToId: 'incoming-1',
+    nativeStreaming: true,
+  });
+
+  await stream.updateInformative();
+  await stream.finalize('Complete reply');
+
+  expect(deleteActivity).toHaveBeenCalledWith('stream-1');
+  expect(sendActivity).toHaveBeenNthCalledWith(3, {
+    type: 'message',
+    text: 'Complete reply',
+    replyToId: 'incoming-1',
+  });
+});
+
+test('honors a user cancellation instead of redelivering the reply', async () => {
+  const sendActivity = vi
+    .fn()
+    .mockResolvedValueOnce({ id: 'stream-1' })
+    .mockRejectedValueOnce({
+      response: {
+        status: 403,
+        data: {
+          error: {
+            code: 'ContentStreamNotAllowed',
+            message: 'Content stream was canceled by user.',
+          },
+        },
+      },
+    });
+  const deleteActivity = vi.fn(async () => {});
+  const onNativeCancellation = vi.fn();
+  const turnContext = {
+    sendActivity,
+    updateActivity: vi.fn(async () => {}),
+    deleteActivity,
+  };
+  const stream = new MSTeamsStreamManager(turnContext as never, {
+    replyStyle: 'thread',
+    replyToId: 'incoming-1',
+    nativeStreaming: true,
+    onNativeCancellation,
+  });
+
+  await stream.updateInformative();
+  await stream.finalize('Do not redeliver this reply');
+
+  expect(onNativeCancellation).toHaveBeenCalledTimes(1);
+  expect(sendActivity).toHaveBeenCalledTimes(2);
+  expect(deleteActivity).not.toHaveBeenCalled();
+});
+
 test('finalize omits the text field for attachment-only Teams stream sends', async () => {
   const sendActivity = vi.fn(async () => ({ id: 'activity-1' }));
   const turnContext = {


### PR DESCRIPTION
## What changed

- use Teams native `streaminfo` activities for Thinking/tool progress and incremental direct-message responses, with cancellation and legacy fallbacks
- recover referenced PDF, Office, image, audio, and video outputs as artifacts instead of leaving sandbox-local links
- strip unusable local artifact URLs from Teams message text and deliver personal-chat files through consent cards
- report the Microsoft Graph/SharePoint requirement explicitly for channel and group-chat files
- document the `supportsFiles` manifest requirement and add focused regression coverage

## Why

Teams 0.28.5 used ordinary message edits and bare typing activities, so clients often showed only the final response. Generated files could also remain model-local links, while non-personal document uploads incorrectly used the generic Bot Framework attachment endpoint. The result was no native activity indicator and PDF links that Teams rendered but could not open.

## Impact

One-on-one chats now show native progress and streaming where supported, then fall back safely when the client rejects native streaming. Referenced deliverables are surfaced as real artifacts; direct-chat files use the Teams consent flow. Unsupported channel/group-chat file delivery no longer silently emits a dead link.

## Validation

- `npm run format`
- `npm run lint`
- `npm run check` (passes with the repository's existing 27 advisory warnings)
- `vitest run tests/msteams*.test.ts tests/gateway-main.test.ts tests/gateway-prompt-env-defaults.test.ts` — 136 tests passed
