### PR TITLE
fix(container): stop republishing whole images on every release

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,6 +12,12 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Constant, not the commit timestamp: layers only dedupe across releases if
+  # unchanged build steps keep producing byte-identical blobs. Paired with
+  # rewrite-timestamp=true on the image exporter.
+  SOURCE_DATE_EPOCH: '1704067200'
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -28,11 +34,14 @@ jobs:
             context: ./container
             file: ./container/Dockerfile
             target: runtime
-            scope: hybridclaw-agent
+            # Build inputs live entirely under container/, so its git tree hash
+            # identifies the image content. The gateway builds from the repo
+            # root, where the tree changes on every commit, so it has no key.
+            reuse_path: container
           - image: hybridclaw-gateway
             context: .
             file: ./Dockerfile
-            scope: hybridclaw-gateway
+            reuse_path: ''
     steps:
       - name: Checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -40,13 +49,29 @@ jobs:
       - name: Resolve image tags
         id: meta
         shell: bash
+        env:
+          REUSE_PATH: ${{ matrix.reuse_path }}
         run: |
           set -euo pipefail
           OWNER_LC="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           SHA_SHORT="${GITHUB_SHA::7}"
           IMAGE="ghcr.io/${OWNER_LC}/${{ matrix.image }}"
           TAGS="${IMAGE}:sha-${SHA_SHORT}"$'\n'"${IMAGE}:main"
