### PR TITLE
fix(console): reauthenticate expired cloud sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- **Cloud admin sessions recover after inactivity**: Expired browser sessions
+  reload through HybridAI sign-in instead of showing an unactionable
+  `WEB_API_TOKEN` prompt. The self-hosted fallback identifies the exact gateway
+  token it accepts and no longer claims to persist it in local storage.
 - **WhatsApp remains strictly install-on-demand**: Its source, dependencies,
   license notices, CI, and releases live in the separate GPL-3.0-only
   `HybridAIOne/hybridclaw-whatsapp` repository. Normal core install, update,

--- a/console/src/api/client.test.ts
+++ b/console/src/api/client.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment-options {"url":"https://instance.example.com/"}
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   AUTH_REQUIRED_EVENT,
@@ -8,7 +9,6 @@ import {
   fetchAdminHybridAIBots,
   fetchAgentList,
   installPlugin,
-  isLoopbackHostnameForTest,
   readStoredToken,
   registerDistillAgent,
   setAuthReloadHandlerForTest,
@@ -220,7 +220,7 @@ describe('client command helpers', () => {
     ]);
   });
 
-  it('reloads local chat surfaces instead of prompting when auth expires', () => {
+  it('reloads admin surfaces instead of prompting when auth expires', () => {
     const reload = vi.fn();
     const restoreReload = setAuthReloadHandlerForTest(reload);
     const events: CustomEvent[] = [];
@@ -229,7 +229,7 @@ describe('client command helpers', () => {
     };
     window.addEventListener(AUTH_REQUIRED_EVENT, listener);
     window.sessionStorage.setItem(TOKEN_STORAGE_KEY, 'stale-token');
-    window.history.pushState(null, '', '/chat/sess_20260514_135843_6136cbbb');
+    window.history.pushState(null, '', '/admin/logs');
 
     dispatchAuthRequired('Unauthorized.');
 
@@ -239,13 +239,6 @@ describe('client command helpers', () => {
 
     window.removeEventListener(AUTH_REQUIRED_EVENT, listener);
     restoreReload();
-  });
-
-  it('matches the server 127/8 loopback hostname range', () => {
-    expect(isLoopbackHostnameForTest('127.0.0.1')).toBe(true);
-    expect(isLoopbackHostnameForTest('127.12.34.56')).toBe(true);
-    expect(isLoopbackHostnameForTest('localhost')).toBe(true);
-    expect(isLoopbackHostnameForTest('example.com')).toBe(false);
   });
 
   it('prompts instead of repeatedly reloading local auth failures', () => {

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -103,8 +103,8 @@ import type {
 export const TOKEN_STORAGE_KEY = 'hybridclaw_token';
 export const AUTH_REQUIRED_EVENT = 'hybridclaw:auth-required';
 const LOCAL_TOKEN_BOOTSTRAP_PARAM = '__hybridclaw_token_bootstrapped';
-const LOCAL_AUTH_RELOAD_STORAGE_KEY = 'hybridclaw_local_auth_reload_at';
-const LOCAL_AUTH_RELOAD_COOLDOWN_MS = 15_000;
+const AUTH_RELOAD_STORAGE_KEY = 'hybridclaw_local_auth_reload_at';
+const AUTH_RELOAD_COOLDOWN_MS = 15_000;
 let reloadForAuth = () => window.location.reload();
 
 export interface WebCommandRequestBody {
@@ -146,7 +146,7 @@ export function buildWebCommandRequestBody(options: {
 
 export function dispatchAuthRequired(message: string): void {
   clearStoredToken();
-  if (reloadLocalWebSurfaceForAuth()) return;
+  if (reloadWebSurfaceForAuth()) return;
   window.dispatchEvent(
     new CustomEvent(AUTH_REQUIRED_EVENT, {
       detail: { message },
@@ -154,27 +154,26 @@ export function dispatchAuthRequired(message: string): void {
   );
 }
 
-function reloadLocalWebSurfaceForAuth(): boolean {
-  if (!isLocalWebSurfaceLocation()) return false;
+function reloadWebSurfaceForAuth(): boolean {
+  if (!isWebSurfaceLocation()) return false;
 
   const now = Date.now();
   const lastReloadAt = Number(
-    window.sessionStorage.getItem(LOCAL_AUTH_RELOAD_STORAGE_KEY) || '0',
+    window.sessionStorage.getItem(AUTH_RELOAD_STORAGE_KEY) || '0',
   );
   if (Number.isFinite(lastReloadAt)) {
     const elapsedMs = now - lastReloadAt;
-    if (elapsedMs >= 0 && elapsedMs < LOCAL_AUTH_RELOAD_COOLDOWN_MS) {
+    if (elapsedMs >= 0 && elapsedMs < AUTH_RELOAD_COOLDOWN_MS) {
       return false;
     }
   }
 
-  window.sessionStorage.setItem(LOCAL_AUTH_RELOAD_STORAGE_KEY, String(now));
+  window.sessionStorage.setItem(AUTH_RELOAD_STORAGE_KEY, String(now));
   reloadForAuth();
   return true;
 }
 
-function isLocalWebSurfaceLocation(): boolean {
-  if (!isLoopbackHostname(window.location.hostname)) return false;
+function isWebSurfaceLocation(): boolean {
   const pathname = window.location.pathname;
   return (
     pathname === '/admin' ||
@@ -184,26 +183,12 @@ function isLocalWebSurfaceLocation(): boolean {
   );
 }
 
-function isLoopbackHostname(value: string): boolean {
-  const hostname = value.toLowerCase();
-  return (
-    hostname === 'localhost' ||
-    hostname === '::1' ||
-    hostname === '[::1]' ||
-    /^127(?:\.\d{1,3}){3}$/.test(hostname)
-  );
-}
-
 export function setAuthReloadHandlerForTest(reload: () => void): () => void {
   const previous = reloadForAuth;
   reloadForAuth = reload;
   return () => {
     reloadForAuth = previous;
   };
-}
-
-export function isLoopbackHostnameForTest(value: string): boolean {
-  return isLoopbackHostname(value);
 }
 
 export async function readErrorResponseMessage(

--- a/console/src/components/login-screen.tsx
+++ b/console/src/components/login-screen.tsx
@@ -15,11 +15,12 @@ export function LoginScreen() {
     <div className="login-shell">
       <div className="login-card">
         <p className="eyebrow">HybridClaw Admin</p>
-        <h1>Enter API token.</h1>
+        <h1>Enter the gateway web token.</h1>
         <p className="supporting-text">
-          This instance has <code>WEB_API_TOKEN</code> enabled. Enter it once
-          and the console will keep it in local storage, the same way
-          <code> /chat</code> already does.
+          This fallback is for self-hosted gateways. Enter the exact{' '}
+          <code>WEB_API_TOKEN</code> configured for this gateway, not a HybridAI
+          API key or scoped admin token. The console uses it only until this
+          page is reloaded.
         </p>
         <form className="stack-form" onSubmit={onSubmit}>
           <label className="field">
@@ -30,7 +31,7 @@ export function LoginScreen() {
               type="password"
               value={token}
               onChange={(event) => setToken(event.target.value)}
-              placeholder="Paste WEB_API_TOKEN"
+              placeholder="Paste this gateway's WEB_API_TOKEN"
             />
           </label>
           {auth.error ? <p className="error-banner">{auth.error}</p> : null}


### PR DESCRIPTION
## Summary

- reload `/admin` and `/chat` after an auth-required response regardless of hostname
- keep the existing 15-second reload cooldown
- clarify that the remaining token form is a self-hosted fallback for the gateway's exact `WEB_API_TOKEN` and is not persisted

## Root cause

After the signed browser session expired, API requests returned 401 while the already-loaded SPA remained active. The console only auto-reloaded loopback surfaces, so hosted instances fell through to the legacy manual-token prompt even though cloud users cannot retrieve the gateway's `WEB_API_TOKEN`. A normal page reload already entered the correct HybridAI login redirect.

## Scope

- client-only change; the gateway and authentication protocol are unchanged
- self-hosted gateways still reach the manual-token fallback after reload
- no token is exposed, embedded in a URL, or newly persisted in browser storage

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npm --workspace console run test -- src/api/client.test.ts src/api/chat.test.ts src/lib/chat-stream.test.ts` (27 passed)
- `npm --workspace console run build`
