### PR TITLE
chore: release v0.28.6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ HybridClaw is a personal AI assistant bot for Discord, powered by HybridAI.
 Enterprise-grade Node.js 22 application with gateway service, TUI client, and
 Docker-sandboxed container runtime.
 
-**Version:** 0.28.4 &ensp;|&ensp; **Package:** `@hybridaione/hybridclaw`
+**Version:** 0.28.6 &ensp;|&ensp; **Package:** `@hybridaione/hybridclaw`
 &ensp;|&ensp; **License:** see `LICENSE`
 
 Architecture: gateway (core runtime, SQLite persistence, REST API, Discord

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.28.6](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.6) - 2026-07-26
+
 ### Changed
 
 - **LINE is now an install-on-demand channel plugin**: The unofficial LINEJS

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Core pieces:
 | Build desktop releases | [Desktop Release Builds](https://hybridaione.github.io/hybridclaw/docs/developer-guide/desktop-release) |
 | Contribute | [CONTRIBUTING.md](./CONTRIBUTING.md), [docs/content/README.md](./docs/content/README.md) |
 
-Latest release: [v0.28.5](https://github.com/HybridAIOne/hybridclaw/releases/tag/v0.28.5).
+Latest release: [v0.28.6](https://github.com/HybridAIOne/hybridclaw/releases/tag/v0.28.6).
 Release notes: [CHANGELOG.md](./CHANGELOG.md)
 
 ## Development

--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hybridaione/hybridclaw-console",
   "private": true,
-  "version": "0.28.5",
+  "version": "0.28.6",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/console/src/release-notes.ts
+++ b/console/src/release-notes.ts
@@ -1,9 +1,10 @@
 export const LATEST_RELEASE_NOTES = {
-  version: '0.28.5',
+  version: '0.28.6',
   highlights: [
-    'Reliable email delivery immediately after setup.',
-    'Runtime Python package installation.',
-    'Fix Provider API error 500 with GPT models.',
+    'Live Microsoft Teams activity and streaming.',
+    'Openable files in Teams direct messages.',
+    'Reliable cloud admin reauthentication.',
+    'LINE and WhatsApp remain install-on-demand.',
   ],
 } as const;
 

--- a/container/npm-shrinkwrap.json
+++ b/container/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.28.5",
+      "version": "0.28.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/container/package-lock.json
+++ b/container/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.28.5",
+      "version": "0.28.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/container/package.json
+++ b/container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@hybridaione/hybridclaw-desktop",
   "productName": "HybridClaw",
   "private": true,
-  "version": "0.28.5",
+  "version": "0.28.6",
   "license": "MIT",
   "type": "module",
   "description": "macOS wrapper for the HybridClaw chat and admin web surfaces",

--- a/docs/content/README.md
+++ b/docs/content/README.md
@@ -27,6 +27,9 @@ doc at once, start from [For Agents](./agents.md).
 
 ## Latest Highlights
 
+- HybridClaw v0.28.6 shows live thinking and tool activity in one-on-one
+  Microsoft Teams chats, streams response text in place, and delivers generated
+  files through openable consent cards instead of sandbox-local links.
 - HybridClaw v0.28.4 keeps conversation prefixes cache-stable across turns and
   tool loops by separating static instructions, workspace memory, skills, and
   turn-local context while preserving complete retained messages.

--- a/docs/content/channels/msteams.md
+++ b/docs/content/channels/msteams.md
@@ -135,6 +135,21 @@ an openable file card. The Teams bot file API supports this flow only in
 one-on-one chats; channel and group-chat file delivery requires a separate
 Microsoft Graph and SharePoint/OneDrive integration.
 
+## Troubleshooting: a generated file is only a link
+
+If a direct-message response names a generated PDF, document, spreadsheet,
+presentation, image, audio file, or video but does not show a file-consent
+card, verify that the bot entry in the installed Teams app manifest contains
+`"supportsFiles": true`. After changing the manifest, download and upload a new
+app package, then reinstall or update the app in Teams.
+
+Select **Accept** on the consent card to complete the upload. Declining the card
+leaves the file in HybridClaw's sandbox and does not create a Teams attachment.
+
+Team channels and group chats cannot use bot file-consent cards. HybridClaw
+reports that limitation in the reply instead of displaying a local link that
+Teams cannot open.
+
 ## Troubleshooting: the bot does not respond
 
 The default DM policy is `allowlist`, so the bot does not respond to a direct

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.28.5",
+      "version": "0.28.6",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -82,7 +82,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.28.5",
+      "version": "0.28.6",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "5.101.2",
@@ -108,7 +108,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.28.5",
+      "version": "0.28.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -136,7 +136,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.28.5",
+      "version": "0.28.6",
       "license": "MIT",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.28.5",
+      "version": "0.28.6",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -82,7 +82,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.28.5",
+      "version": "0.28.6",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "5.101.2",
@@ -108,7 +108,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.28.5",
+      "version": "0.28.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -136,7 +136,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.28.5",
+      "version": "0.28.6",
       "license": "MIT",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "type": "module",
   "description": "Enterprise-ready self-hosted AI assistant runtime with sandboxed execution, secure credentials, approvals, and memory",
   "license": "MIT",

--- a/scripts/dependency-policy-baseline.json
+++ b/scripts/dependency-policy-baseline.json
@@ -1,9 +1,9 @@
 {
   "lockfiles": {
-    "package-lock.json": "fab9448efdd5b3ca526b951636824d157f8eddbd5b5abead7a7b448d77721606",
-    "npm-shrinkwrap.json": "fab9448efdd5b3ca526b951636824d157f8eddbd5b5abead7a7b448d77721606",
-    "container/package-lock.json": "6dc2ad2677de7fa7a14e9f0db71a78c6bb885e331c31ce28ba46de964edffb10",
-    "container/npm-shrinkwrap.json": "6dc2ad2677de7fa7a14e9f0db71a78c6bb885e331c31ce28ba46de964edffb10",
+    "package-lock.json": "424e4e56b3d2f6ad9d503d8a0b19ad84403b19702e769339e8910e115fc313ef",
+    "npm-shrinkwrap.json": "424e4e56b3d2f6ad9d503d8a0b19ad84403b19702e769339e8910e115fc313ef",
+    "container/package-lock.json": "b04d2ccd2be75050a0302c0fef2d9da9f31de4ff04820af7c82c10cac314024d",
+    "container/npm-shrinkwrap.json": "b04d2ccd2be75050a0302c0fef2d9da9f31de4ff04820af7c82c10cac314024d",
     "plugins/brevo-email/package-lock.json": "3377225eb3bdbb252eaa28ad420b9a725ea1da533417388557aa1984730229b5",
     "plugins/line/package-lock.json": "1edbba8cefe83f595528d56ecd9086093c05acdca646594cd3bc043bae9924e8"
   },


### PR DESCRIPTION
## Summary

- bump root, console, desktop, and container package metadata to `0.28.6`
- publish the Microsoft Teams activity, streaming, and generated-file fixes in the changelog and console What's New dialog
- document Teams file-consent troubleshooting and refresh the README release link, docs highlights, lockfile metadata, and policy hashes

## Why

This packages the Microsoft Teams fixes merged in #1374. Direct chats show native thinking and tool activity, stream response text in place, and deliver generated artifacts through openable Teams file-consent cards instead of unusable sandbox-local links.

The patch release also includes the already-merged change that keeps WhatsApp strictly install-on-demand.

## Validation

- `npm run format`
- `npm run lint`
- `npm run build`
- `npm run release:check`
- `npm --prefix container run release:check`
- Teams and gateway targeted suite: 9 files, 136 tests passed
- `git diff --check`