-          { echo "tags<<EOF"; echo "${TAGS}"; echo "EOF"; } >> "${GITHUB_OUTPUT}"
+
+          CONTENT_TAG=""
+          if [[ -n "${REUSE_PATH}" ]]; then
+            TREE="$(git rev-parse "HEAD:${REUSE_PATH}")"
+            CONTENT_TAG="${IMAGE}:tree-${TREE::12}"
+            TAGS="${TAGS}"$'\n'"${CONTENT_TAG}"
+          fi
+
+          {
+            echo "content_tag=${CONTENT_TAG}"
+            echo "cache_ref=${IMAGE}:buildcache"
+            echo "tags<<EOF"
+            echo "${TAGS}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
@@ -61,13 +86,45 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Retagging keeps the release pointed at a manifest users already hold, and
+      # avoids apt/pip drift changing an image whose own inputs did not change.
+      - name: Reuse image built from identical inputs
+        id: reuse
+        if: steps.meta.outputs.content_tag != ''
+        shell: bash
+        env:
+          CONTENT_TAG: ${{ steps.meta.outputs.content_tag }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          if ! docker buildx imagetools inspect "${CONTENT_TAG}" >/dev/null 2>&1; then
+            echo "No image for ${CONTENT_TAG}; building."
+            echo "reused=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          while IFS= read -r tag; do
+            [[ -n "${tag}" ]] || continue
+            if [[ "${tag}" == "${CONTENT_TAG}" ]]; then
+              continue
+            fi
+            if [[ "${tag}" == *"//"* || "${tag}" != *":"* ]]; then
+              echo "Invalid target image tag '${tag}'." >&2
+              exit 1
+            fi
+            docker buildx imagetools create --tag "${tag}" "${CONTENT_TAG}"
+          done <<< "${TAGS}"
+
+          echo "Retagged ${CONTENT_TAG}; skipped rebuild."
+          echo "reused=true" >> "${GITHUB_OUTPUT}"
+
       - name: Build and push
+        if: steps.reuse.outputs.reused != 'true'
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
           target: ${{ matrix.target }}
-          push: true
           provenance: mode=max
           sbom: true
           platforms: linux/amd64,linux/arm64
@@ -75,5 +132,6 @@ jobs:
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-          cache-from: type=gha,scope=${{ matrix.scope }}
-          cache-to: type=gha,mode=max,ignore-error=true,timeout=5m,scope=${{ matrix.scope }}
+          outputs: type=image,push=true,rewrite-timestamp=true
+          cache-from: type=registry,ref=${{ steps.meta.outputs.cache_ref }}
+          cache-to: type=registry,ref=${{ steps.meta.outputs.cache_ref }},mode=max

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -34,14 +34,9 @@ jobs:
             context: ./container
             file: ./container/Dockerfile
             target: runtime
-            # Build inputs live entirely under container/, so its git tree hash
-            # identifies the image content. The gateway builds from the repo
-            # root, where the tree changes on every commit, so it has no key.
-            reuse_path: container
           - image: hybridclaw-gateway
             context: .
             file: ./Dockerfile
-            reuse_path: ''
     steps:
       - name: Checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -49,25 +44,17 @@ jobs:
       - name: Resolve image tags
         id: meta
         shell: bash
-        env:
-          REUSE_PATH: ${{ matrix.reuse_path }}
         run: |
           set -euo pipefail
           OWNER_LC="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           SHA_SHORT="${GITHUB_SHA::7}"
+          VERSION="$(jq -r .version package.json)"
           IMAGE="ghcr.io/${OWNER_LC}/${{ matrix.image }}"
           TAGS="${IMAGE}:sha-${SHA_SHORT}"$'\n'"${IMAGE}:main"
 
-          CONTENT_TAG=""
-          if [[ -n "${REUSE_PATH}" ]]; then
-            TREE="$(git rev-parse "HEAD:${REUSE_PATH}")"
-            CONTENT_TAG="${IMAGE}:tree-${TREE::12}"
-            TAGS="${TAGS}"$'\n'"${CONTENT_TAG}"
-          fi
-
           {
-            echo "content_tag=${CONTENT_TAG}"
             echo "cache_ref=${IMAGE}:buildcache"
+            echo "version=v${VERSION}"
             echo "tags<<EOF"
             echo "${TAGS}"
             echo "EOF"
@@ -86,40 +73,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Retagging keeps the release pointed at a manifest users already hold, and
-      # avoids apt/pip drift changing an image whose own inputs did not change.
-      - name: Reuse image built from identical inputs
-        id: reuse
-        if: steps.meta.outputs.content_tag != ''
-        shell: bash
-        env:
-          CONTENT_TAG: ${{ steps.meta.outputs.content_tag }}
-          TAGS: ${{ steps.meta.outputs.tags }}
-        run: |
-          set -euo pipefail
-          if ! docker buildx imagetools inspect "${CONTENT_TAG}" >/dev/null 2>&1; then
-            echo "No image for ${CONTENT_TAG}; building."
-            echo "reused=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          while IFS= read -r tag; do
-            [[ -n "${tag}" ]] || continue
-            if [[ "${tag}" == "${CONTENT_TAG}" ]]; then
-              continue
-            fi
-            if [[ "${tag}" == *"//"* || "${tag}" != *":"* ]]; then
-              echo "Invalid target image tag '${tag}'." >&2
-              exit 1
-            fi
-            docker buildx imagetools create --tag "${tag}" "${CONTENT_TAG}"
-          done <<< "${TAGS}"
-
-          echo "Retagged ${CONTENT_TAG}; skipped rebuild."
-          echo "reused=true" >> "${GITHUB_OUTPUT}"
-
       - name: Build and push
-        if: steps.reuse.outputs.reused != 'true'
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ${{ matrix.context }}
@@ -132,6 +86,7 @@ jobs:
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
           outputs: type=image,push=true,rewrite-timestamp=true
           cache-from: type=registry,ref=${{ steps.meta.outputs.cache_ref }}
           cache-to: type=registry,ref=${{ steps.meta.outputs.cache_ref }},mode=max

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,6 +19,12 @@ permissions:
   attestations: write
   id-token: write
 
+env:
+  # Constant, not the commit timestamp: layers only dedupe across releases if
+  # unchanged build steps keep producing byte-identical blobs. Paired with
+  # rewrite-timestamp=true on the image exporter.
+  SOURCE_DATE_EPOCH: '1704067200'
+
 jobs:
   # Validate tag/package.json alignment once; both image jobs depend on this.
   validate:
@@ -131,6 +137,7 @@ jobs:
           fi
           {
             echo "source=${SOURCE}"
+            echo "cache_ref=ghcr.io/${OWNER_LC}/hybridclaw-agent:buildcache"
             echo "tags<<EOF"
             echo "${TAGS}"
             echo "EOF"
@@ -169,14 +176,14 @@ jobs:
         with:
           context: ./container
           target: runtime
-          push: true
           provenance: mode=max
           sbom: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ needs.validate.outputs.labels }}
-          cache-from: type=gha,scope=hybridclaw-agent
-          cache-to: type=gha,mode=max,ignore-error=true,timeout=5m,scope=hybridclaw-agent
+          outputs: type=image,push=true,rewrite-timestamp=true
+          cache-from: type=registry,ref=${{ steps.meta.outputs.cache_ref }}
+          cache-to: type=registry,ref=${{ steps.meta.outputs.cache_ref }},mode=max
 
       - name: Verify published agent tags
         uses: ./.github/actions/verify-published-tags
@@ -218,6 +225,7 @@ jobs:
           fi
           {
             echo "source=${SOURCE}"
+            echo "cache_ref=${GHCR_IMAGE}:buildcache"
             echo "tags<<EOF"
             echo "${TAGS}"
             echo "EOF"
@@ -257,14 +265,14 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: true
           provenance: mode=max
           sbom: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ needs.validate.outputs.labels }}
-          cache-from: type=gha,scope=hybridclaw-gateway
-          cache-to: type=gha,mode=max,ignore-error=true,timeout=5m,scope=hybridclaw-gateway
+          outputs: type=image,push=true,rewrite-timestamp=true
+          cache-from: type=registry,ref=${{ steps.meta.outputs.cache_ref }}
+          cache-to: type=registry,ref=${{ steps.meta.outputs.cache_ref }},mode=max
 
       - name: Verify published gateway tags
         uses: ./.github/actions/verify-published-tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,13 @@ RUN npm run build:console
 RUN npx tsc && node -e "require('node:fs').chmodSync('dist/cli.js', 0o755)"
 RUN npm --prefix container run build
 
-# Prune devDeps in place so the runtime stage copies only production deps
+# Prune devDeps in place so the runtime stage copies only production deps.
+# The hidden lockfiles carry the project version, which would give the copied
+# node_modules layers a new digest on every release; nothing reads them here.
 RUN npm prune --omit=dev \
-    && npm --prefix container prune --omit=dev
+    && npm --prefix container prune --omit=dev \
+    && rm -f node_modules/.package-lock.json \
+       container/node_modules/.package-lock.json
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
 FROM node:22-slim@sha256:80fdb3f57c815e1b638d221f30a826823467c4a56c8f6a8d7aa091cd9b1675ea AS runtime

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -20,10 +20,14 @@ RUN npx tsc
 # --- Runtime base (no LibreOffice) ---
 FROM node:22-slim@sha256:80fdb3f57c815e1b638d221f30a826823467c4a56c8f6a8d7aa091cd9b1675ea AS runtime-lite
 
-ARG HYBRIDCLAW_VERSION=0.0.0
 LABEL org.opencontainers.image.source="https://github.com/HybridAIOne/hybridclaw"
 LABEL org.opencontainers.image.description="HybridClaw sandboxed agent runtime"
-LABEL org.opencontainers.image.version="${HYBRIDCLAW_VERSION}"
+
+# npm names its debug logs after the wall clock and leaves a V8 compile cache in
+# /tmp whose contents vary per run; shipping either hands every layer that runs
+# npm a fresh digest on each rebuild.
+ENV NPM_CONFIG_LOGS_MAX=0
+ENV NODE_DISABLE_COMPILE_CACHE=1
 
 RUN --mount=type=cache,target=/root/.npm \
     npm install --global npm@11.10.0 --ignore-scripts --no-audit --fund=false
@@ -64,19 +68,44 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 WORKDIR /app
 
-COPY --link --from=builder /app/.npmrc /app/package.json /app/package-lock.json ./
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci --ignore-scripts --omit=dev
+# Hand /app to node before anything is written into it; a trailing `chown -R`
+# would copy every installed file into a second layer instead. `--link` copies
+# below resolve ownership without passwd, so they name node numerically.
+RUN mkdir -p /ms-playwright && chown node:node /app /ms-playwright
 
-# System deps need root; browser installed as node user so /ms-playwright stays owned by node:node
+COPY --link --chown=1000:1000 --from=builder /app/.npmrc /app/package.json /app/package-lock.json ./
+USER node
+# npm stamps the project version into the hidden lockfile, which would give this
+# ~400 MB layer a new digest on every release even when no dependency changed.
+# Nothing reads it at runtime.
+RUN --mount=type=cache,target=/home/node/.npm,uid=1000,gid=1000 \
+    npm ci --ignore-scripts --omit=dev \
+    && rm -f node_modules/.package-lock.json
+
+# Playwright's system deps need root; the browser itself is installed as node
+# so /ms-playwright stays owned by node:node.
+#
+# apt/dpkg logs and the font and linker caches record the wall clock in their
+# contents, which the exporter's timestamp rewrite cannot normalise, so leaving
+# them would hand this ~300 MB layer a new digest on every rebuild. Fonts are
+# recached against SOURCE_DATE_EPOCH, the mtime the layer is exported with, so
+# the cache still validates at runtime.
+USER root
 RUN DEBIAN_FRONTEND=noninteractive npx playwright install-deps chromium \
-    && mkdir -p /ms-playwright \
-    && chown -R node:node /app /ms-playwright
+    && rm -rf /var/cache/ldconfig/aux-cache \
+    && find /var/log -type f -delete \
+    && find /usr/share/fonts -exec touch -hd @1704067200 {} + \
+    && fc-cache -f -s
 USER node
 RUN npx playwright install --only-shell chromium
 
-COPY --link --from=builder /app/dist/ dist/
-COPY --link --from=builder /app/shared/ shared/
+COPY --link --chown=1000:1000 --from=builder /app/dist/ dist/
+COPY --link --chown=1000:1000 --from=builder /app/shared/ shared/
+
+# Declared last: an ARG invalidates every instruction after it, so a version
+# bump here would otherwise rebuild the whole runtime stage.
+ARG HYBRIDCLAW_VERSION=0.0.0
+LABEL org.opencontainers.image.version="${HYBRIDCLAW_VERSION}"
 
 STOPSIGNAL SIGTERM
 WORKDIR /workspace
@@ -89,5 +118,9 @@ USER root
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    libreoffice-calc libreoffice-impress libreoffice-writer
+    libreoffice-calc libreoffice-impress libreoffice-writer \
+    && rm -rf /var/cache/ldconfig/aux-cache \
+    && find /var/log -type f -delete \
+    && find /usr/share/fonts -exec touch -hd @1704067200 {} + \
+    && fc-cache -f -s
 USER node

--- a/docs/content/developer-guide/runtime.md
+++ b/docs/content/developer-guide/runtime.md
@@ -38,6 +38,17 @@ Maintainer overrides:
 
 Build context hygiene is enforced by `container/.dockerignore` to avoid shipping
 local secrets or artifacts into published images.
+
+Published agent images are content-addressed.
+`.github/workflows/docker-build.yml` tags each build with the git tree hash of
+`container/`; when a later commit leaves those inputs untouched, the workflow
+retags the existing image instead of rebuilding, so the new release tag resolves
+to the same manifest and pulls nothing. Both image builds also export with
+`rewrite-timestamp=true` under a fixed `SOURCE_DATE_EPOCH`, so a step that does
+rerun still yields byte-identical layers when its content is unchanged. Without
+that, differing file mtimes alone gave every layer a fresh digest and each
+upgrade re-downloaded the whole image rather than a delta.
+
 Published images also include the built `/chat`, `/apps`, and `/agents`
 browser assets so the embedded web surfaces work from release images instead
 of source checkouts only.

--- a/docs/content/developer-guide/runtime.md
+++ b/docs/content/developer-guide/runtime.md
@@ -39,15 +39,13 @@ Maintainer overrides:
 Build context hygiene is enforced by `container/.dockerignore` to avoid shipping
 local secrets or artifacts into published images.
 
-Published agent images are content-addressed.
-`.github/workflows/docker-build.yml` tags each build with the git tree hash of
-`container/`; when a later commit leaves those inputs untouched, the workflow
-retags the existing image instead of rebuilding, so the new release tag resolves
-to the same manifest and pulls nothing. Both image builds also export with
-`rewrite-timestamp=true` under a fixed `SOURCE_DATE_EPOCH`, so a step that does
-rerun still yields byte-identical layers when its content is unchanged. Without
-that, differing file mtimes alone gave every layer a fresh digest and each
-upgrade re-downloaded the whole image rather than a delta.
+Published images export with `rewrite-timestamp=true` under a fixed
+`SOURCE_DATE_EPOCH`, so a step that reruns still yields byte-identical filesystem
+layers when its content is unchanged. Registry-backed build caches avoid
+repeating unchanged work, while each build emits fresh image metadata and
+attestations for its commit. Without timestamp normalization, differing file
+mtimes alone gave every layer a fresh digest and each upgrade re-downloaded the
+whole image rather than a delta.
 
 Published images also include the built `/chat`, `/apps`, and `/agents`
 browser assets so the embedded web surfaces work from release images instead


### PR DESCRIPTION
## Problem

Long-running installs accumulate tens of GB of `hybridclaw-agent` images — 17 tags at ~3.2–3.6 GB each was the report that prompted this. Docker layers *should* make an upgrade cost only a delta, so the working assumption was a diagnosis error. It wasn't.

Comparing the published manifests across adjacent releases, the only layers shared were the pinned `node:22-slim` base:

```
v0.24.0 -> v0.26.0: shared 0.22 GB | NEW 0.63 GB in 8/18 layers
v0.26.0 -> v0.27.0: shared 0.22 GB | NEW 0.63 GB in 7/18 layers
v0.27.0 -> v0.28.0: shared 0.22 GB | NEW 0.63 GB in 7/18 layers
v0.28.0 -> v0.28.1: shared 0.22 GB | NEW 0.63 GB in 8/18 layers
```

74% of every image was fresh blobs, including on a patch bump where nothing in those steps changed.

## Cause

Layer digests cover file mtimes, so identical build steps produced different blobs on each rebuild. Normalising timestamps was necessary but not sufficient — five separate things wrote wall-clock or version data into layer **contents**, which the exporter's timestamp rewrite cannot touch. Each was found by diffing actual layer contents:

| Source | Invalidated per release | Fix |
| --- | --- | --- |
| `chown -R` copying up all of `node_modules` | ~414 MB | own `/app` before writing into it |
| `.package-lock.json` (npm stamps the project version) | 414 MB agent + 1.65 GB gateway | remove after install |
| npm debug logs (timestamped filename) | 114 MB | `NPM_CONFIG_LOGS_MAX=0` |
| apt/dpkg logs, ldconfig + font caches | 133 MB + 148 MB | clear; recache fonts to `SOURCE_DATE_EPOCH` |
| V8 compile cache in `/tmp` | 114 MB | `NODE_DISABLE_COMPILE_CACHE=1` |

## Changes

- **Reproducible builds** — `rewrite-timestamp=true` on the image exporter under a fixed `SOURCE_DATE_EPOCH`. Constant rather than the commit timestamp, since the usual convention would defeat cross-release dedupe.
- **Fresh metadata with cached layers** — every main build emits current OCI labels and attestations; registry-backed BuildKit caches and reproducible exports preserve unchanged filesystem layer digests without retagging a stale manifest.
- **Registry build cache** — the GHA backend silently dropped exports past its 10 GB quota (`ignore-error=true,timeout=5m`), and release builds shared those scopes with PR preflight builds. PR builds in `ci.yml` are deliberately left on GHA — they use `load: true`, which conflicts with `rewrite-timestamp`.
- `ARG HYBRIDCLAW_VERSION` moved to the end of the stage. CI never passed it, so published images carried a bogus `version=0.0.0` label, while local builds do pass it and invalidated every apt/pip/playwright layer on each version bump.

## Verification

Built the full `runtime` target, applied a release version bump, rebuilt, and compared layer digests:

```
full agent image: 739.3 MB compressed
new bytes for the next release: 0.03 MB (0.00%)
```

Every layer identical except the 0.03 MB copy of the manifests — down from 627 MB. A real release also changes `container/src`, so expect ~0.4 MB in practice.

Runtime behaviour unchanged: runs as `node`, `/app` and `node_modules` node-owned and writable, chromium and LibreOffice present, fonts intact (58 fonts, `fc-match sans` resolves, 20 valid caches, no stale-cache rescans). The reproducibility mechanism was also confirmed against a local registry on the same `docker-container` driver CI uses, with `provenance: mode=max` + `sbom: true` enabled — the filesystem layers are bit-identical while commit-specific image metadata and attestations are refreshed.

`actionlint` is clean on both workflows.

## Notes for reviewers

- **The first release after this merges is still a full download.** The Dockerfile edits change instruction strings, so every layer gets a new digest once; the benefit starts with the release after.
- **This does not reclaim images already on disk** — that needs `docker image prune -a`. Nothing in `src/infra/` ever removes an old agent tag, so auto-pruning on update is still worth doing separately.
- `cache-to: mode=max` on the gateway pushes a large cache manifest to GHCR on every `main` commit (the gateway has no reuse key, so it always rebuilds). Standard practice and unbounded unlike the GHA quota, but it will accumulate storage; `mode=min` would shrink it at the cost of slower builds.
- No `CHANGELOG.md` entry — the user-facing note would be that agent upgrades now download a delta, and that already-accumulated tags still need a manual prune.