### PR TITLE
fix: preserve Teams message line breaks

### DIFF
--- a/src/channels/msteams/delivery.ts
+++ b/src/channels/msteams/delivery.ts
@@ -4,6 +4,7 @@ import {
   type Activity,
   ActivityTypes,
   type Attachment,
+  TextFormatTypes,
 } from 'botframework-schema';
 import { MSTEAMS_TEXT_CHUNK_LIMIT } from '../../config/config.js';
 import type { MSTeamsReplyStyle } from '../../config/runtime-config.js';
@@ -58,11 +59,36 @@ export function buildAdaptiveCardAttachment(
   return CardFactory.adaptiveCard(card);
 }
 
+export function formatMSTeamsMarkdown(text: string): string {
+  const lines = text.replace(/\r\n?/g, '\n').split('\n');
+  let inCodeFence = false;
+
+  return lines
+    .map((line, index) => {
+      if (line.trim().startsWith('```')) {
+        inCodeFence = !inCodeFence;
+        return line;
+      }
+
+      const nextLine = lines[index + 1];
+      if (
+        inCodeFence ||
+        !line.trim() ||
+        !nextLine?.trim() ||
+        line.endsWith('  ')
+      ) {
+        return line;
+      }
+      return `${line}  `;
+    })
+    .join('\n');
+}
+
 export function prepareChunkedActivities(params: {
   text: string;
   attachments?: Attachment[];
 }): MSTeamsChunkedActivity[] {
-  const chunks = chunkMessage(params.text, {
+  const chunks = chunkMessage(formatMSTeamsMarkdown(params.text), {
     maxChars: Math.max(200, Math.min(20_000, MSTEAMS_TEXT_CHUNK_LIMIT)),
     maxLines: 120,
   }).filter((entry) => entry.trim().length > 0);
@@ -89,7 +115,9 @@ export function buildMSTeamsMessageActivity(
   return {
     type: ActivityTypes.Message,
     ...(params.id ? { id: params.id } : {}),
-    ...(params.text ? { text: params.text } : {}),
+    ...(params.text
+      ? { text: params.text, textFormat: TextFormatTypes.Markdown }
+      : {}),
     ...(params.attachments?.length ? { attachments: params.attachments } : {}),
     ...(params.replyStyle === 'thread' && params.replyToId
       ? { replyToId: params.replyToId }

--- a/src/channels/msteams/stream.ts
+++ b/src/channels/msteams/stream.ts
@@ -3,6 +3,7 @@ import {
   type Activity,
   ActivityTypes,
   type Attachment,
+  TextFormatTypes,
 } from 'botframework-schema';
 import type { MSTeamsReplyStyle } from '../../config/runtime-config.js';
 import { logger } from '../../logger.js';
@@ -359,6 +360,7 @@ export class MSTeamsStreamManager {
       {
         type: ActivityTypes.Typing,
         text,
+        textFormat: TextFormatTypes.Markdown,
         entities: [
           buildNativeStreamEntity({
             streamId: this.nativeStreamId,
@@ -393,6 +395,7 @@ export class MSTeamsStreamManager {
       {
         type: ActivityTypes.Message,
         text,
+        textFormat: TextFormatTypes.Markdown,
         ...(attachments?.length ? { attachments } : {}),
         entities: [
           buildNativeStreamEntity({

--- a/tests/msteams.delivery.test.ts
+++ b/tests/msteams.delivery.test.ts
@@ -1,6 +1,8 @@
 import { expect, test, vi } from 'vitest';
 
 import {
+  buildMSTeamsMessageActivity,
+  formatMSTeamsMarkdown,
   prepareChunkedActivities,
   sendChunkedReply,
   stripUnusableMSTeamsArtifactLinks,
@@ -36,6 +38,49 @@ test('prepareChunkedActivities keeps attachment-only Teams sends empty', () => {
       attachments,
     },
   ]);
+});
+
+test('formatMSTeamsMarkdown preserves visible line breaks outside code blocks', () => {
+  expect(
+    formatMSTeamsMarkdown(
+      [
+        'First line',
+        'Second line',
+        '',
+        '```ts',
+        'const first = 1;',
+        'const second = 2;',
+        '```',
+        'Final line',
+      ].join('\n'),
+    ),
+  ).toBe(
+    [
+      'First line  ',
+      'Second line',
+      '',
+      '```ts',
+      'const first = 1;',
+      'const second = 2;',
+      '```',
+      'Final line',
+    ].join('\n'),
+  );
+});
+
+test('buildMSTeamsMessageActivity marks text as Teams markdown', () => {
+  expect(
+    buildMSTeamsMessageActivity({
+      text: 'First line  \nSecond line',
+      replyStyle: 'thread',
+      replyToId: 'incoming-1',
+    }),
+  ).toEqual({
+    type: 'message',
+    text: 'First line  \nSecond line',
+    textFormat: 'markdown',
+    replyToId: 'incoming-1',
+  });
 });
 
 test('sendChunkedReply omits the text field for attachment-only Teams sends', async () => {
@@ -95,11 +140,13 @@ test('sendChunkedReply retries transient Teams transport failures', async () => 
     expect(sendActivity).toHaveBeenNthCalledWith(1, {
       type: 'message',
       text: 'Hello',
+      textFormat: 'markdown',
       replyToId: 'incoming-1',
     });
     expect(sendActivity).toHaveBeenNthCalledWith(2, {
       type: 'message',
       text: 'Hello',
+      textFormat: 'markdown',
       replyToId: 'incoming-1',
     });
   } finally {

--- a/tests/msteams.stream.test.ts
+++ b/tests/msteams.stream.test.ts
@@ -25,6 +25,7 @@ test('uses the Teams streaminfo protocol for direct-message progress and text', 
     expect(sendActivity).toHaveBeenNthCalledWith(1, {
       type: 'typing',
       text: 'Thinking…',
+      textFormat: 'markdown',
       entities: [
         {
           type: 'streaminfo',
@@ -38,6 +39,7 @@ test('uses the Teams streaminfo protocol for direct-message progress and text', 
     expect(sendActivity).toHaveBeenNthCalledWith(2, {
       type: 'typing',
       text: 'Searching…',
+      textFormat: 'markdown',
       entities: [
         {
           type: 'streaminfo',
@@ -53,6 +55,7 @@ test('uses the Teams streaminfo protocol for direct-message progress and text', 
     expect(sendActivity).toHaveBeenNthCalledWith(3, {
       type: 'typing',
       text: 'Hello',
+      textFormat: 'markdown',
       entities: [
         {
           type: 'streaminfo',
@@ -67,6 +70,7 @@ test('uses the Teams streaminfo protocol for direct-message progress and text', 
     expect(sendActivity).toHaveBeenNthCalledWith(4, {
       type: 'message',
       text: 'Hello world',
+      textFormat: 'markdown',
       entities: [
         {
           type: 'streaminfo',
@@ -103,6 +107,7 @@ test('falls back to normal Teams messages when native streaming is unavailable',
   expect(sendActivity).toHaveBeenNthCalledWith(2, {
     type: 'message',
     text: 'Fallback reply',
+    textFormat: 'markdown',
     replyToId: 'incoming-1',
   });
 });
@@ -132,6 +137,7 @@ test('delivers the full reply when Teams rejects native stream finalization', as
   expect(sendActivity).toHaveBeenNthCalledWith(3, {
     type: 'message',
     text: 'Complete reply',
+    textFormat: 'markdown',
     replyToId: 'incoming-1',
   });
 });
@@ -227,6 +233,7 @@ test('append throttles Teams stream edits instead of syncing every delta', async
     expect(sendActivity).toHaveBeenCalledWith({
       type: 'message',
       text: 'Hello',
+      textFormat: 'markdown',
       replyToId: 'incoming-1',
     });
 
@@ -242,6 +249,7 @@ test('append throttles Teams stream edits instead of syncing every delta', async
       id: 'activity-1',
       type: 'message',
       text: 'Hello world',
+      textFormat: 'markdown',
       replyToId: 'incoming-1',
     });
 
@@ -278,11 +286,13 @@ test('append surfaces send failures with a terminal Teams error message', async 
     expect(sendActivity).toHaveBeenNthCalledWith(1, {
       type: 'message',
       text: 'Hello',
+      textFormat: 'markdown',
       replyToId: 'incoming-1',
     });
     expect(sendActivity).toHaveBeenNthCalledWith(2, {
       type: 'message',
       text: 'Hello\n\nTeams streaming was interrupted while sending the reply. Please retry.',
+      textFormat: 'markdown',
       replyToId: 'incoming-1',
     });
 
@@ -340,6 +350,7 @@ test('stream retries transient Teams send and update failures', async () => {
       id: 'activity-1',
       type: 'message',
       text: 'Hello world',
+      textFormat: 'markdown',
       replyToId: 'incoming-1',
     });
   } finally {


### PR DESCRIPTION
## Summary

- mark outbound Teams text activities as Markdown explicitly
- preserve single line breaks as Markdown hard breaks while leaving triple-backtick code fences unchanged
- apply the same text format to native direct-message streaming activities
- add regression coverage for multiline delivery and streaming payloads

## Root cause

HybridClaw sent newline-delimited text without an explicit Teams `textFormat`. Teams rendered ordinary single newlines as Markdown soft breaks, collapsing status and other multiline output into one paragraph.

## Impact

Multiline Teams replies now retain their intended layout in personal chats, group chats, and channels. Native streaming scope is unchanged; Microsoft supports that progress experience only in one-on-one chats, so group chats and channels continue using the existing fallback.

## Validation

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `./node_modules/.bin/vitest run tests/msteams*.test.ts` (63 tests passed)
