### PR TITLE
feat(agents): log field-level agent settings changes with attribution

### DIFF
--- a/src/memory/agents.ts
+++ b/src/memory/agents.ts
@@ -504,7 +504,94 @@ export function listAgents(): AgentConfig[] {
   return rows.map(mapAgentRow);
 }
 
-export function upsertAgent(agent: AgentConfig): AgentConfig {
+interface SerializedAgentSettings {
+  name: string | null;
+  displayName: string | null;
+  imageAsset: string | null;
+  emptyChatHeader: string | null;
+  model: string | null;
+  skills: string | null;
+  chatbotId: string | null;
+  enableRag: number | null;
+  workspace: string | null;
+  owner: string | null;
+  role: string | null;
+  reportsTo: string | null;
+  delegatesTo: string | null;
+  peers: string | null;
+  cv: string | null;
+  escalationTarget: string | null;
+  a2a: string | null;
+  proxy: string | null;
+}
+
+function serializeAgentSettings(agent: AgentConfig): SerializedAgentSettings {
+  return {
+    name: agent.name?.trim() || null,
+    displayName: agent.displayName?.trim() || null,
+    imageAsset: agent.imageAsset?.trim() || null,
+    emptyChatHeader: agent.emptyChatHeader?.trim() || null,
+    model: serializeAgentModelConfig(agent.model),
+    skills: serializeAgentSkillsConfig(agent.skills),
+    chatbotId: agent.chatbotId?.trim() || null,
+    enableRag:
+      typeof agent.enableRag === 'boolean' ? (agent.enableRag ? 1 : 0) : null,
+    workspace: agent.workspace?.trim() || null,
+    owner: agent.owner?.trim() || null,
+    role: agent.role?.trim() || null,
+    reportsTo: agent.reportsTo?.trim() || null,
+    delegatesTo: serializeAgentStringArray(agent.delegatesTo),
+    peers: serializeAgentStringArray(agent.peers),
+    cv: serializeAgentCv(agent.cv),
+    escalationTarget: serializeAgentEscalationTarget(agent.escalationTarget),
+    a2a: serializeAgentA2AConfig(agent.a2a),
+    proxy: serializeAgentProxyConfig(agent.proxy),
+  };
+}
+
+// Field names only — values may embed customer configuration, so the log
+// records what changed and who asked, never the contents.
+function logAgentSettingsChange(params: {
+  agentId: string;
+  previous: SerializedAgentSettings | null;
+  next: SerializedAgentSettings;
+  meta?: RuntimeConfigChangeMeta;
+}): void {
+  const attribution = {
+    ...(params.meta?.actor ? { actor: params.meta.actor } : {}),
+    ...(params.meta?.route ? { route: params.meta.route } : {}),
+    ...(params.meta?.source ? { source: params.meta.source } : {}),
+  };
+  const { previous } = params;
+  if (!previous) {
+    logger.info({ agentId: params.agentId, ...attribution }, 'Agent created');
+    return;
+  }
+  const fields = Object.keys(params.next) as Array<
+    keyof SerializedAgentSettings
+  >;
+  const changedFields = fields.filter(
+    (field) => params.next[field] !== previous[field],
+  );
+  if (changedFields.length === 0) return;
+  const clearedFields = changedFields.filter(
+    (field) => params.next[field] === null,
+  );
+  logger.info(
+    {
+      agentId: params.agentId,
+      changedFields,
+      ...(clearedFields.length > 0 ? { clearedFields } : {}),
+      ...attribution,
+    },
+    'Agent settings updated',
+  );
+}
+
+export function upsertAgent(
+  agent: AgentConfig,
+  options?: { meta?: RuntimeConfigChangeMeta },
+): AgentConfig {
   const normalizedId = agent.id.trim();
   if (!normalizedId) {
     throw new Error('Agent id is required.');
@@ -518,25 +605,7 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
       : existingAgent?.archived
         ? 1
         : 0;
-  const normalizedName = agent.name?.trim() || null;
-  const normalizedDisplayName = agent.displayName?.trim() || null;
-  const normalizedImageAsset = agent.imageAsset?.trim() || null;
-  const normalizedEmptyChatHeader = agent.emptyChatHeader?.trim() || null;
-  const normalizedModel = serializeAgentModelConfig(agent.model);
-  const normalizedSkills = serializeAgentSkillsConfig(agent.skills);
-  const normalizedChatbotId = agent.chatbotId?.trim() || null;
-  const normalizedWorkspace = agent.workspace?.trim() || null;
-  const normalizedOwner = agent.owner?.trim() || null;
-  const normalizedRole = agent.role?.trim() || null;
-  const normalizedReportsTo = agent.reportsTo?.trim() || null;
-  const normalizedDelegatesTo = serializeAgentStringArray(agent.delegatesTo);
-  const normalizedPeers = serializeAgentStringArray(agent.peers);
-  const normalizedCv = serializeAgentCv(agent.cv);
-  const normalizedEscalationTarget = serializeAgentEscalationTarget(
-    agent.escalationTarget,
-  );
-  const normalizedA2A = serializeAgentA2AConfig(agent.a2a);
-  const normalizedProxy = serializeAgentProxyConfig(agent.proxy);
+  const settings = serializeAgentSettings(agent);
   const explicitIdentity = normalizeAgentIdentityFields({
     canonicalId: agent.canonicalId,
     ownerUserId: agent.ownerUserId,
@@ -547,7 +616,7 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
   const shouldReplaceDefaultIdentity =
     !explicitOwnerUserId &&
     !explicitCanonicalId &&
-    Boolean(normalizedOwner) &&
+    Boolean(settings.owner) &&
     isDefaultPlaceholderIdentity(existingAgent);
   const existingOwnerUserId = shouldReplaceDefaultIdentity
     ? undefined
@@ -571,14 +640,12 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
     : allocateCanonicalAgentIdentity({
         database: getAgentDatabase(),
         agentId: normalizedId,
-        owner: normalizedOwner,
+        owner: settings.owner,
         ownerUserId: normalizedOwnerUserId,
       });
   const canonicalId =
     explicitCanonicalId || existingCanonicalId || identity?.canonicalId || null;
   const ownerUserId = normalizedOwnerUserId || identity?.ownerUserId || null;
-  const enableRag =
-    typeof agent.enableRag === 'boolean' ? (agent.enableRag ? 1 : 0) : null;
   getAgentDatabase()
     .prepare(
       `INSERT INTO agents (
@@ -636,29 +703,35 @@ export function upsertAgent(agent: AgentConfig): AgentConfig {
       archived,
       canonicalId,
       ownerUserId,
-      normalizedName,
-      normalizedDisplayName,
-      normalizedImageAsset,
-      normalizedEmptyChatHeader,
-      normalizedModel,
-      normalizedSkills,
-      normalizedChatbotId,
-      enableRag,
-      normalizedWorkspace,
-      normalizedOwner,
-      normalizedRole,
-      normalizedReportsTo,
-      normalizedDelegatesTo,
-      normalizedPeers,
-      normalizedCv,
-      normalizedEscalationTarget,
-      normalizedA2A,
-      normalizedProxy,
+      settings.name,
+      settings.displayName,
+      settings.imageAsset,
+      settings.emptyChatHeader,
+      settings.model,
+      settings.skills,
+      settings.chatbotId,
+      settings.enableRag,
+      settings.workspace,
+      settings.owner,
+      settings.role,
+      settings.reportsTo,
+      settings.delegatesTo,
+      settings.peers,
+      settings.cv,
+      settings.escalationTarget,
+      settings.a2a,
+      settings.proxy,
     );
   const storedAgent = getAgentById(normalizedId);
   if (!storedAgent) {
     throw new Error(`Failed to read persisted agent: ${normalizedId}`);
   }
+  logAgentSettingsChange({
+    agentId: normalizedId,
+    previous: existingAgent ? serializeAgentSettings(existingAgent) : null,
+    next: settings,
+    meta: options?.meta,
+  });
   return storedAgent;
 }
 
@@ -686,7 +759,7 @@ export function upsertAgentWithTeamRevision(params: {
   return withRuntimeRevisionDatabaseAttached(() => {
     const upsert = getAgentDatabase().transaction(() => {
       syncAttachedTeamRevisionState(listAgents(), params.meta);
-      const stored = upsertAgent(params.agent);
+      const stored = upsertAgent(params.agent, { meta: params.meta });
       syncAttachedTeamRevisionState(params.finalAgents, params.meta);
       return stored;
     });
@@ -703,7 +776,7 @@ export function upsertAgentsWithTeamRevision(params: {
     const upsert = getAgentDatabase().transaction(() => {
       syncAttachedTeamRevisionState(listAgents(), params.meta);
       for (const agent of params.agents) {
-        upsertAgent(agent);
+        upsertAgent(agent, { meta: params.meta });
       }
       syncAttachedTeamRevisionState(params.finalAgents, params.meta);
       return listAgents();

--- a/tests/agent-change-logging.test.ts
+++ b/tests/agent-change-logging.test.ts
@@ -1,0 +1,126 @@
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
+
+const ORIGINAL_HOME = process.env.HOME;
+
+const makeTempHome = useTempDir('hybridclaw-agent-logs-');
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+useCleanMocks({
+  restoreAllMocks: true,
+  cleanup: async () => {
+    const { resetAgentRegistryForTesting } = await import(
+      '../src/agents/agent-registry.ts'
+    );
+    resetAgentRegistryForTesting();
+    restoreEnvVar('HOME', ORIGINAL_HOME);
+  },
+  resetModules: true,
+  unmock: ['../src/logger.js'],
+});
+
+test('agent upserts log field-level changes with revision attribution', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const { getStoredAgentConfig, initAgentRegistry, upsertRegisteredAgent } =
+    await import('../src/agents/agent-registry.ts');
+  const { logger } = await import('../src/logger.js');
+  const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+
+  const configuredList = [
+    { id: 'main', name: 'Main Agent' },
+    { id: 'gateway', name: 'Gateway Agent', model: 'gpt-5-mini' },
+  ];
+
+  initDatabase({ quiet: true });
+  updateRuntimeConfig((draft) => {
+    draft.agents.list = configuredList;
+  });
+  initAgentRegistry({ list: configuredList });
+
+  const createdCalls = infoSpy.mock.calls.filter(
+    ([, message]) => message === 'Agent created',
+  );
+  expect(createdCalls.map(([payload]) => payload)).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        agentId: 'gateway',
+        route: 'agents.team.config_sync',
+        source: 'agent-registry',
+      }),
+    ]),
+  );
+
+  // Re-running the same sync must stay silent — this path fires on every
+  // gateway boot for every agent.
+  infoSpy.mockClear();
+  initAgentRegistry({ list: configuredList });
+  expect(
+    infoSpy.mock.calls.filter(
+      ([, message]) =>
+        message === 'Agent settings updated' || message === 'Agent created',
+    ),
+  ).toEqual([]);
+
+  // A runtime edit logs which fields changed and who asked.
+  infoSpy.mockClear();
+  upsertRegisteredAgent({
+    ...getStoredAgentConfig('gateway')!,
+    chatbotId: 'bot-gateway',
+    proxy: {
+      kind: 'hybridai',
+      baseUrl: 'https://hybridai.example',
+      chatbotId: 'bot-proxy',
+      apiKey: { source: 'store', id: 'HYBRIDAI_API_KEY' },
+    },
+  });
+  const updatedCalls = infoSpy.mock.calls.filter(
+    ([, message]) => message === 'Agent settings updated',
+  );
+  expect(updatedCalls).toHaveLength(1);
+  expect(updatedCalls[0]?.[0]).toEqual(
+    expect.objectContaining({
+      agentId: 'gateway',
+      changedFields: expect.arrayContaining(['chatbotId', 'proxy']),
+      route: 'agents.team.upsert#gateway',
+      source: 'agent-registry',
+    }),
+  );
+  expect(updatedCalls[0]?.[0]).not.toHaveProperty('clearedFields');
+
+  // Clearing a setting is called out explicitly.
+  infoSpy.mockClear();
+  const { proxy: _cleared, ...storedWithoutProxy } =
+    getStoredAgentConfig('gateway')!;
+  upsertRegisteredAgent(storedWithoutProxy);
+  const clearedCalls = infoSpy.mock.calls.filter(
+    ([, message]) => message === 'Agent settings updated',
+  );
+  expect(clearedCalls).toHaveLength(1);
+  expect(clearedCalls[0]?.[0]).toEqual(
+    expect.objectContaining({
+      agentId: 'gateway',
+      changedFields: ['proxy'],
+      clearedFields: ['proxy'],
+    }),
+  );
+
+  // Log payloads must never include setting values, only field names.
+  for (const [payload] of [...updatedCalls, ...clearedCalls]) {
+    expect(JSON.stringify(payload)).not.toContain('bot-proxy');
+    expect(JSON.stringify(payload)).not.toContain('HYBRIDAI_API_KEY');
+  }
+});

--- a/tests/skills-observation.test.ts
+++ b/tests/skills-observation.test.ts
@@ -1499,14 +1499,18 @@ test('captures opt-in skill_run trajectories in append-only files keyed by date 
       }
     ).event.tool_executions_full[0]?.result.content.length,
   ).toBeGreaterThan(4_500);
-  expect(infoSpy).toHaveBeenCalledTimes(1);
-  expect(infoSpy).toHaveBeenCalledWith(
-    {
-      agentCount: 1,
-      storeDir,
-    },
-    `Trajectory capture enabled for 1 agent(s) -> ${storeDir}`,
+  const trajectoryLogs = infoSpy.mock.calls.filter(([, message]) =>
+    String(message).startsWith('Trajectory capture enabled'),
   );
+  expect(trajectoryLogs).toEqual([
+    [
+      {
+        agentCount: 1,
+        storeDir,
+      },
+      `Trajectory capture enabled for 1 agent(s) -> ${storeDir}`,
+    ],
+  ]);
   infoSpy.mockRestore();
   if (process.platform !== 'win32') {
     expect(fs.statSync(storeDir).mode & 0o777).toBe(0o700);


### PR DESCRIPTION
## Problem

Persisted agent settings can change — or be silently cleared — with no forensic trail. Team-structure revisions only capture org-chart fields (`role`, `reportsTo`, `delegatesTo`, `peers`); everything else (`proxy`, `chatbotId`, `model`, `cv`, …) is written by `upsertAgent` as a whole row with no record of what actually changed. When a stored setting was lost on a production sandbox (see #1387), the persistent gateway log offered nothing to reconstruct when the value disappeared or through which write path.

## Change

`upsertAgent` now diffs the serialized settings columns against the stored row and logs through the standard gateway logger, attributed with the same `RuntimeConfigChangeMeta` (`actor`/`route`/`source`) the revision system already threads through the team-revision wrappers:

- `Agent created` — `{agentId, route, source}` on first insert.
- `Agent settings updated` — `{agentId, changedFields, clearedFields?, route, source}` when stored values actually change. `clearedFields` calls out set→NULL transitions separately, since that is the signature of accidental data loss.

Design constraints, matching existing conventions:

- **Field names only, never values** — settings may embed customer configuration and secret refs; the log answers "what changed, when, via which route", the DB holds the content (same philosophy as the existing `configLength`-style warn logs).
- **No-op upserts stay silent** — the boot-time config sync upserts every agent on every start; unchanged rows produce no log line.
- The serialization used for the insert and for the diff lives in one shared helper (`serializeAgentSettings`) so they cannot drift.
- Identity fields and `archived` are excluded — `upsertAgent` has dedicated preserve semantics for them.

With this in place, the incident behind #1387 would have left a single grep-able line in the persistent gateway log: `Agent settings updated {…, clearedFields:["proxy"], route:"agents.team.config_sync", source:"agent-registry"}`. The two PRs are independent and compose.

## Testing

- New `tests/agent-change-logging.test.ts`: creation logging with sync attribution, silent no-op re-sync, changed-field logging with console-route attribution, explicit-clear logging, and a guard that payloads never contain setting values.
- Adjusted one assertion in `tests/skills-observation.test.ts` that counted total `logger.info` calls (it now asserts the specific trajectory-capture message, which is what it was testing).
- Full unit suite run: no regressions beyond a pre-existing, environment-dependent `host-runner.redaction` failure that also fails on `main` locally.
- `tsc --noEmit --noUnusedLocals --noUnusedParameters` and `biome check` clean.