### PR TITLE
feat: default HybridAI to gpt-5.6-luna

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,5 @@
 {
-  "version": 36,
+  "version": 37,
   "security": {
     "trustModelAccepted": false,
     "trustModelAcceptedAt": "",
@@ -352,7 +352,7 @@
   },
   "hybridai": {
     "baseUrl": "https://hybridai.one",
-    "defaultModel": "gpt-4.1-mini",
+    "defaultModel": "gpt-5.6-luna",
     "onboardingModel": "",
     "defaultChatbotId": "",
     "maxTokens": 4096,

--- a/console/src/generated/settings-registry.ts
+++ b/console/src/generated/settings-registry.ts
@@ -1274,7 +1274,7 @@ export const GENERATED_SETTINGS_REGISTRY: ReadonlyArray<GeneratedSettingEntry> =
       path: 'hybridai.defaultModel',
       section: 'hybridai',
       kind: 'string',
-      defaultValue: 'gpt-5.4-mini',
+      defaultValue: 'gpt-5.6-luna',
     },
     {
       path: 'hybridai.enableRag',

--- a/console/src/generated/settings-registry.ts
+++ b/console/src/generated/settings-registry.ts
@@ -2691,7 +2691,7 @@ export const GENERATED_SETTINGS_REGISTRY: ReadonlyArray<GeneratedSettingEntry> =
       path: 'version',
       section: 'version',
       kind: 'number',
-      defaultValue: 36,
+      defaultValue: 37,
     },
     {
       path: 'voice.enabled',

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -152,7 +152,7 @@ import { DEFAULT_RUNTIME_HOME_DIR } from './runtime-paths.js';
 export const CONFIG_FILE_NAME = 'config.json';
 export const CONFIG_VERSION = 36;
 export const SECURITY_POLICY_VERSION = '2026-02-28';
-export const DEFAULT_HYBRIDAI_MODEL = 'gpt-5.4-mini';
+export const DEFAULT_HYBRIDAI_MODEL = 'gpt-5.6-luna';
 export const DEFAULT_HYBRIDAI_ONBOARDING_MODEL = '';
 const LEGACY_DEFAULT_DB_PATH = 'data/hybridclaw.db';
 const DEFAULT_VOICE_CHANNEL_INSTRUCTIONS = [

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -150,10 +150,15 @@ import {
 import { DEFAULT_RUNTIME_HOME_DIR } from './runtime-paths.js';
 
 export const CONFIG_FILE_NAME = 'config.json';
-export const CONFIG_VERSION = 36;
+export const CONFIG_VERSION = 37;
 export const SECURITY_POLICY_VERSION = '2026-02-28';
 export const DEFAULT_HYBRIDAI_MODEL = 'gpt-5.6-luna';
 export const DEFAULT_HYBRIDAI_ONBOARDING_MODEL = '';
+const HYBRIDAI_LUNA_DEFAULT_CONFIG_VERSION = 37;
+const LEGACY_HYBRIDAI_DEFAULT_MODELS = new Set([
+  'gpt-5.4-mini',
+  'hybridai/gpt-5.4-mini',
+]);
 const LEGACY_DEFAULT_DB_PATH = 'data/hybridclaw.db';
 const DEFAULT_VOICE_CHANNEL_INSTRUCTIONS = [
   'This is a live phone call. Produce plain spoken text only.',
@@ -6995,6 +7000,10 @@ function normalizeRuntimeConfig(
   };
 
   const raw = patch ?? {};
+  const sourceVersion =
+    typeof raw.version === 'number' && Number.isFinite(raw.version)
+      ? raw.version
+      : null;
 
   const rawSecurity = isRecord(raw.security) ? raw.security : {};
   const rawDeployment = isRecord(raw.deployment) ? raw.deployment : {};
@@ -7294,11 +7303,17 @@ function normalizeRuntimeConfig(
     DEFAULT_RUNTIME_CONFIG.hybridai.defaultChatbotId,
     { allowEmpty: true },
   );
-  const hybridDefaultModel = normalizeString(
+  const normalizedHybridDefaultModel = normalizeString(
     rawHybridAi.defaultModel,
     DEFAULT_RUNTIME_CONFIG.hybridai.defaultModel,
     { allowEmpty: false },
   );
+  const hybridDefaultModel =
+    (sourceVersion === null ||
+      sourceVersion < HYBRIDAI_LUNA_DEFAULT_CONFIG_VERSION) &&
+    LEGACY_HYBRIDAI_DEFAULT_MODELS.has(normalizedHybridDefaultModel)
+      ? DEFAULT_HYBRIDAI_MODEL
+      : normalizedHybridDefaultModel;
   const hybridOnboardingModel = normalizeString(
     rawHybridAi.onboardingModel,
     DEFAULT_RUNTIME_CONFIG.hybridai.onboardingModel,

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -13,6 +13,7 @@ import {
 import { refreshRuntimeSecretsFromEnv } from './config/config.js';
 import {
   acceptSecurityTrustModel,
+  DEFAULT_HYBRIDAI_MODEL,
   ensureRuntimeConfigFile,
   getLastKnownGoodRuntimeConfigMetadata,
   getRuntimeConfig,
@@ -366,7 +367,7 @@ function defaultHybridAIModel(): string {
   const config = getRuntimeConfig();
   const current = config.hybridai.defaultModel.trim();
   if (current && resolveModelProvider(current) === 'hybridai') return current;
-  return 'gpt-4.1-mini';
+  return DEFAULT_HYBRIDAI_MODEL;
 }
 
 function defaultCodexModel(): string {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -4762,7 +4762,7 @@ describe('CLI hybridai commands', () => {
     expect(logSpy).toHaveBeenCalledWith(
       'Disabled local backends: ollama, lmstudio, llamacpp, vllm.',
     );
-    expect(logSpy).toHaveBeenCalledWith('Default model: hybridai/gpt-4.1-mini');
+    expect(logSpy).toHaveBeenCalledWith('Default model: hybridai/gpt-5.6-luna');
   });
 
   it('treats top-level login as an unknown command', async () => {

--- a/tests/configured-models.test.ts
+++ b/tests/configured-models.test.ts
@@ -131,6 +131,16 @@ describe('env var overrides', () => {
 });
 
 describe('configured model catalog', () => {
+  it('uses Luna as the example HybridAI default model', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir);
+
+    const config = await importFreshConfig(homeDir);
+    const snapshot = config.getConfigSnapshot();
+
+    expect(snapshot.hybridai.defaultModel).toBe('gpt-5.6-luna');
+  });
+
   it('defaults the onboarding model override to empty', async () => {
     const homeDir = makeTempHome();
     writeRuntimeConfig(homeDir);

--- a/tests/gateway-service.btw-command.test.ts
+++ b/tests/gateway-service.btw-command.test.ts
@@ -98,7 +98,7 @@ test('btw command answers side question using a tool-less model call', async () 
   expect(call?.task).toBe('btw');
   expect(call?.tools).toEqual([]);
   expect(call?.model).toBeUndefined();
-  expect(call?.fallbackModel).toBe('gpt-5.4-mini');
+  expect(call?.fallbackModel).toBe('gpt-5.6-luna');
   expect(call?.maxTokens).toBe(160);
   expect(call?.timeoutMs).toBe(300_000);
   const systemMessage = call?.messages?.find((m) => m.role === 'system');

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -3271,7 +3271,7 @@ test('model list includes discovered OpenRouter models', async () => {
     throw new Error(`Unexpected result kind: ${result.kind}`);
   }
   expect(result.title).toBe('Available Models');
-  expect(result.text).toContain('hybridai/gpt-4.1-mini');
+  expect(result.text).toContain('hybridai/gpt-5.6-luna');
   expect(result.text).toContain('openrouter/openai/gpt-4.1-mini');
   expect(result.text).toContain(
     'openrouter/nvidia/nemotron-3-super-120b-a12b:free',
@@ -3279,8 +3279,8 @@ test('model list includes discovered OpenRouter models', async () => {
   expect(result.modelCatalog).toEqual(
     expect.arrayContaining([
       {
-        value: 'hybridai/gpt-4.1-mini',
-        label: 'hybridai/gpt-4.1-mini (current)',
+        value: 'hybridai/gpt-5.6-luna',
+        label: 'hybridai/gpt-5.6-luna (current)',
         isFree: false,
       },
       {
@@ -3579,7 +3579,7 @@ test('model list includes discovered HybridAI models', async () => {
     throw new Error(`Unexpected result kind: ${result.kind}`);
   }
   expect(result.title).toBe('Available Models (hybridai)');
-  expect(result.text).toContain('hybridai/gpt-4.1-mini');
+  expect(result.text).toContain('hybridai/gpt-5.6-luna');
   expect(result.text).toContain('hybridai/gpt-5-ultra');
   expect(result.text).toContain('hybridai/mistral/mistral-small');
   expect(fetchMock).toHaveBeenCalledTimes(1);

--- a/tests/local-cli.test.ts
+++ b/tests/local-cli.test.ts
@@ -211,10 +211,10 @@ test('local configure without model enables the backend and preserves the defaul
   expect(config.local.backends.lmstudio.baseUrl).toBe(
     'http://127.0.0.1:1234/v1',
   );
-  expect(config.hybridai.defaultModel).toBe('gpt-5.4-mini');
+  expect(config.hybridai.defaultModel).toBe('gpt-5.6-luna');
   expect(logSpy).toHaveBeenCalledWith('Configured model: none');
   expect(logSpy).toHaveBeenCalledWith(
-    'Default model unchanged: hybridai/gpt-5.4-mini',
+    'Default model unchanged: hybridai/gpt-5.6-luna',
   );
   expect(logSpy).toHaveBeenCalledWith('  /model list lmstudio');
 });
@@ -235,7 +235,7 @@ test('local configure --no-default preserves the existing default model', async 
 
   const config = readRuntimeConfig(homeDir);
   expect(config.local.backends.lmstudio.enabled).toBe(true);
-  expect(config.hybridai.defaultModel).toBe('gpt-5.4-mini');
+  expect(config.hybridai.defaultModel).toBe('gpt-5.6-luna');
 });
 
 test('help local prints local command usage', async () => {
@@ -1061,7 +1061,7 @@ test('local configure vllm with name stores a named endpoint secret ref', async 
     apiKey: 'gemma-secret-key',
     zone: 'cloud',
   });
-  expect(config.hybridai.defaultModel).toBe('gpt-5.4-mini');
+  expect(config.hybridai.defaultModel).toBe('gpt-5.6-luna');
   expect(rawEndpoint?.apiKey).toEqual({
     source: 'store',
     id: 'LOCAL_ENDPOINT_HAIGPU2_API_KEY',

--- a/tests/model-catalog.test.ts
+++ b/tests/model-catalog.test.ts
@@ -276,7 +276,7 @@ test('available model catalog merges the current default model with discovered l
 
   expect(choices).toEqual(
     expect.arrayContaining([
-      { name: 'hybridai/gpt-4.1-mini', value: 'hybridai/gpt-4.1-mini' },
+      { name: 'hybridai/gpt-5.6-luna', value: 'hybridai/gpt-5.6-luna' },
       {
         name: 'lmstudio/qwen/qwen3.5-9b',
         value: 'lmstudio/qwen/qwen3.5-9b',
@@ -294,7 +294,7 @@ test('available model catalog merges the current default model with discovered l
     catalog.getModelCatalogMetadata('lmstudio/qwen/qwen3.5-9b').zone,
   ).toBe('local');
   expect(catalog.getAvailableModelList('hybridai')).toContain(
-    'hybridai/gpt-4.1-mini',
+    'hybridai/gpt-5.6-luna',
   );
 });
 

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -55,9 +55,16 @@ function writeRuntimeConfig(
   fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
 }
 
-async function runHybridAIOnboarding(commandName: string): Promise<string> {
+async function runHybridAIOnboarding(
+  commandName: string,
+  initialDefaultModel?: string,
+): Promise<{ homeDir: string; output: string }> {
   const homeDir = makeTempHome();
-  writeRuntimeConfig(homeDir);
+  writeRuntimeConfig(homeDir, (config) => {
+    if (initialDefaultModel) {
+      config.hybridai.defaultModel = initialDefaultModel;
+    }
+  });
 
   process.env.HOME = homeDir;
   process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
@@ -72,7 +79,15 @@ async function runHybridAIOnboarding(commandName: string): Promise<string> {
     configurable: true,
   });
 
-  const answers = ['n', 'n', '', '', 'hai-testkey1234567890', ''];
+  const answers = [
+    'n',
+    'n',
+    '',
+    '',
+    'hai-testkey1234567890',
+    '',
+    ...(initialDefaultModel ? [''] : []),
+  ];
   vi.doMock('node:readline/promises', () => ({
     default: {
       createInterface: () => ({
@@ -145,7 +160,7 @@ async function runHybridAIOnboarding(commandName: string): Promise<string> {
     preferredAuth: 'hybridai',
   });
 
-  return lines.join('\n');
+  return { homeDir, output: lines.join('\n') };
 }
 
 afterEach(() => {
@@ -194,9 +209,22 @@ afterEach(() => {
 });
 
 test('interactive onboarding suggests starting the TUI after HybridAI setup', async () => {
-  const output = await runHybridAIOnboarding('hybridclaw onboarding');
+  const { output } = await runHybridAIOnboarding('hybridclaw onboarding');
 
   expect(output).toContain('Start HybridClaw now with `hybridclaw tui`.');
+});
+
+test('interactive HybridAI onboarding falls back to the runtime default model', async () => {
+  const { homeDir, output } = await runHybridAIOnboarding(
+    'hybridclaw onboarding',
+    'anthropic/claude-sonnet-4-6',
+  );
+  const config = JSON.parse(
+    fs.readFileSync(path.join(homeDir, '.hybridclaw', 'config.json'), 'utf-8'),
+  ) as RuntimeConfig;
+
+  expect(config.hybridai.defaultModel).toBe('gpt-5.6-luna');
+  expect(output).toContain('Default model set to: gpt-5.6-luna');
 });
 
 test('interactive onboarding offers last-known-good restore when runtime config is invalid JSON', async () => {
@@ -530,7 +558,7 @@ test('non-interactive onboarding reports invalid runtime config before trust acc
 });
 
 test('interactive onboarding does not print the start hint when TUI is already launching', async () => {
-  const output = await runHybridAIOnboarding('hybridclaw tui');
+  const { output } = await runHybridAIOnboarding('hybridclaw tui');
 
   expect(output).not.toContain('Start HybridClaw now with `hybridclaw tui`.');
 });
@@ -588,7 +616,7 @@ test('tui bootstrap does not prompt for remote auth when trust is already accept
 });
 
 test('interactive onboarding does not print the start hint after auth login', async () => {
-  const output = await runHybridAIOnboarding('hybridclaw auth login');
+  const { output } = await runHybridAIOnboarding('hybridclaw auth login');
 
   expect(output).not.toContain('Start HybridClaw now with `hybridclaw tui`.');
 });

--- a/tests/runtime-config.migration-logging.test.ts
+++ b/tests/runtime-config.migration-logging.test.ts
@@ -135,6 +135,58 @@ describe('runtime config migration logging', () => {
     expect(stored.local.backends.ollama.enabled).toBe(false);
   });
 
+  it.each(['gpt-5.4-mini', 'hybridai/gpt-5.4-mini'])(
+    'migrates the previous HybridAI default %s to Luna',
+    async (previousDefault) => {
+      const homeDir = makeTempHome();
+      writeRuntimeConfig(homeDir, (config) => {
+        config.version = 36;
+        config.hybridai.defaultModel = previousDefault;
+      });
+
+      const runtimeConfig = await importFreshRuntimeConfig(homeDir);
+      const stored = JSON.parse(
+        fs.readFileSync(
+          path.join(homeDir, '.hybridclaw', 'config.json'),
+          'utf-8',
+        ),
+      ) as RuntimeConfig;
+
+      expect(runtimeConfig.getRuntimeConfig().hybridai.defaultModel).toBe(
+        'gpt-5.6-luna',
+      );
+      expect(stored.hybridai.defaultModel).toBe('gpt-5.6-luna');
+      expect(stored.version).toBe(runtimeConfig.CONFIG_VERSION);
+    },
+  );
+
+  it('preserves a custom HybridAI default during the Luna migration', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir, (config) => {
+      config.version = 36;
+      config.hybridai.defaultModel = 'gpt-5-nano';
+    });
+
+    const runtimeConfig = await importFreshRuntimeConfig(homeDir);
+
+    expect(runtimeConfig.getRuntimeConfig().hybridai.defaultModel).toBe(
+      'gpt-5-nano',
+    );
+  });
+
+  it('preserves an explicit GPT-5.4 Mini selection after migration', async () => {
+    const homeDir = makeTempHome();
+    writeRuntimeConfig(homeDir, (config) => {
+      config.hybridai.defaultModel = 'gpt-5.4-mini';
+    });
+
+    const runtimeConfig = await importFreshRuntimeConfig(homeDir);
+
+    expect(runtimeConfig.getRuntimeConfig().hybridai.defaultModel).toBe(
+      'gpt-5.4-mini',
+    );
+  });
+
   it('preserves explicitly enabled Ollama backends', async () => {
     const homeDir = makeTempHome();
     writeRuntimeConfig(homeDir, (config) => {


### PR DESCRIPTION
## Summary

- change the HybridAI provider default model from `gpt-5.4-mini` to `gpt-5.6-luna`
- regenerate the console settings registry so the UI reflects the runtime default
- update local-provider CLI tests that verify the global default remains unchanged

## Impact

Fresh configurations and configurations without an explicit HybridAI default will use `gpt-5.6-luna`. Existing explicit user model selections remain unchanged.

## Validation

- `npm run format`
- `npm run lint`
- `vitest run tests/local-cli.test.ts` (39 tests passed)