### PR TITLE
fix(observability): default ingest base URL to HYBRIDAI_BASE_URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
 
 ### Fixed
 
+- **Observability ingest follows `HYBRIDAI_BASE_URL`**: When the platform base
+  URL is set via the `HYBRIDAI_BASE_URL` environment variable, the
+  observability ingest endpoint now defaults to that same host instead of the
+  built-in default. Deployments pointed at a non-default platform host no
+  longer post observability events to the wrong platform (which surfaced as a
+  recurring `Observability ingest token unavailable: Invalid API key` warning).
+  An explicit `observability.baseUrl` in the config file still wins.
 - **Cloud admin sessions recover after inactivity**: Expired browser sessions
   reload through HybridAI sign-in instead of showing an unactionable
   `WEB_API_TOKEN` prompt. The self-hosted fallback identifies the exact gateway

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -8521,7 +8521,15 @@ function normalizeRuntimeConfig(
         rawObservability.enabled,
         DEFAULT_RUNTIME_CONFIG.observability.enabled,
       ),
-      baseUrl: normalizeBaseUrl(rawObservability.baseUrl, hybridBaseUrl),
+      // Observability posts to the same platform the agent talks to. The
+      // HYBRIDAI_BASE_URL env override wins over the config-file hybridai
+      // baseUrl for LLM calls (see applyRuntimeConfig), so the ingest default
+      // must follow it too — otherwise a deployment pointed elsewhere via env
+      // silently reports to the default platform host with a foreign API key.
+      baseUrl: normalizeBaseUrl(
+        rawObservability.baseUrl,
+        normalizeBaseUrl(process.env.HYBRIDAI_BASE_URL, hybridBaseUrl),
+      ),
       ingestPath: normalizeApiPath(
         rawObservability.ingestPath,
         DEFAULT_RUNTIME_CONFIG.observability.ingestPath,

--- a/tests/observability-base-url.test.ts
+++ b/tests/observability-base-url.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from 'vitest';
+import { setupGatewayTest } from './helpers/gateway-test-setup.js';
+
+const { setupHome } = setupGatewayTest({
+  tempHomePrefix: 'hybridclaw-observability-base-url-',
+  envVars: ['HYBRIDAI_BASE_URL'],
+});
+
+test('observability baseUrl follows HYBRIDAI_BASE_URL from the environment', async () => {
+  setupHome({ HYBRIDAI_BASE_URL: 'https://platform.example.test/' });
+
+  const { getRuntimeConfig } = await import('../src/config/runtime-config.ts');
+
+  expect(getRuntimeConfig().observability.baseUrl).toBe(
+    'https://platform.example.test',
+  );
+});
+
+test('an explicit observability baseUrl wins over the environment', async () => {
+  setupHome({ HYBRIDAI_BASE_URL: 'https://platform.example.test' });
+
+  const { getRuntimeConfig, saveRuntimeConfig, reloadRuntimeConfig } =
+    await import('../src/config/runtime-config.ts');
+  const runtimeConfig = getRuntimeConfig();
+  saveRuntimeConfig({
+    ...runtimeConfig,
+    observability: {
+      ...runtimeConfig.observability,
+      baseUrl: 'https://observability.example.test',
+    },
+  });
+
+  expect(reloadRuntimeConfig().observability.baseUrl).toBe(
+    'https://observability.example.test',
+  );
+});
+
+test('observability baseUrl keeps the hybridai config default without env', async () => {
+  setupHome();
+  delete process.env.HYBRIDAI_BASE_URL;
+
+  const { getRuntimeConfig } = await import('../src/config/runtime-config.ts');
+
+  expect(getRuntimeConfig().observability.baseUrl).toBe(
+    getRuntimeConfig().hybridai.baseUrl,
+  );
+});


### PR DESCRIPTION
## Problem

The `HYBRIDAI_BASE_URL` environment variable overrides the config-file `hybridai.baseUrl` for LLM calls, but the observability ingest default only followed the config-file value. A gateway pointed at a non-default platform host via env therefore posted observability events to the built-in default host, where its API key is invalid. Symptom: an endless warning loop every flush interval —

```
WARN: Observability ingest token unavailable {"tokenReason":"failed to ensure observability ingest token: Invalid API key"}
```

— and no events ingested anywhere.

## Fix

Feed the env override into the observability `baseUrl` fallback chain in `normalizeRuntimeConfig`. Precedence, most specific first:

1. explicit `observability.baseUrl` in the config file (unchanged — still wins)
2. `HYBRIDAI_BASE_URL` from the environment (new)
3. config-file `hybridai.baseUrl`
4. built-in default

This matches the precedence the platform base URL itself gets in `applyRuntimeConfig`, so observability always reports to the host the agent actually talks to unless explicitly configured otherwise.

## Testing

- New `tests/observability-base-url.test.ts`: env-follow, explicit-config-wins, and no-env default cases.
- `tests/observability-ingest.test.ts` still green; `tsc --noEmit` clean.