### PR TITLE
docs: require module headers; add risk-class + attention-routing addendum to approvals v2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,8 +258,41 @@ hybridclaw gateway status             # gateway liveness, PID, build/version dia
 - **File size:** aim for ~500 LOC; split when it improves clarity or
   testability. `src/skills/skills-guard.ts` and `src/skills/skills.ts` are
   current large exceptions — do not grow them further without splitting.
-- **Comments:** brief comments for tricky or non-obvious logic only. Do not add
-  comments, docstrings, or type annotations to code you did not change.
+- **Module headers:** every **new** file under `src/`, `container/src/`, and
+  `console/src/` opens with a short block comment (2–6 lines) stating the
+  contract, not the mechanics. Name the invariant the module guarantees, the
+  neighbour it is most often confused with, and what it deliberately does
+  *not* do. "What it does" is already readable from the exports; write down
+  what a reader cannot infer.
+
+  ```ts
+  /**
+   * Pending-approval registry — the store of record for prompts awaiting a human.
+   *
+   * Each prompt is `pending → resolved` exactly once, idempotent and
+   * first-responder-wins, so answering from Slack, Discord, the TUI, or the
+   * console is safe under a race. Channel button handlers are transports of
+   * these records, never a second registry.
+   *
+   * NOT the escalation router (`approval-presentation.ts` decides *where* a
+   * prompt is shown); this module only decides *whether it is still open*.
+   */
+  ```
+
+  When you materially change an existing file's contract, add or update its
+  header in the same PR. Backfill headers only for files whose invariants
+  cross module boundaries (approvals, policy, A2A, gateway routing, secrets) —
+  do not open drive-by header-only PRs across the tree.
+- **Decision provenance:** when a value, list, or threshold exists because
+  someone made a call rather than because it is derivable, record the call in
+  the comment: date, who decided, and what was deliberately deferred. Applies
+  to curated model lists, default tiers, timeouts, and pinned-red defaults.
+  Example: `// 120s (owner call, 2026-07-24): matches the inline prompt window;
+  queued-approval TTL semantics deferred to approvals-v2 phase 2.5.`
+- **Comments:** brief inline comments for tricky or non-obvious logic only. Do
+  not add inline comments or type annotations to code you did not change; the
+  module-header rule above is the exception and applies to new or
+  contract-changed files.
 - **Imports:** let Biome organize imports. Do not mix dynamic
   `await import()` and static `import` for the same module in production paths.
 - **Dependencies:** root `package.json` is for gateway/CLI deps. Container-only

