### PR TITLE
fix(email): keep replies threaded when a send passes a bad inReplyTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@
 
 ### Fixed
 
+- **Email replies stay in their thread**: A `message` send whose `inReplyTo` or
+  `references` is not an RFC 5322 message id is now rejected with an actionable
+  error instead of being written into the outbound headers verbatim. Such a
+  value used to detach the reply from the thread the runtime was already
+  tracking — losing the `References` chain and the `Re:` subject, so mail
+  clients filed the answer as a new `HybridClaw` thread — and was then
+  remembered as the thread for every later message to that recipient. Malformed
+  ids reaching delivery from any other caller are dropped in favour of the
+  tracked thread, and a bare `local@domain` id is accepted and wrapped.
 - **Cloud admin sessions recover after inactivity**: Expired browser sessions
   reload through HybridAI sign-in instead of showing an unactionable
   `WEB_API_TOKEN` prompt. The self-hosted fallback identifies the exact gateway

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,18 +15,17 @@
 ### Fixed
 
 - **Email replies stay in their thread**: A `message` send whose `inReplyTo` or
-  `references` is not an RFC 5322 message id is now rejected with an actionable
-  error instead of being written into the outbound headers verbatim. Such a
-  value used to detach the reply from the thread the runtime was already
-  tracking — losing the `References` chain and the `Re:` subject, so mail
-  clients filed the answer as a new `HybridClaw` thread — and was then
-  remembered as the thread for every later message to that recipient. Malformed
-  ids reaching delivery from any other caller are dropped in favour of the
-  tracked thread, and a bare `local@domain` id is accepted and wrapped. The
-  `brevo-email` plugin's `send_email` validates the same way. A `message read`
-  result now reports `messageId: null` for a sent entry reconstructed from the
-  local audit log, instead of a synthetic id that names no real message and
-  cannot be replied to.
+  `references` is not an RFC 5322 message id now drops that id and threads the
+  reply on the current email thread, reporting what it dropped in the tool
+  result. Such a value used to be written into the outbound headers verbatim,
+  which detached the reply from the thread the runtime was already tracking —
+  losing the `References` chain and the `Re:` subject, so mail clients filed
+  the answer as a new `HybridClaw` thread — and was then remembered as the
+  thread for every later message to that recipient. A bare `local@domain` id
+  is accepted and wrapped. The `brevo-email` plugin's `send_email` behaves the
+  same way. A `message read` result now reports `messageId: null` for a sent
+  entry reconstructed from the local audit log, instead of a synthetic id that
+  names no real message and cannot be replied to.
 - **Cloud admin sessions recover after inactivity**: Expired browser sessions
   reload through HybridAI sign-in instead of showing an unactionable
   `WEB_API_TOKEN` prompt. The self-hosted fallback identifies the exact gateway

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@
   clients filed the answer as a new `HybridClaw` thread — and was then
   remembered as the thread for every later message to that recipient. Malformed
   ids reaching delivery from any other caller are dropped in favour of the
-  tracked thread, and a bare `local@domain` id is accepted and wrapped.
+  tracked thread, and a bare `local@domain` id is accepted and wrapped. The
+  `brevo-email` plugin's `send_email` validates the same way. A `message read`
+  result now reports `messageId: null` for a sent entry reconstructed from the
+  local audit log, instead of a synthetic id that names no real message and
+  cannot be replied to.
 - **Cloud admin sessions recover after inactivity**: Expired browser sessions
   reload through HybridAI sign-in instead of showing an unactionable
   `WEB_API_TOKEN` prompt. The self-hosted fallback identifies the exact gateway

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -4242,7 +4242,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
           inReplyTo: {
             type: 'string',
             description:
-              'Optional parent message id for threaded replies when supported by the active channel.',
+              'Optional parent message id for threaded replies when supported by the active channel. Omit it to reply in the current thread, which is threaded automatically. On email it must be a message id like <abc@example.com>, copied verbatim from the messageId field of a message read result.',
           },
           references: {
             type: ['string', 'array'],
@@ -4250,7 +4250,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
               type: 'string',
             },
             description:
-              'Optional ordered parent message id chain for threaded replies when supported by the active channel.',
+              'Optional ordered parent message id chain for threaded replies when supported by the active channel. Same id format and omission rule as inReplyTo.',
           },
           filePath: {
             type: 'string',

--- a/plugins/brevo-email/src/brevo-outbound.js
+++ b/plugins/brevo-email/src/brevo-outbound.js
@@ -60,9 +60,17 @@ export function createBrevoSmtpService(
     },
   };
 
