### PR TITLE
fix(agents): stop config sync from clearing database-only agent settings

### DIFF
--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -482,8 +482,64 @@ function configuredAgentForDatabase(agent: AgentConfig): AgentConfig {
   };
 }
 
+// Database-backed fields that runtime surfaces (gateway admin console, CLI,
+// distill service) may set without a corresponding entry in the runtime
+// config. Identity fields and `archived` are excluded because upsertAgent
+// already preserves them; `budget` and `webSearch` are config-only and never
+// stored in the database.
+const DB_BACKED_OPTIONAL_AGENT_FIELDS = [
+  'name',
+  'displayName',
+  'imageAsset',
+  'emptyChatHeader',
+  'model',
+  'skills',
+  'workspace',
+  'chatbotId',
+  'enableRag',
+  'owner',
+  'role',
+  'reportsTo',
+  'delegatesTo',
+  'peers',
+  'cv',
+  'escalationTarget',
+  'a2a',
+  'proxy',
+] as const satisfies ReadonlyArray<keyof AgentConfig>;
+
+function mergeConfiguredAgentWithStored(
+  configured: AgentConfig,
+  stored: AgentConfig | undefined,
+): AgentConfig {
+  if (!stored) return configured;
+  // Config sync must not clear settings it does not manage: runtime edits
+  // (for example enabling proxy mode in the gateway console) are persisted
+  // only in the database, so a config entry that omits a field keeps the
+  // stored value instead of overwriting it with NULL on every reload.
+  // Config-specified values still take precedence.
+  const merged: AgentConfig = { ...configured };
+  for (const field of DB_BACKED_OPTIONAL_AGENT_FIELDS) {
+    copyStoredAgentFieldIfUnset(merged, stored, field);
+  }
+  return merged;
+}
+
+function copyStoredAgentFieldIfUnset<Field extends keyof AgentConfig>(
+  merged: AgentConfig,
+  stored: AgentConfig,
+  field: Field,
+): void {
+  if (merged[field] === undefined && stored[field] !== undefined) {
+    merged[field] = stored[field];
+  }
+}
+
 function syncConfiguredAgentsToDatabase(): void {
   const currentAgents = dbListAgents();
+  const storedAgentsById = new Map(
+    currentAgents.map((agent) => [agent.id, agent] as const),
+  );
   const mainAgent = configuredAgents.find(
     (entry) => entry.id === DEFAULT_AGENT_ID,
   );
@@ -492,16 +548,25 @@ function syncConfiguredAgentsToDatabase(): void {
     currentAgents.map((agent) => [agent.id, agent] as const),
   );
   if (!mainAgent) {
-    const defaultMainAgent = {
-      id: DEFAULT_AGENT_ID,
-      name: 'Main Agent',
-    };
+    const storedMainAgent = storedAgentsById.get(DEFAULT_AGENT_ID);
+    const defaultMainAgent = storedMainAgent
+      ? mergeConfiguredAgentWithStored(
+          { id: DEFAULT_AGENT_ID },
+          storedMainAgent,
+        )
+      : {
+          id: DEFAULT_AGENT_ID,
+          name: 'Main Agent',
+        };
     agentsToUpsert.push(defaultMainAgent);
     finalAgentsById.set(DEFAULT_AGENT_ID, defaultMainAgent);
   }
 
   for (const agent of configuredAgents) {
-    const nextAgent = configuredAgentForDatabase(agent);
+    const nextAgent = mergeConfiguredAgentWithStored(
+      configuredAgentForDatabase(agent),
+      storedAgentsById.get(agent.id),
+    );
     agentsToUpsert.push(nextAgent);
     finalAgentsById.set(nextAgent.id, nextAgent);
   }

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -190,6 +190,78 @@ test('listAgents refreshes externally updated database-backed registry', async (
   expect(listAgents().map((agent) => agent.id)).toEqual(['main', 'external']);
 });
 
+test('config sync preserves database-only agent settings across registry reloads', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { getAgentById, getStoredAgentConfig, initAgentRegistry, upsertRegisteredAgent } =
+    await import('../src/agents/agent-registry.ts');
+
+  const configuredList = [
+    { id: 'main', name: 'Main Agent' },
+    { id: 'gateway', name: 'Gateway Agent', model: 'gpt-5-mini' },
+  ];
+
+  initDatabase({ quiet: true });
+  initAgentRegistry({ list: configuredList });
+
+  // Simulate runtime edits (gateway console) that persist only to the DB.
+  upsertRegisteredAgent({
+    ...getStoredAgentConfig('gateway')!,
+    chatbotId: 'bot-gateway',
+    proxy: {
+      kind: 'hybridai',
+      baseUrl: 'https://hybridai.example',
+      chatbotId: 'bot-proxy',
+      apiKey: { source: 'store', id: 'HYBRIDAI_API_KEY' },
+    },
+  });
+  upsertRegisteredAgent({
+    ...getStoredAgentConfig('main')!,
+    chatbotId: 'bot-main',
+  });
+
+  // Simulate a gateway restart: the registry re-initializes from the same
+  // runtime config, which does not mention proxy or chatbotId.
+  initAgentRegistry({ list: configuredList });
+
+  expect(getAgentById('gateway')?.proxy).toEqual(
+    expect.objectContaining({
+      kind: 'hybridai',
+      chatbotId: 'bot-proxy',
+    }),
+  );
+  expect(getAgentById('gateway')?.chatbotId).toBe('bot-gateway');
+  expect(getAgentById('main')?.chatbotId).toBe('bot-main');
+
+  // Config-specified values still win over stored ones on reload.
+  initAgentRegistry({
+    list: [
+      { id: 'main', name: 'Main Agent' },
+      { id: 'gateway', name: 'Gateway Agent', model: 'gpt-5.2' },
+    ],
+  });
+  expect(getAgentById('gateway')?.model).toBe('gpt-5.2');
+  expect(getAgentById('gateway')?.proxy).toEqual(
+    expect.objectContaining({ chatbotId: 'bot-proxy' }),
+  );
+
+  // A reload whose config omits the main agent seeds it from the stored row
+  // instead of resetting it.
+  initAgentRegistry({
+    list: [{ id: 'gateway', name: 'Gateway Agent', model: 'gpt-5.2' }],
+  });
+  expect(getAgentById('main')?.chatbotId).toBe('bot-main');
+
+  // Explicit clears through the registry API still remove the setting.
+  const { proxy: _cleared, ...storedWithoutProxy } =
+    getStoredAgentConfig('gateway')!;
+  upsertRegisteredAgent(storedWithoutProxy);
+  expect(getAgentById('gateway')?.proxy).toBeUndefined();
+});
+
 test('agent skill allowlists persist through runtime config normalization and the registry', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;


### PR DESCRIPTION
## Problem

`syncConfiguredAgentsToDatabase()` rebuilds every agent row purely from the runtime config entry and upserts it with `proxy = excluded.proxy` (and likewise for every other optional column). Any setting edited at runtime and persisted only in the agents table — **proxy mode**, chatbot bindings, distilled CVs, org-chart edits — is silently wiped to NULL on every gateway restart or agents-config reload. There is no log line and no audit event for the wipe.

This is not theoretical: on a production sandbox, proxy mode was enabled in the gateway console and worked for over a day. A version-upgrade container recreation then wiped it (config.json's agent entry had been snapshotted at provisioning time, before proxy was configured), and the agent silently fell back to the account-default chatbot until an operator re-enabled the proxy — which the next restart would have wiped again.

The seeded default `main` agent had the same bug: when the config list omits `main`, sync upserted a bare `{id, name}` row over whatever the database held.

## Fix

Config sync now merges each configured entry over the stored row before upserting:

- fields the config **specifies still win** (config remains authoritative for what it manages),
- fields the config **omits keep their stored value** instead of being overwritten with NULL,
- the seeded default main agent is built from the stored row when one exists.

Explicit clears are unaffected: the admin console, CLI, and `applyAgentConfigJson` all submit complete rows through `upsertRegisteredAgent`, which keeps its overwrite semantics. Identity fields and `archived` stay out of the merge because `upsertAgent` already preserves them; `budget`/`webSearch` are config-only and never stored.

## Testing

- New regression test: runtime-set proxy/chatbot survive registry re-init from the same config, config-specified values still override, a config that omits `main` no longer resets it, and an explicit API clear still removes the setting.
- `npx vitest run tests/agent-registry.test.ts` — 16/16 pass.
- `tsc --noEmit --noUnusedLocals --noUnusedParameters` and `biome check` clean.