--- a/docs/content/internal/risk-class-and-attention-routing.md
+++ b/docs/content/internal/risk-class-and-attention-routing.md
@@ -1,0 +1,191 @@
+---
+title: Risk Class And Attention Routing — Design Addendum
+description: Two structural changes to Approvals v2 — a side-effect taxonomy (read/write_local/exec/external) alongside the green/yellow/red severity scale, and splitting the autonomy ceiling from where the human is reached (inline vs queued attention).
+---
+
+> **Internal document.** Addendum to `approvals-v2-design.md`. Status: **Proposal**
+> (2026-07-24).
+
+# Risk Class and Attention Routing
+
+Addendum to `approvals-v2-design.md` (branch `claude/approvals-v2`, not yet on
+`main`). Two changes to that proposal, both structural rather than additive:
+give the pipeline a side-effect taxonomy alongside its severity scale, and
+split "how much may the agent do" from "where does the human get asked".
+
+Neither idea is new machinery — both re-express state the approval pipeline
+already computes, so the cost is in the declaration and the tests, not in a
+new engine.
+
+## 1. Risk class — what kind of side effect, not how scary
+
+`ApprovalTier` (`green | yellow | red`, `src/types/execution.ts:82`) is a
+severity scale. It answers "how loud should this be" and nothing else. The
+orthogonal question — *what kind of blast radius does this call have* — is
+currently spread across three fields of `ClassifiedAction`
+(`container/src/approval-policy.ts:155`): `writeIntent`, `pathHints`,
+`hostHints`, plus string matching on `actionKey`. Every rule that needs the
+answer re-derives it: `pinned_red` for path safeguards, `red_promotable` and
+`stickyYellow` for promotion eligibility, `full_auto.never_approve`, and the
+durable-trust rules for what may be granted "for all".
+
+Add one declared field:
+
+```ts
+export type RiskClass =
+  | 'read'         // no side effects
+  | 'write_local'  // mutates the filesystem inside the workspace fence
+  | 'exec'         // runs a command (shell, container exec)
+  | 'external';    // side effects off this machine — messages, API writes, A2A sends
+```
+
+`riskClass` and `tier` are independent. A `read` can be red (reading
+`~/.ssh/id_rsa`); an `external` can be green (an `allow` rule for
+`slack:C0123`). Severity is *policy output*; class is *call input*.
+
+### What falls out mechanically
+
+The point of the field is that it turns several hand-maintained name lists
+into type-level facts:
+
+| Class | Durable grant eligibility | Scoping key |
+| --- | --- | --- |
+| `read` | n/a — never prompts except via `pinned_red` | — |
+| `write_local` | only with an explicit `paths:` glob under the fence | path |
+| `exec` | only with an explicit `command:` glob; never wildcard | command prefix |
+| `external` | target-bound rule (`tool + exact target`) | target address |
+
+`external` is the only class with a stable, nameable target — a channel
+address, a recipient, a host, a peer agent id. That is precisely why it is the
+only class where "always allow this" is safe to offer as a one-tap grant, and
+why shell must keep asking unless the operator wrote a glob by hand. Today
+that distinction lives in reviewers' heads and in the `pinned_red` default
+list; making it a class means a new tool inherits the right behavior without
+anyone remembering to add it to a list.
+
+Concretely, in the §2 grant writer of approvals-v2: a "yes for all" reply mints
+a rule only if `riskClass === 'external'` and the tool declares a target
+argument. Everything else stays a one-time or session approval, fail-closed.
+
+### Landing it
+
+1. `classify_action` sets `riskClass` from the existing action-key table plus
+   `writeIntent`/`hostHints`. Derivable for every shipped tool; no config.
+2. Emit it on `ToolExecution` and every tool-execution audit event, next to
+   `approvalTier`.
+3. Ship steps 1–2 with **no gating behavior** first. That validates the
+   taxonomy against real traffic (and against the anomaly reranker's
+   trajectories) before anything depends on it.
+4. Then move grant eligibility, `never_approve`, and promotion eligibility to
+   read the class instead of re-deriving.
+
+Tools declaring their own class (plugins, MCP) resolve as: user-local override
+→ declared class → conservative default. MCP tools default to `external`,
+which is the safe reading of an unknown remote tool and matches how
+`requires_approval` metadata is treated today.
+
+## 2. Attention routing is not autonomy
+
+`full` mode / `/fullauto` currently conflates two independent things:
+
+- **Autonomy ceiling** — how much the agent may do without a human.
+- **Attention routing** — where a human gets asked, and whether one is
+  present at all.
+
+The practical cost shows up in scheduled runs. When a cron-fired turn hits a
+red prompt at 03:00 the only levers are "raise the mode so it doesn't ask" or
+"let the prompt expire into a denial". Both are wrong answers to "the person
+is asleep". `escalationTarget` is the only routing primitive we have, it is
+per-agent, and it is undocumented (approvals-v2 §3 already moves it).
+
+Add a second per-session axis:
+
+```yaml
+approval:
+  mode: auto            # ask | auto | full | custom   — the autonomy ceiling
+  attention: inline     # inline | queued              — where the human is reached
+```
+
+- `inline` (default): prompts render in the session that raised them; the
+  requester answers; today's behavior exactly.
+- `queued`: the session is unattended. Anything that would prompt inline
+  becomes a queued item, the turn suspends, and the composer is disabled.
+
+**The contract, and it is the whole point: `queued` never raises the ceiling.**
+A red prompt under `mode: ask` with `attention: queued` still blocks. It
+blocks in the queue instead of on screen. Turning on "I'm away" must never be
+a way to grant autonomy, and today's `/fullauto` is exactly that.
+
+This is also what makes approvals-v2 §3 (Approvers) implementable without
+special cases:
+
+- `inline` + approvers → requester waits, designated approver answers from
+  wherever they are.
+- `queued` + `approvers.escalate` → the item is routed to the security
+  channel and resolved there.
+
+Both are the same record resolved by the same chokepoint.
+
+### Landing it on `pending-approvals.ts`
+
+`PendingApprovalPrompt` (`src/gateway/pending-approvals.ts:24`) is already
+most of a queue: per-session records, TTL, durable persistence via runtime
+assets. Three deltas:
+
+1. **`visibility: 'inline' | 'queued'`** on the record. `attention` is the
+   per-session default that stamps it at creation.
+2. **Cross-session listing.** Today the map is keyed one-prompt-per-session
+   (`pendingApprovalBySession`); a queue needs "everything waiting on me,
+   across sessions", which is what the console Approvals page and
+   `/approvals` should both render.
+3. **TTL semantics must differ by visibility.** `APPROVAL_PROMPT_DEFAULT_TTL_MS`
+   is 120s (`src/gateway/pending-approvals.ts:11`), which is right for an
+   inline prompt and wrong for a queued one — a queued item silently aging
+   into a denial while the operator is asleep is the failure mode this axis
+   exists to prevent. Queued items get no TTL, and `expired` becomes a state
+   distinct from `denied`.
+
+`authorizeApprovalResponse` (approvals-v2 §3) then becomes the single resolver
+for every transport. Make its contract explicit and test it: **`pending →
+resolved` exactly once, idempotent, first-responder-wins.** Discord buttons,
+Slack buttons, `/approve`, plain-text `yes`, voice, and the console card are
+transports of one record — never parallel registries. The current
+`claimPendingApprovalByApprovalId` ownership check exists only on Discord and
+Slack buttons, so the race is reachable today.
+
+Generalizing the record's `kind` beyond approvals (`question`, `notification`,
+`plan`) is the natural follow-on but is not required for this split; keep it
+out of the first PR.
+
+### Managed overlay
+
+The platform overlay (approvals-v2 §4) may pin `attention` the same way it
+pins `mode_max` — an unattended fleet can be forced to `queued` so no run can
+ever park a prompt where nobody is looking.
+
+## Phasing delta
+
+Against the five phases in `approvals-v2-design.md`:
+
+- **Phase 1 (Mode)** — unchanged, plus `riskClass` on `ClassifiedAction` and
+  audit events, observability only.
+- **Phase 2 (Grants → policy)** — grant eligibility keyed on `riskClass` per
+  the table above, replacing the name lists.
+- **Phase 2.5 (new)** — `attention` axis; `visibility` + TTL split on
+  `pending-approvals.ts`; `/approvals attention <inline|queued>`; `/fullauto`
+  folds into `mode`, not into this.
+- **Phase 3 (Approvers)** — unchanged, but `authorizeApprovalResponse` now
+  resolves queue items and its idempotency contract is tested.
+- **Phase 4–5** — unchanged; overlay gains `attention`.
+
+## Open questions
+
+- Does `read` short-circuit the pipeline? It cannot skip `pinned_red` (reading
+  `~/.ssh/id_rsa` is red). Recommendation: `read` runs `pinned_red` and then
+  returns green, skipping stakes/anomaly/trust — a measurable latency win on
+  the most common call class.
+- Is an A2A send `external`, or its own class? Recommendation: `external`,
+  target = peer agent id; it needs the same target-bound grant shape.
+- Does `queued` disable the composer, or allow steering without answering?
+  Recommendation: disable, matching the "the human is not here" premise;
+  revisit if operators want to redirect a parked run.


