### PR TITLE
feat: add server-backed webchat dictation and read-aloud

### DIFF
--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -240,6 +240,10 @@ export interface MediaUploadResponse {
   media: MediaItem;
 }
 
+export interface DictationTranscriptionResponse {
+  text: string;
+}
+
 export interface BranchResponse {
   sessionId: string;
 }

--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -244,6 +244,11 @@ export interface DictationTranscriptionResponse {
   text: string;
 }
 
+export interface MediaCapabilitiesResponse {
+  dictation: boolean;
+  readAloud: boolean;
+}
+
 export interface BranchResponse {
   sessionId: string;
 }

--- a/console/src/api/chat.ts
+++ b/console/src/api/chat.ts
@@ -7,15 +7,16 @@ import type {
   ChatMobileQrResponse,
   ChatRecentResponse,
   DictationTranscriptionResponse,
+  MediaCapabilitiesResponse,
   MediaUploadResponse,
   RateResponseRequest,
   RateResponseResponse,
 } from './chat-types';
 import {
   buildWebCommandRequestBody,
-  dispatchAuthRequired,
   requestHeaders,
   requestJson,
+  throwResponseError,
   validateToken,
 } from './client';
 import type { AdminCommandResult } from './types';
@@ -184,6 +185,29 @@ export function transcribeDictation(
   });
 }
 
+export function fetchMediaCapabilities(
+  token: string,
+): Promise<MediaCapabilitiesResponse> {
+  return requestJson<MediaCapabilitiesResponse>('/api/media/capabilities', {
+    token,
+  });
+}
+
+export async function synthesizeSpeech(
+  token: string,
+  text: string,
+  signal?: AbortSignal,
+): Promise<Blob> {
+  const response = await fetch('/api/media/speech', {
+    method: 'POST',
+    headers: requestHeaders(token, { text }),
+    body: JSON.stringify({ text }),
+    signal,
+  });
+  if (!response.ok) await throwResponseError(response);
+  return response.blob();
+}
+
 export function artifactUrl(path: string): string {
   const params = new URLSearchParams({ path });
   return `/api/artifact?${params.toString()}`;
@@ -203,26 +227,7 @@ async function fetchAuthenticatedBlob(
   });
 
   if (!response.ok) {
-    const contentType = (response.headers.get('content-type') || '')
-      .toLowerCase()
-      .trim();
-    let message = `${response.status} ${response.statusText}`;
-
-    if (contentType.includes('application/json')) {
-      const payload = (await response.json().catch(() => null)) as {
-        error?: string;
-        text?: string;
-      } | null;
-      message = payload?.error || payload?.text || message;
-    } else {
-      const text = (await response.text().catch(() => '')).trim();
-      if (text) message = text;
-    }
-
-    if (response.status === 401) {
-      dispatchAuthRequired(message);
-    }
-    throw new Error(message);
+    await throwResponseError(response);
   }
 
   return response.blob();

