### PR TITLE
fix(console): refine provider, channel, and output guard UI

### DIFF
--- a/console/src/components/provider-configuration.module.css
+++ b/console/src/components/provider-configuration.module.css
@@ -18,12 +18,6 @@
   font-size: 1.05rem;
 }
 
-.providerGrid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 14px;
-}
-
 .providerCard {
   min-width: 0;
 }
@@ -39,6 +33,19 @@
 .providerFields {
   display: grid;
   gap: 14px;
+}
+
+.providerCredential {
+  display: grid;
+  gap: 12px;
+}
+
+.providerCredentialLabel {
+  width: fit-content;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.4;
+  color: var(--text);
 }
 
 .statusHealthy,
@@ -69,12 +76,6 @@
   color: var(--primary);
   font-weight: 650;
   text-decoration: none;
-}
-
-@media (max-width: 980px) {
-  .providerGrid {
-    grid-template-columns: 1fr;
-  }
 }
 
 @media (max-width: 680px) {

--- a/console/src/components/provider-configuration.test.tsx
+++ b/console/src/components/provider-configuration.test.tsx
@@ -59,27 +59,22 @@ describe('ProviderConfiguration', () => {
   it('edits provider enablement and endpoint from the Providers page', async () => {
     renderWithProviders(
       <ProviderConfiguration
-        filter=""
-        statuses={[
-          [
-            'openai',
-            {
-              kind: 'remote',
-              reachable: false,
-              detail: 'Not authenticated',
-              modelCount: 1,
-            },
-          ],
-        ]}
+        providerId="openai"
+        status={{
+          kind: 'remote',
+          reachable: false,
+          detail: 'Not authenticated',
+          modelCount: 1,
+        }}
       />,
     );
 
     expect(await screen.findByText('OpenAI')).toBeTruthy();
-    const credential = screen.getByLabelText(
-      'API key secret',
-    ) as HTMLSelectElement;
-    expect(credential.value).toBe('OPENAI_API_KEY');
-    expect(credential.disabled).toBe(true);
+    expect(screen.getByText('OPENAI_API_KEY')).toBeTruthy();
+    expect(await screen.findByText('Available')).toBeTruthy();
+    expect(
+      screen.queryByRole('combobox', { name: 'API key credential' }),
+    ).toBeNull();
 
     fireEvent.click(screen.getByRole('switch', { name: 'Enable OpenAI' }));
     fireEvent.change(screen.getByLabelText('OpenAI base URL'), {

--- a/console/src/components/provider-configuration.tsx
+++ b/console/src/components/provider-configuration.tsx
@@ -18,7 +18,7 @@ import { Input } from './input';
 import { NativeSelect, NativeSelectOption } from './native-select';
 import styles from './provider-configuration.module.css';
 import type { ProviderEntry } from './provider-health';
-import { SecretRefPicker } from './secret-ref-picker';
+import { CanonicalSecretStatus, SecretRefPicker } from './secret-ref-picker';
 import { Switch } from './switch';
 import { useToast } from './toast';
 
@@ -290,31 +290,33 @@ function ProviderConfigCard(props: {
         ) : null}
 
         {descriptor.secretName ? (
-          <Field>
-            <FieldLabel>API key secret</FieldLabel>
-            <SecretRefPicker
-              value={secretRefId(
-                descriptor.secretPath
-                  ? settingValue(props.draft, descriptor.secretPath)
-                  : undefined,
-                descriptor.secretName,
-              )}
-              disabled={!descriptor.secretPath}
-              onValueChange={(id) => {
-                if (!descriptor.secretPath) return;
-                props.onSettingChange(
-                  descriptor.secretPath,
-                  id ? { source: 'store', id } : '',
-                );
-              }}
-            />
-            {!descriptor.secretPath ? (
-              <FieldDescription>
-                This provider reads the canonical {descriptor.secretName}{' '}
-                secret.
-              </FieldDescription>
-            ) : null}
-          </Field>
+          descriptor.secretPath ? (
+            <Field>
+              <FieldLabel>API key credential</FieldLabel>
+              <SecretRefPicker
+                value={secretRefId(
+                  settingValue(props.draft, descriptor.secretPath),
+                  descriptor.secretName,
+                )}
+                onValueChange={(id) =>
+                  props.onSettingChange(
+                    descriptor.secretPath as string,
+                    id ? { source: 'store', id } : '',
+                  )
+                }
+              />
+            </Field>
+          ) : (
+            <div className={styles.providerCredential}>
+              <span className={styles.providerCredentialLabel}>
+                API key credential
+              </span>
+              <CanonicalSecretStatus
+                name={descriptor.secretName}
+                providerReachable={props.status?.reachable}
+              />
+            </div>
+          )
         ) : null}
 
         {descriptor.select ? (
@@ -345,8 +347,8 @@ function ProviderConfigCard(props: {
 }
 
 export function ProviderConfiguration(props: {
-  filter: string;
-  statuses: ReadonlyArray<[string, ProviderEntry]>;
+  providerId: string;
+  status?: ProviderEntry;
 }) {
   const auth = useAuth();
   const toast = useToast();
@@ -373,14 +375,19 @@ export function ProviderConfiguration(props: {
   }
   if (!draft) return null;
 
-  const needle = props.filter.trim().toLowerCase();
-  const visibleProviders = PROVIDERS.filter(
+  const descriptor = PROVIDERS.find(
     (provider) =>
-      settingValue(draft, provider.sectionPath) !== undefined &&
-      (!needle ||
-        `${provider.label} ${provider.id}`.toLowerCase().includes(needle)),
+      provider.id === props.providerId &&
+      settingValue(draft, provider.sectionPath) !== undefined,
   );
-  const statusMap = new Map(props.statuses);
+
+  if (!descriptor) {
+    return (
+      <div className="empty-state">
+        No editable configuration is available for this provider.
+      </div>
+    );
+  }
 
   return (
     <Form
@@ -403,24 +410,16 @@ export function ProviderConfiguration(props: {
           ) : null}
         </div>
       </div>
-      <div className={styles.providerGrid}>
-        {visibleProviders.map((descriptor) => (
-          <ProviderConfigCard
-            key={descriptor.id}
-            descriptor={descriptor}
-            draft={draft}
-            status={statusMap.get(descriptor.id)}
-            onSettingChange={(path, value) =>
-              setDraft((current) =>
-                current ? withSettingValue(current, path, value) : current,
-              )
-            }
-          />
-        ))}
-      </div>
-      {visibleProviders.length === 0 ? (
-        <div className="empty-state">No providers match this filter.</div>
-      ) : null}
+      <ProviderConfigCard
+        descriptor={descriptor}
+        draft={draft}
+        status={props.status}
+        onSettingChange={(path, value) =>
+          setDraft((current) =>
+            current ? withSettingValue(current, path, value) : current,
+          )
+        }
+      />
       <div className={styles.credentialsLink}>
         <a href="/admin/credentials">Manage all credentials →</a>
       </div>

--- a/console/src/components/provider-health.module.css
+++ b/console/src/components/provider-health.module.css
@@ -33,10 +33,30 @@
 .row {
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
+  width: 100%;
   padding: 9px 16px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.05);
   border-left: 2.5px solid transparent;
+  border-top: 0;
+  border-right: 0;
   transition: background 0.1s ease;
+}
+
+.rowButton {
+  appearance: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.rowButton:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 2px solid color-mix(in srgb, var(--accent) 60%, transparent);
+  outline-offset: -2px;
 }
 
 .row:last-of-type {
@@ -63,6 +83,12 @@
 
 .rowDown:hover {
   background: rgba(239, 68, 68, 0.04);
+}
+
+.rowSelected,
+.rowSelected:hover {
+  border-left-color: var(--accent);
+  background: var(--accent-soft);
 }
 
 .rowTop {
@@ -264,6 +290,12 @@
 
 :global(html[data-theme="dark"]) .rowDown:hover {
   background: rgba(239, 68, 68, 0.07);
+}
+
+:global(html[data-theme="dark"]) .rowSelected,
+:global(html[data-theme="dark"]) .rowSelected:hover {
+  border-left-color: var(--accent);
+  background: var(--accent-soft);
 }
 
 :global(html[data-theme="dark"]) .name {

--- a/console/src/components/provider-health.test.tsx
+++ b/console/src/components/provider-health.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { type ProviderEntry, ProviderHealth } from './provider-health';
 
 const ENTRIES: Array<[string, ProviderEntry]> = [
@@ -52,5 +52,25 @@ describe('ProviderHealth', () => {
     );
 
     expect(screen.getByText(diagnostic).getAttribute('title')).toBe(diagnostic);
+  });
+
+  it('selects provider rows when used as a configuration navigator', () => {
+    const onSelect = vi.fn();
+    render(
+      <ProviderHealth
+        title="Provider health"
+        entries={ENTRIES}
+        selectedName="hybridai"
+        onSelect={onSelect}
+      />,
+    );
+
+    const hybridai = screen.getByRole('button', { name: /hybridai/i });
+    const ollama = screen.getByRole('button', { name: /ollama/i });
+    expect(hybridai.getAttribute('aria-pressed')).toBe('true');
+    expect(ollama.getAttribute('aria-pressed')).toBe('false');
+
+    fireEvent.click(ollama);
+    expect(onSelect).toHaveBeenCalledWith('ollama');
   });
 });

--- a/console/src/components/provider-health.tsx
+++ b/console/src/components/provider-health.tsx
@@ -45,9 +45,16 @@ const DOT_CLASS: Record<HealthStatus, string> = {
 interface ProviderRowProps {
   name: string;
   provider: ProviderEntry;
+  selected?: boolean;
+  onSelect?: (name: string) => void;
 }
 
-function ProviderRow({ name, provider }: ProviderRowProps) {
+function ProviderRow({
+  name,
+  provider,
+  selected = false,
+  onSelect,
+}: ProviderRowProps) {
   const status = resolveStatus(name, provider);
   const isLocal = isLocalProvider(name, provider);
   const modelCount = provider.modelCount ?? 0;
@@ -60,14 +67,16 @@ function ProviderRow({ name, provider }: ProviderRowProps) {
 
   const rowClass = [
     styles.row,
+    onSelect ? styles.rowButton : '',
+    selected ? styles.rowSelected : '',
     status === 'warning' ? styles.rowWarning : '',
     status === 'down' ? styles.rowDown : '',
   ]
     .filter(Boolean)
     .join(' ');
 
-  return (
-    <div className={rowClass}>
+  const content = (
+    <>
       <div className={styles.rowTop}>
         <div className={styles.nameGroup}>
           <span
@@ -91,26 +100,61 @@ function ProviderRow({ name, provider }: ProviderRowProps) {
           <span className={styles.statusLabel}>{status}</span>
         </div>
       </div>
-    </div>
+    </>
   );
+
+  if (onSelect) {
+    return (
+      <button
+        type="button"
+        className={rowClass}
+        aria-pressed={selected}
+        onClick={() => onSelect(name)}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return <div className={rowClass}>{content}</div>;
 }
 
 export interface ProviderHealthProps {
   title: string;
   entries: Array<[string, ProviderEntry]>;
+  selectedName?: string | null;
+  onSelect?: (name: string) => void;
 }
 
-export function ProviderHealth({ title, entries }: ProviderHealthProps) {
-  // Split into active (visible rows) and inactive (collapsed footer)
-  const activeEntries = entries.filter(([name, p]) => {
-    const status = resolveStatus(name, p);
-    return status !== 'inactive';
-  });
+function isInactiveEntry([name, provider]: [string, ProviderEntry]): boolean {
+  return resolveStatus(name, provider) === 'inactive';
+}
 
-  const inactiveEntries = entries.filter(([name, p]) => {
-    const status = resolveStatus(name, p);
-    return status === 'inactive';
-  });
+function isActiveEntry(entry: [string, ProviderEntry]): boolean {
+  return !isInactiveEntry(entry);
+}
+
+function renderProviderRow(
+  [name, provider]: [string, ProviderEntry],
+  props: ProviderHealthProps,
+) {
+  return (
+    <ProviderRow
+      key={name}
+      name={name}
+      provider={provider}
+      selected={props.selectedName === name}
+      onSelect={props.onSelect}
+    />
+  );
+}
+
+export function ProviderHealth(props: ProviderHealthProps) {
+  const { title, entries } = props;
+  const activeEntries = props.onSelect
+    ? entries
+    : entries.filter(isActiveEntry);
+  const inactiveEntries = props.onSelect ? [] : entries.filter(isInactiveEntry);
   return (
     <section className={styles.panel}>
       <div className={styles.panelHeader}>
@@ -121,9 +165,7 @@ export function ProviderHealth({ title, entries }: ProviderHealthProps) {
         <p className={styles.panelEmpty}>No provider health data available.</p>
       ) : (
         <>
-          {activeEntries.map(([name, provider]) => (
-            <ProviderRow key={name} name={name} provider={provider} />
-          ))}
+          {activeEntries.map((entry) => renderProviderRow(entry, props))}
           {inactiveEntries.length > 0 && (
             <div className={styles.inactiveFooter}>
               <span className={styles.inactiveDot} />

--- a/console/src/components/secret-ref-picker.module.css
+++ b/console/src/components/secret-ref-picker.module.css
@@ -4,6 +4,58 @@
   min-width: 0;
 }
 
+.status {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel-muted);
+}
+
+.statusLine {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
+.statusLine code {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text);
+  font-size: 0.84rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.statusAvailable,
+.statusMissing {
+  flex: none;
+  padding: 3px 8px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 650;
+}
+
+.statusAvailable {
+  background: color-mix(in srgb, var(--success) 12%, transparent);
+  color: var(--success);
+}
+
+.statusMissing {
+  background: var(--panel-bg);
+  color: var(--muted-foreground);
+}
+
+.statusDescription {
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
 .meta {
   display: flex;
   align-items: center;

--- a/console/src/components/secret-ref-picker.tsx
+++ b/console/src/components/secret-ref-picker.tsx
@@ -11,6 +11,53 @@ export interface SecretRefPickerProps {
   disabled?: boolean;
 }
 
+export function CanonicalSecretStatus(props: {
+  name: string;
+  providerReachable?: boolean;
+}) {
+  const { token } = useAuth();
+  const secretsQuery = useQuery({
+    queryKey: ['admin', 'secrets', token],
+    queryFn: () => fetchAdminSecrets(token),
+    retry: false,
+  });
+  const entry = secretsQuery.data?.secrets.find(
+    (secret) => secret.name === props.name,
+  );
+  const stored = entry?.state === 'set';
+  const available = stored || props.providerReachable === true;
+  const status = secretsQuery.isPending
+    ? 'Checking…'
+    : available
+      ? 'Available'
+      : 'Not configured';
+  const description = stored
+    ? 'Stored in the runtime secret store.'
+    : props.providerReachable
+      ? 'Available to the running provider outside the runtime secret store.'
+      : secretsQuery.isError
+        ? 'Credential metadata is unavailable.'
+        : 'No credential is available to this provider.';
+
+  return (
+    <div
+      className={styles.status}
+      role="status"
+      aria-label={`${props.name} credential status`}
+    >
+      <div className={styles.statusLine}>
+        <code>{props.name}</code>
+        <span
+          className={available ? styles.statusAvailable : styles.statusMissing}
+        >
+          {status}
+        </span>
+      </div>
+      <span className={styles.statusDescription}>{description}</span>
+    </div>
+  );
+}
+
 export function SecretRefPicker({
   value,
   onValueChange,

--- a/console/src/routes/models.test.tsx
+++ b/console/src/routes/models.test.tsx
@@ -24,7 +24,14 @@ vi.mock('../api/client', () => ({
   fetchAdminSecrets: () =>
     Promise.resolve({ secrets: [], total: 0, actions: [] }),
   fetchConfig: () =>
-    Promise.resolve({ path: '/tmp/config.json', config: {} as AdminConfig }),
+    Promise.resolve({
+      path: '/tmp/config.json',
+      config: {
+        hybridai: {
+          baseUrl: 'https://hybridai.one',
+        },
+      } as AdminConfig,
+    }),
   fetchModels: () => fetchModelsMock(),
   saveConfig: () => Promise.resolve({ path: '/tmp/config.json', config: {} }),
   saveModels: (token: string, payload: unknown) =>
@@ -216,6 +223,31 @@ describe('ModelsPage', () => {
     await screen.findByText('Default model');
     expect(screen.queryByText('Configured HybridAI models')).toBeNull();
     expect(screen.queryByText('Configured Codex models')).toBeNull();
+  });
+
+  it('shows provider configuration on the right only after selection', async () => {
+    fetchModelsMock.mockResolvedValue(makeModelsResponse());
+
+    renderModelsPage();
+
+    expect(
+      await screen.findByText('Select a provider to view its settings.'),
+    ).toBeTruthy();
+    expect(screen.queryByLabelText('HybridAI base URL')).toBeNull();
+
+    fireEvent.click(await screen.findByRole('button', { name: /hybridai/i }));
+
+    expect(await screen.findByLabelText('HybridAI base URL')).toBeTruthy();
+    expect(screen.getByText('HYBRIDAI_API_KEY')).toBeTruthy();
+    expect(await screen.findByText('Available')).toBeTruthy();
+    expect(
+      screen.getByText(
+        'Available to the running provider outside the runtime secret store.',
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText('Select a provider to view its settings.')).toBe(
+      null,
+    );
   });
 
   it('changes the default model through NativeSelect and saves it', async () => {

--- a/console/src/routes/models.tsx
+++ b/console/src/routes/models.tsx
@@ -167,6 +167,7 @@ export function ModelsPage() {
   const toast = useToast();
   const [filter, setFilter] = useState('');
   const [draft, setDraft] = useState<ModelDraft>(createDraft());
+  const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
 
   const modelsQuery = useQuery({
     queryKey: ['models', auth.token],
@@ -238,55 +239,73 @@ export function ModelsPage() {
         }
       />
 
-      <div className="two-column-grid">
-        <ProviderHealth title="Provider health" entries={providerEntries} />
-
-        <Card variant="muted">
-          <CardHeader>
-            <CardTitle>Selection</CardTitle>
-          </CardHeader>
-          <CardContent>
-            {modelsQuery.isLoading ? (
-              <div className="empty-state">Loading model catalog...</div>
-            ) : (
-              <div className="stack-form">
-                <Field>
-                  <FieldLabel>Default model</FieldLabel>
-                  <NativeSelect
-                    value={draft.defaultModel}
-                    onChange={(event) =>
-                      setDraft((current) => ({
-                        ...current,
-                        defaultModel: event.target.value,
-                      }))
-                    }
-                  >
-                    <NativeSelectOption value="">
-                      Select model
+      <Card variant="muted">
+        <CardHeader>
+          <CardTitle>Selection</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {modelsQuery.isLoading ? (
+            <div className="empty-state">Loading model catalog...</div>
+          ) : (
+            <div className="stack-form">
+              <Field>
+                <FieldLabel>Default model</FieldLabel>
+                <NativeSelect
+                  value={draft.defaultModel}
+                  onChange={(event) =>
+                    setDraft((current) => ({
+                      ...current,
+                      defaultModel: event.target.value,
+                    }))
+                  }
+                >
+                  <NativeSelectOption value="">Select model</NativeSelectOption>
+                  {(modelsQuery.data?.models || []).map((model) => (
+                    <NativeSelectOption key={model.id} value={model.id}>
+                      {model.id}
                     </NativeSelectOption>
-                    {(modelsQuery.data?.models || []).map((model) => (
-                      <NativeSelectOption key={model.id} value={model.id}>
-                        {model.id}
-                      </NativeSelectOption>
-                    ))}
-                  </NativeSelect>
-                </Field>
+                  ))}
+                </NativeSelect>
+              </Field>
 
-                <div className="button-row">
-                  <Button
-                    disabled={saveMutation.isPending}
-                    onClick={() => saveMutation.mutate()}
-                  >
-                    {saveMutation.isPending ? 'Saving...' : 'Save selection'}
-                  </Button>
-                </div>
+              <div className="button-row">
+                <Button
+                  disabled={saveMutation.isPending}
+                  onClick={() => saveMutation.mutate()}
+                >
+                  {saveMutation.isPending ? 'Saving...' : 'Save selection'}
+                </Button>
               </div>
-            )}
-          </CardContent>
-        </Card>
-      </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
-      <ProviderConfiguration filter={filter} statuses={providerEntries} />
+      <div className="two-column-grid">
+        <ProviderHealth
+          title="Provider health"
+          entries={providerEntries}
+          selectedName={selectedProvider}
+          onSelect={setSelectedProvider}
+        />
+        {selectedProvider ? (
+          <ProviderConfiguration
+            providerId={selectedProvider}
+            status={
+              providerEntries.find(([name]) => name === selectedProvider)?.[1]
+            }
+          />
+        ) : (
+          <Card variant="muted">
+            <CardHeader>
+              <CardTitle>Provider configuration</CardTitle>
+              <CardDescription>
+                Select a provider to view its settings.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        )}
+      </div>
 
       <Card>
         <CardHeader>

--- a/console/src/routes/output-guard.test.tsx
+++ b/console/src/routes/output-guard.test.tsx
@@ -192,6 +192,50 @@ afterEach(() => {
 });
 
 describe('OutputGuardPage', () => {
+  it('hides configuration fields while the guard is disabled', async () => {
+    fetchOutputGuardProfileMock.mockResolvedValue({
+      profile: {
+        enabled: false,
+        mode: 'rewrite',
+        policy: 'Hidden until enabled.',
+        doList: [],
+        dontList: [],
+        bannedPhrases: [],
+        bannedPatterns: [],
+        requirePhrases: [],
+        classifier: {
+          provider: 'default',
+          model: '',
+        },
+        rewriter: {
+          provider: 'default',
+          model: '',
+        },
+      },
+      revisions: [],
+    });
+
+    renderOutputGuardPage();
+
+    expect(
+      await screen.findByText(
+        'Enable Output Guard to configure its policy and models.',
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole('group', { name: 'Output guard mode' }),
+    ).toBeNull();
+    expect(screen.queryByText('Classifier')).toBeNull();
+    expect(screen.queryByDisplayValue('Hidden until enabled.')).toBeNull();
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Enabled' }));
+
+    expect(
+      screen.getByRole('group', { name: 'Output guard mode' }),
+    ).toBeTruthy();
+    expect(screen.getByDisplayValue('Hidden until enabled.')).toBeTruthy();
+  });
+
   it('edits profile lists and scores a pasted sample', async () => {
     renderOutputGuardPage();
 

--- a/console/src/routes/output-guard.tsx
+++ b/console/src/routes/output-guard.tsx
@@ -431,128 +431,145 @@ export function OutputGuardPage() {
                     <FieldLabel>Enabled</FieldLabel>
                   </FieldContent>
                 </Field>
-                <div className="field">
-                  <span>Mode</span>
-                  <SegmentedToggle
-                    ariaLabel="Output guard mode"
-                    value={profile.mode}
-                    options={[
-                      { value: 'rewrite', label: 'rewrite' },
-                      { value: 'block', label: 'block' },
-                      { value: 'flag', label: 'flag' },
-                    ]}
-                    onChange={(mode) =>
-                      setProfile((current) => ({
-                        ...current,
-                        mode,
-                      }))
-                    }
-                  />
-                </div>
-                <ModelSourceControl
-                  label="Classifier"
-                  ariaLabel="Output guard classifier source"
-                  value={profile.classifier}
-                  modelOptions={modelOptions}
-                  defaultOtherModelId={defaultOtherModelId}
-                  activeModelId={
-                    profile.classifier.provider === 'default'
-                      ? defaultModelId
-                      : auxiliaryModelId
-                  }
-                  activeModelFallback={
-                    profile.classifier.provider === 'default'
-                      ? 'No default model'
-                      : auxiliaryProvider === 'disabled'
-                        ? 'Aux model disabled'
-                        : 'Auto routing'
-                  }
-                  modelsLoading={modelsQuery.isLoading}
-                  onChange={(classifier) =>
-                    setProfile((current) => ({ ...current, classifier }))
-                  }
-                />
-                <ModelSourceControl
-                  label="Rewriter"
-                  ariaLabel="Output guard rewriter source"
-                  value={profile.rewriter}
-                  modelOptions={modelOptions}
-                  defaultOtherModelId={defaultOtherModelId}
-                  activeModelId={
-                    profile.rewriter.provider === 'default'
-                      ? defaultModelId
-                      : auxiliaryModelId
-                  }
-                  activeModelFallback={
-                    profile.rewriter.provider === 'default'
-                      ? 'No default model'
-                      : auxiliaryProvider === 'disabled'
-                        ? 'Aux model disabled'
-                        : 'Auto routing'
-                  }
-                  modelsLoading={modelsQuery.isLoading}
-                  onChange={(rewriter) =>
-                    setProfile((current) => ({ ...current, rewriter }))
-                  }
-                />
-                <label className="field textarea-field">
-                  <span>Policy</span>
-                  <Textarea
-                    rows={5}
-                    value={profile.policy}
-                    onChange={(event) =>
-                      setProfile((current) => ({
-                        ...current,
-                        policy: event.target.value,
-                      }))
-                    }
-                    placeholder="Clear, direct, concrete. No hype."
-                  />
-                </label>
-                <ListEditor
-                  label="Do"
-                  values={profile.doList}
-                  placeholder="Use concrete nouns"
-                  onChange={(doList) =>
-                    setProfile((current) => ({ ...current, doList }))
-                  }
-                />
-                <ListEditor
-                  label="Don't"
-                  values={profile.dontList}
-                  placeholder="Use hype or vague claims"
-                  onChange={(dontList) =>
-                    setProfile((current) => ({ ...current, dontList }))
-                  }
-                />
-                <small className="output-guard-list-note">
-                  Do and Don't guide rewrites and classifier context; banned and
-                  required rules stay deterministic.
-                </small>
-                <ListEditor
-                  label="Banned phrases"
-                  values={profile.bannedPhrases}
-                  placeholder="game changing"
-                  onChange={(bannedPhrases) =>
-                    setProfile((current) => ({ ...current, bannedPhrases }))
-                  }
-                />
-                <ListEditor
-                  label="Banned patterns"
-                  values={profile.bannedPatterns}
-                  placeholder="/\\bguarantee[sd]?\\b/i"
-                  onChange={(bannedPatterns) =>
-                    setProfile((current) => ({ ...current, bannedPatterns }))
-                  }
-                />
-                <ListEditor
-                  label="Required phrases"
-                  values={profile.requirePhrases}
-                  placeholder="Best regards"
-                  onChange={(requirePhrases) =>
-                    setProfile((current) => ({ ...current, requirePhrases }))
-                  }
-                />
+                {profile.enabled ? (
+                  <>
+                    <div className="field">
+                      <span>Mode</span>
+                      <SegmentedToggle
+                        ariaLabel="Output guard mode"
+                        value={profile.mode}
+                        options={[
+                          { value: 'rewrite', label: 'rewrite' },
+                          { value: 'block', label: 'block' },
+                          { value: 'flag', label: 'flag' },
+                        ]}
+                        onChange={(mode) =>
+                          setProfile((current) => ({
+                            ...current,
+                            mode,
+                          }))
+                        }
+                      />
+                    </div>
+                    <ModelSourceControl
+                      label="Classifier"
+                      ariaLabel="Output guard classifier source"
+                      value={profile.classifier}
+                      modelOptions={modelOptions}
+                      defaultOtherModelId={defaultOtherModelId}
+                      activeModelId={
+                        profile.classifier.provider === 'default'
+                          ? defaultModelId
+                          : auxiliaryModelId
+                      }
+                      activeModelFallback={
+                        profile.classifier.provider === 'default'
+                          ? 'No default model'
+                          : auxiliaryProvider === 'disabled'
+                            ? 'Aux model disabled'
+                            : 'Auto routing'
+                      }
+                      modelsLoading={modelsQuery.isLoading}
+                      onChange={(classifier) =>
+                        setProfile((current) => ({ ...current, classifier }))
+                      }
+                    />
+                    <ModelSourceControl
+                      label="Rewriter"
+                      ariaLabel="Output guard rewriter source"
+                      value={profile.rewriter}
+                      modelOptions={modelOptions}
+                      defaultOtherModelId={defaultOtherModelId}
+                      activeModelId={
+                        profile.rewriter.provider === 'default'
+                          ? defaultModelId
+                          : auxiliaryModelId
+                      }
+                      activeModelFallback={
+                        profile.rewriter.provider === 'default'
+                          ? 'No default model'
+                          : auxiliaryProvider === 'disabled'
+                            ? 'Aux model disabled'
+                            : 'Auto routing'
+                      }
+                      modelsLoading={modelsQuery.isLoading}
+                      onChange={(rewriter) =>
+                        setProfile((current) => ({ ...current, rewriter }))
+                      }
+                    />
+                    <label className="field textarea-field">
+                      <span>Policy</span>
+                      <Textarea
+                        rows={5}
+                        value={profile.policy}
+                        onChange={(event) =>
+                          setProfile((current) => ({
+                            ...current,
+                            policy: event.target.value,
+                          }))
+                        }
+                        placeholder="Clear, direct, concrete. No hype."
+                      />
+                    </label>
+                    <ListEditor
+                      label="Do"
+                      values={profile.doList}
+                      placeholder="Use concrete nouns"
+                      onChange={(doList) =>
+                        setProfile((current) => ({ ...current, doList }))
+                      }
+                    />
+                    <ListEditor
+                      label="Don't"
+                      values={profile.dontList}
+                      placeholder="Use hype or vague claims"
+                      onChange={(dontList) =>
+                        setProfile((current) => ({ ...current, dontList }))
+                      }
+                    />
+                    <small className="output-guard-list-note">
+                      Do and Don't guide rewrites and classifier context; banned
+                      and required rules stay deterministic.
+                    </small>
+                    <ListEditor
+                      label="Banned phrases"
+                      values={profile.bannedPhrases}
+                      placeholder="game changing"
+                      onChange={(bannedPhrases) =>
+                        setProfile((current) => ({
+                          ...current,
+                          bannedPhrases,
+                        }))
+                      }
+                    />
+                    <ListEditor
+                      label="Banned patterns"
+                      values={profile.bannedPatterns}
+                      placeholder="/\\bguarantee[sd]?\\b/i"
+                      onChange={(bannedPatterns) =>
+                        setProfile((current) => ({
+                          ...current,
+                          bannedPatterns,
+                        }))
+                      }
+                    />
+                    <ListEditor
+                      label="Required phrases"
+                      values={profile.requirePhrases}
+                      placeholder="Best regards"
+                      onChange={(requirePhrases) =>
+                        setProfile((current) => ({
+                          ...current,
+                          requirePhrases,
+                        }))
+                      }
+                    />
+                  </>
+                ) : (
+                  <p className="supporting-text">
+                    Enable Output Guard to configure its policy and models.
+                  </p>
+                )}
               </div>
             )}
           </CardContent>

--- a/console/src/routes/statistics.test.tsx
+++ b/console/src/routes/statistics.test.tsx
@@ -1,0 +1,71 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { AdminStatisticsResponse } from '../api/types';
+import { renderWithProviders } from '../test-utils';
+import { StatisticsPage } from './statistics';
+
+const teamsThreadId =
+  '19:2aYaLicf8I08ay4ANzoMK6JFd3LBw5AT3JeKZCLOQTk1@thread.tacv2;messageid=1784888241570';
+const teamsChatId = 'a:1uoW2tioFMsv_ZBPO8jcd9Gv91vgn0M';
+
+vi.mock('../api/client', () => ({
+  fetchStatistics: (): Promise<AdminStatisticsResponse> =>
+    Promise.resolve({
+      rangeDays: 30,
+      startDate: '2026-06-26',
+      endDate: '2026-07-25',
+      totals: {
+        newSessions: 3,
+        activeSessions: 3,
+        totalMessages: 8,
+        userMessages: 4,
+        assistantMessages: 4,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalTokens: 0,
+        totalCostUsd: 0,
+        callCount: 0,
+        totalToolCalls: 0,
+      },
+      trend: [],
+      channels: [
+        {
+          channelId: teamsThreadId,
+          sessionCount: 2,
+          userMessages: 3,
+          assistantMessages: 3,
+          totalMessages: 6,
+        },
+        {
+          channelId: teamsChatId,
+          sessionCount: 1,
+          userMessages: 1,
+          assistantMessages: 1,
+          totalMessages: 2,
+        },
+        {
+          channelId: 'web',
+          sessionCount: 1,
+          userMessages: 1,
+          assistantMessages: 1,
+          totalMessages: 2,
+        },
+      ],
+    }),
+}));
+
+vi.mock('../auth', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+describe('StatisticsPage', () => {
+  it('groups raw Teams conversation ids under the Teams channel type', async () => {
+    renderWithProviders(<StatisticsPage />);
+
+    expect(await screen.findByText('Microsoft Teams')).toBeTruthy();
+    expect(screen.getByText('2 destinations')).toBeTruthy();
+    expect(screen.getByText('Web')).toBeTruthy();
+    expect(screen.queryByText(teamsThreadId)).toBeNull();
+    expect(screen.queryByText(teamsChatId)).toBeNull();
+  });
+});

--- a/console/src/routes/statistics.tsx
+++ b/console/src/routes/statistics.tsx
@@ -185,7 +185,7 @@ export function StatisticsPage(
         <CardHeader>
           <CardTitle>Channel breakdown</CardTitle>
           <CardDescription>
-            Distribution of sessions and messages by channel
+            Distribution of sessions and messages by channel type
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -352,11 +352,12 @@ function ChannelBreakdown(props: { channels: AdminStatisticsChannelRow[] }) {
     );
   }
 
-  const totalSessions = props.channels.reduce(
+  const groupedChannels = groupChannelRows(props.channels);
+  const totalSessions = groupedChannels.reduce(
     (sum, row) => sum + row.sessionCount,
     0,
   );
-  const totalMessages = props.channels.reduce(
+  const totalMessages = groupedChannels.reduce(
     (sum, row) => sum + row.totalMessages,
     0,
   );
@@ -375,18 +376,21 @@ function ChannelBreakdown(props: { channels: AdminStatisticsChannelRow[] }) {
           </tr>
         </thead>
         <tbody>
-          {props.channels.map((channel) => {
+          {groupedChannels.map((channel) => {
             const share =
               totalMessages > 0 ? channel.totalMessages / totalMessages : 0;
             return (
-              <tr key={channel.channelId}>
+              <tr key={channel.key}>
                 <td>
-                  <strong>{channel.channelId || '(unknown)'}</strong>
+                  <strong title={channel.title}>{channel.label}</strong>
                   <small>
                     {totalSessions > 0
                       ? `${Math.round((channel.sessionCount / totalSessions) * 100)}% of sessions`
                       : '—'}
                   </small>
+                  {channel.destinationCount > 1 ? (
+                    <small>{`${channel.destinationCount} destinations`}</small>
+                  ) : null}
                 </td>
                 <td style={{ textAlign: 'right' }}>{channel.sessionCount}</td>
                 <td style={{ textAlign: 'right' }}>{channel.totalMessages}</td>
@@ -428,5 +432,70 @@ function ChannelBreakdown(props: { channels: AdminStatisticsChannelRow[] }) {
         </tbody>
       </table>
     </div>
+  );
+}
+
+function compactDestination(value: string): string {
+  if (value.length <= 40) return value;
+  return `${value.slice(0, 24)}…${value.slice(-12)}`;
+}
+
+function formatChannelGroup(channelId: string): {
+  key: string;
+  label: string;
+  title?: string;
+} {
+  const normalized = channelId.trim();
+  if (!normalized || normalized === '(unknown)') {
+    return { key: 'unknown', label: 'Unknown' };
+  }
+  if (normalized === 'web') return { key: 'web', label: 'Web' };
+  if (normalized === 'tui') return { key: 'tui', label: 'TUI' };
+  if (normalized.startsWith('19:') || normalized.startsWith('a:')) {
+    return { key: 'msteams', label: 'Microsoft Teams' };
+  }
+  if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized)) {
+    return { key: 'email', label: 'Email' };
+  }
+  return {
+    key: `raw:${normalized}`,
+    label: compactDestination(normalized),
+    ...(normalized.length > 40 ? { title: normalized } : {}),
+  };
+}
+
+type GroupedChannelRow = AdminStatisticsChannelRow & {
+  key: string;
+  label: string;
+  title?: string;
+  destinationCount: number;
+};
+
+function groupChannelRows(
+  channels: AdminStatisticsChannelRow[],
+): GroupedChannelRow[] {
+  const grouped = new Map<string, GroupedChannelRow>();
+  for (const channel of channels) {
+    const display = formatChannelGroup(channel.channelId);
+    const current = grouped.get(display.key);
+    if (current) {
+      current.sessionCount += channel.sessionCount;
+      current.userMessages += channel.userMessages;
+      current.assistantMessages += channel.assistantMessages;
+      current.totalMessages += channel.totalMessages;
+      current.destinationCount += 1;
+      continue;
+    }
+    grouped.set(display.key, {
+      ...channel,
+      ...display,
+      destinationCount: 1,
+    });
+  }
+  return [...grouped.values()].sort(
+    (left, right) =>
+      right.totalMessages - left.totalMessages ||
+      right.sessionCount - left.sessionCount ||
+      left.label.localeCompare(right.label),
   );
 }


### PR DESCRIPTION
## Summary

- group raw Microsoft Teams conversation IDs under the Microsoft Teams channel type in statistics
- make provider health rows select the single provider configuration shown in the right pane
- replace fixed, disabled credential dropdowns with an effective credential-status readout
- hide Output Guard policy and model controls while the guard is disabled
- add focused coverage for channel grouping, provider navigation, credential state, and disabled Output Guard behavior

## Root cause

The statistics table rendered stored delivery `channel_id` values directly, so Teams thread and chat identifiers appeared as separate channels. Provider configuration rendered every provider at once and reused the selectable secret picker for canonical, non-selectable credentials. That picker only reflected the encrypted runtime store, while provider health can succeed with credentials injected through the cloud process environment. Output Guard rendered its full form regardless of its enabled state.

## Impact

Operators now see channel-level Teams statistics, configure one provider at a time, get an accurate indication when a credential is available outside the runtime store, and avoid inactive Output Guard controls until the feature is enabled.

## Validation

- `npm run format`
- `npm run lint`
- `npm --workspace console run build`
- focused console tests: 13 passed
- complete console test suite: 889 passed