### PR DESCRIPTION
## Summary

- **Problem:** Two structural gaps in how we record design intent. First, module invariants that cross boundaries — approvals, policy, gateway routing — are not written down anywhere near the code: a sampled count found header comments on **9 of 400** files under `src/`. Second, our approval pipeline has a severity scale (`green|yellow|red`) but no declared side-effect taxonomy, and no way to say "the operator is away" without also saying "act without asking".
- **Why it matters:** The missing taxonomy means grant eligibility, `never_approve`, promotion eligibility, and `pinned_red` each re-derive "what kind of call is this" from `writeIntent` + `pathHints` + `hostHints` + action-key matching — so a newly added tool inherits the right behavior only if someone remembers to update a list. The missing attention axis means a scheduled run that hits a red prompt at 03:00 has two bad options: raise the mode, or let the prompt expire into a denial.
- **What changed:** `AGENTS.md` gains a module-header requirement and a decision-provenance rule under Coding Style. `docs/content/internal/risk-class-and-attention-routing.md` is a new internal design addendum to `approvals-v2-design.md`.
- **What did not change:** No runtime behavior, no config schema, no tests. Both files are documentation; the addendum is a proposal that slots into the existing five-phase approvals-v2 plan rather than replacing it.

### Detail: `AGENTS.md`