--- a/console/src/api/chat.ts
+++ b/console/src/api/chat.ts
@@ -6,6 +6,7 @@ import type {
   ChatHistoryResponse,
   ChatMobileQrResponse,
   ChatRecentResponse,
+  DictationTranscriptionResponse,
   MediaUploadResponse,
   RateResponseRequest,
   RateResponseResponse,
@@ -164,6 +165,22 @@ export function uploadMedia(
       'Content-Type': file.type || 'application/octet-stream',
       'X-Hybridclaw-Filename': encodeURIComponent(file.name || 'upload'),
     },
+  });
+}
+
+export function transcribeDictation(
+  token: string,
+  recording: Blob,
+  signal?: AbortSignal,
+): Promise<DictationTranscriptionResponse> {
+  return requestJson<DictationTranscriptionResponse>('/api/media/transcribe', {
+    token,
+    method: 'POST',
+    rawBody: recording,
+    extraHeaders: {
+      'Content-Type': recording.type || 'audio/webm',
+    },
+    signal,
   });
 }
 

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -238,6 +238,7 @@ export async function requestJson<T>(
     rawBody?: BodyInit;
     extraHeaders?: HeadersInit;
     onAuthError?: 'dispatch' | 'ignore';
+    signal?: AbortSignal;
   },
 ): Promise<T> {
   const response = await fetch(pathname, {
@@ -250,6 +251,7 @@ export async function requestJson<T>(
       options.body !== undefined
         ? JSON.stringify(options.body)
         : (options.rawBody ?? undefined),
+    signal: options.signal,
   });
 
   if (!response.ok) {

--- a/console/src/routes/chat/audio-unlock.test.ts
+++ b/console/src/routes/chat/audio-unlock.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getAudioElement,
+  playAudioClip,
+  resetAudioUnlockForTests,
+  unlockAudio,
+} from './audio-unlock';
+
+class FakeAudio extends EventTarget {
+  currentTime = 0;
+  ended = false;
+  muted = false;
+  preload = '';
+  src = '';
+  pause = vi.fn(() => {
+    this.dispatchEvent(new Event('pause'));
+  });
+  play = vi.fn(async () => undefined);
+}
+
+describe('iOS audio unlock', () => {
+  const audioInstances: FakeAudio[] = [];
+
+  beforeEach(() => {
+    resetAudioUnlockForTests();
+    audioInstances.length = 0;
+    vi.stubGlobal('navigator', {
+      userAgent: 'Mozilla/5.0 (iPhone)',
+      platform: 'iPhone',
+      maxTouchPoints: 1,
+    });
+    vi.stubGlobal(
+      'Audio',
+      class extends FakeAudio {
+        constructor() {
+          super();
+          audioInstances.push(this);
+        }
+      },
+    );
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:generated-audio');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('warms and reuses the same audio element for generated clips', async () => {
+    unlockAudio();
+    await Promise.resolve();
+
+    const audio = getAudioElement() as unknown as FakeAudio;
+    expect(audioInstances).toHaveLength(1);
+    expect(audio.play).toHaveBeenCalledTimes(1);
+    expect(audio.muted).toBe(false);
+
+    const started = vi.fn();
+    const playback = playAudioClip(
+      new Blob(['mp3'], { type: 'audio/mpeg' }),
+      started,
+    );
+    expect(audioInstances).toHaveLength(1);
+    expect(audio.src).toBe('blob:generated-audio');
+    expect(started).toHaveBeenCalledWith(audio);
+    audio.ended = true;
+    audio.dispatchEvent(new Event('ended'));
+    await playback;
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:generated-audio');
+  });
+
+  it('settles a clip when explicit stop pauses the shared element', async () => {
+    const audio = getAudioElement() as unknown as FakeAudio;
+    const playback = playAudioClip(
+      new Blob(['mp3'], { type: 'audio/mpeg' }),
+      vi.fn(),
+    );
+
+    audio.pause();
+    await expect(playback).resolves.toBeUndefined();
+  });
+});

--- a/console/src/routes/chat/audio-unlock.ts
+++ b/console/src/routes/chat/audio-unlock.ts
@@ -1,0 +1,90 @@
+/**
+ * Webchat audio unlock — keeps one user-gesture-authorized playback element.
+ *
+ * iOS grants autoplay permission to an element, so every generated clip reuses
+ * the exact element warmed synchronously by the read-aloud button.
+ *
+ * NOT speech generation or playback queue ownership.
+ */
+
+const SILENT_MP3 =
+  'data:audio/mp3;base64,SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU4Ljc2LjEwMAAAAAAAAAAAAAAA//tQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWGluZwAAAA8AAAACAAABhgC7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7//////////////////////////////////////////////////////////////////8AAAAATGF2YzU4LjEzAAAAAAAAAAAAAAAAJAAAAAAAAAAAAYYoRwmHAAAAAAD/+1DEAAAGAAGn9AAAIgAANIAAAARMQU1FMy4xMDBVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVf/7UMQbgAAADSAAAAAAAAANIAAAABVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVQ==';
+
+let audioElement: HTMLAudioElement | null = null;
+let unlocked = false;
+
+function isIos(): boolean {
+  return (
+    /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+  );
+}
+
+export function getAudioElement(): HTMLAudioElement {
+  audioElement ??= new Audio();
+  audioElement.preload = 'auto';
+  return audioElement;
+}
+
+export function unlockAudio(): void {
+  if (unlocked || !isIos()) return;
+  const audio = getAudioElement();
+  audio.src = SILENT_MP3;
+  audio.muted = true;
+
+  const settle = () => {
+    audio.pause();
+    audio.currentTime = 0;
+    audio.muted = false;
+    unlocked = true;
+  };
+  const played = audio.play();
+  if (played === undefined) {
+    settle();
+    return;
+  }
+  played.then(settle).catch(() => {
+    audio.muted = false;
+  });
+}
+
+export function playAudioClip(
+  blob: Blob,
+  onStart: (audio: HTMLAudioElement) => void,
+): Promise<void> {
+  return new Promise((resolve) => {
+    const audio = getAudioElement();
+    const url = URL.createObjectURL(blob);
+    const previousUrl = audio.src;
+    let settled = false;
+
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      audio.removeEventListener('ended', done);
+      audio.removeEventListener('error', done);
+      audio.removeEventListener('pause', onPause);
+      URL.revokeObjectURL(url);
+      resolve();
+    };
+    const onPause = () => {
+      if (!audio.ended) done();
+    };
+
+    audio.addEventListener('ended', done);
+    audio.addEventListener('error', done);
+    audio.addEventListener('pause', onPause);
+    if (previousUrl.startsWith('blob:')) {
+      URL.revokeObjectURL(previousUrl);
+    }
+    audio.src = url;
+    audio.muted = false;
+    onStart(audio);
+    audio.play().catch(done);
+  });
+}
+
+export function resetAudioUnlockForTests(): void {
+  audioElement = null;
+  unlocked = false;
+}

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1100,6 +1100,17 @@ aside[data-state="collapsed"] .chatSidebarContent {
   color: var(--success);
 }
 
+.messageActions .actionButtonPlaying {
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
+  color: var(--primary);
+}
+
+.messageSpeechStatus {
+  align-self: center;
+  color: var(--muted-foreground);
+  font-size: 0.72rem;
+}
+
 .branchSwitcher {
   display: inline-flex;
   align-items: center;
@@ -1641,6 +1652,14 @@ aside[data-state="collapsed"] .chatSidebarContent {
   min-width: 0;
 }
 
+.composerRightActions {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
 .composerInputWrap {
   position: relative;
   flex: 1 1 auto;
@@ -1733,6 +1752,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 .attachButton,
+.dictationButton,
 .sendButton {
   display: flex;
   align-items: center;
@@ -1749,6 +1769,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 .attachButton:focus-visible,
+.dictationButton:focus-visible,
 .sendButton:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
   outline-offset: 2px;
@@ -1763,6 +1784,59 @@ aside[data-state="collapsed"] .chatSidebarContent {
 .attachButton:hover {
   background: var(--chat-hover-bg);
   color: var(--text);
+}
+
+.dictationButton {
+  background: transparent;
+  color: var(--muted-foreground);
+}
+
+.dictationButton:hover:not(:disabled) {
+  background: var(--chat-hover-bg);
+  color: var(--text);
+}
+
+.dictationButton:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.dictationButtonRecording {
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  color: var(--danger);
+  animation: dictationPulse 1.4s ease-in-out infinite;
+}
+
+.speechStatus {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 8px);
+  width: max-content;
+  max-width: min(320px, calc(100vw - 48px));
+  padding: 5px 9px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel-bg);
+  box-shadow: var(--shadow-card);
+  color: var(--muted-foreground);
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.speechStatusActive {
+  color: var(--danger);
+}
+
+@keyframes dictationPulse {
+  50% {
+    box-shadow: 0 0 0 5px color-mix(in srgb, var(--danger) 10%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dictationButtonRecording {
+    animation: none;
+  }
 }
 
 /* Shared pill chrome used by the agent and model switchers sitting side-by-side

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1811,6 +1811,9 @@ aside[data-state="collapsed"] .chatSidebarContent {
   position: absolute;
   right: 0;
   bottom: calc(100% + 8px);
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
   width: max-content;
   max-width: min(320px, calc(100vw - 48px));
   padding: 5px 9px;
@@ -1827,6 +1830,22 @@ aside[data-state="collapsed"] .chatSidebarContent {
   color: var(--danger);
 }
 
+.dictationWave {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  height: 14px;
+}
+
+.dictationWave > span {
+  width: 2px;
+  height: 12px;
+  border-radius: 999px;
+  background: currentColor;
+  transform: scaleY(var(--dictation-scale));
+  transition: transform 75ms linear;
+}
+
 @keyframes dictationPulse {
   50% {
     box-shadow: 0 0 0 5px color-mix(in srgb, var(--danger) 10%, transparent);
@@ -1836,6 +1855,10 @@ aside[data-state="collapsed"] .chatSidebarContent {
 @media (prefers-reduced-motion: reduce) {
   .dictationButtonRecording {
     animation: none;
+  }
+
+  .dictationWave > span {
+    transition: none;
   }
 }
 

--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -120,6 +120,10 @@ vi.mock('../../api/chat', () => ({
     token: string,
     params: { channelId?: string; keepSessionId?: string },
   ) => cleanupNoUserChatSessionsMock(token, params),
+  fetchMediaCapabilities: vi.fn(async () => ({
+    dictation: false,
+    readAloud: false,
+  })),
   fetchAppStatus: (token: string) => fetchAppStatusMock(token),
   fetchChatRecent: (
     token: string,

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -11,6 +11,7 @@ import type {
   ChatCommandSuggestion,
   ChatCommandsResponse,
   DictationTranscriptionResponse,
+  MediaCapabilitiesResponse,
   MediaItem,
 } from '../../api/chat-types';
 import { HttpResponseError } from '../../api/client';
@@ -30,12 +31,15 @@ const transcribeDictationMock =
       signal?: AbortSignal,
     ) => Promise<DictationTranscriptionResponse>
   >();
+const fetchMediaCapabilitiesMock =
+  vi.fn<(token: string) => Promise<MediaCapabilitiesResponse>>();
 
 vi.mock('../../api/chat', () => ({
   fetchAgentAvatarBlob: (token: string, imageUrl: string) =>
     fetchAgentAvatarBlobMock(token, imageUrl),
   fetchChatCommands: (token: string, query?: string) =>
     fetchChatCommandsMock(token, query),
+  fetchMediaCapabilities: (token: string) => fetchMediaCapabilitiesMock(token),
   transcribeDictation: (token: string, recording: Blob, signal?: AbortSignal) =>
     transcribeDictationMock(token, recording, signal),
 }));
@@ -76,6 +80,11 @@ describe('Composer', () => {
   beforeEach(() => {
     fetchAgentAvatarBlobMock.mockReset();
     fetchChatCommandsMock.mockReset();
+    fetchMediaCapabilitiesMock.mockReset();
+    fetchMediaCapabilitiesMock.mockResolvedValue({
+      dictation: true,
+      readAloud: true,
+    });
     transcribeDictationMock.mockReset();
     Object.defineProperty(URL, 'createObjectURL', {
       configurable: true,
@@ -90,59 +99,6 @@ describe('Composer', () => {
     clearAgentAvatarUrlCacheForTest();
   });
 
-  it('uses browser speech recognition and keeps the transcript editable', async () => {
-    class FakeSpeechRecognition {
-      continuous = false;
-      interimResults = false;
-      lang = '';
-      onend: ((event: Event) => void) | null = null;
-      onerror: ((event: Event) => void) | null = null;
-      onresult: ((event: Event) => void) | null = null;
-      onstart: ((event: Event) => void) | null = null;
-
-      start() {
-        this.onstart?.(new Event('start'));
-      }
-
-      stop() {
-        const result = {
-          0: { transcript: 'browser dictated message' },
-          length: 1,
-        };
-        this.onresult?.(
-          Object.assign(new Event('result'), {
-            resultIndex: 0,
-            results: { 0: result, length: 1 },
-          }),
-        );
-        this.onend?.(new Event('end'));
-      }
-
-      abort() {
-        this.onend?.(new Event('end'));
-      }
-    }
-
-    vi.stubGlobal('SpeechRecognition', FakeSpeechRecognition);
-    const onSend = vi.fn();
-
-    try {
-      renderComposer({ onSend });
-      fireEvent.click(screen.getByRole('button', { name: 'Voice input' }));
-      await screen.findByRole('button', { name: 'Stop recording' });
-      fireEvent.click(screen.getByRole('button', { name: 'Stop recording' }));
-
-      await waitFor(() =>
-        expect(getTextarea().value).toBe('browser dictated message'),
-      );
-      expect(transcribeDictationMock).not.toHaveBeenCalled();
-      expect(onSend).not.toHaveBeenCalled();
-      expect(document.activeElement).toBe(getTextarea());
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-
   it('inserts dictated text for review without sending it', async () => {
     const originalMediaDevices = Object.getOwnPropertyDescriptor(
       navigator,
@@ -152,6 +108,8 @@ describe('Composer', () => {
     const stream = {
       getTracks: () => [{ stop: stopTrack }],
     } as unknown as MediaStream;
+    const getUserMedia = vi.fn(async () => stream);
+    const recorderStart = vi.fn();
 
     class FakeMediaRecorder {
       static isTypeSupported = vi.fn((type: string) => type === 'audio/mp4');
@@ -165,14 +123,15 @@ describe('Composer', () => {
         this.mimeType = options?.mimeType || '';
       }
 
-      start() {
+      start(timeslice?: number) {
         this.state = 'recording';
+        recorderStart(timeslice);
       }
 
       stop() {
         this.state = 'inactive';
         this.ondataavailable?.({
-          data: new Blob(['voice'], { type: this.mimeType }),
+          data: new Blob(['voice'.repeat(20)], { type: this.mimeType }),
         } as BlobEvent);
         this.onstop?.(new Event('stop'));
       }
@@ -180,7 +139,7 @@ describe('Composer', () => {
 
     Object.defineProperty(navigator, 'mediaDevices', {
       configurable: true,
-      value: { getUserMedia: vi.fn(async () => stream) },
+      value: { getUserMedia },
     });
     vi.stubGlobal(
       'MediaRecorder',
@@ -193,7 +152,11 @@ describe('Composer', () => {
 
     try {
       renderComposer({ onSend });
-      fireEvent.click(screen.getByRole('button', { name: 'Voice input' }));
+      const voiceInput = screen.getByRole('button', { name: 'Voice input' });
+      await waitFor(() =>
+        expect(voiceInput.hasAttribute('disabled')).toBe(false),
+      );
+      fireEvent.click(voiceInput);
       await screen.findByRole('button', { name: 'Stop recording' });
       fireEvent.click(screen.getByRole('button', { name: 'Stop recording' }));
 
@@ -204,6 +167,14 @@ describe('Composer', () => {
         expect.any(AbortSignal),
       );
       expect(onSend).not.toHaveBeenCalled();
+      expect(getUserMedia).toHaveBeenCalledWith({
+        audio: {
+          noiseSuppression: { ideal: true },
+          echoCancellation: { ideal: true },
+          autoGainControl: { ideal: true },
+        },
+      });
+      expect(recorderStart).toHaveBeenCalledWith(1_000);
       expect(document.activeElement).toBe(getTextarea());
       expect(stopTrack).toHaveBeenCalled();
 
@@ -244,7 +215,11 @@ describe('Composer', () => {
 
     try {
       renderComposer();
-      fireEvent.click(screen.getByRole('button', { name: 'Voice input' }));
+      const voiceInput = screen.getByRole('button', { name: 'Voice input' });
+      await waitFor(() =>
+        expect(voiceInput.hasAttribute('disabled')).toBe(false),
+      );
+      fireEvent.click(voiceInput);
 
       expect(
         await screen.findByText(

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -90,6 +90,59 @@ describe('Composer', () => {
     clearAgentAvatarUrlCacheForTest();
   });
 
+  it('uses browser speech recognition and keeps the transcript editable', async () => {
+    class FakeSpeechRecognition {
+      continuous = false;
+      interimResults = false;
+      lang = '';
+      onend: ((event: Event) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+      onresult: ((event: Event) => void) | null = null;
+      onstart: ((event: Event) => void) | null = null;
+
+      start() {
+        this.onstart?.(new Event('start'));
+      }
+
+      stop() {
+        const result = {
+          0: { transcript: 'browser dictated message' },
+          length: 1,
+        };
+        this.onresult?.(
+          Object.assign(new Event('result'), {
+            resultIndex: 0,
+            results: { 0: result, length: 1 },
+          }),
+        );
+        this.onend?.(new Event('end'));
+      }
+
+      abort() {
+        this.onend?.(new Event('end'));
+      }
+    }
+
+    vi.stubGlobal('SpeechRecognition', FakeSpeechRecognition);
+    const onSend = vi.fn();
+
+    try {
+      renderComposer({ onSend });
+      fireEvent.click(screen.getByRole('button', { name: 'Voice input' }));
+      await screen.findByRole('button', { name: 'Stop recording' });
+      fireEvent.click(screen.getByRole('button', { name: 'Stop recording' }));
+
+      await waitFor(() =>
+        expect(getTextarea().value).toBe('browser dictated message'),
+      );
+      expect(transcribeDictationMock).not.toHaveBeenCalled();
+      expect(onSend).not.toHaveBeenCalled();
+      expect(document.activeElement).toBe(getTextarea());
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('inserts dictated text for review without sending it', async () => {
     const originalMediaDevices = Object.getOwnPropertyDescriptor(
       navigator,

--- a/console/src/routes/chat/composer.test.tsx
+++ b/console/src/routes/chat/composer.test.tsx
@@ -10,8 +10,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   ChatCommandSuggestion,
   ChatCommandsResponse,
+  DictationTranscriptionResponse,
   MediaItem,
 } from '../../api/chat-types';
+import { HttpResponseError } from '../../api/client';
 import { clearAgentAvatarUrlCacheForTest } from './agent-avatar-url';
 import css from './chat-page.module.css';
 import { Composer } from './composer';
@@ -20,12 +22,22 @@ const fetchChatCommandsMock =
   vi.fn<(token: string, query?: string) => Promise<ChatCommandsResponse>>();
 const fetchAgentAvatarBlobMock =
   vi.fn<(token: string, imageUrl: string) => Promise<Blob>>();
+const transcribeDictationMock =
+  vi.fn<
+    (
+      token: string,
+      recording: Blob,
+      signal?: AbortSignal,
+    ) => Promise<DictationTranscriptionResponse>
+  >();
 
 vi.mock('../../api/chat', () => ({
   fetchAgentAvatarBlob: (token: string, imageUrl: string) =>
     fetchAgentAvatarBlobMock(token, imageUrl),
   fetchChatCommands: (token: string, query?: string) =>
     fetchChatCommandsMock(token, query),
+  transcribeDictation: (token: string, recording: Blob, signal?: AbortSignal) =>
+    transcribeDictationMock(token, recording, signal),
 }));
 
 const APPROVE: ChatCommandSuggestion = {
@@ -64,6 +76,7 @@ describe('Composer', () => {
   beforeEach(() => {
     fetchAgentAvatarBlobMock.mockReset();
     fetchChatCommandsMock.mockReset();
+    transcribeDictationMock.mockReset();
     Object.defineProperty(URL, 'createObjectURL', {
       configurable: true,
       writable: true,
@@ -75,6 +88,130 @@ describe('Composer', () => {
       value: vi.fn(),
     });
     clearAgentAvatarUrlCacheForTest();
+  });
+
+  it('inserts dictated text for review without sending it', async () => {
+    const originalMediaDevices = Object.getOwnPropertyDescriptor(
+      navigator,
+      'mediaDevices',
+    );
+    const stopTrack = vi.fn();
+    const stream = {
+      getTracks: () => [{ stop: stopTrack }],
+    } as unknown as MediaStream;
+
+    class FakeMediaRecorder {
+      static isTypeSupported = vi.fn((type: string) => type === 'audio/mp4');
+      state: RecordingState = 'inactive';
+      mimeType: string;
+      ondataavailable: ((event: BlobEvent) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+      onstop: ((event: Event) => void) | null = null;
+
+      constructor(_stream: MediaStream, options?: MediaRecorderOptions) {
+        this.mimeType = options?.mimeType || '';
+      }
+
+      start() {
+        this.state = 'recording';
+      }
+
+      stop() {
+        this.state = 'inactive';
+        this.ondataavailable?.({
+          data: new Blob(['voice'], { type: this.mimeType }),
+        } as BlobEvent);
+        this.onstop?.(new Event('stop'));
+      }
+    }
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia: vi.fn(async () => stream) },
+    });
+    vi.stubGlobal(
+      'MediaRecorder',
+      FakeMediaRecorder as unknown as typeof MediaRecorder,
+    );
+    transcribeDictationMock.mockResolvedValue({
+      text: 'dictated message',
+    });
+    const onSend = vi.fn();
+
+    try {
+      renderComposer({ onSend });
+      fireEvent.click(screen.getByRole('button', { name: 'Voice input' }));
+      await screen.findByRole('button', { name: 'Stop recording' });
+      fireEvent.click(screen.getByRole('button', { name: 'Stop recording' }));
+
+      await waitFor(() => expect(getTextarea().value).toBe('dictated message'));
+      expect(transcribeDictationMock).toHaveBeenCalledWith(
+        'test-token',
+        expect.any(Blob),
+        expect.any(AbortSignal),
+      );
+      expect(onSend).not.toHaveBeenCalled();
+      expect(document.activeElement).toBe(getTextarea());
+      expect(stopTrack).toHaveBeenCalled();
+
+      transcribeDictationMock.mockRejectedValueOnce(
+        new HttpResponseError('No speech was detected in the recording.', 422),
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Voice input' }));
+      await screen.findByRole('button', { name: 'Stop recording' });
+      fireEvent.click(screen.getByRole('button', { name: 'Stop recording' }));
+      expect(
+        await screen.findByText('No speech was detected. Please try again.'),
+      ).not.toBeNull();
+      expect(getTextarea().value).toBe('dictated message');
+    } finally {
+      vi.unstubAllGlobals();
+      if (originalMediaDevices) {
+        Object.defineProperty(navigator, 'mediaDevices', originalMediaDevices);
+      } else {
+        Reflect.deleteProperty(navigator, 'mediaDevices');
+      }
+    }
+  });
+
+  it('shows permission denial and leaves text chat usable', async () => {
+    const originalMediaDevices = Object.getOwnPropertyDescriptor(
+      navigator,
+      'mediaDevices',
+    );
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        getUserMedia: vi.fn(async () => {
+          throw new DOMException('denied', 'NotAllowedError');
+        }),
+      },
+    });
+    vi.stubGlobal('MediaRecorder', class {} as unknown as typeof MediaRecorder);
+
+    try {
+      renderComposer();
+      fireEvent.click(screen.getByRole('button', { name: 'Voice input' }));
+
+      expect(
+        await screen.findByText(
+          'No access to the microphone. Please allow it in your browser settings.',
+        ),
+      ).not.toBeNull();
+      expect(getTextarea().hasAttribute('disabled')).toBe(false);
+      expect(
+        screen
+          .getByRole('button', { name: 'Voice input' })
+          .hasAttribute('disabled'),
+      ).toBe(false);
+    } finally {
+      vi.unstubAllGlobals();
+      if (originalMediaDevices) {
+        Object.defineProperty(navigator, 'mediaDevices', originalMediaDevices);
+      } else {
+        Reflect.deleteProperty(navigator, 'mediaDevices');
+      }
+    }
   });
 
   it('strips the leading slash before fetching command suggestions', async () => {

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -1,3 +1,10 @@
+/**
+ * Webchat composer — keeps drafts, attachments, mentions, and dictation under
+ * user control until an explicit send action.
+ *
+ * NOT the chat transport; it prepares reviewed input and delegates submission.
+ */
+
 import {
   type ChangeEvent,
   type ClipboardEvent,
@@ -23,6 +30,7 @@ import {
   AgentSwitchSelect,
 } from './agent-switch-select';
 import css from './chat-page.module.css';
+import { DictationControl } from './dictation-control';
 import {
   type ModelSwitchEntry,
   ModelSwitchSelect,
@@ -401,6 +409,31 @@ export function Composer(props: {
     [closePanel, resize, restoreComposerFocusAt],
   );
 
+  const insertDictationTranscript = useCallback(
+    (transcript: string) => {
+      const ta = textareaRef.current;
+      const normalized = transcript.trim();
+      if (!ta || !normalized) return;
+
+      const selectionStart = ta.selectionStart ?? ta.value.length;
+      const selectionEnd = ta.selectionEnd ?? selectionStart;
+      const before = ta.value.slice(0, selectionStart);
+      const after = ta.value.slice(selectionEnd);
+      const leadingSpace = before && !/\s$/u.test(before) ? ' ' : '';
+      const trailingSpace = after && !/^\s/u.test(after) ? ' ' : '';
+      const inserted = `${leadingSpace}${normalized}${trailingSpace}`;
+      ta.value = `${before}${inserted}${after}`;
+      const nextCursor = before.length + inserted.length;
+      ta.setSelectionRange(nextCursor, nextCursor);
+      setComposerValue(ta.value);
+      setComposerCaretIndex(nextCursor);
+      closePanel();
+      resize();
+      restoreComposerFocusAt(nextCursor);
+    },
+    [closePanel, resize, restoreComposerFocusAt],
+  );
+
   const submit = () => {
     if (props.isStreaming) {
       props.onStop();
@@ -617,39 +650,49 @@ export function Composer(props: {
                 onSwitch={(modelId) => props.onModelSwitch?.(modelId)}
               />
             </div>
-            <button
-              type="button"
-              className={cx(css.sendButton, props.isStreaming && css.stopping)}
-              onClick={submit}
-              aria-label={props.isStreaming ? 'Stop' : 'Send message'}
-            >
-              {props.isStreaming ? (
-                <svg
-                  viewBox="0 0 24 24"
-                  width="16"
-                  height="16"
-                  fill="currentColor"
-                  aria-hidden="true"
-                >
-                  <rect x="6" y="6" width="12" height="12" rx="2" />
-                </svg>
-              ) : (
-                <svg
-                  viewBox="0 0 24 24"
-                  width="16"
-                  height="16"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2.4"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  aria-hidden="true"
-                >
-                  <path d="M12 19V5" />
-                  <path d="m5 12 7-7 7 7" />
-                </svg>
-              )}
-            </button>
+            <div className={css.composerRightActions}>
+              <DictationControl
+                token={props.token}
+                disabled={props.isStreaming}
+                onTranscript={insertDictationTranscript}
+              />
+              <button
+                type="button"
+                className={cx(
+                  css.sendButton,
+                  props.isStreaming && css.stopping,
+                )}
+                onClick={submit}
+                aria-label={props.isStreaming ? 'Stop' : 'Send message'}
+              >
+                {props.isStreaming ? (
+                  <svg
+                    viewBox="0 0 24 24"
+                    width="16"
+                    height="16"
+                    fill="currentColor"
+                    aria-hidden="true"
+                  >
+                    <rect x="6" y="6" width="12" height="12" rx="2" />
+                  </svg>
+                ) : (
+                  <svg
+                    viewBox="0 0 24 24"
+                    width="16"
+                    height="16"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2.4"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <path d="M12 19V5" />
+                    <path d="m5 12 7-7 7 7" />
+                  </svg>
+                )}
+              </button>
+            </div>
             <input
               ref={fileInputRef}
               type="file"

--- a/console/src/routes/chat/dictation-control.tsx
+++ b/console/src/routes/chat/dictation-control.tsx
@@ -1,11 +1,10 @@
 /**
- * Dictation control — owns one explicit, cancellable microphone session.
+ * Dictation control — owns one explicit, cancellable microphone recording.
  *
- * Browser speech recognition handles the common Chrome/Safari path; browsers
- * without it record into HybridClaw's authenticated transcription route.
- * Either path returns editable composer text and never sends it automatically.
+ * Every take goes through HybridClaw's authenticated transcription route and
+ * returns editable composer text; raw audio is never attached or auto-sent.
  *
- * NOT a send action or realtime voice session; it never submits chat content.
+ * NOT browser speech recognition or a realtime voice session.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -13,72 +12,27 @@ import { transcribeDictation } from '../../api/chat';
 import { HttpResponseError } from '../../api/client';
 import { cx } from '../../lib/cx';
 import css from './chat-page.module.css';
+import { DictationWave } from './dictation-wave';
+import { useMediaCapabilities } from './media-capabilities';
 import { getSpeechCopy } from './speech-copy';
 
 type DictationState = 'idle' | 'requesting' | 'recording' | 'transcribing';
 
-interface BrowserSpeechRecognitionAlternative {
-  transcript: string;
-}
-
-interface BrowserSpeechRecognitionResult {
-  readonly length: number;
-  readonly [index: number]: BrowserSpeechRecognitionAlternative;
-}
-
-interface BrowserSpeechRecognitionResultList {
-  readonly length: number;
-  readonly [index: number]: BrowserSpeechRecognitionResult;
-}
-
-interface BrowserSpeechRecognitionEvent extends Event {
-  resultIndex: number;
-  results: BrowserSpeechRecognitionResultList;
-}
-
-interface BrowserSpeechRecognitionErrorEvent extends Event {
-  error: string;
-}
-
-interface BrowserSpeechRecognition {
-  continuous: boolean;
-  interimResults: boolean;
-  lang: string;
-  onend: ((event: Event) => void) | null;
-  onerror: ((event: BrowserSpeechRecognitionErrorEvent) => void) | null;
-  onresult: ((event: BrowserSpeechRecognitionEvent) => void) | null;
-  onstart: ((event: Event) => void) | null;
-  abort(): void;
-  start(): void;
-  stop(): void;
-}
-
-type BrowserSpeechRecognitionConstructor = new () => BrowserSpeechRecognition;
-
-// 120s (Codex implementation call, 2026-07-29): enough for composer
-// dictation while bounding forgotten recordings; configurable durations and
-// realtime voice activity detection are deliberately deferred.
-const MAX_DICTATION_DURATION_MS = 120_000;
+// Recording defaults (maintainer decision, 2026-07-29): user-selectable
+// thresholds are deliberately deferred until HybridClaw has a general voice
+// settings surface.
+const MAX_DICTATION_DURATION_MS = 300_000;
+const MIN_RECORDING_BYTES = 50;
+const SPEECH_RMS_THRESHOLD = 0.1;
+const TRAILING_SILENCE_MS = 3_000;
 const MIME_TYPE_CANDIDATES = [
-  'audio/webm;codecs=opus',
   'audio/mp4',
   'audio/webm',
+  'audio/webm;codecs=opus',
   'audio/ogg;codecs=opus',
 ] as const;
 
-function getBrowserSpeechRecognitionConstructor(): BrowserSpeechRecognitionConstructor | null {
-  const speechWindow = window as Window & {
-    SpeechRecognition?: BrowserSpeechRecognitionConstructor;
-    webkitSpeechRecognition?: BrowserSpeechRecognitionConstructor;
-  };
-  return (
-    speechWindow.SpeechRecognition ??
-    speechWindow.webkitSpeechRecognition ??
-    null
-  );
-}
-
-function canRecordForServerTranscription(): boolean {
+function canRecord(): boolean {
   return (
     typeof navigator.mediaDevices?.getUserMedia === 'function' &&
     typeof window.MediaRecorder === 'function'
@@ -86,8 +40,10 @@ function canRecordForServerTranscription(): boolean {
 }
 
 function preferredMimeType(): string | undefined {
-  if (typeof window.MediaRecorder !== 'function') return undefined;
-  if (typeof window.MediaRecorder.isTypeSupported !== 'function') {
+  if (
+    typeof window.MediaRecorder !== 'function' ||
+    typeof window.MediaRecorder.isTypeSupported !== 'function'
+  ) {
     return undefined;
   }
   return MIME_TYPE_CANDIDATES.find((candidate) =>
@@ -106,68 +62,64 @@ function isPermissionDenied(error: unknown): boolean {
   );
 }
 
-function readRecognitionTranscript(
-  results: BrowserSpeechRecognitionResultList,
-): string {
-  const segments: string[] = [];
-  for (let index = 0; index < results.length; index += 1) {
-    const transcript = results[index]?.[0]?.transcript.trim();
-    if (transcript) segments.push(transcript);
-  }
-  return segments.join(' ').trim();
-}
-
 export function DictationControl(props: {
   disabled: boolean;
   onTranscript: (text: string) => void;
   token: string;
 }) {
   const copy = useMemo(() => getSpeechCopy(navigator.language), []);
-  const recognitionConstructor = getBrowserSpeechRecognitionConstructor();
-  const supported =
-    recognitionConstructor !== null || canRecordForServerTranscription();
+  const capabilities = useMediaCapabilities(props.token);
+  const browserSupported = canRecord();
+  const available = browserSupported && capabilities?.dictation === true;
   const [state, setState] = useState<DictationState>('idle');
+  const [level, setLevel] = useState(0);
   const [message, setMessage] = useState('');
-  const recognitionRef = useRef<BrowserSpeechRecognition | null>(null);
-  const recognitionTranscriptRef = useRef('');
   const recorderRef = useRef<MediaRecorder | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const chunksRef = useRef<Blob[]>([]);
   const requestSequenceRef = useRef(0);
-  const timeoutRef = useRef<number | null>(null);
+  const maxTimerRef = useRef<number | null>(null);
+  const silenceTimerRef = useRef<number | null>(null);
+  const animationFrameRef = useRef<number | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
   const transcriptionAbortRef = useRef<AbortController | null>(null);
   const mountedRef = useRef(true);
 
-  const clearTimeoutRef = useCallback(() => {
-    if (timeoutRef.current === null) return;
-    window.clearTimeout(timeoutRef.current);
-    timeoutRef.current = null;
+  const clearTimers = useCallback(() => {
+    if (maxTimerRef.current !== null) {
+      window.clearTimeout(maxTimerRef.current);
+      maxTimerRef.current = null;
+    }
+    if (silenceTimerRef.current !== null) {
+      window.clearTimeout(silenceTimerRef.current);
+      silenceTimerRef.current = null;
+    }
+  }, []);
+
+  const stopAnalysis = useCallback(() => {
+    if (animationFrameRef.current !== null) {
+      window.cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
+    }
+    void audioContextRef.current?.close().catch(() => undefined);
+    audioContextRef.current = null;
+    if (mountedRef.current) setLevel(0);
   }, []);
 
   const resetRecording = useCallback(() => {
-    clearTimeoutRef();
+    clearTimers();
+    stopAnalysis();
     recorderRef.current = null;
     stopTracks(streamRef.current);
     streamRef.current = null;
-  }, [clearTimeoutRef]);
-
-  const resetRecognition = useCallback(() => {
-    clearTimeoutRef();
-    const recognition = recognitionRef.current;
-    recognitionRef.current = null;
-    if (!recognition) return;
-    recognition.onstart = null;
-    recognition.onresult = null;
-    recognition.onerror = null;
-    recognition.onend = null;
-  }, [clearTimeoutRef]);
+  }, [clearTimers, stopAnalysis]);
 
   const transcribe = useCallback(
     async (chunks: Blob[], mimeType: string) => {
       const recording = new Blob(chunks, {
         type: mimeType || 'audio/webm',
       });
-      if (recording.size === 0) {
+      if (recording.size <= MIN_RECORDING_BYTES) {
         if (mountedRef.current) {
           setState('idle');
           setMessage(copy.noSpeech);
@@ -212,118 +164,98 @@ export function DictationControl(props: {
   );
 
   const stopRecording = useCallback(() => {
-    clearTimeoutRef();
+    clearTimers();
     const recorder = recorderRef.current;
     if (!recorder || recorder.state === 'inactive') return;
+    setState('transcribing');
+    setMessage(copy.transcribing);
     recorder.stop();
-  }, [clearTimeoutRef]);
+  }, [clearTimers, copy.transcribing]);
 
-  const startBrowserRecognition = useCallback(() => {
-    if (!recognitionConstructor || props.disabled) return;
-    const sequence = ++requestSequenceRef.current;
-    setState('requesting');
-    setMessage(copy.requestingMic);
+  const startLevelAnalysis = useCallback(
+    (stream: MediaStream, recorder: MediaRecorder) => {
+      try {
+        const AudioContextConstructor =
+          window.AudioContext ??
+          (
+            window as Window & {
+              webkitAudioContext?: typeof AudioContext;
+            }
+          ).webkitAudioContext;
+        if (!AudioContextConstructor) return;
 
-    const recognition = new recognitionConstructor();
-    let errorMessage = '';
-    recognitionRef.current = recognition;
-    recognitionTranscriptRef.current = '';
-    recognition.lang = navigator.language || 'en-US';
-    recognition.continuous = false;
-    recognition.interimResults = true;
-    recognition.onstart = () => {
-      if (
-        !mountedRef.current ||
-        sequence !== requestSequenceRef.current ||
-        recognitionRef.current !== recognition
-      ) {
-        recognition.abort();
-        return;
-      }
-      setState('recording');
-      setMessage(copy.listening);
-    };
-    recognition.onresult = (event) => {
-      recognitionTranscriptRef.current = readRecognitionTranscript(
-        event.results,
-      );
-    };
-    recognition.onerror = (event) => {
-      if (event.error === 'aborted') return;
-      if (
-        event.error === 'not-allowed' ||
-        event.error === 'service-not-allowed'
-      ) {
-        errorMessage = copy.micDenied;
-        return;
-      }
-      errorMessage =
-        event.error === 'no-speech' ? copy.noSpeech : copy.micFailed;
-    };
-    recognition.onend = () => {
-      const transcript = recognitionTranscriptRef.current.trim();
-      resetRecognition();
-      if (!mountedRef.current || sequence !== requestSequenceRef.current) {
-        return;
-      }
-      setState('idle');
-      if (errorMessage) {
-        setMessage(errorMessage);
-        return;
-      }
-      if (!transcript) {
-        setMessage(copy.noSpeech);
-        return;
-      }
-      setMessage('');
-      props.onTranscript(transcript);
-    };
+        const audioContext = new AudioContextConstructor();
+        audioContextRef.current = audioContext;
+        const analyser = audioContext.createAnalyser();
+        analyser.fftSize = 2_048;
+        audioContext.createMediaStreamSource(stream).connect(analyser);
+        const samples = new Float32Array(analyser.fftSize);
+        let speechSeen = false;
 
-    try {
-      recognition.start();
-      timeoutRef.current = window.setTimeout(() => {
-        if (recognitionRef.current !== recognition) return;
-        setState('transcribing');
-        setMessage(copy.transcribing);
-        recognition.stop();
-      }, MAX_DICTATION_DURATION_MS);
-    } catch (error) {
-      resetRecognition();
-      if (!mountedRef.current || sequence !== requestSequenceRef.current) {
-        return;
-      }
-      setState('idle');
-      setMessage(isPermissionDenied(error) ? copy.micDenied : copy.micFailed);
-    }
-  }, [
-    copy,
-    props.disabled,
-    props.onTranscript,
-    recognitionConstructor,
-    resetRecognition,
-  ]);
+        const sample = () => {
+          if (recorder.state === 'inactive') return;
+          analyser.getFloatTimeDomainData(samples);
+          let sumSquares = 0;
+          for (const amplitude of samples) {
+            sumSquares += amplitude * amplitude;
+          }
+          const rms = Math.sqrt(sumSquares / samples.length);
+          setLevel(Math.min(1, rms * 4));
 
-  const startServerRecording = useCallback(async () => {
-    if (!canRecordForServerTranscription() || props.disabled) return;
+          if (rms > SPEECH_RMS_THRESHOLD) {
+            speechSeen = true;
+            if (silenceTimerRef.current !== null) {
+              window.clearTimeout(silenceTimerRef.current);
+              silenceTimerRef.current = null;
+            }
+          } else if (speechSeen && silenceTimerRef.current === null) {
+            silenceTimerRef.current = window.setTimeout(
+              stopRecording,
+              TRAILING_SILENCE_MS,
+            );
+          }
+          animationFrameRef.current = window.requestAnimationFrame(sample);
+        };
+        animationFrameRef.current = window.requestAnimationFrame(sample);
+      } catch {
+        stopAnalysis();
+      }
+    },
+    [stopAnalysis, stopRecording],
+  );
+
+  const startRecording = useCallback(async () => {
+    if (!available || props.disabled) return;
     const sequence = ++requestSequenceRef.current;
     setState('requesting');
     setMessage(copy.requestingMic);
 
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          noiseSuppression: { ideal: true },
+          echoCancellation: { ideal: true },
+          autoGainControl: { ideal: true },
+        },
+      });
       if (!mountedRef.current || sequence !== requestSequenceRef.current) {
         stopTracks(stream);
         return;
       }
 
       const mimeType = preferredMimeType();
-      const recorder = mimeType
-        ? new MediaRecorder(stream, { mimeType })
-        : new MediaRecorder(stream);
+      let recorder: MediaRecorder;
+      try {
+        recorder = mimeType
+          ? new MediaRecorder(stream, { mimeType })
+          : new MediaRecorder(stream);
+      } catch {
+        recorder = new MediaRecorder(stream);
+      }
+
       streamRef.current = stream;
       recorderRef.current = recorder;
       chunksRef.current = [];
-
       recorder.ondataavailable = (event) => {
         if (event.data.size > 0) chunksRef.current.push(event.data);
       };
@@ -345,10 +277,11 @@ export function DictationControl(props: {
         void transcribe(chunks, recordedMimeType);
       };
 
-      recorder.start();
+      recorder.start(1_000);
       setState('recording');
       setMessage(copy.listening);
-      timeoutRef.current = window.setTimeout(
+      startLevelAnalysis(stream, recorder);
+      maxTimerRef.current = window.setTimeout(
         stopRecording,
         MAX_DICTATION_DURATION_MS,
       );
@@ -360,36 +293,20 @@ export function DictationControl(props: {
       setState('idle');
       setMessage(isPermissionDenied(error) ? copy.micDenied : copy.micFailed);
     }
-  }, [copy, props.disabled, resetRecording, stopRecording, transcribe]);
+  }, [
+    copy,
+    props.disabled,
+    resetRecording,
+    startLevelAnalysis,
+    stopRecording,
+    available,
+    transcribe,
+  ]);
 
-  const stopDictation = useCallback(() => {
-    const recognition = recognitionRef.current;
-    if (recognition) {
-      clearTimeoutRef();
-      setState('transcribing');
-      setMessage(copy.transcribing);
-      recognition.stop();
-      return;
-    }
-    stopRecording();
-  }, [clearTimeoutRef, copy.transcribing, stopRecording]);
-
-  const startDictation = useCallback(() => {
-    if (recognitionConstructor) {
-      startBrowserRecognition();
-      return;
-    }
-    void startServerRecording();
-  }, [recognitionConstructor, startBrowserRecognition, startServerRecording]);
-
-  const cancel = useCallback(() => {
+  const releaseRecording = useCallback(() => {
     requestSequenceRef.current += 1;
     transcriptionAbortRef.current?.abort();
     transcriptionAbortRef.current = null;
-    const recognition = recognitionRef.current;
-    resetRecognition();
-    recognitionTranscriptRef.current = '';
-    recognition?.abort();
     const recorder = recorderRef.current;
     recorderRef.current = null;
     if (recorder && recorder.state !== 'inactive') {
@@ -400,9 +317,13 @@ export function DictationControl(props: {
     }
     resetRecording();
     chunksRef.current = [];
+  }, [resetRecording]);
+
+  const cancel = useCallback(() => {
+    releaseRecording();
     setState('idle');
     setMessage('');
-  }, [resetRecognition, resetRecording]);
+  }, [releaseRecording]);
 
   useEffect(() => {
     if (props.disabled && state !== 'idle') cancel();
@@ -411,43 +332,29 @@ export function DictationControl(props: {
   useEffect(() => {
     return () => {
       mountedRef.current = false;
-      requestSequenceRef.current += 1;
-      transcriptionAbortRef.current?.abort();
-      const recognition = recognitionRef.current;
-      resetRecognition();
-      recognition?.abort();
-      const recorder = recorderRef.current;
-      recorderRef.current = null;
-      if (recorder && recorder.state !== 'inactive') {
-        recorder.ondataavailable = null;
-        recorder.onstop = null;
-        recorder.onerror = null;
-        recorder.stop();
-      }
-      resetRecording();
+      releaseRecording();
     };
-  }, [resetRecognition, resetRecording]);
+  }, [releaseRecording]);
 
   const handleClick = () => {
     if (state === 'idle') {
-      startDictation();
-      return;
+      void startRecording();
+    } else if (state === 'recording') {
+      stopRecording();
+    } else {
+      cancel();
     }
-    if (state === 'recording') {
-      stopDictation();
-      return;
-    }
-    cancel();
   };
 
-  const label =
-    state === 'recording'
-      ? copy.stopDictation
-      : state === 'requesting' || state === 'transcribing'
-        ? copy.cancelDictation
-        : supported
-          ? copy.dictate
-          : copy.micUnsupported;
+  const label = !browserSupported
+    ? copy.micUnsupported
+    : capabilities?.dictation === false
+      ? copy.micUnavailable
+      : state === 'recording'
+        ? copy.stopDictation
+        : state === 'requesting' || state === 'transcribing'
+          ? copy.cancelDictation
+          : copy.dictate;
 
   return (
     <>
@@ -460,25 +367,38 @@ export function DictationControl(props: {
         onClick={handleClick}
         aria-label={label}
         aria-pressed={state === 'recording'}
-        disabled={props.disabled || !supported}
+        disabled={props.disabled || !available}
         title={label}
+        data-dictation-state={state}
       >
-        <svg
-          viewBox="0 0 24 24"
-          width="17"
-          height="17"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <rect x="9" y="2" width="6" height="12" rx="3" />
-          <path d="M5 10a7 7 0 0 0 14 0" />
-          <path d="M12 17v5" />
-          <path d="M8 22h8" />
-        </svg>
+        {state === 'recording' ? (
+          <svg
+            viewBox="0 0 24 24"
+            width="14"
+            height="14"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <rect x="6" y="6" width="12" height="12" rx="2" />
+          </svg>
+        ) : (
+          <svg
+            viewBox="0 0 24 24"
+            width="17"
+            height="17"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="9" y="2" width="6" height="12" rx="3" />
+            <path d="M5 10a7 7 0 0 0 14 0" />
+            <path d="M12 17v5" />
+            <path d="M8 22h8" />
+          </svg>
+        )}
       </button>
       {message ? (
         <span
@@ -489,7 +409,8 @@ export function DictationControl(props: {
           role="status"
           aria-live="polite"
         >
-          {message}
+          {state === 'recording' ? <DictationWave level={level} /> : null}
+          <span>{message}</span>
         </span>
       ) : null}
     </>

--- a/console/src/routes/chat/dictation-control.tsx
+++ b/console/src/routes/chat/dictation-control.tsx
@@ -193,7 +193,7 @@ export function DictationControl(props: {
         let speechSeen = false;
 
         const sample = () => {
-          if (recorder.state === 'inactive') return;
+          if (!mountedRef.current || recorder.state === 'inactive') return;
           analyser.getFloatTimeDomainData(samples);
           let sumSquares = 0;
           for (const amplitude of samples) {

--- a/console/src/routes/chat/dictation-control.tsx
+++ b/console/src/routes/chat/dictation-control.tsx
@@ -1,0 +1,315 @@
+/**
+ * Dictation control — owns one explicit, cancellable microphone recording.
+ *
+ * Recordings are sent only to HybridClaw's authenticated transcription route,
+ * then the returned text is handed to the composer for review and editing.
+ *
+ * NOT a send action or realtime voice session; it never submits chat content.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { transcribeDictation } from '../../api/chat';
+import { HttpResponseError } from '../../api/client';
+import { cx } from '../../lib/cx';
+import css from './chat-page.module.css';
+import { getSpeechCopy } from './speech-copy';
+
+type DictationState = 'idle' | 'requesting' | 'recording' | 'transcribing';
+
+// 120s (Codex implementation call, 2026-07-29): enough for composer
+// dictation while bounding forgotten recordings; configurable durations and
+// realtime voice activity detection are deliberately deferred.
+const MAX_DICTATION_DURATION_MS = 120_000;
+const MIME_TYPE_CANDIDATES = [
+  'audio/webm;codecs=opus',
+  'audio/mp4',
+  'audio/webm',
+  'audio/ogg;codecs=opus',
+] as const;
+
+function canRecordAudio(): boolean {
+  return (
+    typeof navigator.mediaDevices?.getUserMedia === 'function' &&
+    typeof window.MediaRecorder === 'function'
+  );
+}
+
+function preferredMimeType(): string | undefined {
+  if (typeof window.MediaRecorder !== 'function') return undefined;
+  if (typeof window.MediaRecorder.isTypeSupported !== 'function') {
+    return undefined;
+  }
+  return MIME_TYPE_CANDIDATES.find((candidate) =>
+    window.MediaRecorder.isTypeSupported(candidate),
+  );
+}
+
+function stopTracks(stream: MediaStream | null): void {
+  for (const track of stream?.getTracks() ?? []) track.stop();
+}
+
+function isPermissionDenied(error: unknown): boolean {
+  return (
+    error instanceof DOMException &&
+    (error.name === 'NotAllowedError' || error.name === 'SecurityError')
+  );
+}
+
+export function DictationControl(props: {
+  disabled: boolean;
+  onTranscript: (text: string) => void;
+  token: string;
+}) {
+  const copy = useMemo(() => getSpeechCopy(navigator.language), []);
+  const supported = canRecordAudio();
+  const [state, setState] = useState<DictationState>('idle');
+  const [message, setMessage] = useState('');
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const requestSequenceRef = useRef(0);
+  const timeoutRef = useRef<number | null>(null);
+  const transcriptionAbortRef = useRef<AbortController | null>(null);
+  const mountedRef = useRef(true);
+
+  const clearTimeoutRef = useCallback(() => {
+    if (timeoutRef.current === null) return;
+    window.clearTimeout(timeoutRef.current);
+    timeoutRef.current = null;
+  }, []);
+
+  const resetRecording = useCallback(() => {
+    clearTimeoutRef();
+    recorderRef.current = null;
+    stopTracks(streamRef.current);
+    streamRef.current = null;
+  }, [clearTimeoutRef]);
+
+  const transcribe = useCallback(
+    async (chunks: Blob[], mimeType: string) => {
+      const recording = new Blob(chunks, {
+        type: mimeType || 'audio/webm',
+      });
+      if (recording.size === 0) {
+        if (mountedRef.current) {
+          setState('idle');
+          setMessage(copy.noSpeech);
+        }
+        return;
+      }
+
+      const abortController = new AbortController();
+      transcriptionAbortRef.current = abortController;
+      setState('transcribing');
+      setMessage(copy.transcribing);
+      try {
+        const result = await transcribeDictation(
+          props.token,
+          recording,
+          abortController.signal,
+        );
+        if (!mountedRef.current || abortController.signal.aborted) return;
+        const text = result.text.trim();
+        setState('idle');
+        if (!text) {
+          setMessage(copy.noSpeech);
+          return;
+        }
+        setMessage('');
+        props.onTranscript(text);
+      } catch (error) {
+        if (!mountedRef.current || abortController.signal.aborted) return;
+        setState('idle');
+        setMessage(
+          error instanceof HttpResponseError && error.status === 422
+            ? copy.noSpeech
+            : copy.micFailed,
+        );
+      } finally {
+        if (transcriptionAbortRef.current === abortController) {
+          transcriptionAbortRef.current = null;
+        }
+      }
+    },
+    [copy, props.onTranscript, props.token],
+  );
+
+  const stopRecording = useCallback(() => {
+    clearTimeoutRef();
+    const recorder = recorderRef.current;
+    if (!recorder || recorder.state === 'inactive') return;
+    recorder.stop();
+  }, [clearTimeoutRef]);
+
+  const startRecording = useCallback(async () => {
+    if (!supported || props.disabled) return;
+    const sequence = ++requestSequenceRef.current;
+    setState('requesting');
+    setMessage(copy.requestingMic);
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      if (!mountedRef.current || sequence !== requestSequenceRef.current) {
+        stopTracks(stream);
+        return;
+      }
+
+      const mimeType = preferredMimeType();
+      const recorder = mimeType
+        ? new MediaRecorder(stream, { mimeType })
+        : new MediaRecorder(stream);
+      streamRef.current = stream;
+      recorderRef.current = recorder;
+      chunksRef.current = [];
+
+      recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) chunksRef.current.push(event.data);
+      };
+      recorder.onerror = () => {
+        recorder.ondataavailable = null;
+        recorder.onstop = null;
+        recorder.onerror = null;
+        resetRecording();
+        if (!mountedRef.current) return;
+        setState('idle');
+        setMessage(copy.micFailed);
+      };
+      recorder.onstop = () => {
+        const chunks = chunksRef.current;
+        chunksRef.current = [];
+        const recordedMimeType = recorder.mimeType || mimeType || 'audio/webm';
+        resetRecording();
+        if (!mountedRef.current) return;
+        void transcribe(chunks, recordedMimeType);
+      };
+
+      recorder.start();
+      setState('recording');
+      setMessage(copy.listening);
+      timeoutRef.current = window.setTimeout(
+        stopRecording,
+        MAX_DICTATION_DURATION_MS,
+      );
+    } catch (error) {
+      resetRecording();
+      if (!mountedRef.current || sequence !== requestSequenceRef.current) {
+        return;
+      }
+      setState('idle');
+      setMessage(isPermissionDenied(error) ? copy.micDenied : copy.micFailed);
+    }
+  }, [
+    copy,
+    props.disabled,
+    resetRecording,
+    stopRecording,
+    supported,
+    transcribe,
+  ]);
+
+  const cancel = useCallback(() => {
+    requestSequenceRef.current += 1;
+    transcriptionAbortRef.current?.abort();
+    transcriptionAbortRef.current = null;
+    const recorder = recorderRef.current;
+    recorderRef.current = null;
+    if (recorder && recorder.state !== 'inactive') {
+      recorder.ondataavailable = null;
+      recorder.onstop = null;
+      recorder.onerror = null;
+      recorder.stop();
+    }
+    resetRecording();
+    chunksRef.current = [];
+    setState('idle');
+    setMessage('');
+  }, [resetRecording]);
+
+  useEffect(() => {
+    if (props.disabled && state !== 'idle') cancel();
+  }, [cancel, props.disabled, state]);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      requestSequenceRef.current += 1;
+      transcriptionAbortRef.current?.abort();
+      const recorder = recorderRef.current;
+      recorderRef.current = null;
+      if (recorder && recorder.state !== 'inactive') {
+        recorder.ondataavailable = null;
+        recorder.onstop = null;
+        recorder.onerror = null;
+        recorder.stop();
+      }
+      resetRecording();
+    };
+  }, [resetRecording]);
+
+  const handleClick = () => {
+    if (state === 'idle') {
+      void startRecording();
+      return;
+    }
+    if (state === 'recording') {
+      stopRecording();
+      return;
+    }
+    cancel();
+  };
+
+  const label =
+    state === 'recording'
+      ? copy.stopDictation
+      : state === 'requesting' || state === 'transcribing'
+        ? copy.cancelDictation
+        : supported
+          ? copy.dictate
+          : copy.micUnsupported;
+
+  return (
+    <>
+      <button
+        type="button"
+        className={cx(
+          css.dictationButton,
+          state === 'recording' && css.dictationButtonRecording,
+        )}
+        onClick={handleClick}
+        aria-label={label}
+        aria-pressed={state === 'recording'}
+        disabled={props.disabled || !supported}
+        title={label}
+      >
+        <svg
+          viewBox="0 0 24 24"
+          width="17"
+          height="17"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <rect x="9" y="2" width="6" height="12" rx="3" />
+          <path d="M5 10a7 7 0 0 0 14 0" />
+          <path d="M12 17v5" />
+          <path d="M8 22h8" />
+        </svg>
+      </button>
+      {message ? (
+        <span
+          className={cx(
+            css.speechStatus,
+            state === 'recording' && css.speechStatusActive,
+          )}
+          role="status"
+          aria-live="polite"
+        >
+          {message}
+        </span>
+      ) : null}
+    </>
+  );
+}

--- a/console/src/routes/chat/dictation-control.tsx
+++ b/console/src/routes/chat/dictation-control.tsx
@@ -1,8 +1,9 @@
 /**
- * Dictation control — owns one explicit, cancellable microphone recording.
+ * Dictation control — owns one explicit, cancellable microphone session.
  *
- * Recordings are sent only to HybridClaw's authenticated transcription route,
- * then the returned text is handed to the composer for review and editing.
+ * Browser speech recognition handles the common Chrome/Safari path; browsers
+ * without it record into HybridClaw's authenticated transcription route.
+ * Either path returns editable composer text and never sends it automatically.
  *
  * NOT a send action or realtime voice session; it never submits chat content.
  */
@@ -16,6 +17,44 @@ import { getSpeechCopy } from './speech-copy';
 
 type DictationState = 'idle' | 'requesting' | 'recording' | 'transcribing';
 
+interface BrowserSpeechRecognitionAlternative {
+  transcript: string;
+}
+
+interface BrowserSpeechRecognitionResult {
+  readonly length: number;
+  readonly [index: number]: BrowserSpeechRecognitionAlternative;
+}
+
+interface BrowserSpeechRecognitionResultList {
+  readonly length: number;
+  readonly [index: number]: BrowserSpeechRecognitionResult;
+}
+
+interface BrowserSpeechRecognitionEvent extends Event {
+  resultIndex: number;
+  results: BrowserSpeechRecognitionResultList;
+}
+
+interface BrowserSpeechRecognitionErrorEvent extends Event {
+  error: string;
+}
+
+interface BrowserSpeechRecognition {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onend: ((event: Event) => void) | null;
+  onerror: ((event: BrowserSpeechRecognitionErrorEvent) => void) | null;
+  onresult: ((event: BrowserSpeechRecognitionEvent) => void) | null;
+  onstart: ((event: Event) => void) | null;
+  abort(): void;
+  start(): void;
+  stop(): void;
+}
+
+type BrowserSpeechRecognitionConstructor = new () => BrowserSpeechRecognition;
+
 // 120s (Codex implementation call, 2026-07-29): enough for composer
 // dictation while bounding forgotten recordings; configurable durations and
 // realtime voice activity detection are deliberately deferred.
@@ -27,7 +66,19 @@ const MIME_TYPE_CANDIDATES = [
   'audio/ogg;codecs=opus',
 ] as const;
 
-function canRecordAudio(): boolean {
+function getBrowserSpeechRecognitionConstructor(): BrowserSpeechRecognitionConstructor | null {
+  const speechWindow = window as Window & {
+    SpeechRecognition?: BrowserSpeechRecognitionConstructor;
+    webkitSpeechRecognition?: BrowserSpeechRecognitionConstructor;
+  };
+  return (
+    speechWindow.SpeechRecognition ??
+    speechWindow.webkitSpeechRecognition ??
+    null
+  );
+}
+
+function canRecordForServerTranscription(): boolean {
   return (
     typeof navigator.mediaDevices?.getUserMedia === 'function' &&
     typeof window.MediaRecorder === 'function'
@@ -55,15 +106,30 @@ function isPermissionDenied(error: unknown): boolean {
   );
 }
 
+function readRecognitionTranscript(
+  results: BrowserSpeechRecognitionResultList,
+): string {
+  const segments: string[] = [];
+  for (let index = 0; index < results.length; index += 1) {
+    const transcript = results[index]?.[0]?.transcript.trim();
+    if (transcript) segments.push(transcript);
+  }
+  return segments.join(' ').trim();
+}
+
 export function DictationControl(props: {
   disabled: boolean;
   onTranscript: (text: string) => void;
   token: string;
 }) {
   const copy = useMemo(() => getSpeechCopy(navigator.language), []);
-  const supported = canRecordAudio();
+  const recognitionConstructor = getBrowserSpeechRecognitionConstructor();
+  const supported =
+    recognitionConstructor !== null || canRecordForServerTranscription();
   const [state, setState] = useState<DictationState>('idle');
   const [message, setMessage] = useState('');
+  const recognitionRef = useRef<BrowserSpeechRecognition | null>(null);
+  const recognitionTranscriptRef = useRef('');
   const recorderRef = useRef<MediaRecorder | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const chunksRef = useRef<Blob[]>([]);
@@ -83,6 +149,17 @@ export function DictationControl(props: {
     recorderRef.current = null;
     stopTracks(streamRef.current);
     streamRef.current = null;
+  }, [clearTimeoutRef]);
+
+  const resetRecognition = useCallback(() => {
+    clearTimeoutRef();
+    const recognition = recognitionRef.current;
+    recognitionRef.current = null;
+    if (!recognition) return;
+    recognition.onstart = null;
+    recognition.onresult = null;
+    recognition.onerror = null;
+    recognition.onend = null;
   }, [clearTimeoutRef]);
 
   const transcribe = useCallback(
@@ -141,8 +218,93 @@ export function DictationControl(props: {
     recorder.stop();
   }, [clearTimeoutRef]);
 
-  const startRecording = useCallback(async () => {
-    if (!supported || props.disabled) return;
+  const startBrowserRecognition = useCallback(() => {
+    if (!recognitionConstructor || props.disabled) return;
+    const sequence = ++requestSequenceRef.current;
+    setState('requesting');
+    setMessage(copy.requestingMic);
+
+    const recognition = new recognitionConstructor();
+    let errorMessage = '';
+    recognitionRef.current = recognition;
+    recognitionTranscriptRef.current = '';
+    recognition.lang = navigator.language || 'en-US';
+    recognition.continuous = false;
+    recognition.interimResults = true;
+    recognition.onstart = () => {
+      if (
+        !mountedRef.current ||
+        sequence !== requestSequenceRef.current ||
+        recognitionRef.current !== recognition
+      ) {
+        recognition.abort();
+        return;
+      }
+      setState('recording');
+      setMessage(copy.listening);
+    };
+    recognition.onresult = (event) => {
+      recognitionTranscriptRef.current = readRecognitionTranscript(
+        event.results,
+      );
+    };
+    recognition.onerror = (event) => {
+      if (event.error === 'aborted') return;
+      if (
+        event.error === 'not-allowed' ||
+        event.error === 'service-not-allowed'
+      ) {
+        errorMessage = copy.micDenied;
+        return;
+      }
+      errorMessage =
+        event.error === 'no-speech' ? copy.noSpeech : copy.micFailed;
+    };
+    recognition.onend = () => {
+      const transcript = recognitionTranscriptRef.current.trim();
+      resetRecognition();
+      if (!mountedRef.current || sequence !== requestSequenceRef.current) {
+        return;
+      }
+      setState('idle');
+      if (errorMessage) {
+        setMessage(errorMessage);
+        return;
+      }
+      if (!transcript) {
+        setMessage(copy.noSpeech);
+        return;
+      }
+      setMessage('');
+      props.onTranscript(transcript);
+    };
+
+    try {
+      recognition.start();
+      timeoutRef.current = window.setTimeout(() => {
+        if (recognitionRef.current !== recognition) return;
+        setState('transcribing');
+        setMessage(copy.transcribing);
+        recognition.stop();
+      }, MAX_DICTATION_DURATION_MS);
+    } catch (error) {
+      resetRecognition();
+      if (!mountedRef.current || sequence !== requestSequenceRef.current) {
+        return;
+      }
+      setState('idle');
+      setMessage(isPermissionDenied(error) ? copy.micDenied : copy.micFailed);
+    }
+  }, [
+    copy,
+    props.disabled,
+    props.onTranscript,
+    recognitionConstructor,
+    resetRecognition,
+  ]);
+
+  const startServerRecording = useCallback(async () => {
+    if (!canRecordForServerTranscription() || props.disabled) return;
     const sequence = ++requestSequenceRef.current;
     setState('requesting');
     setMessage(copy.requestingMic);
@@ -198,19 +360,36 @@ export function DictationControl(props: {
       setState('idle');
       setMessage(isPermissionDenied(error) ? copy.micDenied : copy.micFailed);
     }
-  }, [
-    copy,
-    props.disabled,
-    resetRecording,
-    stopRecording,
-    supported,
-    transcribe,
-  ]);
+  }, [copy, props.disabled, resetRecording, stopRecording, transcribe]);
+
+  const stopDictation = useCallback(() => {
+    const recognition = recognitionRef.current;
+    if (recognition) {
+      clearTimeoutRef();
+      setState('transcribing');
+      setMessage(copy.transcribing);
+      recognition.stop();
+      return;
+    }
+    stopRecording();
+  }, [clearTimeoutRef, copy.transcribing, stopRecording]);
+
+  const startDictation = useCallback(() => {
+    if (recognitionConstructor) {
+      startBrowserRecognition();
+      return;
+    }
+    void startServerRecording();
+  }, [recognitionConstructor, startBrowserRecognition, startServerRecording]);
 
   const cancel = useCallback(() => {
     requestSequenceRef.current += 1;
     transcriptionAbortRef.current?.abort();
     transcriptionAbortRef.current = null;
+    const recognition = recognitionRef.current;
+    resetRecognition();
+    recognitionTranscriptRef.current = '';
+    recognition?.abort();
     const recorder = recorderRef.current;
     recorderRef.current = null;
     if (recorder && recorder.state !== 'inactive') {
@@ -223,7 +402,7 @@ export function DictationControl(props: {
     chunksRef.current = [];
     setState('idle');
     setMessage('');
-  }, [resetRecording]);
+  }, [resetRecognition, resetRecording]);
 
   useEffect(() => {
     if (props.disabled && state !== 'idle') cancel();
@@ -234,6 +413,9 @@ export function DictationControl(props: {
       mountedRef.current = false;
       requestSequenceRef.current += 1;
       transcriptionAbortRef.current?.abort();
+      const recognition = recognitionRef.current;
+      resetRecognition();
+      recognition?.abort();
       const recorder = recorderRef.current;
       recorderRef.current = null;
       if (recorder && recorder.state !== 'inactive') {
@@ -244,15 +426,15 @@ export function DictationControl(props: {
       }
       resetRecording();
     };
-  }, [resetRecording]);
+  }, [resetRecognition, resetRecording]);
 
   const handleClick = () => {
     if (state === 'idle') {
-      void startRecording();
+      startDictation();
       return;
     }
     if (state === 'recording') {
-      stopRecording();
+      stopDictation();
       return;
     }
     cancel();

--- a/console/src/routes/chat/dictation-wave.tsx
+++ b/console/src/routes/chat/dictation-wave.tsx
@@ -1,0 +1,44 @@
+/**
+ * Dictation waveform — maps the recorder's live input level to a calm pulse.
+ *
+ * Bars animate only with transform so recording never triggers layout work;
+ * the recorder, not this visual, decides when silence ends a take.
+ *
+ * NOT an audio analyser or recorded-waveform editor.
+ */
+
+import type { CSSProperties } from 'react';
+import css from './chat-page.module.css';
+
+const BARS = [
+  ['far-left', 0.35],
+  ['outer-left', 0.55],
+  ['mid-left', 0.8],
+  ['inner-left', 1],
+  ['center-left', 0.72],
+  ['center-right', 0.45],
+  ['inner-right', 0.64],
+  ['mid-right', 0.9],
+  ['outer-right', 0.6],
+  ['far-right', 0.4],
+] as const;
+
+export function DictationWave(props: { level: number }) {
+  return (
+    <span className={css.dictationWave} aria-hidden="true">
+      {BARS.map(([id, factor]) => (
+        <span
+          key={id}
+          style={
+            {
+              '--dictation-scale': Math.max(
+                0.18,
+                Math.min(1, props.level * factor),
+              ),
+            } as CSSProperties
+          }
+        />
+      ))}
+    </span>
+  );
+}

--- a/console/src/routes/chat/media-capabilities.test.tsx
+++ b/console/src/routes/chat/media-capabilities.test.tsx
@@ -1,0 +1,77 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  resetMediaCapabilitiesForTests,
+  useMediaCapabilities,
+} from './media-capabilities';
+
+const fetchMediaCapabilitiesMock = vi.hoisted(() =>
+  vi.fn(async (_token: string) => ({ dictation: true, readAloud: true })),
+);
+
+vi.mock('../../api/chat', () => ({
+  fetchMediaCapabilities: (token: string) => fetchMediaCapabilitiesMock(token),
+}));
+
+describe('useMediaCapabilities', () => {
+  beforeEach(() => {
+    resetMediaCapabilitiesForTests();
+    fetchMediaCapabilitiesMock.mockReset();
+    fetchMediaCapabilitiesMock.mockResolvedValue({
+      dictation: true,
+      readAloud: true,
+    });
+  });
+
+  afterEach(() => {
+    resetMediaCapabilitiesForTests();
+  });
+
+  it('probes once and shares the result across mounts for one token', async () => {
+    const first = renderHook(() => useMediaCapabilities('token-a'));
+    await waitFor(() => {
+      expect(first.result.current).toEqual({
+        dictation: true,
+        readAloud: true,
+      });
+    });
+
+    const second = renderHook(() => useMediaCapabilities('token-a'));
+    await waitFor(() => {
+      expect(second.result.current).toEqual({
+        dictation: true,
+        readAloud: true,
+      });
+    });
+    expect(fetchMediaCapabilitiesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-probes when the token changes so stale capabilities do not stick', async () => {
+    const { result, rerender } = renderHook(
+      ({ token }: { token: string }) => useMediaCapabilities(token),
+      { initialProps: { token: 'token-a' } },
+    );
+    await waitFor(() => {
+      expect(result.current).toEqual({ dictation: true, readAloud: true });
+    });
+
+    fetchMediaCapabilitiesMock.mockResolvedValue({
+      dictation: false,
+      readAloud: false,
+    });
+    rerender({ token: 'token-b' });
+    await waitFor(() => {
+      expect(result.current).toEqual({ dictation: false, readAloud: false });
+    });
+    expect(fetchMediaCapabilitiesMock).toHaveBeenCalledTimes(2);
+    expect(fetchMediaCapabilitiesMock).toHaveBeenLastCalledWith('token-b');
+  });
+
+  it('reports both capabilities unavailable when the probe fails', async () => {
+    fetchMediaCapabilitiesMock.mockRejectedValue(new Error('offline'));
+    const { result } = renderHook(() => useMediaCapabilities('token-a'));
+    await waitFor(() => {
+      expect(result.current).toEqual({ dictation: false, readAloud: false });
+    });
+  });
+});

--- a/console/src/routes/chat/media-capabilities.ts
+++ b/console/src/routes/chat/media-capabilities.ts
@@ -1,8 +1,9 @@
 /**
  * Webchat media capability cache — exposes the gateway's current audio support.
  *
- * All message controls share one authenticated probe without retaining a token;
- * failed probes remain retryable after authentication or configuration changes.
+ * All message controls share one authenticated probe per token; a token change
+ * (sign-in/out, session rotation) invalidates the cache, and failed probes
+ * remain retryable after authentication or configuration changes.
  *
  * NOT browser feature detection; microphone and audio-element support stay local.
  */
@@ -11,20 +12,30 @@ import { useEffect, useState } from 'react';
 import { fetchMediaCapabilities } from '../../api/chat';
 import type { MediaCapabilitiesResponse } from '../../api/chat-types';
 
+let cachedToken: string | null = null;
 let cachedCapabilities: MediaCapabilitiesResponse | null = null;
 let pendingCapabilities: Promise<MediaCapabilitiesResponse> | null = null;
 
 function loadCapabilities(token: string): Promise<MediaCapabilitiesResponse> {
+  // A token change (sign-in/out, session rotation) can change what the
+  // gateway reports, so the cache is only valid for the token that filled it.
+  if (token !== cachedToken) {
+    cachedToken = token;
+    cachedCapabilities = null;
+    pendingCapabilities = null;
+  }
   if (cachedCapabilities) return Promise.resolve(cachedCapabilities);
-  pendingCapabilities ??= fetchMediaCapabilities(token)
+  if (pendingCapabilities) return pendingCapabilities;
+  const pending = fetchMediaCapabilities(token)
     .then((capabilities) => {
-      cachedCapabilities = capabilities;
+      if (token === cachedToken) cachedCapabilities = capabilities;
       return capabilities;
     })
     .finally(() => {
-      pendingCapabilities = null;
+      if (pendingCapabilities === pending) pendingCapabilities = null;
     });
-  return pendingCapabilities;
+  pendingCapabilities = pending;
+  return pending;
 }
 
 export function useMediaCapabilities(
@@ -52,6 +63,7 @@ export function useMediaCapabilities(
 }
 
 export function resetMediaCapabilitiesForTests(): void {
+  cachedToken = null;
   cachedCapabilities = null;
   pendingCapabilities = null;
 }

--- a/console/src/routes/chat/media-capabilities.ts
+++ b/console/src/routes/chat/media-capabilities.ts
@@ -1,0 +1,57 @@
+/**
+ * Webchat media capability cache — exposes the gateway's current audio support.
+ *
+ * All message controls share one authenticated probe without retaining a token;
+ * failed probes remain retryable after authentication or configuration changes.
+ *
+ * NOT browser feature detection; microphone and audio-element support stay local.
+ */
+
+import { useEffect, useState } from 'react';
+import { fetchMediaCapabilities } from '../../api/chat';
+import type { MediaCapabilitiesResponse } from '../../api/chat-types';
+
+let cachedCapabilities: MediaCapabilitiesResponse | null = null;
+let pendingCapabilities: Promise<MediaCapabilitiesResponse> | null = null;
+
+function loadCapabilities(token: string): Promise<MediaCapabilitiesResponse> {
+  if (cachedCapabilities) return Promise.resolve(cachedCapabilities);
+  pendingCapabilities ??= fetchMediaCapabilities(token)
+    .then((capabilities) => {
+      cachedCapabilities = capabilities;
+      return capabilities;
+    })
+    .finally(() => {
+      pendingCapabilities = null;
+    });
+  return pendingCapabilities;
+}
+
+export function useMediaCapabilities(
+  token: string,
+): MediaCapabilitiesResponse | null {
+  const [capabilities, setCapabilities] = useState(cachedCapabilities);
+
+  useEffect(() => {
+    let mounted = true;
+    void loadCapabilities(token)
+      .then((next) => {
+        if (mounted) setCapabilities(next);
+      })
+      .catch(() => {
+        if (mounted) {
+          setCapabilities({ dictation: false, readAloud: false });
+        }
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [token]);
+
+  return capabilities;
+}
+
+export function resetMediaCapabilitiesForTests(): void {
+  cachedCapabilities = null;
+  pendingCapabilities = null;
+}

--- a/console/src/routes/chat/message-block.test.tsx
+++ b/console/src/routes/chat/message-block.test.tsx
@@ -24,6 +24,10 @@ vi.mock('../../api/chat', () => ({
     fetchAgentAvatarBlobMock(token, imageUrl),
   fetchArtifactBlob: (token: string, artifactPath: string) =>
     fetchArtifactBlobMock(token, artifactPath),
+  fetchMediaCapabilities: vi.fn(async () => ({
+    dictation: false,
+    readAloud: false,
+  })),
 }));
 
 vi.mock('../../api/client', () => ({

--- a/console/src/routes/chat/message-block.tsx
+++ b/console/src/routes/chat/message-block.tsx
@@ -582,7 +582,7 @@ export const MessageBlock = memo(function MessageBlock(props: {
           ) : null}
           {isAssistant ? (
             <>
-              <ReadAloudControl text={speechText} />
+              <ReadAloudControl text={speechText} token={token} />
               <Button
                 variant="ghost"
                 size="icon"

--- a/console/src/routes/chat/message-block.tsx
+++ b/console/src/routes/chat/message-block.tsx
@@ -1,3 +1,10 @@
+/**
+ * Chat message presentation — renders persisted/streaming turns and explicit
+ * per-message actions without changing conversation state on its own.
+ *
+ * NOT the chat stream or history store; callbacks own all durable mutations.
+ */
+
 import {
   memo,
   type ReactNode,
@@ -25,6 +32,10 @@ import { findAgentMentions } from './agent-mention-display';
 import { ApprovalCard } from './approval-card';
 import css from './chat-page.module.css';
 import type { ChatUiMessage } from './chat-ui-message';
+import {
+  ReadAloudControl,
+  textFromRenderedMarkdown,
+} from './read-aloud-control';
 import { TraceBlock } from './trace-block';
 
 const STREAM_MARKDOWN_RENDER_INTERVAL_MS = 120;
@@ -478,6 +489,7 @@ export const MessageBlock = memo(function MessageBlock(props: {
 
   const isUser = msg.role === 'user';
   const isAssistant = msg.role === 'assistant';
+  const speechText = isAssistant ? textFromRenderedMarkdown(renderedHtml) : '';
   const shouldRenderBubble =
     isUser ||
     isA2ADeliveryStatus ||
@@ -570,6 +582,7 @@ export const MessageBlock = memo(function MessageBlock(props: {
           ) : null}
           {isAssistant ? (
             <>
+              <ReadAloudControl text={speechText} />
               <Button
                 variant="ghost"
                 size="icon"

--- a/console/src/routes/chat/read-aloud-control.test.tsx
+++ b/console/src/routes/chat/read-aloud-control.test.tsx
@@ -1,56 +1,80 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ReadAloudControl,
   textFromRenderedMarkdown,
 } from './read-aloud-control';
 
-class FakeUtterance {
-  lang = '';
-  onend: (() => void) | null = null;
-  onerror: (() => void) | null = null;
+const mocks = vi.hoisted(() => ({
+  capabilities: { dictation: true, readAloud: true },
+  playback: vi.fn(),
+  unlockAudio: vi.fn(),
+}));
 
-  constructor(readonly text: string) {}
-}
+vi.mock('./audio-unlock', () => ({
+  unlockAudio: mocks.unlockAudio,
+}));
 
-function installSpeechSynthesis() {
-  const synthesis = {
-    cancel: vi.fn(),
-    speak: vi.fn(),
-  };
-  vi.stubGlobal(
-    'SpeechSynthesisUtterance',
-    FakeUtterance as unknown as typeof SpeechSynthesisUtterance,
-  );
-  vi.stubGlobal('speechSynthesis', synthesis as unknown as SpeechSynthesis);
-  return synthesis;
-}
+vi.mock('./media-capabilities', () => ({
+  useMediaCapabilities: () => mocks.capabilities,
+}));
+
+vi.mock('./speech-playback', () => ({
+  SpeechPlayback: class {
+    readonly implementation: { start: () => void; dispose: () => void };
+
+    constructor(params: unknown) {
+      this.implementation = mocks.playback(params);
+    }
+
+    start() {
+      this.implementation.start();
+    }
+
+    dispose() {
+      this.implementation.dispose();
+    }
+  },
+}));
 
 describe('ReadAloudControl', () => {
+  beforeEach(() => {
+    mocks.capabilities = { dictation: true, readAloud: true };
+    mocks.playback.mockReset();
+    mocks.unlockAudio.mockReset();
+    vi.stubGlobal('Audio', class {});
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it('starts and stops speech only from an explicit button action', () => {
-    const synthesis = installSpeechSynthesis();
-    render(<ReadAloudControl text="A concise response." />);
+  it('unlocks and starts generated speech only from an explicit action', () => {
+    const start = vi.fn();
+    const dispose = vi.fn();
+    mocks.playback.mockImplementation(() => ({ start, dispose }));
+    render(<ReadAloudControl text="A concise response." token="test-token" />);
 
-    expect(synthesis.speak).not.toHaveBeenCalled();
-    const start = screen.getByRole('button', { name: 'Read response aloud' });
-    fireEvent.click(start);
+    expect(mocks.playback).not.toHaveBeenCalled();
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Read response aloud' }),
+    );
 
-    expect(synthesis.speak).toHaveBeenCalledTimes(1);
-    const utterance = synthesis.speak.mock.calls[0]?.[0] as unknown as {
-      lang: string;
-      text: string;
+    expect(mocks.unlockAudio).toHaveBeenCalledTimes(1);
+    expect(mocks.playback).toHaveBeenCalledWith({
+      token: 'test-token',
+      text: 'A concise response.',
+      onPlaying: expect.any(Function),
+      onSettled: expect.any(Function),
+    });
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('status').textContent).toBe('Preparing audio…');
+
+    const callbacks = mocks.playback.mock.calls[0]?.[0] as {
+      onPlaying: () => void;
+      onSettled: (failed: boolean) => void;
     };
-    expect(utterance.text).toBe('A concise response.');
-    expect(utterance.lang).toBe(navigator.language);
-    expect(
-      screen
-        .getByRole('button', { name: 'Stop reading response' })
-        .getAttribute('aria-pressed'),
-    ).toBe('true');
+    act(() => callbacks.onPlaying());
     expect(screen.getByRole('status').textContent).toBe(
       'Reading response aloud…',
     );
@@ -58,41 +82,45 @@ describe('ReadAloudControl', () => {
     fireEvent.click(
       screen.getByRole('button', { name: 'Stop reading response' }),
     );
-    expect(synthesis.cancel).toHaveBeenCalled();
-    expect(
-      screen
-        .getByRole('button', { name: 'Read response aloud' })
-        .getAttribute('aria-pressed'),
-    ).toBe('false');
+    expect(dispose).toHaveBeenCalled();
+    expect(screen.queryByRole('status')).toBeNull();
   });
 
-  it('finishes cleanly when the browser reports the utterance ended', async () => {
-    const synthesis = installSpeechSynthesis();
-    render(<ReadAloudControl text="Done." />);
+  it('shows a retryable error when generated speech fails', () => {
+    mocks.playback.mockImplementation(() => ({
+      start: vi.fn(),
+      dispose: vi.fn(),
+    }));
+    render(<ReadAloudControl text="Done." token="test-token" />);
 
     fireEvent.click(
       screen.getByRole('button', { name: 'Read response aloud' }),
     );
-    const utterance = synthesis.speak.mock.calls[0]?.[0] as unknown as {
-      onend: () => void;
+    const callbacks = mocks.playback.mock.calls[0]?.[0] as {
+      onSettled: (failed: boolean) => void;
     };
-    await act(async () => utterance.onend());
+    act(() => callbacks.onSettled(true));
 
+    expect(screen.getByRole('status').textContent).toBe(
+      'The response could not be read aloud. Please try again.',
+    );
     expect(
       screen
         .getByRole('button', { name: 'Read response aloud' })
-        .getAttribute('aria-pressed'),
-    ).toBe('false');
-    expect(screen.queryByRole('status')).toBeNull();
+        .hasAttribute('disabled'),
+    ).toBe(false);
   });
 
-  it('degrades to a disabled control when speech synthesis is unsupported', () => {
-    render(<ReadAloudControl text="Text remains readable." />);
+  it('degrades to a disabled control when server speech is unavailable', () => {
+    mocks.capabilities = { dictation: true, readAloud: false };
+    render(
+      <ReadAloudControl text="Text remains readable." token="test-token" />,
+    );
 
     expect(
       screen
         .getByRole('button', {
-          name: 'Your browser does not support read aloud.',
+          name: 'Read aloud requires an OpenAI API key.',
         })
         .hasAttribute('disabled'),
     ).toBe(true);

--- a/console/src/routes/chat/read-aloud-control.test.tsx
+++ b/console/src/routes/chat/read-aloud-control.test.tsx
@@ -1,0 +1,108 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  ReadAloudControl,
+  textFromRenderedMarkdown,
+} from './read-aloud-control';
+
+class FakeUtterance {
+  lang = '';
+  onend: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(readonly text: string) {}
+}
+
+function installSpeechSynthesis() {
+  const synthesis = {
+    cancel: vi.fn(),
+    speak: vi.fn(),
+  };
+  vi.stubGlobal(
+    'SpeechSynthesisUtterance',
+    FakeUtterance as unknown as typeof SpeechSynthesisUtterance,
+  );
+  vi.stubGlobal('speechSynthesis', synthesis as unknown as SpeechSynthesis);
+  return synthesis;
+}
+
+describe('ReadAloudControl', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('starts and stops speech only from an explicit button action', () => {
+    const synthesis = installSpeechSynthesis();
+    render(<ReadAloudControl text="A concise response." />);
+
+    expect(synthesis.speak).not.toHaveBeenCalled();
+    const start = screen.getByRole('button', { name: 'Read response aloud' });
+    fireEvent.click(start);
+
+    expect(synthesis.speak).toHaveBeenCalledTimes(1);
+    const utterance = synthesis.speak.mock.calls[0]?.[0] as unknown as {
+      lang: string;
+      text: string;
+    };
+    expect(utterance.text).toBe('A concise response.');
+    expect(utterance.lang).toBe(navigator.language);
+    expect(
+      screen
+        .getByRole('button', { name: 'Stop reading response' })
+        .getAttribute('aria-pressed'),
+    ).toBe('true');
+    expect(screen.getByRole('status').textContent).toBe(
+      'Reading response aloud…',
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Stop reading response' }),
+    );
+    expect(synthesis.cancel).toHaveBeenCalled();
+    expect(
+      screen
+        .getByRole('button', { name: 'Read response aloud' })
+        .getAttribute('aria-pressed'),
+    ).toBe('false');
+  });
+
+  it('finishes cleanly when the browser reports the utterance ended', async () => {
+    const synthesis = installSpeechSynthesis();
+    render(<ReadAloudControl text="Done." />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Read response aloud' }),
+    );
+    const utterance = synthesis.speak.mock.calls[0]?.[0] as unknown as {
+      onend: () => void;
+    };
+    await act(async () => utterance.onend());
+
+    expect(
+      screen
+        .getByRole('button', { name: 'Read response aloud' })
+        .getAttribute('aria-pressed'),
+    ).toBe('false');
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('degrades to a disabled control when speech synthesis is unsupported', () => {
+    render(<ReadAloudControl text="Text remains readable." />);
+
+    expect(
+      screen
+        .getByRole('button', {
+          name: 'Your browser does not support read aloud.',
+        })
+        .hasAttribute('disabled'),
+    ).toBe(true);
+  });
+
+  it('turns rendered markdown into natural speech text', () => {
+    expect(
+      textFromRenderedMarkdown(
+        '<h2>Result</h2><p>Hello <strong>there</strong>.</p>',
+      ),
+    ).toBe('Result Hello there.');
+  });
+});

--- a/console/src/routes/chat/read-aloud-control.test.tsx
+++ b/console/src/routes/chat/read-aloud-control.test.tsx
@@ -120,7 +120,7 @@ describe('ReadAloudControl', () => {
     expect(
       screen
         .getByRole('button', {
-          name: 'Read aloud requires an OpenAI API key.',
+          name: 'Read aloud requires a HybridAI or OpenAI API key.',
         })
         .hasAttribute('disabled'),
     ).toBe(true);

--- a/console/src/routes/chat/read-aloud-control.tsx
+++ b/console/src/routes/chat/read-aloud-control.tsx
@@ -1,0 +1,161 @@
+/**
+ * Read-aloud control — speaks exactly one assistant response on user request.
+ *
+ * Playback is globally exclusive and starts synchronously in the click handler
+ * for iOS Safari; starting another response cancels the current one.
+ *
+ * NOT automatic TTS or realtime voice chat; it never speaks streamed content.
+ */
+
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { Button } from '../../components/button';
+import { cx } from '../../lib/cx';
+import css from './chat-page.module.css';
+import { getSpeechCopy } from './speech-copy';
+
+interface ActiveReadAloud {
+  id: string;
+  stop: () => void;
+}
+
+let activeReadAloud: ActiveReadAloud | null = null;
+
+function canReadAloud(): boolean {
+  return Boolean(
+    window.speechSynthesis &&
+      typeof window.SpeechSynthesisUtterance === 'function',
+  );
+}
+
+export function textFromRenderedMarkdown(html: string): string {
+  const root = document.createElement('div');
+  root.innerHTML = html;
+  for (const element of root.querySelectorAll(
+    'blockquote, br, div, h1, h2, h3, h4, h5, h6, li, p, pre, section',
+  )) {
+    element.append(' ');
+  }
+  return (root.textContent || '').replace(/\s+/g, ' ').trim();
+}
+
+export function ReadAloudControl(props: { text: string }) {
+  const id = useId();
+  const copy = useMemo(() => getSpeechCopy(navigator.language), []);
+  const supported = canReadAloud();
+  const [playing, setPlaying] = useState(false);
+  const [error, setError] = useState('');
+  const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
+
+  const stop = () => {
+    if (activeReadAloud?.id === id) activeReadAloud = null;
+    utteranceRef.current = null;
+    window.speechSynthesis?.cancel();
+    setPlaying(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (activeReadAloud?.id === id) {
+        activeReadAloud = null;
+        window.speechSynthesis?.cancel();
+      }
+    };
+  }, [id]);
+
+  const handleClick = () => {
+    if (!supported) return;
+    if (playing) {
+      stop();
+      return;
+    }
+
+    if (activeReadAloud) activeReadAloud.stop();
+    else window.speechSynthesis.cancel();
+    setError('');
+
+    const utterance = new SpeechSynthesisUtterance(props.text);
+    utterance.lang = navigator.language;
+    utterance.onend = () => {
+      if (utteranceRef.current !== utterance) return;
+      utteranceRef.current = null;
+      if (activeReadAloud?.id === id) activeReadAloud = null;
+      setPlaying(false);
+    };
+    utterance.onerror = () => {
+      if (utteranceRef.current !== utterance) return;
+      utteranceRef.current = null;
+      if (activeReadAloud?.id === id) activeReadAloud = null;
+      setPlaying(false);
+      setError(copy.readFailed);
+    };
+    utteranceRef.current = utterance;
+    activeReadAloud = { id, stop };
+    setPlaying(true);
+
+    // Keep this synchronous with the pointer/keyboard activation. iOS Safari
+    // rejects speech started after an awaited task because the user gesture
+    // has expired.
+    try {
+      window.speechSynthesis.speak(utterance);
+    } catch {
+      utteranceRef.current = null;
+      if (activeReadAloud?.id === id) activeReadAloud = null;
+      setPlaying(false);
+      setError(copy.readFailed);
+    }
+  };
+
+  const label = !supported
+    ? copy.readUnsupported
+    : playing
+      ? copy.stopReading
+      : copy.read;
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        className={cx(css.actionButton, playing && css.actionButtonPlaying)}
+        title={label}
+        aria-label={label}
+        aria-pressed={playing}
+        disabled={!supported || !props.text}
+        onClick={handleClick}
+      >
+        {playing ? (
+          <svg
+            viewBox="0 0 24 24"
+            width="14"
+            height="14"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <rect x="6" y="6" width="12" height="12" rx="2" />
+          </svg>
+        ) : (
+          <svg
+            viewBox="0 0 24 24"
+            width="14"
+            height="14"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M11 5 6 9H3v6h3l5 4z" />
+            <path d="M15.5 8.5a5 5 0 0 1 0 7" />
+            <path d="M18 6a8.5 8.5 0 0 1 0 12" />
+          </svg>
+        )}
+      </Button>
+      {playing || error ? (
+        <span className={css.messageSpeechStatus} role="status">
+          {playing ? copy.reading : error}
+        </span>
+      ) : null}
+    </>
+  );
+}

--- a/console/src/routes/chat/read-aloud-control.tsx
+++ b/console/src/routes/chat/read-aloud-control.tsx
@@ -1,17 +1,20 @@
 /**
- * Read-aloud control — speaks exactly one assistant response on user request.
+ * Read-aloud control — owns explicit playback for one completed response.
  *
- * Playback is globally exclusive and starts synchronously in the click handler
- * for iOS Safari; starting another response cancels the current one.
+ * Starting one response stops any other, unlocks audio in the click gesture,
+ * and delegates authenticated speech generation to the gateway.
  *
- * NOT automatic TTS or realtime voice chat; it never speaks streamed content.
+ * NOT automatic narration or browser speech synthesis.
  */
 
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { Button } from '../../components/button';
 import { cx } from '../../lib/cx';
+import { unlockAudio } from './audio-unlock';
 import css from './chat-page.module.css';
+import { useMediaCapabilities } from './media-capabilities';
 import { getSpeechCopy } from './speech-copy';
+import { SpeechPlayback } from './speech-playback';
 
 interface ActiveReadAloud {
   id: string;
@@ -19,13 +22,6 @@ interface ActiveReadAloud {
 }
 
 let activeReadAloud: ActiveReadAloud | null = null;
-
-function canReadAloud(): boolean {
-  return Boolean(
-    window.speechSynthesis &&
-      typeof window.SpeechSynthesisUtterance === 'function',
-  );
-}
 
 export function textFromRenderedMarkdown(html: string): string {
   const root = document.createElement('div');
@@ -38,92 +34,87 @@ export function textFromRenderedMarkdown(html: string): string {
   return (root.textContent || '').replace(/\s+/g, ' ').trim();
 }
 
-export function ReadAloudControl(props: { text: string }) {
+export function ReadAloudControl(props: { text: string; token: string }) {
   const id = useId();
   const copy = useMemo(() => getSpeechCopy(navigator.language), []);
-  const supported = canReadAloud();
-  const [playing, setPlaying] = useState(false);
+  const capabilities = useMediaCapabilities(props.token);
+  const browserSupported = typeof window.Audio === 'function';
+  const available = capabilities?.readAloud === true;
+  const [status, setStatus] = useState<'idle' | 'loading' | 'playing'>('idle');
   const [error, setError] = useState('');
-  const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
+  const playbackRef = useRef<SpeechPlayback | null>(null);
 
   const stop = () => {
+    playbackRef.current?.dispose();
+    playbackRef.current = null;
     if (activeReadAloud?.id === id) activeReadAloud = null;
-    utteranceRef.current = null;
-    window.speechSynthesis?.cancel();
-    setPlaying(false);
+    setStatus('idle');
   };
 
   useEffect(() => {
     return () => {
-      if (activeReadAloud?.id === id) {
-        activeReadAloud = null;
-        window.speechSynthesis?.cancel();
-      }
+      playbackRef.current?.dispose();
+      playbackRef.current = null;
+      if (activeReadAloud?.id === id) activeReadAloud = null;
     };
   }, [id]);
 
   const handleClick = () => {
-    if (!supported) return;
-    if (playing) {
+    if (!available || !browserSupported) return;
+    if (status !== 'idle') {
       stop();
       return;
     }
 
-    if (activeReadAloud) activeReadAloud.stop();
-    else window.speechSynthesis.cancel();
+    // This must remain synchronous with the click: iOS expires the playback
+    // gesture before the authenticated speech request resolves.
+    unlockAudio();
+    activeReadAloud?.stop();
     setError('');
+    setStatus('loading');
 
-    const utterance = new SpeechSynthesisUtterance(props.text);
-    utterance.lang = navigator.language;
-    utterance.onend = () => {
-      if (utteranceRef.current !== utterance) return;
-      utteranceRef.current = null;
-      if (activeReadAloud?.id === id) activeReadAloud = null;
-      setPlaying(false);
-    };
-    utterance.onerror = () => {
-      if (utteranceRef.current !== utterance) return;
-      utteranceRef.current = null;
-      if (activeReadAloud?.id === id) activeReadAloud = null;
-      setPlaying(false);
-      setError(copy.readFailed);
-    };
-    utteranceRef.current = utterance;
+    let playback: SpeechPlayback | null = null;
+    playback = new SpeechPlayback({
+      token: props.token,
+      text: props.text,
+      onPlaying: () => {
+        if (playback && playbackRef.current === playback) setStatus('playing');
+      },
+      onSettled: (failed) => {
+        if (!playback || playbackRef.current !== playback) return;
+        playbackRef.current = null;
+        if (activeReadAloud?.id === id) activeReadAloud = null;
+        setStatus('idle');
+        if (failed) setError(copy.readFailed);
+      },
+    });
+    playbackRef.current = playback;
     activeReadAloud = { id, stop };
-    setPlaying(true);
-
-    // Keep this synchronous with the pointer/keyboard activation. iOS Safari
-    // rejects speech started after an awaited task because the user gesture
-    // has expired.
-    try {
-      window.speechSynthesis.speak(utterance);
-    } catch {
-      utteranceRef.current = null;
-      if (activeReadAloud?.id === id) activeReadAloud = null;
-      setPlaying(false);
-      setError(copy.readFailed);
-    }
+    playback.start();
   };
 
-  const label = !supported
+  const active = status !== 'idle';
+  const label = !browserSupported
     ? copy.readUnsupported
-    : playing
-      ? copy.stopReading
-      : copy.read;
+    : capabilities?.readAloud === false
+      ? copy.readUnavailable
+      : active
+        ? copy.stopReading
+        : copy.read;
 
   return (
     <>
       <Button
         variant="ghost"
         size="icon"
-        className={cx(css.actionButton, playing && css.actionButtonPlaying)}
+        className={cx(css.actionButton, active && css.actionButtonPlaying)}
         title={label}
         aria-label={label}
-        aria-pressed={playing}
-        disabled={!supported || !props.text}
+        aria-pressed={active}
+        disabled={!available || !browserSupported || !props.text}
         onClick={handleClick}
       >
-        {playing ? (
+        {active ? (
           <svg
             viewBox="0 0 24 24"
             width="14"
@@ -151,9 +142,13 @@ export function ReadAloudControl(props: { text: string }) {
           </svg>
         )}
       </Button>
-      {playing || error ? (
+      {active || error ? (
         <span className={css.messageSpeechStatus} role="status">
-          {playing ? copy.reading : error}
+          {status === 'loading'
+            ? copy.preparingSpeech
+            : status === 'playing'
+              ? copy.reading
+              : error}
         </span>
       ) : null}
     </>

--- a/console/src/routes/chat/speech-copy.test.ts
+++ b/console/src/routes/chat/speech-copy.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { getSpeechCopy } from './speech-copy';
+
+describe('getSpeechCopy', () => {
+  it('localizes speech controls for supported browser locales', () => {
+    expect(getSpeechCopy('de-DE').dictate).toBe('Spracheingabe');
+    expect(getSpeechCopy('fr-FR').read).toBe('Lire la réponse à voix haute');
+  });
+
+  it('falls back to English for other locales', () => {
+    expect(getSpeechCopy('ja-JP').dictate).toBe('Voice input');
+  });
+});

--- a/console/src/routes/chat/speech-copy.ts
+++ b/console/src/routes/chat/speech-copy.ts
@@ -43,7 +43,7 @@ const ENGLISH: SpeechCopy = {
   read: 'Read response aloud',
   readFailed: 'The response could not be read aloud. Please try again.',
   readUnsupported: 'Your browser does not support read aloud.',
-  readUnavailable: 'Read aloud requires an OpenAI API key.',
+  readUnavailable: 'Read aloud requires a HybridAI or OpenAI API key.',
   reading: 'Reading response aloud…',
   requestingMic: 'Requesting microphone access…',
   stopDictation: 'Stop recording',
@@ -68,7 +68,8 @@ const GERMAN: SpeechCopy = {
   readFailed:
     'Die Antwort konnte nicht vorgelesen werden. Bitte versuchen Sie es erneut.',
   readUnsupported: 'Ihr Browser unterstützt kein Vorlesen.',
-  readUnavailable: 'Für Vorlesen ist ein OpenAI-API-Schlüssel erforderlich.',
+  readUnavailable:
+    'Für Vorlesen ist ein HybridAI- oder OpenAI-API-Schlüssel erforderlich.',
   reading: 'Antwort wird vorgelesen…',
   requestingMic: 'Mikrofonzugriff wird angefragt…',
   stopDictation: 'Aufnahme stoppen',
@@ -93,7 +94,8 @@ const FRENCH: SpeechCopy = {
     "La réponse n'a pas pu être lue à voix haute. Veuillez réessayer.",
   readUnsupported:
     'Votre navigateur ne prend pas en charge la lecture à voix haute.',
-  readUnavailable: 'La lecture à voix haute nécessite une clé API OpenAI.',
+  readUnavailable:
+    'La lecture à voix haute nécessite une clé API HybridAI ou OpenAI.',
   reading: 'Lecture de la réponse…',
   requestingMic: "Demande d'accès au microphone…",
   stopDictation: "Arrêter l'enregistrement",

--- a/console/src/routes/chat/speech-copy.ts
+++ b/console/src/routes/chat/speech-copy.ts
@@ -15,10 +15,13 @@ export interface SpeechCopy {
   micDenied: string;
   micFailed: string;
   micUnsupported: string;
+  micUnavailable: string;
   noSpeech: string;
+  preparingSpeech: string;
   read: string;
   readFailed: string;
   readUnsupported: string;
+  readUnavailable: string;
   reading: string;
   requestingMic: string;
   stopDictation: string;
@@ -34,10 +37,13 @@ const ENGLISH: SpeechCopy = {
     'No access to the microphone. Please allow it in your browser settings.',
   micFailed: 'The recording could not be transcribed. Please try again.',
   micUnsupported: 'Your browser does not support voice input.',
+  micUnavailable: 'Voice input requires an audio transcription backend.',
   noSpeech: 'No speech was detected. Please try again.',
+  preparingSpeech: 'Preparing audio…',
   read: 'Read response aloud',
   readFailed: 'The response could not be read aloud. Please try again.',
   readUnsupported: 'Your browser does not support read aloud.',
+  readUnavailable: 'Read aloud requires an OpenAI API key.',
   reading: 'Reading response aloud…',
   requestingMic: 'Requesting microphone access…',
   stopDictation: 'Stop recording',
@@ -54,11 +60,15 @@ const GERMAN: SpeechCopy = {
   micFailed:
     'Die Aufnahme konnte nicht transkribiert werden. Bitte versuchen Sie es erneut.',
   micUnsupported: 'Ihr Browser unterstützt keine Spracheingabe.',
+  micUnavailable:
+    'Für Spracheingabe ist ein Audio-Transkriptionsdienst erforderlich.',
   noSpeech: 'Es wurde keine Sprache erkannt. Bitte versuchen Sie es erneut.',
+  preparingSpeech: 'Audio wird vorbereitet…',
   read: 'Antwort vorlesen',
   readFailed:
     'Die Antwort konnte nicht vorgelesen werden. Bitte versuchen Sie es erneut.',
   readUnsupported: 'Ihr Browser unterstützt kein Vorlesen.',
+  readUnavailable: 'Für Vorlesen ist ein OpenAI-API-Schlüssel erforderlich.',
   reading: 'Antwort wird vorgelesen…',
   requestingMic: 'Mikrofonzugriff wird angefragt…',
   stopDictation: 'Aufnahme stoppen',
@@ -74,12 +84,16 @@ const FRENCH: SpeechCopy = {
     "Aucun accès au microphone. Veuillez l'autoriser dans les réglages de votre navigateur.",
   micFailed: "L'enregistrement n'a pas pu être transcrit. Veuillez réessayer.",
   micUnsupported: 'Votre navigateur ne prend pas en charge la saisie vocale.',
+  micUnavailable:
+    'La saisie vocale nécessite un service de transcription audio.',
   noSpeech: "Aucune parole n'a été détectée. Veuillez réessayer.",
+  preparingSpeech: 'Préparation de l’audio…',
   read: 'Lire la réponse à voix haute',
   readFailed:
     "La réponse n'a pas pu être lue à voix haute. Veuillez réessayer.",
   readUnsupported:
     'Votre navigateur ne prend pas en charge la lecture à voix haute.',
+  readUnavailable: 'La lecture à voix haute nécessite une clé API OpenAI.',
   reading: 'Lecture de la réponse…',
   requestingMic: "Demande d'accès au microphone…",
   stopDictation: "Arrêter l'enregistrement",

--- a/console/src/routes/chat/speech-copy.ts
+++ b/console/src/routes/chat/speech-copy.ts
@@ -1,0 +1,95 @@
+/**
+ * Webchat speech copy — the localized labels and status text for audio UX.
+ *
+ * Locale selection follows the browser because the console has no global
+ * translation runtime; the same locale is also passed to speech synthesis.
+ *
+ * NOT a general console i18n registry; it deliberately covers only dictation
+ * and read-aloud controls.
+ */
+
+export interface SpeechCopy {
+  cancelDictation: string;
+  dictate: string;
+  listening: string;
+  micDenied: string;
+  micFailed: string;
+  micUnsupported: string;
+  noSpeech: string;
+  read: string;
+  readFailed: string;
+  readUnsupported: string;
+  reading: string;
+  requestingMic: string;
+  stopDictation: string;
+  stopReading: string;
+  transcribing: string;
+}
+
+const ENGLISH: SpeechCopy = {
+  cancelDictation: 'Cancel voice input',
+  dictate: 'Voice input',
+  listening: 'Just start speaking…',
+  micDenied:
+    'No access to the microphone. Please allow it in your browser settings.',
+  micFailed: 'The recording could not be transcribed. Please try again.',
+  micUnsupported: 'Your browser does not support voice input.',
+  noSpeech: 'No speech was detected. Please try again.',
+  read: 'Read response aloud',
+  readFailed: 'The response could not be read aloud. Please try again.',
+  readUnsupported: 'Your browser does not support read aloud.',
+  reading: 'Reading response aloud…',
+  requestingMic: 'Requesting microphone access…',
+  stopDictation: 'Stop recording',
+  stopReading: 'Stop reading response',
+  transcribing: 'Transcribing…',
+};
+
+const GERMAN: SpeechCopy = {
+  cancelDictation: 'Spracheingabe abbrechen',
+  dictate: 'Spracheingabe',
+  listening: 'Sprechen Sie einfach los…',
+  micDenied:
+    'Kein Zugriff auf das Mikrofon. Bitte erlauben Sie ihn in Ihren Browsereinstellungen.',
+  micFailed:
+    'Die Aufnahme konnte nicht transkribiert werden. Bitte versuchen Sie es erneut.',
+  micUnsupported: 'Ihr Browser unterstützt keine Spracheingabe.',
+  noSpeech: 'Es wurde keine Sprache erkannt. Bitte versuchen Sie es erneut.',
+  read: 'Antwort vorlesen',
+  readFailed:
+    'Die Antwort konnte nicht vorgelesen werden. Bitte versuchen Sie es erneut.',
+  readUnsupported: 'Ihr Browser unterstützt kein Vorlesen.',
+  reading: 'Antwort wird vorgelesen…',
+  requestingMic: 'Mikrofonzugriff wird angefragt…',
+  stopDictation: 'Aufnahme stoppen',
+  stopReading: 'Vorlesen stoppen',
+  transcribing: 'Wird transkribiert…',
+};
+
+const FRENCH: SpeechCopy = {
+  cancelDictation: 'Annuler la saisie vocale',
+  dictate: 'Saisie vocale',
+  listening: 'Commencez simplement à parler…',
+  micDenied:
+    "Aucun accès au microphone. Veuillez l'autoriser dans les réglages de votre navigateur.",
+  micFailed: "L'enregistrement n'a pas pu être transcrit. Veuillez réessayer.",
+  micUnsupported: 'Votre navigateur ne prend pas en charge la saisie vocale.',
+  noSpeech: "Aucune parole n'a été détectée. Veuillez réessayer.",
+  read: 'Lire la réponse à voix haute',
+  readFailed:
+    "La réponse n'a pas pu être lue à voix haute. Veuillez réessayer.",
+  readUnsupported:
+    'Votre navigateur ne prend pas en charge la lecture à voix haute.',
+  reading: 'Lecture de la réponse…',
+  requestingMic: "Demande d'accès au microphone…",
+  stopDictation: "Arrêter l'enregistrement",
+  stopReading: 'Arrêter la lecture',
+  transcribing: 'Transcription…',
+};
+
+export function getSpeechCopy(language?: string): SpeechCopy {
+  const locale = (language || '').trim().toLowerCase().split('-')[0];
+  if (locale === 'de') return GERMAN;
+  if (locale === 'fr') return FRENCH;
+  return ENGLISH;
+}

--- a/console/src/routes/chat/speech-playback.test.ts
+++ b/console/src/routes/chat/speech-playback.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SpeechPlayback, splitSpeechText } from './speech-playback';
+
+const mocks = vi.hoisted(() => ({
+  playAudioClip: vi.fn(),
+  synthesizeSpeech: vi.fn(),
+}));
+
+vi.mock('../../api/chat', () => ({
+  synthesizeSpeech: mocks.synthesizeSpeech,
+}));
+
+vi.mock('./audio-unlock', () => ({
+  playAudioClip: mocks.playAudioClip,
+}));
+
+describe('SpeechPlayback', () => {
+  beforeEach(() => {
+    mocks.playAudioClip.mockReset();
+    mocks.playAudioClip.mockImplementation(
+      async (_blob: Blob, onStart: (audio: HTMLAudioElement) => void) => {
+        onStart({} as HTMLAudioElement);
+      },
+    );
+    mocks.synthesizeSpeech.mockReset();
+  });
+
+  it('splits at natural pauses and plays fetched clips in order', async () => {
+    const text =
+      'This first sentence starts promptly. This second sentence is deliberately long enough to become the next generated speech clip.';
+    const chunks = splitSpeechText(text);
+    expect(chunks).toEqual([
+      'This first sentence starts promptly.',
+      'This second sentence is deliberately long enough to become the next generated speech clip.',
+    ]);
+    chunks.forEach((_chunk, index) => {
+      mocks.synthesizeSpeech.mockResolvedValueOnce(
+        new Blob([String(index)], { type: 'audio/mpeg' }),
+      );
+    });
+    const onPlaying = vi.fn();
+    const onSettled = vi.fn();
+
+    const playback = new SpeechPlayback({
+      token: 'test-token',
+      text,
+      onPlaying,
+      onSettled,
+    });
+    playback.start();
+
+    await vi.waitFor(() => expect(onSettled).toHaveBeenCalledWith(false));
+    expect(mocks.synthesizeSpeech).toHaveBeenCalledTimes(2);
+    expect(mocks.synthesizeSpeech.mock.calls[0]?.slice(0, 2)).toEqual([
+      'test-token',
+      chunks[0],
+    ]);
+    expect(mocks.synthesizeSpeech.mock.calls[1]?.slice(0, 2)).toEqual([
+      'test-token',
+      chunks[1],
+    ]);
+    expect(mocks.playAudioClip).toHaveBeenCalledTimes(2);
+    expect(onPlaying).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborts pending generation and settles without an error on stop', () => {
+    let capturedSignal: AbortSignal | undefined;
+    mocks.synthesizeSpeech.mockImplementation(
+      (_token: string, _text: string, signal?: AbortSignal) => {
+        capturedSignal = signal;
+        return new Promise<Blob>(() => undefined);
+      },
+    );
+    const onSettled = vi.fn();
+    const playback = new SpeechPlayback({
+      token: 'test-token',
+      text: 'A response waiting for generated speech.',
+      onPlaying: vi.fn(),
+      onSettled,
+    });
+
+    playback.start();
+    playback.dispose();
+
+    expect(capturedSignal?.aborted).toBe(true);
+    expect(onSettled).not.toHaveBeenCalled();
+  });
+});

--- a/console/src/routes/chat/speech-playback.ts
+++ b/console/src/routes/chat/speech-playback.ts
@@ -1,0 +1,112 @@
+/**
+ * Per-response speech playback — fetches sentence-ish audio clips in parallel.
+ *
+ * Clips play in source order through the shared iOS-unlocked audio element and
+ * disposal aborts pending requests plus the active clip immediately.
+ *
+ * NOT automatic narration or streaming assistant-token playback.
+ */
+
+import { synthesizeSpeech } from '../../api/chat';
+import { playAudioClip } from './audio-unlock';
+
+const FIRST_CHUNK_CHARS = 30;
+const NEXT_CHUNK_CHARS = 100;
+const BREAKPOINT_LOOKAHEAD = 50;
+
+function findBreakpoint(
+  pending: string,
+  minimum: number,
+  isFinal: boolean,
+): number {
+  if (isFinal) return pending.length;
+  if (pending.length < minimum) return -1;
+  const window = pending.slice(0, minimum + BREAKPOINT_LOOKAHEAD);
+  const sentence = /[.!?](\s|$)/.exec(window);
+  if (sentence && sentence.index > 0) return sentence.index + 1;
+  const space = window.lastIndexOf(' ');
+  return space > 0 ? space : minimum;
+}
+
+export function splitSpeechText(text: string): string[] {
+  const chunks: string[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    const pending = text.slice(cursor).trimStart();
+    cursor += text.slice(cursor).length - pending.length;
+    if (!pending) break;
+    const minimum = chunks.length === 0 ? FIRST_CHUNK_CHARS : NEXT_CHUNK_CHARS;
+    const cut = findBreakpoint(
+      pending,
+      minimum,
+      pending.length <= minimum + BREAKPOINT_LOOKAHEAD,
+    );
+    if (cut <= 0) break;
+    const chunk = pending.slice(0, cut).trim();
+    cursor += cut;
+    if (chunk) chunks.push(chunk);
+  }
+  return chunks;
+}
+
+export class SpeechPlayback {
+  readonly #abortController = new AbortController();
+  readonly #clips: Promise<Blob>[];
+  readonly #onPlaying: () => void;
+  readonly #onSettled: (failed: boolean) => void;
+  #audio: HTMLAudioElement | null = null;
+  #disposed = false;
+
+  constructor(params: {
+    token: string;
+    text: string;
+    onPlaying: () => void;
+    onSettled: (failed: boolean) => void;
+  }) {
+    this.#onPlaying = params.onPlaying;
+    this.#onSettled = params.onSettled;
+    this.#clips = splitSpeechText(params.text).map((chunk) => {
+      const request = synthesizeSpeech(
+        params.token,
+        chunk,
+        this.#abortController.signal,
+      );
+      request.catch(() => undefined);
+      return request;
+    });
+  }
+
+  start(): void {
+    void this.#play();
+  }
+
+  dispose(): void {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    this.#abortController.abort();
+    this.#clips.length = 0;
+    this.#audio?.pause();
+    this.#audio = null;
+  }
+
+  async #play(): Promise<void> {
+    let failed = false;
+    try {
+      while (this.#clips.length > 0 && !this.#disposed) {
+        const next = this.#clips.shift();
+        if (!next) break;
+        const clip = await next;
+        if (this.#disposed) return;
+        await playAudioClip(clip, (audio) => {
+          this.#audio = audio;
+          this.#onPlaying();
+        });
+        this.#audio = null;
+      }
+    } catch {
+      failed = !this.#abortController.signal.aborted;
+    } finally {
+      if (!this.#disposed) this.#onSettled(failed);
+    }
+  }
+}

--- a/docs/content/guides/voice-tts.md
+++ b/docs/content/guides/voice-tts.md
@@ -10,6 +10,24 @@ HybridClaw has shared inbound audio transcription, but it does not currently
 ship a first-party `tts.*` runtime config or a built-in speech-synthesis
 provider.
 
+The webchat has user-controlled audio conveniences that do not require a
+`tts.*` provider:
+
+- The composer microphone records a short dictation take and sends it to the
+  configured `media.audio` transcription chain. The transcript is inserted
+  into the composer for review and editing; it is not sent automatically.
+- Each completed assistant message has a read-aloud action backed by the
+  browser's speech-synthesis engine. Playback starts and stops only through
+  that message action.
+- Unsupported browsers and denied microphone permissions keep normal text chat
+  available. Labels and status text follow English, German, or French browser
+  locales, with English as the fallback.
+
+Dictation audio is written to a private operating-system temporary file only
+while transcription runs, then removed. It is not added to the uploaded-media
+cache or conversation history. The resulting text follows the same persistence
+path as typed text after the user sends it.
+
 If you are looking for the Twilio phone channel, inbound and outbound call
 setup, or ConversationRelay webhooks, see
 [Twilio Voice](./twilio-voice.md).

--- a/docs/content/guides/voice-tts.md
+++ b/docs/content/guides/voice-tts.md
@@ -6,31 +6,34 @@ sidebar_position: 6
 
 # Voice And TTS
 
-HybridClaw has shared inbound audio transcription, but it does not currently
-ship a first-party `tts.*` runtime config or a built-in speech-synthesis
-provider.
+HybridClaw has shared inbound audio transcription and explicit webchat
+read-aloud playback. It does not ship a general-purpose `tts.*` runtime config
+or agent-facing speech-synthesis tool.
 
-The webchat has user-controlled audio conveniences that do not require a
-`tts.*` provider:
+The webchat has two user-controlled audio conveniences:
 
-- The composer microphone uses the browser's speech-recognition service in
-  Chrome and Safari. In browsers without that API, it records a short
-  dictation take and sends it to the configured `media.audio` transcription
-  chain. The transcript is inserted into the composer for review and editing;
-  it is not sent automatically.
-- Each completed assistant message has a read-aloud action backed by the
-  browser's speech-synthesis engine. Playback starts and stops only through
-  that message action.
+- The composer microphone records a dictation take and sends it through the
+  configured `media.audio` transcription chain. The transcript is inserted
+  into the composer for review and editing; it is not sent automatically.
+- Each completed assistant message has a read-aloud action. The gateway
+  generates short MP3 clips through OpenAI TTS using `OPENAI_API_KEY`, then the
+  browser plays them in order. Playback starts and stops only through that
+  message action.
 - Unsupported browsers and denied microphone permissions keep normal text chat
   available. Labels and status text follow English, German, or French browser
   locales, with English as the fallback.
 
-Browser-native dictation is handled under the browser vendor's speech-service
-terms and is not uploaded to HybridClaw. On the server fallback path, dictation
-audio is written to a private operating-system temporary file only while
-transcription runs, then removed. It is not added to the uploaded-media cache
-or conversation history. The resulting text follows the same persistence path
-as typed text after the user sends it.
+Dictation audio is sent only to the authenticated gateway. It is written to a
+private operating-system temporary file while transcription runs, then
+removed; it is not added to the uploaded-media cache or conversation history.
+The resulting text follows the same persistence path as typed text only after
+the user sends it.
+
+Read-aloud sends bounded text chunks from the existing assistant response to
+the configured `openai.baseUrl`. The gateway does not store the generated audio
+and marks each response `Cache-Control: no-store`. The OpenAI API key remains
+gateway-side. On iOS, HybridClaw warms and reuses one audio element during the
+explicit button gesture so fetched clips can play after the request completes.
 
 If you are looking for the Twilio phone channel, inbound and outbound call
 setup, or ConversationRelay webhooks, see
@@ -47,6 +50,8 @@ exists:
 
 - **Inbound audio**: the gateway can transcribe attached `audio/*` media before
   the agent runs via `media.audio`.
+- **Webchat read-aloud**: completed assistant responses can be played with
+  OpenAI TTS when `OPENAI_API_KEY` is configured.
 - **Outbound audio**: HybridClaw can send generated audio files back to
   supported channels:
   - Discord sends local file attachments.
@@ -151,5 +156,7 @@ tool notes.
 Do not confuse these two paths:
 
 - `media.audio` is **speech-to-text** for inbound attachments
-- TTS is **text-to-speech** for outbound replies and currently depends on your
-  own local tool, MCP server, or custom script
+- the webchat read-aloud action is **text-to-speech** for local playback and
+  uses the gateway's `OPENAI_API_KEY`
+- agent-generated TTS artifacts for outbound channel replies still depend on
+  your own local tool, MCP server, or custom script

--- a/docs/content/guides/voice-tts.md
+++ b/docs/content/guides/voice-tts.md
@@ -13,9 +13,11 @@ provider.
 The webchat has user-controlled audio conveniences that do not require a
 `tts.*` provider:
 
-- The composer microphone records a short dictation take and sends it to the
-  configured `media.audio` transcription chain. The transcript is inserted
-  into the composer for review and editing; it is not sent automatically.
+- The composer microphone uses the browser's speech-recognition service in
+  Chrome and Safari. In browsers without that API, it records a short
+  dictation take and sends it to the configured `media.audio` transcription
+  chain. The transcript is inserted into the composer for review and editing;
+  it is not sent automatically.
 - Each completed assistant message has a read-aloud action backed by the
   browser's speech-synthesis engine. Playback starts and stops only through
   that message action.
@@ -23,10 +25,12 @@ The webchat has user-controlled audio conveniences that do not require a
   available. Labels and status text follow English, German, or French browser
   locales, with English as the fallback.
 
-Dictation audio is written to a private operating-system temporary file only
-while transcription runs, then removed. It is not added to the uploaded-media
-cache or conversation history. The resulting text follows the same persistence
-path as typed text after the user sends it.
+Browser-native dictation is handled under the browser vendor's speech-service
+terms and is not uploaded to HybridClaw. On the server fallback path, dictation
+audio is written to a private operating-system temporary file only while
+transcription runs, then removed. It is not added to the uploaded-media cache
+or conversation history. The resulting text follows the same persistence path
+as typed text after the user sends it.
 
 If you are looking for the Twilio phone channel, inbound and outbound call
 setup, or ConversationRelay webhooks, see

--- a/docs/content/guides/voice-tts.md
+++ b/docs/content/guides/voice-tts.md
@@ -16,9 +16,10 @@ The webchat has two user-controlled audio conveniences:
   configured `media.audio` transcription chain. The transcript is inserted
   into the composer for review and editing; it is not sent automatically.
 - Each completed assistant message has a read-aloud action. The gateway
-  generates short MP3 clips through OpenAI TTS using `OPENAI_API_KEY`, then the
-  browser plays them in order. Playback starts and stops only through that
-  message action.
+  generates short MP3 clips through HybridAI's OpenAI-compatible speech
+  endpoint — no extra credential beyond your HybridAI login — falling back to
+  OpenAI TTS when `OPENAI_API_KEY` is configured. The browser plays the clips
+  in order. Playback starts and stops only through that message action.
 - Unsupported browsers and denied microphone permissions keep normal text chat
   available. Labels and status text follow English, German, or French browser
   locales, with English as the fallback.
@@ -30,9 +31,10 @@ The resulting text follows the same persistence path as typed text only after
 the user sends it.
 
 Read-aloud sends bounded text chunks from the existing assistant response to
-the configured `openai.baseUrl`. The gateway does not store the generated audio
-and marks each response `Cache-Control: no-store`. The OpenAI API key remains
-gateway-side. On iOS, HybridClaw warms and reuses one audio element during the
+whichever speech backend is configured: `<hybridai.baseUrl>/v1/audio/speech`
+first, then `<openai.baseUrl>/audio/speech`. The gateway does not store the
+generated audio and marks each response `Cache-Control: no-store`. Provider API
+keys remain gateway-side. On iOS, HybridClaw warms and reuses one audio element during the
 explicit button gesture so fetched clips can play after the request completes.
 
 If you are looking for the Twilio phone channel, inbound and outbound call
@@ -50,8 +52,8 @@ exists:
 
 - **Inbound audio**: the gateway can transcribe attached `audio/*` media before
   the agent runs via `media.audio`.
-- **Webchat read-aloud**: completed assistant responses can be played with
-  OpenAI TTS when `OPENAI_API_KEY` is configured.
+- **Webchat read-aloud**: completed assistant responses can be played through
+  HybridAI (default) or OpenAI TTS.
 - **Outbound audio**: HybridClaw can send generated audio files back to
   supported channels:
   - Discord sends local file attachments.
@@ -157,6 +159,6 @@ Do not confuse these two paths:
 
 - `media.audio` is **speech-to-text** for inbound attachments
 - the webchat read-aloud action is **text-to-speech** for local playback and
-  uses the gateway's `OPENAI_API_KEY`
+  uses the gateway's HybridAI credentials, or `OPENAI_API_KEY` as a fallback
 - agent-generated TTS artifacts for outbound channel replies still depend on
   your own local tool, MCP server, or custom script

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -158,7 +158,7 @@ saved revision history directly.
 - `openai.enabled`, `openai.baseUrl`, and `openai.models` configure the direct
   OpenAI Responses API provider. Store its API key as `OPENAI_API_KEY` in the
   encrypted runtime secret store and select models with the `openai/` prefix.
-  Webchat read-aloud also uses this base URL and key for authenticated,
+  Webchat read-aloud falls back to this base URL and key for authenticated,
   non-retained OpenAI TTS requests.
 - `HYBRIDAI_FALLBACK_CHAIN` accepts a JSON array of fallback entries with
   `model`, optional `baseUrl`, `keyEnv`, `chatbotId`, and `agentId`. Gateway
@@ -420,7 +420,11 @@ instead of per-channel temp directories.
 
 `media.audio` auto-detect prefers local CLIs first
 (`sherpa-onnx-offline`, `whisper-cli`, `whisper`), then `gemini`, then
-provider-backed APIs (`openai`, `groq`, `deepgram`, `google`).
+provider-backed APIs (`hybridai`, `openai`, `groq`, `deepgram`, `google`).
+`hybridai` leads the provider group because it is the default chat provider, so
+a signed-in operator gets transcription with no extra credential; it calls
+HybridAI's OpenAI-compatible `/v1/audio/transcriptions`. A backend that fails
+falls through to the next one in the chain.
 
 `whisper-cli` auto-detect also requires a whisper.cpp model file. If the
 binary exists but HybridClaw still skips local transcription, set

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -158,6 +158,8 @@ saved revision history directly.
 - `openai.enabled`, `openai.baseUrl`, and `openai.models` configure the direct
   OpenAI Responses API provider. Store its API key as `OPENAI_API_KEY` in the
   encrypted runtime secret store and select models with the `openai/` prefix.
+  Webchat read-aloud also uses this base URL and key for authenticated,
+  non-retained OpenAI TTS requests.
 - `HYBRIDAI_FALLBACK_CHAIN` accepts a JSON array of fallback entries with
   `model`, optional `baseUrl`, `keyEnv`, `chatbotId`, and `agentId`. Gateway
   model calls use the chain for auth and rate-limit failures, then cool down

--- a/src/auth/hybridai-auth.ts
+++ b/src/auth/hybridai-auth.ts
@@ -85,6 +85,17 @@ export function getHybridAIApiKey(): string {
   return apiKey;
 }
 
+/**
+ * The HybridAI key when one is configured, otherwise null.
+ *
+ * For callers that treat "not signed in" as a capability being unavailable
+ * rather than an error — feature discovery and optional backends — where
+ * catching {@link getHybridAIApiKey}'s throw would be control flow.
+ */
+export function readHybridAIApiKey(): string | null {
+  return readCurrentApiKey() || null;
+}
+
 function normalizeBaseUrl(raw: string): string {
   return raw.trim().replace(/\/+$/, '') || DEFAULT_BASE_URL;
 }

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -317,6 +317,7 @@ export type IMessageBackend = 'local' | 'bluebubbles';
 export type IMessageDmPolicy = 'open' | 'allowlist' | 'disabled';
 export type IMessageGroupPolicy = 'open' | 'allowlist' | 'disabled';
 export type RuntimeAudioTranscriptionProvider =
+  | 'hybridai'
   | 'openai'
   | 'groq'
   | 'deepgram'
@@ -6588,6 +6589,7 @@ function normalizeAudioTranscriptionProvider(
 ): RuntimeAudioTranscriptionProvider | null {
   if (typeof value !== 'string') return null;
   const normalized = value.trim().toLowerCase();
+  if (normalized === 'hybridai') return 'hybridai';
   if (normalized === 'openai') return 'openai';
   if (normalized === 'groq') return 'groq';
   if (normalized === 'deepgram') return 'deepgram';

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -3485,6 +3485,13 @@ async function handleApiMediaTranscription(
     return;
   }
 
+  if (!(await isWebchatDictationAvailable().catch(() => false))) {
+    sendJson(res, 503, {
+      error: 'No audio transcription backend is available.',
+    });
+    return;
+  }
+
   const buffer = await readRequestBody(req, MAX_MEDIA_UPLOAD_BYTES);
   if (buffer.length === 0) {
     sendJson(res, 400, { error: 'Dictation recording is empty.' });
@@ -3508,8 +3515,8 @@ async function handleApiMediaTranscription(
 
   const abortController = new AbortController();
   const abort = () => abortController.abort();
-  req.once('aborted', abort);
-  res.once('close', abort);
+  req.on('aborted', abort);
+  res.on('close', abort);
   try {
     const text = await transcribeWebchatDictation({
       audio: buffer,
@@ -3558,6 +3565,13 @@ async function handleApiMediaSpeech(
     return;
   }
 
+  if (!isWebchatSpeechAvailable()) {
+    sendJson(res, 503, {
+      error: 'Read aloud requires a HybridAI or OpenAI API key.',
+    });
+    return;
+  }
+
   const quotaDecision = consumeGatewayMediaUploadQuota({
     key: resolveApiMediaUploadQuotaKey(req),
     bytes: Buffer.byteLength(text, 'utf8'),
@@ -3575,8 +3589,8 @@ async function handleApiMediaSpeech(
 
   const abortController = new AbortController();
   const abort = () => abortController.abort();
-  req.once('aborted', abort);
-  res.once('close', abort);
+  req.on('aborted', abort);
+  res.on('close', abort);
   try {
     const audio = await synthesizeWebchatSpeech({
       text,

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -447,8 +447,14 @@ import {
 } from './text-channel-commands.js';
 import {
   isSupportedDictationMimeType,
+  isWebchatDictationAvailable,
   transcribeWebchatDictation,
 } from './webchat-dictation.js';
+import {
+  isWebchatSpeechAvailable,
+  MAX_WEBCHAT_SPEECH_CHARS,
+  synthesizeWebchatSpeech,
+} from './webchat-speech.js';
 
 const SITE_DIR = resolveInstallPath('docs');
 const CONSOLE_DIST_DIR = resolveInstallPath('console', 'dist');
@@ -3503,6 +3509,7 @@ async function handleApiMediaTranscription(
   const abortController = new AbortController();
   const abort = () => abortController.abort();
   req.once('aborted', abort);
+  res.once('close', abort);
   try {
     const text = await transcribeWebchatDictation({
       audio: buffer,
@@ -3512,6 +3519,78 @@ async function handleApiMediaTranscription(
     sendJson(res, 200, { text });
   } finally {
     req.off('aborted', abort);
+    res.off('close', abort);
+  }
+}
+
+async function handleApiMediaCapabilities(res: ServerResponse): Promise<void> {
+  const dictation = await isWebchatDictationAvailable().catch(() => false);
+  sendJson(res, 200, {
+    dictation,
+    readAloud: isWebchatSpeechAvailable(),
+  });
+}
+
+async function handleApiMediaSpeech(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const body = await readJsonBody(req);
+  if (
+    !body ||
+    typeof body !== 'object' ||
+    Array.isArray(body) ||
+    typeof (body as { text?: unknown }).text !== 'string'
+  ) {
+    sendJson(res, 400, { error: 'Missing `text` in request body.' });
+    return;
+  }
+
+  const text = (body as { text: string }).text.trim();
+  if (!text) {
+    sendJson(res, 400, { error: 'Speech text is empty.' });
+    return;
+  }
+  if (text.length > MAX_WEBCHAT_SPEECH_CHARS) {
+    sendJson(res, 413, {
+      error: `Speech text exceeds ${MAX_WEBCHAT_SPEECH_CHARS} characters.`,
+    });
+    return;
+  }
+
+  const quotaDecision = consumeGatewayMediaUploadQuota({
+    key: resolveApiMediaUploadQuotaKey(req),
+    bytes: Buffer.byteLength(text, 'utf8'),
+  });
+  if (!quotaDecision.allowed) {
+    res.setHeader(
+      'Retry-After',
+      String(Math.max(1, Math.ceil(quotaDecision.retryAfterMs / 1_000))),
+    );
+    sendJson(res, 429, {
+      error: 'Speech generation quota exceeded. Try again later.',
+    });
+    return;
+  }
+
+  const abortController = new AbortController();
+  const abort = () => abortController.abort();
+  req.once('aborted', abort);
+  res.once('close', abort);
+  try {
+    const audio = await synthesizeWebchatSpeech({
+      text,
+      abortSignal: abortController.signal,
+    });
+    res.writeHead(200, {
+      'Cache-Control': 'no-store',
+      'Content-Length': String(audio.length),
+      'Content-Type': 'audio/mpeg',
+    });
+    res.end(audio);
+  } finally {
+    req.off('aborted', abort);
+    res.off('close', abort);
   }
 }
 
@@ -11047,8 +11126,16 @@ export function startGatewayHttpServer(): GatewayHttpServer {
             await handleApiMediaUpload(req, res);
             return;
           }
+          if (pathname === '/api/media/capabilities' && method === 'GET') {
+            await handleApiMediaCapabilities(res);
+            return;
+          }
           if (pathname === '/api/media/transcribe' && method === 'POST') {
             await handleApiMediaTranscription(req, res);
+            return;
+          }
+          if (pathname === '/api/media/speech' && method === 'POST') {
+            await handleApiMediaSpeech(req, res);
             return;
           }
           if (pathname === '/api/command' && method === 'POST') {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -1,3 +1,12 @@
+/**
+ * Gateway HTTP boundary — authenticates and validates every console/API route.
+ *
+ * Route handlers may invoke host services, but must not bypass their policy,
+ * retention, quota, or path-containment contracts.
+ *
+ * NOT the gateway chat runtime; this module only owns HTTP transport concerns.
+ */
+
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import http, { type IncomingMessage, type ServerResponse } from 'node:http';
@@ -436,6 +445,10 @@ import {
   renderTextChannelCommandResult,
   resolveTextChannelSlashCommands,
 } from './text-channel-commands.js';
+import {
+  isSupportedDictationMimeType,
+  transcribeWebchatDictation,
+} from './webchat-dictation.js';
 
 const SITE_DIR = resolveInstallPath('docs');
 const CONSOLE_DIST_DIR = resolveInstallPath('console', 'dist');
@@ -3452,6 +3465,54 @@ async function handleApiMediaUpload(
       filename: stored.filename,
     },
   });
+}
+
+async function handleApiMediaTranscription(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const mimeType = normalizeMimeType(
+    normalizeHeaderValue(req.headers['content-type']),
+  );
+  if (!mimeType || !isSupportedDictationMimeType(mimeType)) {
+    sendJson(res, 415, { error: 'Unsupported dictation audio format.' });
+    return;
+  }
+
+  const buffer = await readRequestBody(req, MAX_MEDIA_UPLOAD_BYTES);
+  if (buffer.length === 0) {
+    sendJson(res, 400, { error: 'Dictation recording is empty.' });
+    return;
+  }
+
+  const quotaDecision = consumeGatewayMediaUploadQuota({
+    key: resolveApiMediaUploadQuotaKey(req),
+    bytes: buffer.length,
+  });
+  if (!quotaDecision.allowed) {
+    res.setHeader(
+      'Retry-After',
+      String(Math.max(1, Math.ceil(quotaDecision.retryAfterMs / 1_000))),
+    );
+    sendJson(res, 429, {
+      error: 'Media upload quota exceeded. Try again later.',
+    });
+    return;
+  }
+
+  const abortController = new AbortController();
+  const abort = () => abortController.abort();
+  req.once('aborted', abort);
+  try {
+    const text = await transcribeWebchatDictation({
+      audio: buffer,
+      mimeType,
+      abortSignal: abortController.signal,
+    });
+    sendJson(res, 200, { text });
+  } finally {
+    req.off('aborted', abort);
+  }
 }
 
 async function handleApiChatStream(
@@ -10984,6 +11045,10 @@ export function startGatewayHttpServer(): GatewayHttpServer {
           }
           if (pathname === '/api/media/upload' && method === 'POST') {
             await handleApiMediaUpload(req, res);
+            return;
+          }
+          if (pathname === '/api/media/transcribe' && method === 'POST') {
+            await handleApiMediaTranscription(req, res);
             return;
           }
           if (pathname === '/api/command' && method === 'POST') {

--- a/src/gateway/webchat-dictation.ts
+++ b/src/gateway/webchat-dictation.ts
@@ -1,0 +1,104 @@
+/**
+ * Webchat dictation boundary — transcribes one short-lived browser recording.
+ *
+ * Audio exists only in an OS temporary directory and is removed after the
+ * configured transcription chain settles; unlike media uploads, it is never
+ * added to the managed cache or conversation history.
+ *
+ * NOT the inbound-media prelude (`media/audio-transcription.ts`); that path
+ * transcribes already-retained message attachments during an agent turn.
+ */
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { getRuntimeConfig } from '../config/runtime-config.js';
+import { GatewayRequestError } from '../errors/gateway-request-error.js';
+import {
+  resolveAudioTranscriptionModels,
+  transcribeAudioWithFallback,
+} from '../media/audio-transcription-backends.js';
+import { normalizeMimeType } from '../media/mime-utils.js';
+
+const DICTATION_EXTENSION_BY_MIME_TYPE: Readonly<Record<string, string>> = {
+  'audio/aac': '.aac',
+  'audio/mp4': '.m4a',
+  'audio/mpeg': '.mp3',
+  'audio/ogg': '.ogg',
+  'audio/opus': '.opus',
+  'audio/wav': '.wav',
+  'audio/webm': '.webm',
+  'video/mp4': '.m4a',
+};
+
+export function isSupportedDictationMimeType(
+  value: string | null | undefined,
+): boolean {
+  const mimeType = normalizeMimeType(value);
+  return mimeType ? mimeType in DICTATION_EXTENSION_BY_MIME_TYPE : false;
+}
+
+export async function transcribeWebchatDictation(params: {
+  audio: Buffer;
+  mimeType: string;
+  abortSignal?: AbortSignal;
+}): Promise<string> {
+  const mimeType = normalizeMimeType(params.mimeType);
+  if (!mimeType || !isSupportedDictationMimeType(mimeType)) {
+    throw new GatewayRequestError(415, 'Unsupported dictation audio format.');
+  }
+  if (params.audio.length === 0) {
+    throw new GatewayRequestError(400, 'Dictation recording is empty.');
+  }
+
+  const config = getRuntimeConfig().media.audio;
+  if (!config.enabled) {
+    throw new GatewayRequestError(
+      503,
+      'Audio transcription is disabled in the runtime configuration.',
+    );
+  }
+
+  const models = await resolveAudioTranscriptionModels(config);
+  if (models.length === 0) {
+    throw new GatewayRequestError(
+      503,
+      'No audio transcription backend is available.',
+    );
+  }
+
+  const tempDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'hybridclaw-dictation-'),
+  );
+  const fileName = `dictation${DICTATION_EXTENSION_BY_MIME_TYPE[mimeType]}`;
+  const filePath = path.join(tempDir, fileName);
+
+  try {
+    await fs.writeFile(filePath, params.audio, { mode: 0o600 });
+    const result = await transcribeAudioWithFallback({
+      filePath,
+      fileName,
+      mimeType,
+      config,
+      models,
+      abortSignal: params.abortSignal,
+    });
+    if (!result) {
+      throw new GatewayRequestError(
+        502,
+        'The recording could not be transcribed.',
+      );
+    }
+    const text = result.text.trim();
+    if (!text) {
+      throw new GatewayRequestError(
+        422,
+        'No speech was detected in the recording.',
+      );
+    }
+    return text;
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}

--- a/src/gateway/webchat-dictation.ts
+++ b/src/gateway/webchat-dictation.ts
@@ -39,6 +39,12 @@ export function isSupportedDictationMimeType(
   return mimeType ? mimeType in DICTATION_EXTENSION_BY_MIME_TYPE : false;
 }
 
+export async function isWebchatDictationAvailable(): Promise<boolean> {
+  const config = getRuntimeConfig().media.audio;
+  if (!config.enabled) return false;
+  return (await resolveAudioTranscriptionModels(config)).length > 0;
+}
+
 export async function transcribeWebchatDictation(params: {
   audio: Buffer;
   mimeType: string;

--- a/src/gateway/webchat-speech.ts
+++ b/src/gateway/webchat-speech.ts
@@ -1,0 +1,103 @@
+/**
+ * Webchat speech boundary — turns one bounded text chunk into ephemeral audio.
+ *
+ * It uses the operator's OpenAI credentials without exposing them or retaining
+ * text/audio; the HTTP route owns authentication, request quota, and delivery.
+ *
+ * NOT a voice-call or streaming-conversation runtime.
+ */
+
+import { getRuntimeConfig } from '../config/runtime-config.js';
+import { GatewayRequestError } from '../errors/gateway-request-error.js';
+import { readOpenAIAPIKey } from '../providers/openai.js';
+
+export const MAX_WEBCHAT_SPEECH_CHARS = 4_096;
+
+// TTS defaults (maintainer decision, 2026-07-29): configurable voices are
+// deliberately deferred until HybridClaw has a general speech-output settings
+// surface.
+const WEBCHAT_SPEECH_MODEL = 'gpt-4o-mini-tts';
+const WEBCHAT_SPEECH_VOICE = 'alloy';
+const WEBCHAT_SPEECH_SPEED = 1.15;
+const WEBCHAT_SPEECH_TIMEOUT_MS = 30_000;
+
+function speechEndpoint(): string {
+  const baseUrl = getRuntimeConfig().openai.baseUrl.trim().replace(/\/+$/, '');
+  return `${baseUrl}/audio/speech`;
+}
+
+export function isWebchatSpeechAvailable(): boolean {
+  return Boolean(readOpenAIAPIKey({ required: false }));
+}
+
+export async function synthesizeWebchatSpeech(params: {
+  text: string;
+  abortSignal?: AbortSignal;
+}): Promise<Buffer> {
+  const text = params.text.trim();
+  if (!text) {
+    throw new GatewayRequestError(400, 'Speech text is empty.');
+  }
+  if (text.length > MAX_WEBCHAT_SPEECH_CHARS) {
+    throw new GatewayRequestError(
+      413,
+      `Speech text exceeds ${MAX_WEBCHAT_SPEECH_CHARS} characters.`,
+    );
+  }
+
+  const apiKey = readOpenAIAPIKey({ required: false });
+  if (!apiKey) {
+    throw new GatewayRequestError(
+      503,
+      'Read aloud requires an OpenAI API key.',
+    );
+  }
+
+  const timeoutSignal = AbortSignal.timeout(WEBCHAT_SPEECH_TIMEOUT_MS);
+  const signal = params.abortSignal
+    ? AbortSignal.any([params.abortSignal, timeoutSignal])
+    : timeoutSignal;
+
+  let response: Response;
+  try {
+    response = await fetch(speechEndpoint(), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: WEBCHAT_SPEECH_MODEL,
+        voice: WEBCHAT_SPEECH_VOICE,
+        input: text,
+        response_format: 'mp3',
+        speed: WEBCHAT_SPEECH_SPEED,
+      }),
+      signal,
+    });
+  } catch (error) {
+    if (timeoutSignal.aborted) {
+      throw new GatewayRequestError(504, 'Speech generation timed out.', {
+        cause: error,
+      });
+    }
+    if (params.abortSignal?.aborted) {
+      throw new GatewayRequestError(499, 'Speech generation cancelled.', {
+        cause: error,
+      });
+    }
+    throw new GatewayRequestError(502, 'Speech generation failed.', {
+      cause: error,
+    });
+  }
+
+  if (!response.ok) {
+    throw new GatewayRequestError(502, 'Speech generation failed.');
+  }
+
+  const audio = Buffer.from(await response.arrayBuffer());
+  if (audio.length === 0) {
+    throw new GatewayRequestError(502, 'Speech generation returned no audio.');
+  }
+  return audio;
+}

--- a/src/gateway/webchat-speech.ts
+++ b/src/gateway/webchat-speech.ts
@@ -1,14 +1,24 @@
 /**
  * Webchat speech boundary — turns one bounded text chunk into ephemeral audio.
  *
- * It uses the operator's OpenAI credentials without exposing them or retaining
- * text/audio; the HTTP route owns authentication, request quota, and delivery.
+ * It uses the operator's provider credentials without exposing them or
+ * retaining text/audio; the HTTP route owns authentication, request quota, and
+ * delivery.
+ *
+ * Two backends, both speaking OpenAI's `/audio/speech` shape: HybridAI (the
+ * default provider, so a signed-in operator needs no extra credential) and
+ * OpenAI. HybridAI is tried first and OpenAI is the fallback, which also covers
+ * the rollout window in which an operator's HybridAI deployment does not serve
+ * the audio routes yet.
  *
  * NOT a voice-call or streaming-conversation runtime.
  */
 
+import { readHybridAIApiKey } from '../auth/hybridai-auth.js';
+import { HYBRIDAI_BASE_URL } from '../config/config.js';
 import { getRuntimeConfig } from '../config/runtime-config.js';
 import { GatewayRequestError } from '../errors/gateway-request-error.js';
+import { logger } from '../logger.js';
 import { readOpenAIAPIKey } from '../providers/openai.js';
 
 export const MAX_WEBCHAT_SPEECH_CHARS = 4_096;
@@ -21,49 +31,67 @@ const WEBCHAT_SPEECH_VOICE = 'alloy';
 const WEBCHAT_SPEECH_SPEED = 1.15;
 const WEBCHAT_SPEECH_TIMEOUT_MS = 30_000;
 
-function speechEndpoint(): string {
-  const baseUrl = getRuntimeConfig().openai.baseUrl.trim().replace(/\/+$/, '');
-  return `${baseUrl}/audio/speech`;
+interface SpeechBackend {
+  provider: 'hybridai' | 'openai';
+  endpoint: string;
+  apiKey: string;
+}
+
+function trimBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, '');
+}
+
+/**
+ * Backends to try, in order. Empty when no provider is configured.
+ *
+ * HybridAI leads because it is the default provider; OpenAI follows so an
+ * operator who configured both keeps working if HybridAI cannot serve the
+ * request.
+ */
+function resolveSpeechBackends(): SpeechBackend[] {
+  const backends: SpeechBackend[] = [];
+
+  const hybridAIKey = readHybridAIApiKey();
+  if (hybridAIKey) {
+    backends.push({
+      provider: 'hybridai',
+      endpoint: `${trimBaseUrl(HYBRIDAI_BASE_URL)}/v1/audio/speech`,
+      apiKey: hybridAIKey,
+    });
+  }
+
+  const openAIKey = readOpenAIAPIKey({ required: false });
+  if (openAIKey) {
+    backends.push({
+      provider: 'openai',
+      endpoint: `${trimBaseUrl(getRuntimeConfig().openai.baseUrl)}/audio/speech`,
+      apiKey: openAIKey,
+    });
+  }
+
+  return backends;
 }
 
 export function isWebchatSpeechAvailable(): boolean {
-  return Boolean(readOpenAIAPIKey({ required: false }));
+  return resolveSpeechBackends().length > 0;
 }
 
-export async function synthesizeWebchatSpeech(params: {
-  text: string;
-  abortSignal?: AbortSignal;
-}): Promise<Buffer> {
-  const text = params.text.trim();
-  if (!text) {
-    throw new GatewayRequestError(400, 'Speech text is empty.');
-  }
-  if (text.length > MAX_WEBCHAT_SPEECH_CHARS) {
-    throw new GatewayRequestError(
-      413,
-      `Speech text exceeds ${MAX_WEBCHAT_SPEECH_CHARS} characters.`,
-    );
-  }
-
-  const apiKey = readOpenAIAPIKey({ required: false });
-  if (!apiKey) {
-    throw new GatewayRequestError(
-      503,
-      'Read aloud requires an OpenAI API key.',
-    );
-  }
-
+async function requestSpeech(
+  backend: SpeechBackend,
+  text: string,
+  abortSignal: AbortSignal | undefined,
+): Promise<Buffer> {
   const timeoutSignal = AbortSignal.timeout(WEBCHAT_SPEECH_TIMEOUT_MS);
-  const signal = params.abortSignal
-    ? AbortSignal.any([params.abortSignal, timeoutSignal])
+  const signal = abortSignal
+    ? AbortSignal.any([abortSignal, timeoutSignal])
     : timeoutSignal;
 
   let response: Response;
   try {
-    response = await fetch(speechEndpoint(), {
+    response = await fetch(backend.endpoint, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${apiKey}`,
+        Authorization: `Bearer ${backend.apiKey}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
@@ -81,7 +109,7 @@ export async function synthesizeWebchatSpeech(params: {
         cause: error,
       });
     }
-    if (params.abortSignal?.aborted) {
+    if (abortSignal?.aborted) {
       throw new GatewayRequestError(499, 'Speech generation cancelled.', {
         cause: error,
       });
@@ -100,4 +128,54 @@ export async function synthesizeWebchatSpeech(params: {
     throw new GatewayRequestError(502, 'Speech generation returned no audio.');
   }
   return audio;
+}
+
+export async function synthesizeWebchatSpeech(params: {
+  text: string;
+  abortSignal?: AbortSignal;
+}): Promise<Buffer> {
+  const text = params.text.trim();
+  if (!text) {
+    throw new GatewayRequestError(400, 'Speech text is empty.');
+  }
+  if (text.length > MAX_WEBCHAT_SPEECH_CHARS) {
+    throw new GatewayRequestError(
+      413,
+      `Speech text exceeds ${MAX_WEBCHAT_SPEECH_CHARS} characters.`,
+    );
+  }
+
+  const backends = resolveSpeechBackends();
+  if (backends.length === 0) {
+    throw new GatewayRequestError(
+      503,
+      'Read aloud requires a HybridAI or OpenAI API key.',
+    );
+  }
+
+  let lastError: unknown;
+  for (const [index, backend] of backends.entries()) {
+    try {
+      return await requestSpeech(backend, text, params.abortSignal);
+    } catch (error) {
+      // A cancelled request is the user's decision, not a backend fault —
+      // trying the next one would speak after they asked us to stop.
+      if (error instanceof GatewayRequestError && error.statusCode === 499) {
+        throw error;
+      }
+      lastError = error;
+      const nextBackend = backends[index + 1];
+      if (!nextBackend) break;
+      logger.warn(
+        { provider: backend.provider, next: nextBackend.provider },
+        'Webchat speech backend failed; trying next backend',
+      );
+    }
+  }
+
+  throw lastError instanceof GatewayRequestError
+    ? lastError
+    : new GatewayRequestError(502, 'Speech generation failed.', {
+        cause: lastError,
+      });
 }

--- a/src/media/audio-transcription-backends.ts
+++ b/src/media/audio-transcription-backends.ts
@@ -2,7 +2,8 @@ import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-
+import { readHybridAIApiKey } from '../auth/hybridai-auth.js';
+import { HYBRIDAI_BASE_URL } from '../config/config.js';
 import type {
   RuntimeAudioCliModelConfig,
   RuntimeAudioProviderModelConfig,
@@ -18,6 +19,7 @@ import { expandUserPath } from './path-utils.js';
 const ABSOLUTE_MAX_AUDIO_BYTES = 25 * 1024 * 1024;
 const CLI_OUTPUT_MAX_BUFFER = 5 * 1024 * 1024;
 const GEMINI_CLI_PROBE_TIMEOUT_MS = 8_000;
+const DEFAULT_HYBRIDAI_MODEL = 'gpt-4o-mini-transcribe';
 const DEFAULT_OPENAI_MODEL = 'gpt-4o-mini-transcribe';
 const DEFAULT_GROQ_MODEL = 'whisper-large-v3-turbo';
 const DEFAULT_DEEPGRAM_MODEL = 'nova-3';
@@ -52,6 +54,14 @@ const COMMON_WHISPER_CPP_MODEL_PATHS = [
 export interface AudioTranscriptionResult {
   text: string;
   backend: string;
+}
+
+/**
+ * HybridAI serves audio on its OpenAI-compatible surface, which is rooted at
+ * `/v1` — the same shape every other OpenAI-compatible provider here uses.
+ */
+function hybridAIAudioBaseUrl(): string {
+  return `${HYBRIDAI_BASE_URL.trim().replace(/\/+$/, '')}/v1`;
 }
 
 function normalizeBaseUrl(
@@ -328,6 +338,9 @@ function readProviderApiKey(
   provider: RuntimeAudioTranscriptionProvider,
 ): string | null {
   const storedSecrets = readStoredRuntimeSecrets();
+  if (provider === 'hybridai') {
+    return readHybridAIApiKey();
+  }
   if (provider === 'openai') {
     return (
       String(process.env.OPENAI_API_KEY || '').trim() ||
@@ -364,6 +377,7 @@ function readProviderApiKey(
 function resolveProviderModel(entry: RuntimeAudioProviderModelConfig): string {
   const configured = (entry.model || '').trim();
   if (configured) return configured;
+  if (entry.provider === 'hybridai') return DEFAULT_HYBRIDAI_MODEL;
   if (entry.provider === 'openai') return DEFAULT_OPENAI_MODEL;
   if (entry.provider === 'groq') return DEFAULT_GROQ_MODEL;
   if (entry.provider === 'deepgram') return DEFAULT_DEEPGRAM_MODEL;
@@ -373,6 +387,9 @@ function resolveProviderModel(entry: RuntimeAudioProviderModelConfig): string {
 function resolveProviderBaseUrl(
   entry: RuntimeAudioProviderModelConfig,
 ): string {
+  if (entry.provider === 'hybridai') {
+    return normalizeBaseUrl(entry.baseUrl, hybridAIAudioBaseUrl());
+  }
   if (entry.provider === 'openai') {
     return normalizeBaseUrl(entry.baseUrl, DEFAULT_OPENAI_BASE_URL);
   }
@@ -415,6 +432,12 @@ function resolveEntryLanguage(
 
 function resolveAutoProviderEntries(): RuntimeAudioProviderModelConfig[] {
   const entries: RuntimeAudioProviderModelConfig[] = [];
+  // HybridAI first: it is the default provider, so a signed-in operator gets
+  // dictation with no extra credential to configure. Its endpoint is
+  // OpenAI-compatible, and a failure here falls through to the next backend.
+  if (readProviderApiKey('hybridai')) {
+    entries.push({ type: 'provider', provider: 'hybridai' });
+  }
   if (readProviderApiKey('openai')) {
     entries.push({ type: 'provider', provider: 'openai' });
   }
@@ -895,7 +918,11 @@ async function transcribeWithProvider(params: {
   const timeoutMs = resolveEntryTimeoutMs(params.entry, params.config);
 
   let text: string;
-  if (params.entry.provider === 'openai' || params.entry.provider === 'groq') {
+  if (
+    params.entry.provider === 'hybridai' ||
+    params.entry.provider === 'openai' ||
+    params.entry.provider === 'groq'
+  ) {
     text = await transcribeOpenAiCompatibleAudio({
       baseUrl,
       apiKey,

--- a/tests/audio-transcription-backends.test.ts
+++ b/tests/audio-transcription-backends.test.ts
@@ -10,6 +10,8 @@ import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const ORIGINAL_PATH = process.env.PATH;
 const ORIGINAL_GOOGLE_API_KEY = process.env.GOOGLE_API_KEY;
+const ORIGINAL_HYBRIDAI_API_KEY = process.env.HYBRIDAI_API_KEY;
+const ORIGINAL_OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
 const DEFAULT_AUDIO_CONFIG = {
   enabled: true,
@@ -29,6 +31,8 @@ useCleanMocks({
   cleanup: () => {
     process.env.PATH = ORIGINAL_PATH;
     process.env.GOOGLE_API_KEY = ORIGINAL_GOOGLE_API_KEY;
+    process.env.HYBRIDAI_API_KEY = ORIGINAL_HYBRIDAI_API_KEY;
+    process.env.OPENAI_API_KEY = ORIGINAL_OPENAI_API_KEY;
   },
   restoreAllMocks: false,
   resetModules: true,
@@ -96,4 +100,56 @@ test('google provider fallback uses the current default Gemini model', async () 
     backend: 'google/gemini-3.1-flash-lite-preview',
   });
   expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+
+test('hybridai transcribes through the OpenAI-compatible surface at /v1', async () => {
+  process.env.HYBRIDAI_API_KEY = 'test-hybridai-key';
+
+  const audioDir = makeTempDir('hybridclaw-audio-hybridai-');
+  const audioPath = path.join(audioDir, 'voice-note.ogg');
+  fs.writeFileSync(audioPath, 'audio-bytes', 'utf8');
+
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    expect(String(input)).toBe('https://hybridai.one/v1/audio/transcriptions');
+    expect(new Headers(init?.headers).get('authorization')).toBe(
+      'Bearer test-hybridai-key',
+    );
+    return new Response(JSON.stringify({ text: 'transcribed by hybridai' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  const transcript = await transcribeAudioWithFallback({
+    filePath: audioPath,
+    fileName: 'voice-note.ogg',
+    mimeType: 'audio/ogg',
+    config: DEFAULT_AUDIO_CONFIG,
+    models: [{ type: 'provider', provider: 'hybridai' }],
+  });
+
+  expect(transcript).toEqual({
+    text: 'transcribed by hybridai',
+    backend: 'hybridai/gpt-4o-mini-transcribe',
+  });
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+test('hybridai leads the auto-detected provider order', async () => {
+  // HybridAI is the default provider, so a signed-in operator should get
+  // dictation without configuring a second credential.
+  const binDir = makeTempDir('hybridclaw-audio-order-');
+  process.env.PATH = binDir;
+  process.env.HYBRIDAI_API_KEY = 'test-hybridai-key';
+  process.env.OPENAI_API_KEY = 'test-openai-key';
+
+  const entries = await resolveAudioTranscriptionModels(DEFAULT_AUDIO_CONFIG);
+  const providers = entries
+    .filter((entry) => entry.type === 'provider')
+    .map((entry) => entry.provider);
+
+  expect(providers[0]).toBe('hybridai');
+  expect(providers).toContain('openai');
 });

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -679,6 +679,7 @@ async function importFreshHealth(options?: {
   const loggerError = vi.fn();
   const loggerInfo = vi.fn();
   const loggerWarn = vi.fn();
+  const transcribeWebchatDictation = vi.fn(async () => 'Dictated text');
   const getGatewayHistory = vi.fn((sessionId: string) => ({
     sessionId,
     agentId: 'research',
@@ -2790,6 +2791,11 @@ async function importFreshHealth(options?: {
   vi.doMock('../src/gateway/media-upload-quota.ts', () => ({
     consumeGatewayMediaUploadQuota,
   }));
+  vi.doMock('../src/gateway/webchat-dictation.js', () => ({
+    isSupportedDictationMimeType: (value: string | null | undefined) =>
+      value === 'audio/mp4' || value === 'audio/webm',
+    transcribeWebchatDictation,
+  }));
   vi.doMock('../src/plugins/plugin-manager.js', () => ({
     findLoadedPluginCommand: vi.fn(() => undefined),
     listLoadedPluginCommands,
@@ -2965,6 +2971,7 @@ async function importFreshHealth(options?: {
     claimQueuedProactiveMessages,
     getDelegationJob,
     consumeGatewayMediaUploadQuota,
+    transcribeWebchatDictation,
     listLoadedPluginCommands,
   };
 }
@@ -12803,6 +12810,81 @@ describe('gateway HTTP server', () => {
     expect(fs.existsSync(path.join(dataDir, 'uploaded-media-cache'))).toBe(
       false,
     );
+  });
+
+  test('transcribes authenticated webchat dictation without storing media', async () => {
+    const dataDir = makeTempDataDir();
+    const state = await importFreshHealth({ dataDir });
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/media/transcribe',
+      headers: { 'content-type': 'audio/mp4; codecs=mp4a.40.2' },
+      body: Buffer.from('voice-bytes'),
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ text: 'Dictated text' });
+    expect(state.transcribeWebchatDictation).toHaveBeenCalledWith({
+      audio: Buffer.from('voice-bytes'),
+      mimeType: 'audio/mp4',
+      abortSignal: expect.any(AbortSignal),
+    });
+    expect(state.consumeGatewayMediaUploadQuota).toHaveBeenCalledWith({
+      key: 'gateway-token',
+      bytes: 'voice-bytes'.length,
+    });
+    expect(fs.existsSync(path.join(dataDir, 'uploaded-media-cache'))).toBe(
+      false,
+    );
+  });
+
+  test('rejects unsupported webchat dictation before transcription', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/media/transcribe',
+      headers: { 'content-type': 'text/plain' },
+      body: Buffer.from('not-audio'),
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(415);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Unsupported dictation audio format.',
+    });
+    expect(state.transcribeWebchatDictation).not.toHaveBeenCalled();
+  });
+
+  test('applies media quota limits to webchat dictation', async () => {
+    const state = await importFreshHealth({
+      mediaUploadQuotaDecision: {
+        allowed: false,
+        remainingBytes: 0,
+        retryAfterMs: 2_000,
+        usedBytes: 100 * 1024 * 1024,
+      },
+    });
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/media/transcribe',
+      headers: { 'content-type': 'audio/webm' },
+      body: Buffer.from('voice-bytes'),
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(429);
+    expect(res.headers['Retry-After']).toBe('2');
+    expect(state.transcribeWebchatDictation).not.toHaveBeenCalled();
   });
 
   test('starts with an empty DATA_DIR and returns 503 for media uploads', async () => {

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -476,6 +476,7 @@ function makeResponse() {
     getHeader(name: string) {
       return headers[resolveHeaderKey(name)];
     },
+    on: vi.fn(),
     once: vi.fn(),
     off: vi.fn(),
     writeHead(statusCode: number, headers: Record<string, string | string[]>) {
@@ -12903,6 +12904,28 @@ describe('gateway HTTP server', () => {
     expect(state.transcribeWebchatDictation).not.toHaveBeenCalled();
   });
 
+  test('rejects webchat dictation without consuming quota when unavailable', async () => {
+    const state = await importFreshHealth();
+    state.isWebchatDictationAvailable.mockResolvedValue(false);
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/media/transcribe',
+      headers: { 'content-type': 'audio/webm' },
+      body: Buffer.from('voice-bytes'),
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'No audio transcription backend is available.',
+    });
+    expect(state.consumeGatewayMediaUploadQuota).not.toHaveBeenCalled();
+    expect(state.transcribeWebchatDictation).not.toHaveBeenCalled();
+  });
+
   test('reports authenticated webchat media capabilities', async () => {
     const state = await importFreshHealth();
     const req = makeRequest({
@@ -12943,7 +12966,7 @@ describe('gateway HTTP server', () => {
       text: 'Read this response.',
       abortSignal: expect.any(AbortSignal),
     });
-    expect(res.once).toHaveBeenCalledWith('close', expect.any(Function));
+    expect(res.on).toHaveBeenCalledWith('close', expect.any(Function));
     expect(res.off).toHaveBeenCalledWith('close', expect.any(Function));
     expect(state.consumeGatewayMediaUploadQuota).toHaveBeenCalledWith({
       key: 'gateway-token',
@@ -12995,6 +13018,27 @@ describe('gateway HTTP server', () => {
     expect(limitedRes.statusCode).toBe(429);
     expect(limitedRes.headers['Retry-After']).toBe('3');
     expect(limitedState.synthesizeWebchatSpeech).not.toHaveBeenCalled();
+  });
+
+  test('rejects webchat speech without consuming quota when unavailable', async () => {
+    const state = await importFreshHealth();
+    state.isWebchatSpeechAvailable.mockReturnValue(false);
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/media/speech',
+      body: { text: 'Read this response.' },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Read aloud requires a HybridAI or OpenAI API key.',
+    });
+    expect(state.consumeGatewayMediaUploadQuota).not.toHaveBeenCalled();
+    expect(state.synthesizeWebchatSpeech).not.toHaveBeenCalled();
   });
 
   test('starts with an empty DATA_DIR and returns 503 for media uploads', async () => {

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -476,6 +476,8 @@ function makeResponse() {
     getHeader(name: string) {
       return headers[resolveHeaderKey(name)];
     },
+    once: vi.fn(),
+    off: vi.fn(),
     writeHead(statusCode: number, headers: Record<string, string | string[]>) {
       response.statusCode = statusCode;
       Object.assign(response.headers, headers);
@@ -679,7 +681,12 @@ async function importFreshHealth(options?: {
   const loggerError = vi.fn();
   const loggerInfo = vi.fn();
   const loggerWarn = vi.fn();
+  const isWebchatDictationAvailable = vi.fn(async () => true);
   const transcribeWebchatDictation = vi.fn(async () => 'Dictated text');
+  const isWebchatSpeechAvailable = vi.fn(() => true);
+  const synthesizeWebchatSpeech = vi.fn(async () =>
+    Buffer.from('generated-mp3'),
+  );
   const getGatewayHistory = vi.fn((sessionId: string) => ({
     sessionId,
     agentId: 'research',
@@ -2792,9 +2799,15 @@ async function importFreshHealth(options?: {
     consumeGatewayMediaUploadQuota,
   }));
   vi.doMock('../src/gateway/webchat-dictation.js', () => ({
+    isWebchatDictationAvailable,
     isSupportedDictationMimeType: (value: string | null | undefined) =>
       value === 'audio/mp4' || value === 'audio/webm',
     transcribeWebchatDictation,
+  }));
+  vi.doMock('../src/gateway/webchat-speech.js', () => ({
+    isWebchatSpeechAvailable,
+    MAX_WEBCHAT_SPEECH_CHARS: 4_096,
+    synthesizeWebchatSpeech,
   }));
   vi.doMock('../src/plugins/plugin-manager.js', () => ({
     findLoadedPluginCommand: vi.fn(() => undefined),
@@ -2971,7 +2984,10 @@ async function importFreshHealth(options?: {
     claimQueuedProactiveMessages,
     getDelegationJob,
     consumeGatewayMediaUploadQuota,
+    isWebchatDictationAvailable,
     transcribeWebchatDictation,
+    isWebchatSpeechAvailable,
+    synthesizeWebchatSpeech,
     listLoadedPluginCommands,
   };
 }
@@ -12885,6 +12901,100 @@ describe('gateway HTTP server', () => {
     expect(res.statusCode).toBe(429);
     expect(res.headers['Retry-After']).toBe('2');
     expect(state.transcribeWebchatDictation).not.toHaveBeenCalled();
+  });
+
+  test('reports authenticated webchat media capabilities', async () => {
+    const state = await importFreshHealth();
+    const req = makeRequest({
+      url: '/api/media/capabilities',
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      dictation: true,
+      readAloud: true,
+    });
+    expect(state.isWebchatDictationAvailable).toHaveBeenCalledTimes(1);
+    expect(state.isWebchatSpeechAvailable).toHaveBeenCalledTimes(1);
+  });
+
+  test('generates authenticated webchat speech without retaining it', async () => {
+    const dataDir = makeTempDataDir();
+    const state = await importFreshHealth({ dataDir });
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/media/speech',
+      body: { text: 'Read this response.' },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Content-Type']).toBe('audio/mpeg');
+    expect(res.headers['Cache-Control']).toBe('no-store');
+    expect(Buffer.concat(res.chunks)).toEqual(Buffer.from('generated-mp3'));
+    expect(state.synthesizeWebchatSpeech).toHaveBeenCalledWith({
+      text: 'Read this response.',
+      abortSignal: expect.any(AbortSignal),
+    });
+    expect(res.once).toHaveBeenCalledWith('close', expect.any(Function));
+    expect(res.off).toHaveBeenCalledWith('close', expect.any(Function));
+    expect(state.consumeGatewayMediaUploadQuota).toHaveBeenCalledWith({
+      key: 'gateway-token',
+      bytes: Buffer.byteLength('Read this response.', 'utf8'),
+    });
+    expect(fs.existsSync(path.join(dataDir, 'uploaded-media-cache'))).toBe(
+      false,
+    );
+  });
+
+  test('requires authentication and quota for webchat speech', async () => {
+    const unauthorizedState = await importFreshHealth();
+    const unauthorizedReq = makeRequest({
+      method: 'POST',
+      url: '/api/media/speech',
+      body: { text: 'Private response.' },
+      noAuth: true,
+    });
+    const unauthorizedRes = makeResponse();
+
+    unauthorizedState.handler(
+      unauthorizedReq as never,
+      unauthorizedRes as never,
+    );
+    await waitForResponse(
+      unauthorizedRes,
+      (next) => next.writableEnded,
+    );
+    expect(unauthorizedRes.statusCode).toBe(401);
+    expect(unauthorizedState.synthesizeWebchatSpeech).not.toHaveBeenCalled();
+
+    const limitedState = await importFreshHealth({
+      mediaUploadQuotaDecision: {
+        allowed: false,
+        remainingBytes: 0,
+        retryAfterMs: 3_000,
+        usedBytes: 100 * 1024 * 1024,
+      },
+    });
+    const limitedReq = makeRequest({
+      method: 'POST',
+      url: '/api/media/speech',
+      body: { text: 'Private response.' },
+    });
+    const limitedRes = makeResponse();
+
+    limitedState.handler(limitedReq as never, limitedRes as never);
+    await waitForResponse(limitedRes, (next) => next.writableEnded);
+    expect(limitedRes.statusCode).toBe(429);
+    expect(limitedRes.headers['Retry-After']).toBe('3');
+    expect(limitedState.synthesizeWebchatSpeech).not.toHaveBeenCalled();
   });
 
   test('starts with an empty DATA_DIR and returns 503 for media uploads', async () => {

--- a/tests/webchat-dictation.test.ts
+++ b/tests/webchat-dictation.test.ts
@@ -1,0 +1,139 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { GatewayRequestError } from '../src/errors/gateway-request-error.ts';
+
+const mocks = vi.hoisted(() => ({
+  enabled: true,
+  resolveModels: vi.fn(),
+  transcribe: vi.fn(),
+}));
+
+vi.mock('../src/config/runtime-config.js', () => ({
+  getRuntimeConfig: () => ({
+    media: {
+      audio: {
+        enabled: mocks.enabled,
+        maxBytes: 20 * 1024 * 1024,
+        maxFiles: 4,
+        maxCharsPerTranscript: 8_000,
+        maxTotalChars: 16_000,
+        timeoutMs: 60_000,
+        prompt: 'Transcribe the audio.',
+        language: '',
+        models: [],
+      },
+    },
+  }),
+}));
+
+vi.mock('../src/media/audio-transcription-backends.js', () => ({
+  resolveAudioTranscriptionModels: mocks.resolveModels,
+  transcribeAudioWithFallback: mocks.transcribe,
+}));
+
+import {
+  isSupportedDictationMimeType,
+  transcribeWebchatDictation,
+} from '../src/gateway/webchat-dictation.ts';
+
+describe('webchat dictation boundary', () => {
+  beforeEach(() => {
+    mocks.enabled = true;
+    mocks.resolveModels.mockReset();
+    mocks.resolveModels.mockResolvedValue([
+      { type: 'provider', provider: 'openai' },
+    ]);
+    mocks.transcribe.mockReset();
+  });
+
+  test('transcribes from a private temporary file and deletes it afterwards', async () => {
+    let capturedPath = '';
+    mocks.transcribe.mockImplementation(
+      async (params: {
+        filePath: string;
+        mimeType: string;
+        abortSignal?: AbortSignal;
+      }) => {
+        capturedPath = params.filePath;
+        const stat = await fs.stat(params.filePath);
+        expect(stat.mode & 0o777).toBe(0o600);
+        expect(await fs.readFile(params.filePath, 'utf8')).toBe('voice-bytes');
+        expect(params.mimeType).toBe('audio/mp4');
+        return { text: '  dictated text  ', backend: 'test' };
+      },
+    );
+
+    const abortController = new AbortController();
+    await expect(
+      transcribeWebchatDictation({
+        audio: Buffer.from('voice-bytes'),
+        mimeType: 'audio/mp4; codecs=mp4a.40.2',
+        abortSignal: abortController.signal,
+      }),
+    ).resolves.toBe('dictated text');
+
+    expect(mocks.transcribe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileName: 'dictation.m4a',
+        abortSignal: abortController.signal,
+      }),
+    );
+    await expect(fs.access(path.dirname(capturedPath))).rejects.toThrow();
+  });
+
+  test('deletes temporary audio when transcription fails', async () => {
+    let capturedPath = '';
+    mocks.transcribe.mockImplementation(
+      async (params: { filePath: string }) => {
+        capturedPath = params.filePath;
+        return null;
+      },
+    );
+
+    await expect(
+      transcribeWebchatDictation({
+        audio: Buffer.from('silence'),
+        mimeType: 'audio/webm',
+      }),
+    ).rejects.toMatchObject<Partial<GatewayRequestError>>({
+      statusCode: 502,
+    });
+    await expect(fs.access(path.dirname(capturedPath))).rejects.toThrow();
+  });
+
+  test('reports an empty transcript as no detected speech', async () => {
+    mocks.transcribe.mockResolvedValue({ text: '   ', backend: 'test' });
+
+    await expect(
+      transcribeWebchatDictation({
+        audio: Buffer.from('silence'),
+        mimeType: 'audio/webm',
+      }),
+    ).rejects.toMatchObject<Partial<GatewayRequestError>>({
+      statusCode: 422,
+    });
+  });
+
+  test('fails before writing audio when transcription is unavailable', async () => {
+    mocks.enabled = false;
+
+    await expect(
+      transcribeWebchatDictation({
+        audio: Buffer.from('voice-bytes'),
+        mimeType: 'audio/webm',
+      }),
+    ).rejects.toMatchObject<Partial<GatewayRequestError>>({
+      statusCode: 503,
+    });
+    expect(mocks.resolveModels).not.toHaveBeenCalled();
+    expect(mocks.transcribe).not.toHaveBeenCalled();
+  });
+
+  test('accepts Safari and Chromium recording formats but rejects non-audio', () => {
+    expect(isSupportedDictationMimeType('audio/mp4')).toBe(true);
+    expect(isSupportedDictationMimeType('audio/webm;codecs=opus')).toBe(true);
+    expect(isSupportedDictationMimeType('text/plain')).toBe(false);
+  });
+});

--- a/tests/webchat-speech.test.ts
+++ b/tests/webchat-speech.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { GatewayRequestError } from '../src/errors/gateway-request-error.ts';
 
 const mocks = vi.hoisted(() => ({
-  apiKey: 'test-openai-key',
+  openAIKey: 'test-openai-key',
+  hybridAIKey: '',
   baseUrl: 'https://speech.example.com/v1/',
+  hybridAIBaseUrl: 'https://hybridai.example.com',
 }));
 
 vi.mock('../src/config/runtime-config.js', () => ({
@@ -12,8 +14,22 @@ vi.mock('../src/config/runtime-config.js', () => ({
   }),
 }));
 
+vi.mock('../src/config/config.js', () => ({
+  get HYBRIDAI_BASE_URL() {
+    return mocks.hybridAIBaseUrl;
+  },
+}));
+
+vi.mock('../src/logger.js', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
 vi.mock('../src/providers/openai.js', () => ({
-  readOpenAIAPIKey: () => mocks.apiKey,
+  readOpenAIAPIKey: () => mocks.openAIKey,
+}));
+
+vi.mock('../src/auth/hybridai-auth.js', () => ({
+  readHybridAIApiKey: () => mocks.hybridAIKey || null,
 }));
 
 import {
@@ -22,10 +38,23 @@ import {
   synthesizeWebchatSpeech,
 } from '../src/gateway/webchat-speech.ts';
 
+const HYBRIDAI_ENDPOINT = 'https://hybridai.example.com/v1/audio/speech';
+const OPENAI_ENDPOINT = 'https://speech.example.com/v1/audio/speech';
+
+const EXPECTED_BODY = JSON.stringify({
+  model: 'gpt-4o-mini-tts',
+  voice: 'alloy',
+  input: 'Read this naturally.',
+  response_format: 'mp3',
+  speed: 1.15,
+});
+
 describe('webchat speech boundary', () => {
   beforeEach(() => {
-    mocks.apiKey = 'test-openai-key';
+    mocks.openAIKey = 'test-openai-key';
+    mocks.hybridAIKey = '';
     mocks.baseUrl = 'https://speech.example.com/v1/';
+    mocks.hybridAIBaseUrl = 'https://hybridai.example.com';
     vi.unstubAllGlobals();
   });
 
@@ -40,27 +69,120 @@ describe('webchat speech boundary', () => {
     ).resolves.toEqual(Buffer.from('mp3-bytes'));
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://speech.example.com/v1/audio/speech',
+      OPENAI_ENDPOINT,
       expect.objectContaining({
         method: 'POST',
         headers: {
           Authorization: 'Bearer test-openai-key',
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          model: 'gpt-4o-mini-tts',
-          voice: 'alloy',
-          input: 'Read this naturally.',
-          response_format: 'mp3',
-          speed: 1.15,
-        }),
+        body: EXPECTED_BODY,
         signal: expect.any(AbortSignal),
       }),
     );
   });
 
+  test('prefers HybridAI, the default provider, over OpenAI', async () => {
+    mocks.hybridAIKey = 'test-hybridai-key';
+    const fetchMock = vi.fn(async () => {
+      return new Response(Buffer.from('mp3-bytes'), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      synthesizeWebchatSpeech({ text: 'Read this naturally.' }),
+    ).resolves.toEqual(Buffer.from('mp3-bytes'));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      HYBRIDAI_ENDPOINT,
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer test-hybridai-key',
+          'Content-Type': 'application/json',
+        },
+        body: EXPECTED_BODY,
+      }),
+    );
+  });
+
+  test('speaks through HybridAI alone when no OpenAI key is configured', async () => {
+    mocks.hybridAIKey = 'test-hybridai-key';
+    mocks.openAIKey = '';
+    const fetchMock = vi.fn(async () => {
+      return new Response(Buffer.from('mp3-bytes'), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(isWebchatSpeechAvailable()).toBe(true);
+    await expect(
+      synthesizeWebchatSpeech({ text: 'Read this naturally.' }),
+    ).resolves.toEqual(Buffer.from('mp3-bytes'));
+    expect(fetchMock).toHaveBeenCalledWith(
+      HYBRIDAI_ENDPOINT,
+      expect.anything(),
+    );
+  });
+
+  test('falls back to OpenAI when HybridAI cannot serve the request', async () => {
+    // The rollout case: a HybridAI deployment without the audio routes yet.
+    mocks.hybridAIKey = 'test-hybridai-key';
+    const fetchMock = vi.fn(async (url: string) =>
+      url === HYBRIDAI_ENDPOINT
+        ? new Response('not found', { status: 404 })
+        : new Response(Buffer.from('mp3-bytes'), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      synthesizeWebchatSpeech({ text: 'Read this naturally.' }),
+    ).resolves.toEqual(Buffer.from('mp3-bytes'));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(HYBRIDAI_ENDPOINT);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(OPENAI_ENDPOINT);
+  });
+
+  test('surfaces the failure when every backend fails', async () => {
+    mocks.hybridAIKey = 'test-hybridai-key';
+    const fetchMock = vi.fn(
+      async () => new Response('provider-secret-detail', { status: 500 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      synthesizeWebchatSpeech({ text: 'valid text' }),
+    ).rejects.toMatchObject<Partial<GatewayRequestError>>({
+      statusCode: 502,
+      message: 'Speech generation failed.',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not try the next backend after the client cancels', async () => {
+    mocks.hybridAIKey = 'test-hybridai-key';
+    const controller = new AbortController();
+    const fetchMock = vi.fn(async () => {
+      controller.abort();
+      throw new DOMException('aborted', 'AbortError');
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      synthesizeWebchatSpeech({
+        text: 'valid text',
+        abortSignal: controller.signal,
+      }),
+    ).rejects.toMatchObject<Partial<GatewayRequestError>>({
+      statusCode: 499,
+    });
+    // Speaking through a second backend after Stop would defeat the Stop.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   test('reports unavailable speech without making a provider request', async () => {
-    mocks.apiKey = '';
+    mocks.openAIKey = '';
+    mocks.hybridAIKey = '';
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
 
@@ -69,7 +191,7 @@ describe('webchat speech boundary', () => {
       synthesizeWebchatSpeech({ text: 'Hello' }),
     ).rejects.toMatchObject<Partial<GatewayRequestError>>({
       statusCode: 503,
-      message: 'Read aloud requires an OpenAI API key.',
+      message: 'Read aloud requires a HybridAI or OpenAI API key.',
     });
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/tests/webchat-speech.test.ts
+++ b/tests/webchat-speech.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { GatewayRequestError } from '../src/errors/gateway-request-error.ts';
+
+const mocks = vi.hoisted(() => ({
+  apiKey: 'test-openai-key',
+  baseUrl: 'https://speech.example.com/v1/',
+}));
+
+vi.mock('../src/config/runtime-config.js', () => ({
+  getRuntimeConfig: () => ({
+    openai: { baseUrl: mocks.baseUrl },
+  }),
+}));
+
+vi.mock('../src/providers/openai.js', () => ({
+  readOpenAIAPIKey: () => mocks.apiKey,
+}));
+
+import {
+  isWebchatSpeechAvailable,
+  MAX_WEBCHAT_SPEECH_CHARS,
+  synthesizeWebchatSpeech,
+} from '../src/gateway/webchat-speech.ts';
+
+describe('webchat speech boundary', () => {
+  beforeEach(() => {
+    mocks.apiKey = 'test-openai-key';
+    mocks.baseUrl = 'https://speech.example.com/v1/';
+    vi.unstubAllGlobals();
+  });
+
+  test('generates MP3 audio without exposing the provider key', async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(Buffer.from('mp3-bytes'), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      synthesizeWebchatSpeech({ text: '  Read this naturally.  ' }),
+    ).resolves.toEqual(Buffer.from('mp3-bytes'));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://speech.example.com/v1/audio/speech',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer test-openai-key',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'gpt-4o-mini-tts',
+          voice: 'alloy',
+          input: 'Read this naturally.',
+          response_format: 'mp3',
+          speed: 1.15,
+        }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  test('reports unavailable speech without making a provider request', async () => {
+    mocks.apiKey = '';
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(isWebchatSpeechAvailable()).toBe(false);
+    await expect(
+      synthesizeWebchatSpeech({ text: 'Hello' }),
+    ).rejects.toMatchObject<Partial<GatewayRequestError>>({
+      statusCode: 503,
+      message: 'Read aloud requires an OpenAI API key.',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('bounds speech input and sanitizes upstream failures', async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response('provider-secret-detail', { status: 500 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      synthesizeWebchatSpeech({
+        text: 'x'.repeat(MAX_WEBCHAT_SPEECH_CHARS + 1),
+      }),
+    ).rejects.toMatchObject<Partial<GatewayRequestError>>({
+      statusCode: 413,
+    });
+    await expect(
+      synthesizeWebchatSpeech({ text: 'valid text' }),
+    ).rejects.toMatchObject<Partial<GatewayRequestError>>({
+      statusCode: 502,
+      message: 'Speech generation failed.',
+    });
+  });
+
+  test('treats an empty provider response as a failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(Buffer.alloc(0), { status: 200 })),
+    );
+
+    await expect(
+      synthesizeWebchatSpeech({ text: 'valid text' }),
+    ).rejects.toMatchObject<Partial<GatewayRequestError>>({
+      statusCode: 502,
+      message: 'Speech generation returned no audio.',
+    });
+  });
+});


### PR DESCRIPTION
## What changed

Adds webchat audio controls for editable dictation and explicit read-aloud:

- records microphone input with `MediaRecorder`, transcribes it through the authenticated gateway, and inserts the transcript into the composer for editing before send
- adds explicit per-assistant-message read-aloud controls backed by gateway-side speech synthesis
- uses a shared, gesture-unlocked audio element for reliable mobile browser playback
- adds backend capability discovery so controls fail closed when transcription or speech is not configured
- documents provider requirements and privacy behavior

## Providers

Both features run on **HybridAI's OpenAI-compatible audio endpoints** (HybridAI PR #2109), so a signed-in operator needs no second credential — HybridAI is already HybridClaw's default provider.

**Transcription** gains a `hybridai` provider. It speaks the same OpenAI-compatible shape as the existing `openai`/`groq` backends, so it reuses that request path and only adds credential, base-URL (`<hybridai.baseUrl>/v1`) and default-model resolution. It leads the auto-detected *provider* group — after the local CLIs, which stay preferred because local transcription costs nothing and never leaves the box.

**Read-aloud** gains the backend chain it did not have: HybridAI first, then OpenAI. That ordering also covers the rollout window — a HybridAI deployment that does not serve the audio routes yet returns 404 and falls through to OpenAI instead of breaking read-aloud. A client cancellation is exempt from the fallback: trying the next backend would speak after the user pressed Stop.

Both degrade as before when nothing is configured — capability discovery reports them unavailable and the controls explain why.

`readHybridAIApiKey()` is added alongside `getHybridAIApiKey()` for callers where "not signed in" means a capability is unavailable rather than an error, so feature discovery does not catch a throw as control flow.

## User impact

- Recording shows a live level indicator and stops after three seconds of trailing silence or five minutes maximum.
- Transcription never auto-sends; users can review and edit it.
- Read-aloud shows preparing/playing states and can be stopped immediately.
- Controls explain whether the browser is unsupported or the server capability is unavailable.

## Security and failure boundaries

- Both media endpoints inherit webchat authentication and same-origin protections.
- Existing media quotas apply; uploads are capped at 20 MiB and speech input at 4,096 characters.
- Temporary recording files use mode `0600` and are removed after transcription.
- Provider credentials stay server-side, upstream errors are sanitized, and responses are not retained or cached.
- Client disconnects and Stop actions abort in-flight provider requests.
- Speech text is sent only after an explicit user click to the operator-configured speech endpoint.

## Validation

- `npm run lint`
- `npm run build`
- full console suite: 5,636 tests across 585 files
- 9 webchat speech tests (provider preference, HybridAI-only, rollout fallback to OpenAI, all-backends-fail, no-fallback-after-cancel, availability, bounds, empty response)
- 4 transcription backend tests incl. HybridAI `/v1` routing and auto-detect ordering
- isolated real-browser mobile E2E through the actual gateway routes and a local provider fixture:
  - microphone record → `/api/media/transcribe` → editable composer text → real `/api/chat` request
  - assistant read-aloud → `/api/media/speech` → audio playback state → Stop/client abort
  - verified 1-second recorder slices, audio constraints, track cleanup, authenticated routes, `audio/mpeg`, and `no-store`
- GitHub Actions: test, lint, npm E2E, Docker preflights, CodeQL, secret scan, and DCO all pass

Three failures appear only in the full parallel run and not in isolation: `host-runner.redaction` (bundled agent-browser binary, fails identically on unmodified `HEAD`), `agent-email.e2e` and `install-script.install-e2e` (both pass standalone). None touch the audio surface.

## Merge order

This depends on HybridAI PR #2109 shipping the `/v1/audio/*` endpoints. It is safe to merge first: without them, HybridAI returns 404 and both features fall through to the existing OpenAI path.