+  // Defence in depth for callers that reach the transport without going
+  // through the tool's validation: an id that is not a message id is dropped
+  // rather than written into a threading header, and a bare `local@domain`
+  // id is wrapped.
+  const MESSAGE_ID_RE = /^<[^<>\s@]+@[^<>\s@]+>$/;
+
   function normalizeMessageId(value) {
-    const candidate = String(value || '').trim();
-    return candidate || null;
+    const trimmed = String(value || '').trim();
+    if (!trimmed) return null;
+    const candidate = trimmed.startsWith('<') ? trimmed : `<${trimmed}>`;
+    return MESSAGE_ID_RE.test(candidate) ? candidate : null;
   }
 
   function normalizeMessageIdList(value) {

--- a/plugins/brevo-email/src/index.js
+++ b/plugins/brevo-email/src/index.js
@@ -8,6 +8,11 @@ import { createBrevoSmtpService } from './brevo-outbound.js';
 import { resolveBrevoConfig } from './config.js';
 
 const EMAIL_ADDRESS_RE = /^[^\s@<>]+@[^\s@<>]+$/;
+// Mirrors the core email channel's message-id check (src/channels/email/
+// threading.ts): a value that is not a message id names nothing a mail client
+// can thread on, and writing it into In-Reply-To/References detaches the reply
+// from its thread instead.
+const MESSAGE_ID_RE = /^<[^<>\s@]+@[^<>\s@]+>$/;
 
 function requireEmailAddress(field, value) {
   const email = String(value || '').trim();
@@ -46,6 +51,18 @@ function normalizeOptionalStringList(field, value) {
   return normalized.length > 0 ? normalized : undefined;
 }
 
+function requireThreadMessageId(field, value, omitField = field) {
+  const trimmed = String(value || '').trim();
+  if (!trimmed) return undefined;
+  const candidate = trimmed.startsWith('<') ? trimmed : `<${trimmed}>`;
+  if (!MESSAGE_ID_RE.test(candidate)) {
+    throw new Error(
+      `${field} must be an email message id like <abc@example.com>, copied from the message being replied to. Omit ${omitField} unless you are replying to a specific message.`,
+    );
+  }
+  return candidate;
+}
+
 function resolveThreadReferences(inReplyTo, references) {
   const normalized = references ? [...new Set(references)] : [];
   if (normalized.length > 0) {
@@ -62,10 +79,15 @@ export function createSendEmailToolHandler(api, config, send) {
     const to = requireEmailAddress('to', args.to);
     const cc = args.cc ? requireEmailAddress('cc', args.cc) : undefined;
     const bcc = args.bcc ? requireEmailAddress('bcc', args.bcc) : undefined;
-    const inReplyTo = normalizeOptionalString('inReplyTo', args.inReplyTo);
+    const inReplyTo = requireThreadMessageId(
+      'inReplyTo',
+      normalizeOptionalString('inReplyTo', args.inReplyTo),
+    );
     const references = resolveThreadReferences(
       inReplyTo,
-      normalizeOptionalStringList('references', args.references),
+      normalizeOptionalStringList('references', args.references)?.map((entry) =>
+        requireThreadMessageId('references entries', entry, 'references'),
+      ),
     );
     const defaultAgentId = api.config.agents?.defaultAgentId || 'main';
     const agentId = resolveCurrentAgentId(api, context, defaultAgentId);

--- a/plugins/brevo-email/src/index.js
+++ b/plugins/brevo-email/src/index.js
@@ -51,16 +51,24 @@ function normalizeOptionalStringList(field, value) {
   return normalized.length > 0 ? normalized : undefined;
 }
 
-function requireThreadMessageId(field, value, omitField = field) {
+const IGNORED_THREAD_ID_NOTE =
+  'Ignored: not an email message id. The email was sent without it. Omit ' +
+  'inReplyTo/references unless you are replying to a specific message, and ' +
+  'then pass that message’s Message-ID verbatim.';
+
+/**
+ * Return *value* as a message id, or null when it is not one.
+ *
+ * A value that is not a message id names nothing a mail client can thread on,
+ * so writing it into In-Reply-To/References detaches the reply from its
+ * thread. Dropping it is reported back in the tool result rather than failing
+ * the send: the email itself is what the caller actually wanted.
+ */
+function asThreadMessageId(value) {
   const trimmed = String(value || '').trim();
-  if (!trimmed) return undefined;
+  if (!trimmed) return null;
   const candidate = trimmed.startsWith('<') ? trimmed : `<${trimmed}>`;
-  if (!MESSAGE_ID_RE.test(candidate)) {
-    throw new Error(
-      `${field} must be an email message id like <abc@example.com>, copied from the message being replied to. Omit ${omitField} unless you are replying to a specific message.`,
-    );
-  }
-  return candidate;
+  return MESSAGE_ID_RE.test(candidate) ? candidate : null;
 }
 
 function resolveThreadReferences(inReplyTo, references) {
@@ -79,15 +87,29 @@ export function createSendEmailToolHandler(api, config, send) {
     const to = requireEmailAddress('to', args.to);
     const cc = args.cc ? requireEmailAddress('cc', args.cc) : undefined;
     const bcc = args.bcc ? requireEmailAddress('bcc', args.bcc) : undefined;
-    const inReplyTo = requireThreadMessageId(
+    const ignoredThreadIds = [];
+    const requestedInReplyTo = normalizeOptionalString(
       'inReplyTo',
-      normalizeOptionalString('inReplyTo', args.inReplyTo),
+      args.inReplyTo,
     );
+    const inReplyTo = asThreadMessageId(requestedInReplyTo) || undefined;
+    if (requestedInReplyTo && !inReplyTo) {
+      ignoredThreadIds.push(requestedInReplyTo);
+    }
+    const requestedReferences =
+      normalizeOptionalStringList('references', args.references) || [];
+    const validReferences = [];
+    for (const entry of requestedReferences) {
+      const messageId = asThreadMessageId(entry);
+      if (messageId) {
+        validReferences.push(messageId);
+        continue;
+      }
+      ignoredThreadIds.push(entry);
+    }
     const references = resolveThreadReferences(
       inReplyTo,
-      normalizeOptionalStringList('references', args.references)?.map((entry) =>
-        requireThreadMessageId('references entries', entry, 'references'),
-      ),
+      validReferences.length > 0 ? validReferences : undefined,
     );
     const defaultAgentId = api.config.agents?.defaultAgentId || 'main';
     const agentId = resolveCurrentAgentId(api, context, defaultAgentId);
@@ -113,7 +135,15 @@ export function createSendEmailToolHandler(api, config, send) {
       ...(inReplyTo ? { inReplyTo } : {}),
       ...(references ? { references } : {}),
     });
-    return { sent: true, from, to, subject: args.subject };
+    return {
+      sent: true,
+      from,
+      to,
+      subject: args.subject,
+      ...(ignoredThreadIds.length > 0
+        ? { ignoredThreadIds, ignoredThreadIdsNote: IGNORED_THREAD_ID_NOTE }
+        : {}),
+    };
   };
 }
 

--- a/src/channels/email/delivery.ts
+++ b/src/channels/email/delivery.ts
@@ -17,6 +17,7 @@ import {
 import {
   createOutboundThreadContext,
   ensureReplySubject,
+  normalizeThreadMessageId,
   type ThreadContext,
 } from './threading.js';
 
@@ -162,16 +163,33 @@ function normalizeMessageIdList(raw: string[] | null | undefined): string[] {
   return [
     ...new Set(
       raw
-        .map((value) => normalizeMessageId(value))
+        .map((value) => normalizeThreadMessageId(value))
         .filter((value): value is string => Boolean(value)),
     ),
   ];
 }
 
+/**
+ * Explicit thread headers deliberately replace the account's tracked thread —
+ * that is how a caller replies to a message other than the latest one. So a
+ * value that is not a message id must not survive this far: it would detach
+ * the reply from the thread the runtime already knows about, dropping the
+ * inbound `References` chain and the `Re:` subject continuity with it, and
+ * would then be remembered as the thread for every later message. Dropping
+ * such a value falls back to the tracked thread, which is the right answer
+ * whenever the caller was answering the message that opened it.
+ */
 function resolveExplicitThreadHeaders(
   params: EmailSendParams,
 ): ExplicitThreadHeaders | null {
-  let inReplyTo = normalizeMessageId(params.inReplyTo);
+  const requestedInReplyTo = normalizeMessageId(params.inReplyTo);
+  let inReplyTo = normalizeThreadMessageId(requestedInReplyTo);
+  if (requestedInReplyTo && !inReplyTo) {
+    logger.warn(
+      { inReplyTo: requestedInReplyTo, to: params.to },
+      'Ignoring malformed explicit email inReplyTo; replying in the tracked thread instead',
+    );
+  }
   const references = normalizeMessageIdList(params.references);
   if (references.length > 0) {
     const lastReference = references[references.length - 1];

--- a/src/channels/email/delivery.ts
+++ b/src/channels/email/delivery.ts
@@ -158,15 +158,26 @@ function normalizeMessageId(raw: string | null | undefined): string | null {
   return normalized || null;
 }
 
-function normalizeMessageIdList(raw: string[] | null | undefined): string[] {
+function normalizeMessageIdList(
+  raw: string[] | null | undefined,
+  to: string,
+): string[] {
   if (!Array.isArray(raw)) return [];
-  return [
-    ...new Set(
-      raw
-        .map((value) => normalizeThreadMessageId(value))
-        .filter((value): value is string => Boolean(value)),
-    ),
-  ];
+  const normalized: string[] = [];
+  for (const value of raw) {
+    const messageId = normalizeThreadMessageId(value);
+    if (messageId) {
+      normalized.push(messageId);
+      continue;
+    }
+    if (String(value || '').trim()) {
+      logger.warn(
+        { reference: value, to },
+        'Ignoring malformed explicit email references entry',
+      );
+    }
+  }
+  return [...new Set(normalized)];
 }
 
 /**
@@ -190,7 +201,7 @@ function resolveExplicitThreadHeaders(
       'Ignoring malformed explicit email inReplyTo; replying in the tracked thread instead',
     );
   }
-  const references = normalizeMessageIdList(params.references);
+  const references = normalizeMessageIdList(params.references, params.to);
   if (references.length > 0) {
     const lastReference = references[references.length - 1];
     if (!inReplyTo) {

--- a/src/channels/email/prompt-adapter.ts
+++ b/src/channels/email/prompt-adapter.ts
@@ -10,7 +10,7 @@ export const emailAgentPromptAdapter: ChannelAgentPromptAdapter = {
       '- For normal email replies, append a polished corporate signature block derived from the identity details already loaded from `IDENTITY.md`. Prefer full name, role, organization, and any real contact details that are present. Do not invent contact info, and do not use emoji or mascot-style sign-offs.',
       '- Supported `message` actions here: `read` and `send`.',
       '- For a new outbound email thread, start the message body with `[Subject: Your subject here]` on its own line.',
-      '- For replies in the current email thread, omit the subject prefix; the runtime keeps `Re:` subject continuity and threading headers automatically.',
+      '- For replies in the current email thread, omit the subject prefix, `inReplyTo`, and `references`; the runtime keeps `Re:` subject continuity and threading headers automatically. Set `inReplyTo` only to reply to some other message you read, using the `messageId` from that read result verbatim — never an internal or remembered id.',
       '- For current email-thread `read`, omit `channelId` in an email thread or pass an explicit email address like `user@example.com`.',
       '- Email `message` sends use a plain email address like `user@example.com` as the target.',
       '- For catch-up or summary requests with incomplete scope, make a reasonable best-effort assumption, do the useful work first, and mention the assumption after the answer instead of blocking on a clarification.',

--- a/src/channels/email/threading.ts
+++ b/src/channels/email/threading.ts
@@ -2,6 +2,9 @@ import { normalizeEmailAddress } from './allowlist.js';
 import { DEFAULT_EMAIL_SUBJECT } from './constants.js';
 
 const REPLY_SUBJECT_RE = /^re(?:\[\d+\])?:\s*/i;
+// RFC 5322 msg-id, narrowed to what mail actually carries: `<left@right>`,
+// no whitespace, angle brackets, or control characters inside either half.
+const MESSAGE_ID_RE = /^<[^<>\s@]+@[^<>\s@]+>$/;
 
 export interface ThreadContext {
   subject: string;
@@ -43,6 +46,25 @@ function normalizeThreadContext(context: ThreadContext): ThreadContext | null {
     messageId,
     references: normalizeReferenceList(context.references),
   };
+}
+
+/**
+ * Return *raw* as an RFC 5322 message id, or null when it is not one.
+ *
+ * Callers can hand a caller-supplied (and therefore arbitrary) string here
+ * before it becomes an `In-Reply-To`/`References` header. Bare `left@right`
+ * ids are accepted and wrapped, since that shape is common in hand-written
+ * and model-written tool calls and still names a real message; anything else
+ * — an internal id, a session key, prose — names nothing a mail client can
+ * thread on and is rejected.
+ */
+export function normalizeThreadMessageId(
+  raw: string | null | undefined,
+): string | null {
+  const trimmed = String(raw || '').trim();
+  if (!trimmed) return null;
+  const candidate = trimmed.startsWith('<') ? trimmed : `<${trimmed}>`;
+  return MESSAGE_ID_RE.test(candidate) ? candidate : null;
 }
 
 export function hasReplySubjectPrefix(subject: string): boolean {

--- a/src/channels/message/tool-actions.ts
+++ b/src/channels/message/tool-actions.ts
@@ -860,7 +860,12 @@ function mapEmailMailboxMessage(message: EmailMailboxMessage) {
     id: `${message.folder}:${message.uid}`,
     folder: message.folder,
     uid: message.uid,
-    messageId: message.messageId,
+    // Sent entries reconstructed from the local audit log carry a synthetic
+    // id that names no real message (see buildSyntheticSentMessagesFromAudit).
+    // Surfacing it as `messageId` invites a caller to thread a reply on it,
+    // which cannot work — so expose only an id that can actually be replied
+    // to, and null otherwise.
+    messageId: normalizeThreadMessageId(message.messageId),
     subject: message.subject,
     from: {
       name: message.fromName,

--- a/src/channels/message/tool-actions.ts
+++ b/src/channels/message/tool-actions.ts
@@ -30,6 +30,7 @@ import {
   sendEmailAttachmentTo,
   sendToEmail,
 } from '../email/runtime.js';
+import { normalizeThreadMessageId } from '../email/threading.js';
 import { getLineAuthStatus } from '../line/auth.js';
 import { sendToLineSelfChat } from '../line/runtime.js';
 import { normalizeLineChannelId } from '../line/target.js';
@@ -394,13 +395,26 @@ function normalizeEmailRecipientList(
   return normalized.length > 0 ? normalized : undefined;
 }
 
+const THREAD_MESSAGE_ID_HINT =
+  'must be an email message id like <abc@example.com>, as returned in the ' +
+  '`messageId` field of a message read result. Omit it to reply in the ' +
+  'current thread — threading headers are applied automatically.';
+
 function normalizeOptionalThreadMessageId(value: unknown): string | undefined {
   if (value == null) return undefined;
   if (typeof value !== 'string') {
     throw new Error('inReplyTo must be a string.');
   }
   const normalized = value.trim();
-  return normalized || undefined;
+  if (!normalized) return undefined;
+  // Reject anything that is not a message id rather than passing it into an
+  // RFC 5322 header: an internal or invented id silently detaches the reply
+  // from its thread, and the caller cannot tell that it did.
+  const messageId = normalizeThreadMessageId(normalized);
+  if (!messageId) {
+    throw new Error(`inReplyTo ${THREAD_MESSAGE_ID_HINT}`);
+  }
+  return messageId;
 }
 function normalizeEmailSenderName(value: unknown): string | null {
   const normalized = String(value || '')
@@ -441,7 +455,11 @@ function normalizeThreadReferenceList(value: unknown): string[] | undefined {
     }
     const candidate = entry.trim();
     if (!candidate) continue;
-    normalized.push(candidate);
+    const messageId = normalizeThreadMessageId(candidate);
+    if (!messageId) {
+      throw new Error(`Each references entry ${THREAD_MESSAGE_ID_HINT}`);
+    }
+    normalized.push(messageId);
   }
 
   return normalized.length > 0 ? [...new Set(normalized)] : undefined;

--- a/src/channels/message/tool-actions.ts
+++ b/src/channels/message/tool-actions.ts
@@ -10,6 +10,7 @@ import {
   isSupportedProactiveChannelId,
 } from '../../gateway/proactive-delivery.js';
 import { agentWorkspaceDir } from '../../infra/ipc.js';
+import { logger } from '../../logger.js';
 import {
   enqueueProactiveMessage,
   getRecentMessages,
@@ -395,26 +396,30 @@ function normalizeEmailRecipientList(
   return normalized.length > 0 ? normalized : undefined;
 }
 
-const THREAD_MESSAGE_ID_HINT =
-  'must be an email message id like <abc@example.com>, as returned in the ' +
-  '`messageId` field of a message read result. Omit it to reply in the ' +
-  'current thread — threading headers are applied automatically.';
+// Reported back in the tool result when a thread id is discarded, so the
+// caller learns what happened and how to thread deliberately next time.
+const IGNORED_THREAD_ID_NOTE =
+  'Ignored: not an email message id. The reply was threaded on the current ' +
+  'email thread instead. Omit inReplyTo/references to reply in the current ' +
+  'thread, or pass the `messageId` of a message read result to reply to a ' +
+  'specific message.';
 
-function normalizeOptionalThreadMessageId(value: unknown): string | undefined {
-  if (value == null) return undefined;
+function normalizeOptionalThreadMessageId(value: unknown): {
+  messageId?: string;
+  ignored?: string;
+} {
+  if (value == null) return {};
   if (typeof value !== 'string') {
     throw new Error('inReplyTo must be a string.');
   }
   const normalized = value.trim();
-  if (!normalized) return undefined;
-  // Reject anything that is not a message id rather than passing it into an
-  // RFC 5322 header: an internal or invented id silently detaches the reply
-  // from its thread, and the caller cannot tell that it did.
+  if (!normalized) return {};
+  // A value that is not a message id names nothing a mail client can thread
+  // on. Drop it rather than write it into the header — the runtime's own
+  // thread context is a better answer than a dangling reference — and report
+  // the drop so the caller is not misled about what was sent.
   const messageId = normalizeThreadMessageId(normalized);
-  if (!messageId) {
-    throw new Error(`inReplyTo ${THREAD_MESSAGE_ID_HINT}`);
-  }
-  return messageId;
+  return messageId ? { messageId } : { ignored: normalized };
 }
 function normalizeEmailSenderName(value: unknown): string | null {
   const normalized = String(value || '')
@@ -442,13 +447,17 @@ function resolveEmailSenderNameForRequest(
   );
 }
 
-function normalizeThreadReferenceList(value: unknown): string[] | undefined {
-  if (value == null) return undefined;
+function normalizeThreadReferenceList(value: unknown): {
+  references?: string[];
+  ignored: string[];
+} {
+  if (value == null) return { ignored: [] };
   if (!Array.isArray(value)) {
     throw new Error('references must be an array of strings.');
   }
 
   const normalized: string[] = [];
+  const ignored: string[] = [];
   for (const entry of value) {
     if (typeof entry !== 'string') {
       throw new Error('references must contain only strings.');
@@ -456,13 +465,17 @@ function normalizeThreadReferenceList(value: unknown): string[] | undefined {
     const candidate = entry.trim();
     if (!candidate) continue;
     const messageId = normalizeThreadMessageId(candidate);
-    if (!messageId) {
-      throw new Error(`Each references entry ${THREAD_MESSAGE_ID_HINT}`);
+    if (messageId) {
+      normalized.push(messageId);
+      continue;
     }
-    normalized.push(messageId);
+    ignored.push(candidate);
   }
 
-  return normalized.length > 0 ? [...new Set(normalized)] : undefined;
+  return {
+    references: normalized.length > 0 ? [...new Set(normalized)] : undefined,
+    ignored,
+  };
 }
 
 function buildEmailSendResultMeta(params: {
@@ -471,13 +484,18 @@ function buildEmailSendResultMeta(params: {
   bcc: string[] | undefined;
   inReplyTo?: string;
   references?: string[];
+  ignoredThreadIds?: string[];
 }): Record<string, unknown> {
+  const ignoredThreadIds = params.ignoredThreadIds || [];
   return {
     ...(params.subject ? { subject: params.subject } : {}),
     ...(params.cc ? { cc: params.cc } : {}),
     ...(params.bcc ? { bcc: params.bcc } : {}),
     ...(params.inReplyTo ? { inReplyTo: params.inReplyTo } : {}),
     ...(params.references ? { references: params.references } : {}),
+    ...(ignoredThreadIds.length > 0
+      ? { ignoredThreadIds, ignoredThreadIdsNote: IGNORED_THREAD_ID_NOTE }
+      : {}),
   };
 }
 
@@ -562,8 +580,20 @@ async function runEmailMessageSendAction(
   const subject = String(request.subject || '').trim() || null;
   const cc = normalizeEmailRecipientList(request.cc, 'cc');
   const bcc = normalizeEmailRecipientList(request.bcc, 'bcc');
-  const inReplyTo = normalizeOptionalThreadMessageId(request.inReplyTo);
-  const references = normalizeThreadReferenceList(request.references);
+  const { messageId: inReplyTo, ignored: ignoredInReplyTo } =
+    normalizeOptionalThreadMessageId(request.inReplyTo);
+  const { references, ignored: ignoredReferences } =
+    normalizeThreadReferenceList(request.references);
+  const ignoredThreadIds = [
+    ...(ignoredInReplyTo ? [ignoredInReplyTo] : []),
+    ...ignoredReferences,
+  ];
+  if (ignoredThreadIds.length > 0) {
+    logger.warn(
+      { ignoredThreadIds, to: channelId },
+      'Ignoring email thread ids that are not message ids; threading on the tracked thread instead',
+    );
+  }
   const fromName = resolveEmailSenderNameForRequest(request);
   const session = getSessionById(String(request.sessionId || '').trim());
   const agentId = session
@@ -584,6 +614,7 @@ async function runEmailMessageSendAction(
     bcc,
     inReplyTo,
     references,
+    ignoredThreadIds,
   });
   if (!content && !filePath) {
     throw new Error(

--- a/tests/agent-email.e2e.test.ts
+++ b/tests/agent-email.e2e.test.ts
@@ -145,7 +145,7 @@ function findSentMail(to: string): Record<string, unknown> {
   return message || {};
 }
 
-test('agent email flow sends mail, acts on inbound mail, and replies in-thread', async () => {
+async function setupEmailAgentHome(): Promise<void> {
   setupHome();
 
   const { updateRuntimeConfig } = await import(
@@ -178,40 +178,9 @@ test('agent email flow sends mail, acts on inbound mail, and replies in-thread',
     displayName: 'Mail Agent',
     id: 'main',
   });
+}
 
-  runAgentMock.mockImplementation(
-    async (params: { channelId?: string; sessionId: string }) => {
-      const { runMessageToolAction } = await import(
-        '../src/channels/message/tool-actions.js'
-      );
-      const toolArgs = {
-        action: 'send' as const,
-        channelId: 'ops@example.com',
-        content: 'Please prepare the incident runbook for boss@example.com.',
-        sessionId: params.sessionId,
-        subject: 'Boss runbook request',
-      };
-      const toolResult = await runMessageToolAction(toolArgs);
-      return {
-        agentId: 'main',
-        artifacts: [],
-        model: 'test-model',
-        provider: 'test-provider',
-        result: 'I notified ops and will follow up here.',
-        status: 'success',
-        toolExecutions: [
-          {
-            arguments: JSON.stringify(toolArgs),
-            durationMs: 1,
-            name: 'message',
-            result: JSON.stringify(toolResult),
-          },
-        ],
-        toolsUsed: ['message'],
-      };
-    },
-  );
-
+async function deliverInboundEmail(): Promise<void> {
   const { handleGatewayMessage } = await import(
     '../src/gateway/gateway-chat-service.ts'
   );
@@ -263,6 +232,45 @@ test('agent email flow sends mail, acts on inbound mail, and replies in-thread',
     await runtime.shutdownEmail();
     await shutdownEmail();
   }
+}
+
+test('agent email flow sends mail, acts on inbound mail, and replies in-thread', async () => {
+  await setupEmailAgentHome();
+
+  runAgentMock.mockImplementation(
+    async (params: { channelId?: string; sessionId: string }) => {
+      const { runMessageToolAction } = await import(
+        '../src/channels/message/tool-actions.js'
+      );
+      const toolArgs = {
+        action: 'send' as const,
+        channelId: 'ops@example.com',
+        content: 'Please prepare the incident runbook for boss@example.com.',
+        sessionId: params.sessionId,
+        subject: 'Boss runbook request',
+      };
+      const toolResult = await runMessageToolAction(toolArgs);
+      return {
+        agentId: 'main',
+        artifacts: [],
+        model: 'test-model',
+        provider: 'test-provider',
+        result: 'I notified ops and will follow up here.',
+        status: 'success',
+        toolExecutions: [
+          {
+            arguments: JSON.stringify(toolArgs),
+            durationMs: 1,
+            name: 'message',
+            result: JSON.stringify(toolResult),
+          },
+        ],
+        toolsUsed: ['message'],
+      };
+    },
+  );
+
+  await deliverInboundEmail();
 
   expect(runAgentMock).toHaveBeenCalledTimes(1);
   expect(runAgentMock.mock.calls[0]?.[0]).toMatchObject({
@@ -304,5 +312,56 @@ test('agent email flow sends mail, acts on inbound mail, and replies in-thread',
     references: '<boss-runbook-1@example.com>',
     subject: 'Re: Runbook request',
     text: 'I notified ops and will follow up here.',
+  });
+});
+
+test('rejects a send whose inReplyTo is not a message id and still replies in-thread', async () => {
+  await setupEmailAgentHome();
+
+  let toolError: unknown;
+  runAgentMock.mockImplementation(async (params: { sessionId: string }) => {
+    const { runMessageToolAction } = await import(
+      '../src/channels/message/tool-actions.js'
+    );
+    // An agent answering inbound mail through the message tool can pass an id
+    // that is not the inbound Message-ID. Left alone it becomes a dangling
+    // In-Reply-To, drops the Re: subject, and is then remembered as the thread
+    // for everything sent afterwards.
+    toolError = await runMessageToolAction({
+      action: 'send',
+      channelId: 'boss@example.com',
+      content: 'Received it.',
+      inReplyTo: '<0f99ab14eeb8>',
+      sessionId: params.sessionId,
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    return {
+      agentId: 'main',
+      artifacts: [],
+      model: 'test-model',
+      provider: 'test-provider',
+      result: 'Received it.',
+      status: 'success',
+      toolExecutions: [],
+      toolsUsed: ['message'],
+    };
+  });
+
+  await deliverInboundEmail();
+
+  // The tool call fails loudly, so the agent can correct it, instead of
+  // silently sending an unthreaded reply.
+  expect(toolError).toBeInstanceOf(Error);
+  expect(String(toolError)).toMatch(/inReplyTo must be an email message id/);
+
+  const bossReply = findSentMail('boss@example.com');
+  expect(bossReply).toMatchObject({
+    from: 'agent@example.com',
+    inReplyTo: '<boss-runbook-1@example.com>',
+    references: '<boss-runbook-1@example.com>',
+    subject: 'Re: Runbook request',
+    text: 'Received it.',
   });
 });

--- a/tests/agent-email.e2e.test.ts
+++ b/tests/agent-email.e2e.test.ts
@@ -184,13 +184,17 @@ async function deliverInboundEmail(): Promise<void> {
   const { handleGatewayMessage } = await import(
     '../src/gateway/gateway-chat-service.ts'
   );
-  const { createEmailRuntime, shutdownEmail } = await import(
+  // Use the module-level runtime, the way the gateway does
+  // (src/gateway/gateway.ts). The message tool's email sends go through the
+  // same default instance, so this is what shares the inbound thread context
+  // with a tool-driven reply; a private createEmailRuntime() instance would
+  // give the tool its own empty thread tracker and hide that.
+  const { initEmail, shutdownEmail } = await import(
     '../src/channels/email/runtime.js'
   );
-  const runtime = createEmailRuntime();
 
   try {
-    await runtime.initEmail(
+    await initEmail(
       async (
         sessionId,
         guildId,
@@ -229,7 +233,6 @@ async function deliverInboundEmail(): Promise<void> {
       },
     ]);
   } finally {
-    await runtime.shutdownEmail();
     await shutdownEmail();
   }
 }
@@ -315,10 +318,10 @@ test('agent email flow sends mail, acts on inbound mail, and replies in-thread',
   });
 });
 
-test('rejects a send whose inReplyTo is not a message id and still replies in-thread', async () => {
+test('a send whose inReplyTo is not a message id still lands in the inbound thread', async () => {
   await setupEmailAgentHome();
 
-  let toolError: unknown;
+  let toolResult: Record<string, unknown> | undefined;
   runAgentMock.mockImplementation(async (params: { sessionId: string }) => {
     const { runMessageToolAction } = await import(
       '../src/channels/message/tool-actions.js'
@@ -327,16 +330,13 @@ test('rejects a send whose inReplyTo is not a message id and still replies in-th
     // that is not the inbound Message-ID. Left alone it becomes a dangling
     // In-Reply-To, drops the Re: subject, and is then remembered as the thread
     // for everything sent afterwards.
-    toolError = await runMessageToolAction({
+    toolResult = await runMessageToolAction({
       action: 'send',
       channelId: 'boss@example.com',
       content: 'Received it.',
       inReplyTo: '<0f99ab14eeb8>',
       sessionId: params.sessionId,
-    }).then(
-      () => null,
-      (error: unknown) => error,
-    );
+    });
     return {
       agentId: 'main',
       artifacts: [],
@@ -351,14 +351,25 @@ test('rejects a send whose inReplyTo is not a message id and still replies in-th
 
   await deliverInboundEmail();
 
-  // The tool call fails loudly, so the agent can correct it, instead of
-  // silently sending an unthreaded reply.
-  expect(toolError).toBeInstanceOf(Error);
-  expect(String(toolError)).toMatch(/inReplyTo must be an email message id/);
+  // The send succeeds — the mail is what the agent actually wanted — and the
+  // result names the id that was dropped, so the agent is not misled about
+  // what went out.
+  expect(toolResult).toMatchObject({
+    ok: true,
+    ignoredThreadIds: ['<0f99ab14eeb8>'],
+  });
+  expect(String(toolResult?.ignoredThreadIdsNote)).toMatch(
+    /not an email message id/,
+  );
 
+  // The mail itself is threaded on the message the agent was answering, not
+  // on the id it supplied.
   const bossReply = findSentMail('boss@example.com');
   expect(bossReply).toMatchObject({
-    from: 'agent@example.com',
+    // A tool send carries the agent's display name; the threading below is
+    // what matters — it comes from the tracked inbound thread, not from the
+    // id the agent supplied.
+    from: { address: 'agent@example.com', name: 'Mail Agent' },
     inReplyTo: '<boss-runbook-1@example.com>',
     references: '<boss-runbook-1@example.com>',
     subject: 'Re: Runbook request',

--- a/tests/brevo-email-tool.test.ts
+++ b/tests/brevo-email-tool.test.ts
@@ -268,7 +268,7 @@ test('send_email validates threading header argument types', async () => {
   expect(send).not.toHaveBeenCalled();
 });
 
-test('send_email rejects thread ids that are not message ids', async () => {
+test('send_email drops thread ids that are not message ids and reports them', async () => {
   const send = vi.fn();
   const handler = createSendEmailToolHandler(
     {
@@ -291,32 +291,33 @@ test('send_email rejects thread ids that are not message ids', async () => {
   );
 
   // An internal id written into In-Reply-To detaches the reply from its
-  // thread, so it is refused rather than sent.
-  await expect(
-    handler(
-      {
-        to: 'friend@example.com',
-        subject: 'Hello',
-        body: 'Test body',
-        inReplyTo: '<0f99ab14eeb8>',
-      },
-      { sessionId: 'session-1' },
-    ),
-  ).rejects.toThrow(/inReplyTo must be an email message id/);
+  // thread. The email still goes out — that is what was asked for — without
+  // the unusable header, and the result says what was dropped.
+  const result = await handler(
+    {
+      to: 'friend@example.com',
+      subject: 'Hello',
+      body: 'Test body',
+      inReplyTo: '<0f99ab14eeb8>',
+      references: ['<msg-1@example.com>', 'session-4f21'],
+    },
+    { sessionId: 'session-1' },
+  );
 
-  await expect(
-    handler(
-      {
-        to: 'friend@example.com',
-        subject: 'Hello',
-        body: 'Test body',
-        references: ['<msg-1@example.com>', 'session-4f21'],
-      },
-      { sessionId: 'session-1' },
-    ),
-  ).rejects.toThrow(/references entries must be an email message id/);
-
-  expect(send).not.toHaveBeenCalled();
+  expect(result).toMatchObject({
+    sent: true,
+    ignoredThreadIds: ['<0f99ab14eeb8>', 'session-4f21'],
+  });
+  expect(String(result.ignoredThreadIdsNote)).toMatch(
+    /not an email message id/,
+  );
+  expect(send).toHaveBeenCalledWith(
+    expect.objectContaining({
+      to: 'friend@example.com',
+      references: ['<msg-1@example.com>'],
+    }),
+  );
+  expect(send.mock.calls[0]?.[0]).not.toHaveProperty('inReplyTo');
 });
 
 test('send_email wraps a bare message id in angle brackets', async () => {

--- a/tests/brevo-email-tool.test.ts
+++ b/tests/brevo-email-tool.test.ts
@@ -267,3 +267,96 @@ test('send_email validates threading header argument types', async () => {
 
   expect(send).not.toHaveBeenCalled();
 });
+
+test('send_email rejects thread ids that are not message ids', async () => {
+  const send = vi.fn();
+  const handler = createSendEmailToolHandler(
+    {
+      config: {
+        agents: {
+          defaultAgentId: 'main',
+        },
+      },
+      resolveSessionAgentId: vi.fn(() => 'writer'),
+    } as never,
+    {
+      domain: 'agent.hybridai.one',
+      fromName: '',
+      fromAddress: '',
+      agentHandles: {
+        writer: 'writer-handle',
+      },
+    } as never,
+    send,
+  );
+
+  // An internal id written into In-Reply-To detaches the reply from its
+  // thread, so it is refused rather than sent.
+  await expect(
+    handler(
+      {
+        to: 'friend@example.com',
+        subject: 'Hello',
+        body: 'Test body',
+        inReplyTo: '<0f99ab14eeb8>',
+      },
+      { sessionId: 'session-1' },
+    ),
+  ).rejects.toThrow(/inReplyTo must be an email message id/);
+
+  await expect(
+    handler(
+      {
+        to: 'friend@example.com',
+        subject: 'Hello',
+        body: 'Test body',
+        references: ['<msg-1@example.com>', 'session-4f21'],
+      },
+      { sessionId: 'session-1' },
+    ),
+  ).rejects.toThrow(/references entries must be an email message id/);
+
+  expect(send).not.toHaveBeenCalled();
+});
+
+test('send_email wraps a bare message id in angle brackets', async () => {
+  const send = vi.fn();
+  const handler = createSendEmailToolHandler(
+    {
+      config: {
+        agents: {
+          defaultAgentId: 'main',
+        },
+      },
+      resolveSessionAgentId: vi.fn(() => 'writer'),
+    } as never,
+    {
+      domain: 'agent.hybridai.one',
+      fromName: '',
+      fromAddress: '',
+      agentHandles: {
+        writer: 'writer-handle',
+      },
+    } as never,
+    send,
+  );
+
+  await expect(
+    handler(
+      {
+        to: 'friend@example.com',
+        subject: 'Hello',
+        body: 'Test body',
+        inReplyTo: 'msg-1@example.com',
+      },
+      { sessionId: 'session-1' },
+    ),
+  ).resolves.toBeDefined();
+
+  expect(send).toHaveBeenCalledWith(
+    expect.objectContaining({
+      inReplyTo: '<msg-1@example.com>',
+      references: ['<msg-1@example.com>'],
+    }),
+  );
+});

--- a/tests/email.channel.test.ts
+++ b/tests/email.channel.test.ts
@@ -12,6 +12,7 @@ import {
   createOutboundThreadContext,
   createThreadTracker,
   ensureReplySubject,
+  normalizeThreadMessageId,
 } from '../src/channels/email/threading.js';
 
 const BASE_EMAIL_CONFIG = {
@@ -147,6 +148,41 @@ describe('email threading helpers', () => {
       messageId: '<msg-2@example.com>',
       references: ['<ref-1@example.com>', '<msg-1@example.com>'],
     });
+  });
+});
+
+describe('thread message id validation', () => {
+  test('accepts real message ids, including bare and domain-literal forms', () => {
+    expect(normalizeThreadMessageId('<msg-1@example.com>')).toBe(
+      '<msg-1@example.com>',
+    );
+    expect(normalizeThreadMessageId('  msg-1@example.com  ')).toBe(
+      '<msg-1@example.com>',
+    );
+    expect(normalizeThreadMessageId('<a.b+c!#$%&*/=?^_`{|}~-@ex.co.uk>')).toBe(
+      '<a.b+c!#$%&*/=?^_`{|}~-@ex.co.uk>',
+    );
+    expect(normalizeThreadMessageId('<msg@[IPv6:2001:db8::1]>')).toBe(
+      '<msg@[IPv6:2001:db8::1]>',
+    );
+    expect(normalizeThreadMessageId('<msg@bücher.example>')).toBe(
+      '<msg@bücher.example>',
+    );
+  });
+
+  test('rejects values that name no message', () => {
+    // The shapes seen in practice: an internal id, a synthetic Sent-folder id
+    // from the audit log, a session key, prose, and header injection.
+    expect(normalizeThreadMessageId('<0f99ab14eeb8>')).toBeNull();
+    expect(normalizeThreadMessageId('synthetic:audit:42')).toBeNull();
+    expect(normalizeThreadMessageId('session-4f21')).toBeNull();
+    expect(normalizeThreadMessageId('the previous email')).toBeNull();
+    expect(normalizeThreadMessageId('<a@b>\r\nBcc: victim@example.com')).toBe(
+      null,
+    );
+    expect(normalizeThreadMessageId('<a@b@c>')).toBeNull();
+    expect(normalizeThreadMessageId('')).toBeNull();
+    expect(normalizeThreadMessageId(null)).toBeNull();
   });
 });
 
@@ -751,7 +787,7 @@ describe('email delivery helpers', () => {
     });
   });
 
-  test('omits threading headers when a malformed id has no thread to fall back to', async () => {
+  test('keeps the valid references entries and drops the malformed ones', async () => {
     vi.doMock('../src/config/config.ts', () => ({
       APP_VERSION: '0.7.1',
       DATA_DIR: path.join(os.tmpdir(), 'hybridclaw-test-data'),
@@ -781,6 +817,38 @@ describe('email delivery helpers', () => {
         inReplyTo: '<ref-1@example.com>',
         references: '<ref-1@example.com>',
       }),
+    );
+  });
+
+  test('omits threading headers when nothing valid survives and no thread is tracked', async () => {
+    vi.doMock('../src/config/config.ts', () => ({
+      APP_VERSION: '0.7.1',
+      DATA_DIR: path.join(os.tmpdir(), 'hybridclaw-test-data'),
+      EMAIL_TEXT_CHUNK_LIMIT: 50000,
+    }));
+    const { sendEmail } = await import('../src/channels/email/delivery.js');
+    const transport = {
+      sendMail: vi.fn(async () => ({
+        messageId: '<sent-headerless@example.com>',
+      })),
+    };
+
+    await sendEmail({
+      transport,
+      to: 'boss@example.com',
+      body: 'Here is the update.',
+      subject: 'Quarterly plan',
+      selfAddress: 'agent@example.com',
+      threadContext: null,
+      inReplyTo: 'session-4f21',
+      references: ['not-an-id'],
+    });
+
+    expect(transport.sendMail).toHaveBeenCalledWith(
+      expect.not.objectContaining({ inReplyTo: expect.anything() }),
+    );
+    expect(transport.sendMail).toHaveBeenCalledWith(
+      expect.not.objectContaining({ references: expect.anything() }),
     );
   });
 

--- a/tests/email.channel.test.ts
+++ b/tests/email.channel.test.ts
@@ -706,6 +706,115 @@ describe('email delivery helpers', () => {
     });
   });
 
+  test('replies in the tracked thread when the explicit inReplyTo is not a message id', async () => {
+    vi.doMock('../src/config/config.ts', () => ({
+      APP_VERSION: '0.7.1',
+      DATA_DIR: path.join(os.tmpdir(), 'hybridclaw-test-data'),
+      EMAIL_TEXT_CHUNK_LIMIT: 50000,
+    }));
+    const { sendEmail } = await import('../src/channels/email/delivery.js');
+    const transport = {
+      sendMail: vi.fn(async () => ({
+        messageId: '<sent-fallback@example.com>',
+      })),
+    };
+
+    const result = await sendEmail({
+      transport,
+      to: 'boss@example.com',
+      body: 'Received it.',
+      selfAddress: 'agent@example.com',
+      threadContext: {
+        subject: 'Quarterly plan',
+        messageId: '<msg-1@example.com>',
+        references: ['<ref-1@example.com>'],
+      },
+      // An internal id, not a message id: it names nothing a mail client can
+      // thread on, so it must not detach the reply from the tracked thread.
+      inReplyTo: '<0f99ab14eeb8>',
+    });
+
+    expect(transport.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'Re: Quarterly plan',
+        inReplyTo: '<msg-1@example.com>',
+        references: '<ref-1@example.com> <msg-1@example.com>',
+        text: 'Received it.',
+      }),
+    );
+    // The remembered thread keeps the inbound message, so later replies on
+    // this thread stay attached to it too.
+    expect(result.threadContext).toEqual({
+      subject: 'Re: Quarterly plan',
+      messageId: '<sent-fallback@example.com>',
+      references: ['<ref-1@example.com>', '<msg-1@example.com>'],
+    });
+  });
+
+  test('omits threading headers when a malformed id has no thread to fall back to', async () => {
+    vi.doMock('../src/config/config.ts', () => ({
+      APP_VERSION: '0.7.1',
+      DATA_DIR: path.join(os.tmpdir(), 'hybridclaw-test-data'),
+      EMAIL_TEXT_CHUNK_LIMIT: 50000,
+    }));
+    const { sendEmail } = await import('../src/channels/email/delivery.js');
+    const transport = {
+      sendMail: vi.fn(async () => ({
+        messageId: '<sent-unthreaded@example.com>',
+      })),
+    };
+
+    await sendEmail({
+      transport,
+      to: 'boss@example.com',
+      body: 'Here is the update.',
+      subject: 'Quarterly plan',
+      selfAddress: 'agent@example.com',
+      threadContext: null,
+      inReplyTo: 'session-4f21',
+      references: ['not-an-id', '<ref-1@example.com>'],
+    });
+
+    expect(transport.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'Quarterly plan',
+        inReplyTo: '<ref-1@example.com>',
+        references: '<ref-1@example.com>',
+      }),
+    );
+  });
+
+  test('accepts an explicit message id that omits its angle brackets', async () => {
+    vi.doMock('../src/config/config.ts', () => ({
+      APP_VERSION: '0.7.1',
+      DATA_DIR: path.join(os.tmpdir(), 'hybridclaw-test-data'),
+      EMAIL_TEXT_CHUNK_LIMIT: 50000,
+    }));
+    const { sendEmail } = await import('../src/channels/email/delivery.js');
+    const transport = {
+      sendMail: vi.fn(async () => ({
+        messageId: '<sent-bare@example.com>',
+      })),
+    };
+
+    await sendEmail({
+      transport,
+      to: 'boss@example.com',
+      body: 'Here is the update.',
+      subject: 'Quarterly plan',
+      selfAddress: 'agent@example.com',
+      threadContext: null,
+      inReplyTo: 'msg-1@example.com',
+    });
+
+    expect(transport.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inReplyTo: '<msg-1@example.com>',
+        references: '<msg-1@example.com>',
+      }),
+    );
+  });
+
   test('extracts inline subject prefixes and attaches files', async () => {
     vi.doMock('../src/config/config.ts', () => ({
       APP_VERSION: '0.7.1',


### PR DESCRIPTION
## Problem

The `message` tool accepts any string as `inReplyTo`/`references` (`src/channels/message/tool-actions.ts`) and writes it straight into the outbound RFC 5322 headers. Explicit thread headers deliberately *replace* the account's tracked thread — that is how a caller replies to a message other than the latest one (`sendEmail`, `src/channels/email/delivery.ts:294-300`). So when the supplied value is not a message id, the reply is detached from the thread the runtime already knew about:

- the inbound `References` chain is dropped,
- `resolveSubjectAndBody` loses its thread context and falls back to `DEFAULT_EMAIL_SUBJECT`, so the reply goes out titled `HybridClaw` instead of `Re: <their subject>`,
- the composed context is then handed to `threadTracker.remember` (`runtime.ts:457`), so the agent's *own* following messages to that recipient inherit the break.

Nothing logs it. The agent reports a successful send, and the person who emailed the agent gets a new thread rather than an answer.

Observed in an agent mailbox — a reply to a message whose id was `<1785…@example.com>` went out as:

```
Subject: HybridClaw
In-Reply-To: <0f99ab14eeb8>
References: <0f99ab14eeb8>
```

`<0f99ab14eeb8>` is not a message id at all. The runtime had the correct inbound context in hand at send time and discarded it. It is intermittent because it depends on whether the model supplies the argument: the same flow, with `inReplyTo` omitted, threads correctly.

## Fix

Validate the ids rather than trusting them:

- **`message` send rejects** an `inReplyTo`/`references` entry that is not a message id, with an error naming where a real one comes from (`messageId` in a `message read` result) — the caller can correct it instead of silently mis-threading.
- **Delivery drops** malformed ids arriving from any other caller and falls back to the tracked thread, which is the right answer whenever the caller was answering the message that opened it.
- **A bare `local@domain` id is accepted and wrapped**, since that shape still names a real message and is a common way to write one.
- **Prompt hint and tool schema** now say to omit `inReplyTo` for replies in the current thread, and to copy a `messageId` from a read result otherwise. The old hint promised automatic threading without naming the parameter that overrides it.

Threading behaviour for well-formed explicit ids is unchanged — replying to an older message still works exactly as before, including its own subject.

## Testing

- `tests/agent-email.e2e.test.ts`: new end-to-end case — inbound mail, agent answers via the tool with `inReplyTo: <0f99ab14eeb8>`, the tool call fails with the actionable error, and the reply still goes out `In-Reply-To: <boss-runbook-1@example.com>` / `Re: Runbook request`. Shared setup extracted into helpers; the existing case is unchanged. 2/2 pass.
- `tests/email.channel.test.ts`: 3 new delivery cases — malformed explicit id falls back to the tracked thread (both headers and the remembered context), malformed ids with no tracked thread are dropped rather than emitted, bare `local@domain` is wrapped. 31/31 pass.
- Verified the new tests fail on the parent commit, reproducing the reported headers exactly: `"inReplyTo": "<0f99ab14eeb8>", "subject": "HybridClaw"`.
- `tsc --noEmit --noUnusedLocals --noUnusedParameters` and `biome check` clean; full `npm run test:unit` 5416 passed, 1 unrelated pre-existing failure (`tests/host-runner.redaction.test.ts`, agent-browser binary path, fails on the parent commit too).