- **Module headers** — required on every *new* file under `src/`, `container/src/`, `console/src/`: 2–6 lines stating the contract (the invariant guaranteed, the neighbour it is confused with, what it deliberately does *not* do), not the mechanics. Includes a worked example written against our own `pending-approvals.ts`. Backfill is deliberately scoped to cross-boundary files, with an explicit "no drive-by header-only PRs" so this does not become tree-wide churn.
- **Decision provenance** — record date, decider, and what was deferred for values that exist because someone made a call (default tiers, timeouts, pinned-red defaults).
- The existing **Comments** bullet is narrowed to *inline* comments. Without that edit, "do not add comments or docstrings to code you did not change" directly contradicts the new header rule.

### Detail: the design addendum

- **Risk class** — declare `read | write_local | exec | external` on `ClassifiedAction`, orthogonal to `ApprovalTier`. Severity is policy *output*; class is call *input*. `external` is the only class with a stable nameable target (channel address, recipient, host, peer agent id), which is exactly why it is the only class where a one-tap "always allow" grant is safe; `exec` never gets a wildcard. Proposed to ship **observability-only first** so the taxonomy can be validated against real traffic before it gates anything.
- **Attention routing** — split `mode` (autonomy ceiling) from `attention` (`inline | queued`), with the contract stated bluntly: **`queued` never raises the ceiling**. Today `/fullauto` conflates the two. This also makes approvals-v2 §3 (Approvers) implementable without special cases.

Two pre-existing hazards found while writing it, documented but **not** fixed here:

- `APPROVAL_PROMPT_DEFAULT_TTL_MS` is 120s (`src/gateway/pending-approvals.ts:11`) and applies to every prompt. Correct for an inline prompt; for a parked one it means an unattended approval ages into a denial overnight — precisely the failure the attention axis exists to prevent.
- `claimPendingApprovalByApprovalId` ownership is enforced only on Discord and Slack buttons, so the multi-transport approval race is reachable today (`/approve`, plain-text `yes`, voice, and the console card do not check it).

## Change Type

- [x] Docs
- [ ] Bug fix
- [ ] Feature
- [ ] Tests
- [ ] Refactor required for the fix
- [x] Tooling or workflow
- [ ] Security hardening

## Linked Context

- Related: `docs/content/internal/approvals-v2-design.md` (branch `claude/approvals-v2`, not yet on `main` — the addendum states this at the top)
- Related: `docs/content/internal/approval-rule-pipeline.md`

## Licensing

- [x] All commits are signed off (`git commit -s`) to certify the [DCO](https://developercertificate.org/); the contribution is licensed under the repository's MIT license.

## Manifesto Principle

- **Principle: VII. A coworker you can trust with real responsibility.** "Auditability and reversibility are never traded for speed." Both halves serve it: a declared risk class makes *what a grant actually permits* legible instead of implied, and the attention split removes the incentive to raise autonomy just because nobody is watching.
- Changelog tag: **none added.** No user-visible behavior changed — this is contributor protocol plus an internal proposal. A changelog entry belongs with the implementing PRs (approvals-v2 phases 1–2.5).

## Validation

```bash
npm run lint
```

- Verified manually: every code reference cited in the addendum was checked against the tree — `src/types/execution.ts:82`, `container/src/approval-policy.ts:155`, `src/gateway/pending-approvals.ts:11` and `:24`. One line number was wrong on first draft (`:15` → `:24`) and was corrected before commit.
- Edge cases checked: the new internal doc follows the frontmatter convention used by the newer internal docs (`sso-design.md`, `model-routing.md`); no docs index references `docs/content/internal/*`, so there was nothing to register.
- Skipped checks and why: no unit/e2e run — no source files changed. `npm run lint` (typecheck across root, console, desktop) passes.

## Docs And Config Impact

- [x] README, docs, or examples updated
- [ ] Config or environment behavior changed
- [ ] Templates or workspace bootstrap files changed
- [ ] No docs or config impact

`templates/` untouched, so `src/workspace.ts` and its tests are unaffected.

## Risk Notes

- Security-sensitive paths touched? **No** — documentation only.
- Gateway, audit, approval, or container boundaries touched? **No** — the PR *describes* those boundaries and flags two existing hazards in them, but changes no code. Reviewers who agree the TTL and ownership-check findings are real should treat them as follow-up issues rather than expecting a fix here.

## Secret Handling Checklist

Not applicable — no credential material is read, stored, injected, displayed, logged, traced, audited, deleted, or documented. The addendum discusses approval prompts and grants, not secrets.

## Evidence

- [x] New or updated test coverage — n/a; documentation change

Supporting measurement for the module-header rule — files under `src/` whose first line is a block or line comment, sampled over 400 files:

```
9 / 400
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
