### PR TITLE
Fix skill discovery under prompt limits

### DIFF
--- a/container/shared/skill-catalog.d.ts
+++ b/container/shared/skill-catalog.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Minimal routing identity for one skill eligible in the current session.
+ *
+ * Shared by the host and the container so the `skillCatalog` wire contract
+ * cannot drift between them. Deliberately narrower than the host-side `Skill`:
+ * the container only needs enough to route a request and read the SKILL.md.
+ */
+export interface SessionSkillCatalogEntry {
+  name: string;
+  description: string;
+  category: string;
+  location: string;
+  /** Credential ids the skill declares; omitted when it declares none. */
+  requiredCredentials?: string[];
+}

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -103,6 +103,7 @@ import {
   formatLineSafeToolProgressText,
   formatToolCallStartProgressText,
 } from './tool-progress-log.js';
+import { setEligibleSkillsCatalog } from './tools/skills-list.js';
 import {
   executeToolWithMetadata,
   getMessageToolDescription,
@@ -1977,6 +1978,7 @@ async function main(): Promise<void> {
   await syncMcpConfig(firstInput.mcpServers);
   resetSideEffects();
   setScheduledTasks(firstInput.scheduledTasks);
+  setEligibleSkillsCatalog(firstInput.skillCatalog);
   setScheduleSideEffectsEnabled(
     firstInput.scheduleSideEffectsEnabled !== false,
   );
@@ -2168,6 +2170,7 @@ async function main(): Promise<void> {
     await syncMcpConfig(input.mcpServers);
     resetSideEffects();
     setScheduledTasks(input.scheduledTasks);
+    setEligibleSkillsCatalog(input.skillCatalog);
     setScheduleSideEffectsEnabled(input.scheduleSideEffectsEnabled !== false);
     setSessionContext(input.sessionId);
     setPersistentBashStateEnabled(input.persistBashState !== false);

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -51,6 +51,10 @@ import {
   SEARCH_TOOL_DEFINITIONS,
 } from './tools/search-tools.js';
 import {
+  runSkillsList,
+  SKILLS_LIST_TOOL_DEFINITION,
+} from './tools/skills-list.js';
+import {
   type DelegationSideEffect,
   type DelegationTaskSpec,
   type MediaContextItem,
@@ -2911,6 +2915,9 @@ async function executeToolInternal(
       return result.output;
     }
 
+    case 'skills_list':
+      return runSkillsList(args);
+
     case 'bash': {
       const blocked = guardCommand(args.command);
       if (blocked) return failTool(blocked);
@@ -3953,6 +3960,7 @@ const BASH_TOOL_DEFINITION: ToolDefinition = {
 };
 
 export const TOOL_DEFINITIONS: ToolDefinition[] = [
+  SKILLS_LIST_TOOL_DEFINITION,
   {
     type: 'function',
     function: {

--- a/container/src/tools/skills-list.ts
+++ b/container/src/tools/skills-list.ts
@@ -1,0 +1,58 @@
+import type { SkillCatalogEntry, ToolDefinition } from '../types.js';
+
+let eligibleSkills: SkillCatalogEntry[] = [];
+
+export const SKILLS_LIST_TOOL_DEFINITION: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'skills_list',
+    description:
+      'List or search the complete eligible skill catalog for this agent session. Use this read-only recovery tool when the prompt catalog was compacted or a relevant skill is not visible there.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description:
+            'Optional case-insensitive search across skill name, category, and description.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum results to return (default 20, maximum 100).',
+        },
+      },
+    },
+  },
+};
+
+export function setEligibleSkillsCatalog(
+  skills: readonly SkillCatalogEntry[] | undefined,
+): void {
+  eligibleSkills = (skills || []).map((skill) => ({ ...skill }));
+}
+
+export function runSkillsList(args: Record<string, unknown>): string {
+  const query =
+    typeof args.query === 'string' ? args.query.trim().toLowerCase() : '';
+  const limit =
+    typeof args.limit === 'number' && Number.isFinite(args.limit)
+      ? Math.max(1, Math.min(100, Math.floor(args.limit)))
+      : 20;
+  const matches = eligibleSkills.filter((skill) => {
+    if (!query) return true;
+    return [skill.name, skill.category, skill.description].some((value) =>
+      value.toLowerCase().includes(query),
+    );
+  });
+
+  return JSON.stringify(
+    {
+      skills: matches.slice(0, limit),
+      matchCount: matches.length,
+      eligibleCount: eligibleSkills.length,
+      truncated: matches.length > limit,
+    },
+    null,
+    2,
+  );
+}

--- a/container/src/tools/skills-list.ts
+++ b/container/src/tools/skills-list.ts
@@ -21,6 +21,7 @@ export const SKILLS_LIST_TOOL_DEFINITION: ToolDefinition = {
           description: 'Maximum results to return (default 20, maximum 100).',
         },
       },
+      required: [],
     },
   },
 };

--- a/container/src/tools/skills-list.ts
+++ b/container/src/tools/skills-list.ts
@@ -1,6 +1,6 @@
-import type { SkillCatalogEntry, ToolDefinition } from '../types.js';
+import type { SessionSkillCatalogEntry, ToolDefinition } from '../types.js';
 
-let eligibleSkills: SkillCatalogEntry[] = [];
+let eligibleSkills: SessionSkillCatalogEntry[] = [];
 
 export const SKILLS_LIST_TOOL_DEFINITION: ToolDefinition = {
   type: 'function',
@@ -27,7 +27,7 @@ export const SKILLS_LIST_TOOL_DEFINITION: ToolDefinition = {
 };
 
 export function setEligibleSkillsCatalog(
-  skills: readonly SkillCatalogEntry[] | undefined,
+  skills: readonly SessionSkillCatalogEntry[] | undefined,
 ): void {
   eligibleSkills = (skills || []).map((skill) => ({ ...skill }));
 }

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -223,6 +223,13 @@ export interface AddressEnvelope {
   fanoutAlias?: 'team' | 'all';
 }
 
+export interface SkillCatalogEntry {
+  name: string;
+  description: string;
+  category: string;
+  location: string;
+}
+
 export interface ContainerInput {
   healthCheck?: {
     nonce: string;
@@ -271,6 +278,7 @@ export interface ContainerInput {
   configuredDiscordChannels?: string[];
   activeMessageChannels?: string[];
   scheduledTasks?: ScheduledTaskInput[];
+  skillCatalog?: SkillCatalogEntry[];
   allowedTools?: string[];
   blockedTools?: string[];
   media?: MediaContextItem[];

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -1,3 +1,4 @@
+import type { SessionSkillCatalogEntry } from '../shared/skill-catalog.js';
 import type {
   StakesScore as CanonicalStakesScore,
   StakesSignal as CanonicalStakesSignal,
@@ -193,6 +194,7 @@ export interface ScheduledTaskInput {
   createdAt: string;
 }
 
+export type { SessionSkillCatalogEntry } from '../shared/skill-catalog.js';
 export type { WebSearchConfig } from '../shared/web-search-config.js';
 
 export interface ProviderCredential {
@@ -221,16 +223,6 @@ export interface AddressEnvelope {
   to: string | string[];
   from?: string | null;
   fanoutAlias?: 'team' | 'all';
-}
-
-/** Minimal routing identity for one skill eligible in the current session. */
-export interface SessionSkillCatalogEntry {
-  name: string;
-  description: string;
-  category: string;
-  location: string;
-  /** Credential ids the skill declares; omitted when it declares none. */
-  requiredCredentials?: string[];
 }
 
 export interface ContainerInput {

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -223,11 +223,14 @@ export interface AddressEnvelope {
   fanoutAlias?: 'team' | 'all';
 }
 
-export interface SkillCatalogEntry {
+/** Minimal routing identity for one skill eligible in the current session. */
+export interface SessionSkillCatalogEntry {
   name: string;
   description: string;
   category: string;
   location: string;
+  /** Credential ids the skill declares; omitted when it declares none. */
+  requiredCredentials?: string[];
 }
 
 export interface ContainerInput {
@@ -278,7 +281,7 @@ export interface ContainerInput {
   configuredDiscordChannels?: string[];
   activeMessageChannels?: string[];
   scheduledTasks?: ScheduledTaskInput[];
-  skillCatalog?: SkillCatalogEntry[];
+  skillCatalog?: SessionSkillCatalogEntry[];
   allowedTools?: string[];
   blockedTools?: string[];
   media?: MediaContextItem[];

--- a/docs/content/extensibility/skills.md
+++ b/docs/content/extensibility/skills.md
@@ -34,6 +34,13 @@ HybridClaw uses progressive disclosure for model-visible skills. The system
 prompt starts with compact metadata and a workspace-readable `SKILL.md`
 location; the model reads the full skill only after routing the request.
 
+The prompt entry carries `name`, `category`, `description`, and `location`
+only. Manifest details are deliberately excluded because they do not inform
+routing: `supported_channels` is already a hard filter (a skill unsupported on
+the active channel never reaches the prompt), `id` duplicates `name`, and
+`version` and `capabilities` matter only once the skill is loaded. Declared
+credential ids stay reachable through `skills_list`.
+
 The prompt budget preserves skill names and locations before spending space on
 descriptions. When the catalog is too large, descriptions are shortened first.
 If even the identity-only catalog cannot fit, the prompt includes an explicit

--- a/docs/content/extensibility/skills.md
+++ b/docs/content/extensibility/skills.md
@@ -28,6 +28,23 @@ Skill roots include:
 - trust-aware scanning blocks risky personal or workspace skills
 - bundled repo skills are mirrored into `/workspace/skills/<name>` inside the agent runtime so bundled script paths like `skills/pdf/scripts/...` stay valid
 
+## Runtime Discovery
+
+HybridClaw uses progressive disclosure for model-visible skills. The system
+prompt starts with compact metadata and a workspace-readable `SKILL.md`
+location; the model reads the full skill only after routing the request.
+
+The prompt budget preserves skill names and locations before spending space on
+descriptions. When the catalog is too large, descriptions are shortened first.
+If even the identity-only catalog cannot fit, the prompt includes an explicit
+compaction notice and the runtime emits a structured warning with included and
+omitted counts.
+
+The read-only `skills_list` tool lists or searches the complete catalog of
+skills eligible for the current agent and channel. It is the recovery path when
+prompt metadata was compacted; it does not expose disabled or policy-filtered
+skills.
+
 ## Frontmatter Contract
 
 - required: `name`, `description`

--- a/src/agent/executor-types.ts
+++ b/src/agent/executor-types.ts
@@ -3,6 +3,7 @@ import type {
   AddressEnvelope,
   ContainerOutput,
   MediaContextItem,
+  SkillCatalogEntry,
 } from '../types/container.js';
 import type {
   EscalationTarget,
@@ -40,6 +41,7 @@ export interface ExecutorRequest {
   fullAutoNeverApproveTools?: string[];
   scheduleSideEffectsEnabled?: boolean;
   scheduledTasks?: ScheduledTask[];
+  skillCatalog?: SkillCatalogEntry[];
   allowedTools?: string[];
   blockedTools?: string[];
   onTextDelta?: (delta: string) => void;

--- a/src/agent/executor-types.ts
+++ b/src/agent/executor-types.ts
@@ -3,7 +3,7 @@ import type {
   AddressEnvelope,
   ContainerOutput,
   MediaContextItem,
-  SkillCatalogEntry,
+  SessionSkillCatalogEntry,
 } from '../types/container.js';
 import type {
   EscalationTarget,
@@ -41,7 +41,7 @@ export interface ExecutorRequest {
   fullAutoNeverApproveTools?: string[];
   scheduleSideEffectsEnabled?: boolean;
   scheduledTasks?: ScheduledTask[];
-  skillCatalog?: SkillCatalogEntry[];
+  skillCatalog?: SessionSkillCatalogEntry[];
   allowedTools?: string[];
   blockedTools?: string[];
   onTextDelta?: (delta: string) => void;

--- a/src/agent/tool-summary.ts
+++ b/src/agent/tool-summary.ts
@@ -60,6 +60,10 @@ const TOOL_GROUPS: ToolGroup[] = [
     tools: ['memory', 'session_search'],
   },
   {
+    label: 'Skills',
+    tools: ['skills_list'],
+  },
+  {
     label: 'Vision',
     tools: ['vision_analyze'],
   },

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -81,6 +81,7 @@ import { buildSessionContext } from '../session/session-context.js';
 import { resolveSessionResetChannelKind } from '../session/session-reset.js';
 import { maybeAutoTitleSession } from '../session/session-title.js';
 import { estimateTokenCountFromMessages } from '../session/token-efficiency.js';
+import { buildEligibleSkillCatalog } from '../skills/skill-catalog.js';
 import {
   expandResolvedSkillInvocation,
   promoteWorkspaceSkills,
@@ -2082,6 +2083,7 @@ async function handleGatewayMessageInner(
         fullAutoNeverApproveTools: neverAutoApproveTools,
         scheduleSideEffectsEnabled: !isGoalContinuationSource(source),
         scheduledTasks,
+        skillCatalog: buildEligibleSkillCatalog(skills),
         allowedTools: promptPartDefaults.toolsDisabled ? [] : undefined,
         blockedTools: mediaPolicy.blockedTools,
         onTextDelta: params.onTextDelta,
@@ -2185,6 +2187,7 @@ async function handleGatewayMessageInner(
         fullAutoNeverApproveTools: neverAutoApproveTools,
         scheduleSideEffectsEnabled: !isGoalContinuationSource(source),
         scheduledTasks,
+        skillCatalog: buildEligibleSkillCatalog(skills),
         allowedTools: promptPartDefaults.toolsDisabled ? [] : undefined,
         blockedTools: mediaPolicy.blockedTools,
         onTextDelta: emitTextDeltas,

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -420,6 +420,7 @@ import {
   getAgentScoreboard,
   getObservedAgentSkillCount,
 } from '../skills/agent-scoreboard.js';
+import { buildEligibleSkillCatalog } from '../skills/skill-catalog.js';
 import { loadSkillDocsCatalog } from '../skills/skill-docs.js';
 import {
   type BlockedSkillCatalogEntry,
@@ -8909,7 +8910,7 @@ export async function ensureGatewayBootstrapAutostart(params: {
     }
     const baseAssistantMessages = hasPrelude ? 1 : 0;
 
-    const { messages } = buildConversationContext({
+    const { messages, skills } = buildConversationContext({
       agentId: resolved.agentId,
       history: [],
       currentUserContent: bootstrapAutostartPrompt,
@@ -9131,6 +9132,7 @@ export async function ensureGatewayBootstrapAutostart(params: {
         ...loadPolicyFullAutoNeverApprove(agentWorkspaceDir(resolved.agentId)),
       ],
       scheduledTasks: [],
+      skillCatalog: buildEligibleSkillCatalog(skills),
       pluginTools: pluginManager?.getToolDefinitions() ?? [],
     });
     hatchingCompletion = recordBootstrapHatchingTurnResult({

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -1157,6 +1157,7 @@ async function runContainerInner(
         createdAt: task.created_at,
       }),
     ),
+    skillCatalog: params.skillCatalog,
     allowedTools,
     blockedTools,
     media,

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -1004,6 +1004,7 @@ async function runHostProcessInner(
         createdAt: task.created_at,
       }),
     ),
+    skillCatalog: params.skillCatalog,
     allowedTools,
     blockedTools,
     media,

--- a/src/scheduler/scheduled-task-runner.ts
+++ b/src/scheduler/scheduled-task-runner.ts
@@ -16,6 +16,7 @@ import {
   migrateLegacySessionKey,
 } from '../session/session-key.js';
 import { appendSessionTranscript } from '../session/session-transcripts.js';
+import { buildEligibleSkillCatalog } from '../skills/skill-catalog.js';
 import { buildMediaGenerationUsageEvents } from '../usage/media-generation-usage.js';
 import { resolveUsageCostUsdAfterMetadataRefresh } from '../usage/model-cost.js';
 import { enqueueTokenUsage } from '../usage/token-usage-buffer.js';
@@ -80,7 +81,7 @@ export async function runIsolatedScheduledTask(params: {
     sessionKey: cronSessionId,
     mainSessionKey: mainSessionKey?.trim() || cronSessionId,
   });
-  const { messages } = buildConversationContext({
+  const { messages, skills } = buildConversationContext({
     agentId,
     history: [],
     currentUserContent: prompt,
@@ -134,6 +135,7 @@ export async function runIsolatedScheduledTask(params: {
       agentId,
       channelId,
       blockedTools: ['cron'],
+      skillCatalog: buildEligibleSkillCatalog(skills),
     });
     emitToolExecutionAuditEvents({
       sessionId: activeSessionId,

--- a/src/skills/skill-catalog.ts
+++ b/src/skills/skill-catalog.ts
@@ -1,0 +1,13 @@
+import type { SkillCatalogEntry } from '../types/container.js';
+import type { Skill } from './skills.js';
+
+export function buildEligibleSkillCatalog(
+  skills: readonly Skill[],
+): SkillCatalogEntry[] {
+  return skills.map(({ name, description, category, location }) => ({
+    name,
+    description,
+    category,
+    location,
+  }));
+}

--- a/src/skills/skill-catalog.ts
+++ b/src/skills/skill-catalog.ts
@@ -1,13 +1,24 @@
-import type { SkillCatalogEntry } from '../types/container.js';
+import type { SessionSkillCatalogEntry } from '../types/container.js';
 import type { Skill } from './skills.js';
 
+/**
+ * Project the session's eligible skills onto the routing identity the model
+ * needs. The system prompt carries name/category/description/location only, so
+ * declared credential ids are surfaced here as the `skills_list` recovery path.
+ */
 export function buildEligibleSkillCatalog(
   skills: readonly Skill[],
-): SkillCatalogEntry[] {
-  return skills.map(({ name, description, category, location }) => ({
-    name,
-    description,
-    category,
-    location,
-  }));
+): SessionSkillCatalogEntry[] {
+  return skills.map(({ name, description, category, location, manifest }) => {
+    const requiredCredentials = (manifest?.requiredCredentials ?? []).map(
+      (credential) => credential.id,
+    );
+    return {
+      name,
+      description,
+      category,
+      location,
+      ...(requiredCredentials.length > 0 ? { requiredCredentials } : {}),
+    };
+  });
 }

--- a/src/skills/skills.ts
+++ b/src/skills/skills.ts
@@ -81,6 +81,11 @@ export interface SkillInstallSpec {
   chmod?: string;
 }
 
+/**
+ * A skill as parsed from disk, before any consumer-specific state is attached.
+ * Shared base for `Skill`, `SkillCatalogEntry`, and `BlockedSkillCatalogEntry`;
+ * each adds only the fields its own surface needs.
+ */
 interface SkillCandidate {
   name: string;
   description: string;
@@ -107,30 +112,8 @@ interface SkillCandidate {
   source: SkillSource;
 }
 
-export interface Skill {
-  name: string;
-  description: string;
-  category: string;
-  manifest: SkillManifest;
-  userInvocable: boolean;
-  disableModelInvocation: boolean;
-  always: boolean;
-  requires: {
-    bins: string[];
-    env: string[];
-  };
-  metadata: {
-    hybridclaw: {
-      shortDescription?: string;
-      logoPath?: string;
-      tags: string[];
-      relatedSkills: string[];
-      install: SkillInstallSpec[];
-    };
-  };
-  filePath: string;
-  baseDir: string;
-  source: SkillSource;
+/** A discovered skill resolved for runtime use, with a prompt-visible path. */
+export interface Skill extends SkillCandidate {
   location: string;
 }
 
@@ -1727,30 +1710,8 @@ export function expandResolvedSkillInvocation(
   return lines.join('\n');
 }
 
-export interface SkillCatalogEntry {
-  name: string;
-  description: string;
-  category: string;
-  manifest: SkillManifest;
-  userInvocable: boolean;
-  disableModelInvocation: boolean;
-  always: boolean;
-  requires: {
-    bins: string[];
-    env: string[];
-  };
-  metadata: {
-    hybridclaw: {
-      shortDescription?: string;
-      logoPath?: string;
-      tags: string[];
-      relatedSkills: string[];
-      install: SkillInstallSpec[];
-    };
-  };
-  filePath: string;
-  baseDir: string;
-  source: SkillSource;
+/** A discovered skill as shown on management surfaces, with eligibility state. */
+export interface SkillCatalogEntry extends SkillCandidate {
   available: boolean;
   enabled: boolean;
   missing: string[];

--- a/src/skills/skills.ts
+++ b/src/skills/skills.ts
@@ -136,6 +136,8 @@ export interface Skill {
 
 const SYNCED_SKILLS_DIR = '.synced-skills';
 const MAX_SKILLS_PROMPT_CHARS = 30_000;
+/** Newline plus the empty `<description>` line wrapping a skill description. */
+const DESCRIPTION_LINE_CHARS = '\n    <description></description>'.length;
 const MAX_INVOKED_SKILL_CHARS = 35_000;
 const MAX_ALWAYS_CHARS = 10_000;
 const MAX_SKILL_COMMAND_NAME_LENGTH = 32;
@@ -2378,53 +2380,80 @@ export function buildSkillsPrompt(skills: Skill[]): string {
   if (summaryCandidates.length > 0) {
     lines.push('<available_skills>');
 
-    const compactDescription = (value: string, limit: number) => {
-      const escaped = escapeXml(value);
-      if (limit <= 0 || escaped.length <= limit) return escaped;
+    // Escape once per skill: the binary search below probes the rendered size
+    // O(log maxDescriptionLength) times and must not re-escape the catalog on
+    // every probe. buildSkillsPrompt runs on every prompt build.
+    const summaries = summaryCandidates.map((skill) => {
+      const identityLines = [
+        '  <skill>',
+        `    <name>${escapeXml(skill.name)}</name>`,
+        `    <category>${escapeXml(skill.category)}</category>`,
+      ];
+      const closingLines = [
+        `    <location>${escapeXml(skill.location)}</location>`,
+        '  </skill>',
+      ];
+      return {
+        identityLines,
+        closingLines,
+        rawDescription: skill.description || skill.name,
+        escapedDescription: escapeXml(skill.description || skill.name),
+        identityChars: [...identityLines, ...closingLines].join('\n').length,
+      };
+    });
+    type SkillSummary = (typeof summaries)[number];
+
+    /** Truncate on raw characters so an escape sequence is never split. */
+    const compactDescription = (summary: SkillSummary, limit: number) => {
+      if (limit <= 0) return '';
+      if (summary.escapedDescription.length <= limit) {
+        return summary.escapedDescription;
+      }
       if (limit === 1) return '…';
       let compacted = '';
-      for (const character of value) {
+      for (const character of summary.rawDescription) {
         const escapedCharacter = escapeXml(character);
         if (compacted.length + escapedCharacter.length + 1 > limit) break;
         compacted += escapedCharacter;
       }
       return `${compacted}…`;
     };
-    const renderSummary = (skill: Skill, descriptionLimit: number) => {
-      const description = compactDescription(
-        skill.description || skill.name,
-        descriptionLimit,
-      );
-      return [
-        '  <skill>',
-        `    <name>${escapeXml(skill.name)}</name>`,
-        `    <category>${escapeXml(skill.category)}</category>`,
-        ...(descriptionLimit > 0
-          ? [`    <description>${description}</description>`]
-          : []),
-        `    <location>${escapeXml(skill.location)}</location>`,
-        '  </skill>',
-      ];
-    };
-    const renderedLength = (descriptionLimit: number) =>
-      summaryCandidates.reduce(
-        (total, skill) =>
-          total + renderSummary(skill, descriptionLimit).join('\n').length,
+    const renderSummary = (summary: SkillSummary, descriptionLimit: number) => [
+      ...summary.identityLines,
+      ...(descriptionLimit > 0
+        ? [
+            `    <description>${compactDescription(summary, descriptionLimit)}</description>`,
+          ]
+        : []),
+      ...summary.closingLines,
+    ];
+
+    // Upper bound of the rendered size at a given limit, computed arithmetically
+    // instead of by rendering: compactDescription never returns more than
+    // `limit` characters, so overshooting only picks a slightly tighter limit.
+    const projectedLength = (descriptionLimit: number) =>
+      summaries.reduce(
+        (total, summary) =>
+          total +
+          summary.identityChars +
+          (descriptionLimit > 0
+            ? DESCRIPTION_LINE_CHARS +
+              Math.min(summary.escapedDescription.length, descriptionLimit)
+            : 0),
         0,
       );
 
-    const maxDescriptionLength = summaryCandidates.reduce(
-      (max, skill) =>
-        Math.max(max, escapeXml(skill.description || skill.name).length),
+    const maxDescriptionLength = summaries.reduce(
+      (max, summary) => Math.max(max, summary.escapedDescription.length),
       0,
     );
     let descriptionLimit = maxDescriptionLength;
-    if (renderedLength(descriptionLimit) > MAX_SKILLS_PROMPT_CHARS) {
+    if (projectedLength(descriptionLimit) > MAX_SKILLS_PROMPT_CHARS) {
       let low = 0;
       let high = maxDescriptionLength;
       while (low < high) {
         const middle = Math.ceil((low + high) / 2);
-        if (renderedLength(middle) <= MAX_SKILLS_PROMPT_CHARS) low = middle;
+        if (projectedLength(middle) <= MAX_SKILLS_PROMPT_CHARS) low = middle;
         else high = middle - 1;
       }
       descriptionLimit = low;
@@ -2432,18 +2461,20 @@ export function buildSkillsPrompt(skills: Skill[]): string {
 
     let chars = 0;
     let includedCount = 0;
-    for (const skill of summaryCandidates) {
-      const block = renderSummary(skill, descriptionLimit);
+    for (const summary of summaries) {
+      const block = renderSummary(summary, descriptionLimit);
       const serialized = block.join('\n');
+      // The binary search bottoms out at descriptionLimit = 0 without being able
+      // to guarantee a fit, so identity-only blocks can still overflow. Skip
+      // those instead of breaking, and report them as omitted below.
       if (chars + serialized.length > MAX_SKILLS_PROMPT_CHARS) continue;
       lines.push(...block);
       chars += serialized.length;
       includedCount += 1;
     }
 
-    const compactedDescriptions = summaryCandidates.filter(
-      (skill) =>
-        descriptionLimit < escapeXml(skill.description || skill.name).length,
+    const compactedDescriptions = summaries.filter(
+      (summary) => descriptionLimit < summary.escapedDescription.length,
     ).length;
     const omittedSkills = summaryCandidates.length - includedCount;
     if (compactedDescriptions > 0 || omittedSkills > 0) {

--- a/src/skills/skills.ts
+++ b/src/skills/skills.ts
@@ -135,7 +135,6 @@ export interface Skill {
 }
 
 const SYNCED_SKILLS_DIR = '.synced-skills';
-const MAX_SKILLS_IN_PROMPT = 150;
 const MAX_SKILLS_PROMPT_CHARS = 30_000;
 const MAX_INVOKED_SKILL_CHARS = 35_000;
 const MAX_ALWAYS_CHARS = 10_000;
@@ -1726,10 +1725,6 @@ export function expandResolvedSkillInvocation(
   return lines.join('\n');
 }
 
-function resolveSkillManifest(skill: Skill): SkillManifest {
-  return skill.manifest || createDefaultSkillManifest(skill.name);
-}
-
 export interface SkillCatalogEntry {
   name: string;
   description: string;
@@ -2336,9 +2331,9 @@ function loadSkillsInner(
  * Build compact CLAUDE/OpenClaw-style skill prompt metadata.
  */
 export function buildSkillsPrompt(skills: Skill[]): string {
-  const promptCandidates = skills
-    .filter((skill) => !skill.disableModelInvocation)
-    .slice(0, MAX_SKILLS_IN_PROMPT);
+  const promptCandidates = skills.filter(
+    (skill) => !skill.disableModelInvocation,
+  );
   if (promptCandidates.length === 0) return '';
 
   const lines: string[] = [];
@@ -2383,26 +2378,88 @@ export function buildSkillsPrompt(skills: Skill[]): string {
   if (summaryCandidates.length > 0) {
     lines.push('<available_skills>');
 
-    let chars = 0;
-    for (const skill of summaryCandidates) {
-      const manifest = resolveSkillManifest(skill);
-      const block = [
+    const compactDescription = (value: string, limit: number) => {
+      const escaped = escapeXml(value);
+      if (limit <= 0 || escaped.length <= limit) return escaped;
+      if (limit === 1) return '…';
+      let compacted = '';
+      for (const character of value) {
+        const escapedCharacter = escapeXml(character);
+        if (compacted.length + escapedCharacter.length + 1 > limit) break;
+        compacted += escapedCharacter;
+      }
+      return `${compacted}…`;
+    };
+    const renderSummary = (skill: Skill, descriptionLimit: number) => {
+      const description = compactDescription(
+        skill.description || skill.name,
+        descriptionLimit,
+      );
+      return [
         '  <skill>',
-        `    <id>${escapeXml(manifest.id)}</id>`,
         `    <name>${escapeXml(skill.name)}</name>`,
-        `    <version>${escapeXml(manifest.version)}</version>`,
         `    <category>${escapeXml(skill.category)}</category>`,
-        `    <description>${escapeXml(skill.description || skill.name)}</description>`,
-        `    <capabilities>${escapeXml(manifest.capabilities.join(', '))}</capabilities>`,
-        `    <required_credentials>${escapeXml(manifest.requiredCredentials.map((credential) => credential.id).join(', '))}</required_credentials>`,
-        `    <supported_channels>${escapeXml(manifest.supportedChannels.join(', '))}</supported_channels>`,
+        ...(descriptionLimit > 0
+          ? [`    <description>${description}</description>`]
+          : []),
         `    <location>${escapeXml(skill.location)}</location>`,
         '  </skill>',
       ];
+    };
+    const renderedLength = (descriptionLimit: number) =>
+      summaryCandidates.reduce(
+        (total, skill) =>
+          total + renderSummary(skill, descriptionLimit).join('\n').length,
+        0,
+      );
+
+    const maxDescriptionLength = summaryCandidates.reduce(
+      (max, skill) =>
+        Math.max(max, escapeXml(skill.description || skill.name).length),
+      0,
+    );
+    let descriptionLimit = maxDescriptionLength;
+    if (renderedLength(descriptionLimit) > MAX_SKILLS_PROMPT_CHARS) {
+      let low = 0;
+      let high = maxDescriptionLength;
+      while (low < high) {
+        const middle = Math.ceil((low + high) / 2);
+        if (renderedLength(middle) <= MAX_SKILLS_PROMPT_CHARS) low = middle;
+        else high = middle - 1;
+      }
+      descriptionLimit = low;
+    }
+
+    let chars = 0;
+    let includedCount = 0;
+    for (const skill of summaryCandidates) {
+      const block = renderSummary(skill, descriptionLimit);
       const serialized = block.join('\n');
-      if (chars + serialized.length > MAX_SKILLS_PROMPT_CHARS) break;
+      if (chars + serialized.length > MAX_SKILLS_PROMPT_CHARS) continue;
       lines.push(...block);
       chars += serialized.length;
+      includedCount += 1;
+    }
+
+    const compactedDescriptions = summaryCandidates.filter(
+      (skill) =>
+        descriptionLimit < escapeXml(skill.description || skill.name).length,
+    ).length;
+    const omittedSkills = summaryCandidates.length - includedCount;
+    if (compactedDescriptions > 0 || omittedSkills > 0) {
+      lines.push(
+        `  <skills_catalog_notice compacted_descriptions="${compactedDescriptions}" omitted_skills="${omittedSkills}">Catalog constrained by maxSkillsPromptChars=${MAX_SKILLS_PROMPT_CHARS}. Use skills_list to search the complete eligible catalog.</skills_catalog_notice>`,
+      );
+      logger.warn(
+        {
+          eligibleSkills: summaryCandidates.length,
+          includedSkills: includedCount,
+          compactedDescriptions,
+          omittedSkills,
+          maxSkillsPromptChars: MAX_SKILLS_PROMPT_CHARS,
+        },
+        'Compacted skill catalog for system prompt',
+      );
     }
 
     lines.push('</available_skills>');

--- a/src/types/container.ts
+++ b/src/types/container.ts
@@ -1,3 +1,4 @@
+import type { SessionSkillCatalogEntry } from '../../container/shared/skill-catalog.js';
 import type { WebSearchConfig } from '../../container/shared/web-search-config.js';
 import type { CodexTurnRuntime } from '../config/runtime-config.js';
 import type { ChatMessage } from './api.js';
@@ -32,26 +33,13 @@ export interface MediaContextItem {
   filename: string;
 }
 
+export type { SessionSkillCatalogEntry } from '../../container/shared/skill-catalog.js';
 export type { WebSearchConfig } from '../../container/shared/web-search-config.js';
 
 export interface AddressEnvelope {
   to: string | string[];
   from?: string | null;
   fanoutAlias?: 'team' | 'all';
-}
-
-/**
- * Minimal routing identity for one skill eligible in the current session.
- * Distinct from the richer `SkillCatalogEntry` in `src/skills/skills.ts`, which
- * describes management-surface catalog rows rather than runtime routing.
- */
-export interface SessionSkillCatalogEntry {
-  name: string;
-  description: string;
-  category: string;
-  location: string;
-  /** Credential ids the skill declares; omitted when it declares none. */
-  requiredCredentials?: string[];
 }
 
 export interface ProviderCredential {

--- a/src/types/container.ts
+++ b/src/types/container.ts
@@ -40,6 +40,13 @@ export interface AddressEnvelope {
   fanoutAlias?: 'team' | 'all';
 }
 
+export interface SkillCatalogEntry {
+  name: string;
+  description: string;
+  category: string;
+  location: string;
+}
+
 export interface ProviderCredential {
   apiKey?: string;
   baseUrl?: string;
@@ -97,6 +104,7 @@ export interface ContainerInput {
   configuredDiscordChannels?: string[];
   activeMessageChannels?: string[];
   scheduledTasks?: ScheduledTaskInput[];
+  skillCatalog?: SkillCatalogEntry[];
   allowedTools?: string[];
   blockedTools?: string[];
   media?: MediaContextItem[];

--- a/src/types/container.ts
+++ b/src/types/container.ts
@@ -40,11 +40,18 @@ export interface AddressEnvelope {
   fanoutAlias?: 'team' | 'all';
 }
 
-export interface SkillCatalogEntry {
+/**
+ * Minimal routing identity for one skill eligible in the current session.
+ * Distinct from the richer `SkillCatalogEntry` in `src/skills/skills.ts`, which
+ * describes management-surface catalog rows rather than runtime routing.
+ */
+export interface SessionSkillCatalogEntry {
   name: string;
   description: string;
   category: string;
   location: string;
+  /** Credential ids the skill declares; omitted when it declares none. */
+  requiredCredentials?: string[];
 }
 
 export interface ProviderCredential {
@@ -104,7 +111,7 @@ export interface ContainerInput {
   configuredDiscordChannels?: string[];
   activeMessageChannels?: string[];
   scheduledTasks?: ScheduledTaskInput[];
-  skillCatalog?: SkillCatalogEntry[];
+  skillCatalog?: SessionSkillCatalogEntry[];
   allowedTools?: string[];
   blockedTools?: string[];
   media?: MediaContextItem[];

--- a/tests/container.skills-list.test.ts
+++ b/tests/container.skills-list.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from 'vitest';
+
+import {
+  runSkillsList,
+  setEligibleSkillsCatalog,
+  SKILLS_LIST_TOOL_DEFINITION,
+} from '../container/src/tools/skills-list.js';
+
+test('skills_list searches the complete eligible session catalog', () => {
+  setEligibleSkillsCatalog([
+    {
+      name: 'calendar',
+      description: 'Manage calendar events.',
+      category: 'productivity',
+      location: 'skills/calendar/SKILL.md',
+    },
+    {
+      name: 'pdf',
+      description: 'Create, inspect, and edit PDF files.',
+      category: 'office',
+      location: 'skills/pdf/SKILL.md',
+    },
+  ]);
+
+  const result = JSON.parse(runSkillsList({ query: 'PDF' })) as {
+    skills: Array<{ name: string; location: string }>;
+    matchCount: number;
+    eligibleCount: number;
+    truncated: boolean;
+  };
+
+  expect(SKILLS_LIST_TOOL_DEFINITION.function.name).toBe('skills_list');
+  expect(result.skills).toEqual([
+    {
+      name: 'pdf',
+      description: 'Create, inspect, and edit PDF files.',
+      category: 'office',
+      location: 'skills/pdf/SKILL.md',
+    },
+  ]);
+  expect(result.matchCount).toBe(1);
+  expect(result.eligibleCount).toBe(2);
+  expect(result.truncated).toBe(false);
+});
+
+test('skills_list limits output without losing complete-catalog counts', () => {
+  setEligibleSkillsCatalog(
+    Array.from({ length: 25 }, (_, index) => ({
+      name: `skill-${index}`,
+      description: 'A discoverable skill.',
+      category: 'test',
+      location: `skills/skill-${index}/SKILL.md`,
+    })),
+  );
+
+  const result = JSON.parse(runSkillsList({ limit: 5 })) as {
+    skills: unknown[];
+    matchCount: number;
+    eligibleCount: number;
+    truncated: boolean;
+  };
+
+  expect(result.skills).toHaveLength(5);
+  expect(result.matchCount).toBe(25);
+  expect(result.eligibleCount).toBe(25);
+  expect(result.truncated).toBe(true);
+});

--- a/tests/container.skills-list.test.ts
+++ b/tests/container.skills-list.test.ts
@@ -19,6 +19,7 @@ test('skills_list searches the complete eligible session catalog', () => {
       description: 'Create, inspect, and edit PDF files.',
       category: 'office',
       location: 'skills/pdf/SKILL.md',
+      requiredCredentials: ['pdf-service-token'],
     },
   ]);
 
@@ -36,6 +37,7 @@ test('skills_list searches the complete eligible session catalog', () => {
       description: 'Create, inspect, and edit PDF files.',
       category: 'office',
       location: 'skills/pdf/SKILL.md',
+      requiredCredentials: ['pdf-service-token'],
     },
   ]);
   expect(result.matchCount).toBe(1);

--- a/tests/prompt-hooks.tool-summary.test.ts
+++ b/tests/prompt-hooks.tool-summary.test.ts
@@ -13,6 +13,7 @@ import {
 import * as runtimeConfig from '../src/config/runtime-config.js';
 import * as providerFactory from '../src/providers/factory.js';
 import type { Skill } from '../src/skills/skills.js';
+import { buildSkillsPrompt } from '../src/skills/skills.js';
 
 test('buildToolsSummary groups the full tool catalog', () => {
   const summary = buildToolsSummary();
@@ -30,6 +31,7 @@ test('buildToolsSummary groups the full tool catalog', () => {
   );
   expect(summary).toContain('**Communication**: `message`');
   expect(summary).toContain('**Delegation**: `delegate`');
+  expect(summary).toContain('**Skills**: `skills_list`');
   expect(summary).toContain('**Vision**: `vision_analyze`');
   expect(summary).toContain('**Image Generation**: `image_generate`');
   expect(summary).toContain('**Video Generation**: `video_generate`');
@@ -306,6 +308,48 @@ test('buildSystemPromptFromHooks keeps the skill catalog stable when the user ex
   expect(prompt).toContain('<available_skills>');
   expect(prompt).toContain('<name>pdf</name>');
   expect(prompt).toContain('<name>apple-music</name>');
+});
+
+test('buildSkillsPrompt preserves every skill identity before compacting descriptions', () => {
+  const skills = Array.from({ length: 80 }, (_, index) =>
+    makeSkill({
+      name: index === 79 ? 'pdf' : `catalog-skill-${String(index).padStart(2, '0')}`,
+      category: index === 79 ? 'office' : 'catalog',
+      description: `Skill ${index} ${'detailed routing guidance '.repeat(30)}`,
+      location:
+        index === 79
+          ? 'skills/pdf/SKILL.md'
+          : `skills/catalog-skill-${index}/SKILL.md`,
+    }),
+  );
+
+  const prompt = buildSkillsPrompt(skills);
+
+  for (const skill of skills) {
+    expect(prompt).toContain(`<name>${skill.name}</name>`);
+    expect(prompt).toContain(`<location>${skill.location}</location>`);
+  }
+  expect(prompt).toContain('compacted_descriptions="80"');
+  expect(prompt).toContain('omitted_skills="0"');
+  expect(prompt).toContain('Use skills_list to search');
+  expect(prompt).not.toContain('<capabilities>');
+  expect(prompt).not.toContain('<required_credentials>');
+});
+
+test('buildSkillsPrompt reports identity omissions when the minimum catalog exceeds its budget', () => {
+  const skills = Array.from({ length: 300 }, (_, index) =>
+    makeSkill({
+      name: `oversized-skill-${index}`,
+      description: 'x',
+      location: `skills/${'nested-location-'.repeat(8)}${index}/SKILL.md`,
+    }),
+  );
+
+  const prompt = buildSkillsPrompt(skills);
+  const omitted = Number(prompt.match(/omitted_skills="(\d+)"/)?.[1]);
+
+  expect(omitted).toBeGreaterThan(0);
+  expect(prompt).toContain('Use skills_list to search');
 });
 
 test('buildSystemPromptFromHooks uses the provided workspace path in runtime metadata', () => {

--- a/tests/prompt-hooks.tool-summary.test.ts
+++ b/tests/prompt-hooks.tool-summary.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../src/channels/channel-registry.js';
 import * as runtimeConfig from '../src/config/runtime-config.js';
 import * as providerFactory from '../src/providers/factory.js';
+import { buildEligibleSkillCatalog } from '../src/skills/skill-catalog.js';
 import type { Skill } from '../src/skills/skills.js';
 import { buildSkillsPrompt } from '../src/skills/skills.js';
 
@@ -65,6 +66,20 @@ test('buildToolsSummary groups MCP tools separately from other tools', () => {
   );
   expect(summary).not.toContain('**Other**:');
 });
+
+function makeManifest(): NonNullable<Skill['manifest']> {
+  return {
+    id: 'pdf',
+    name: 'pdf',
+    version: '1.0.0',
+    capabilities: [],
+    middleware: { preSend: false, postReceive: false },
+    requiredCredentials: [],
+    credentials: [],
+    configVariables: [],
+    supportedChannels: [],
+  };
+}
 
 function makeSkill(overrides: Partial<Skill> = {}): Skill {
   return {
@@ -329,6 +344,9 @@ test('buildSkillsPrompt preserves every skill identity before compacting descrip
     expect(prompt).toContain(`<name>${skill.name}</name>`);
     expect(prompt).toContain(`<location>${skill.location}</location>`);
   }
+  // The compaction limit is picked from an arithmetic upper bound of the
+  // rendered size, so the result must still land inside the 30k char budget.
+  expect(prompt.length).toBeLessThan(31_000);
   expect(prompt).toContain('compacted_descriptions="80"');
   expect(prompt).toContain('omitted_skills="0"');
   expect(prompt).toContain('Use skills_list to search');
@@ -350,6 +368,57 @@ test('buildSkillsPrompt reports identity omissions when the minimum catalog exce
 
   expect(omitted).toBeGreaterThan(0);
   expect(prompt).toContain('Use skills_list to search');
+});
+
+test('buildSkillsPrompt never splits an XML escape when compacting', () => {
+  const skills = Array.from({ length: 50 }, (_, index) =>
+    makeSkill({
+      name: `escaping-skill-${index}`,
+      description: '<&>'.repeat(400),
+      location: `skills/escaping-skill-${index}/SKILL.md`,
+    }),
+  );
+
+  const prompt = buildSkillsPrompt(skills);
+  const descriptions = [...prompt.matchAll(/<description>(.*)<\/description>/g)];
+
+  expect(descriptions.length).toBeGreaterThan(0);
+  for (const [, description] of descriptions) {
+    // Every `&` must open a complete entity; a mid-entity cut would leave a
+    // bare `&` or a truncated `&am` behind.
+    expect(description.replace(/&(amp|lt|gt|quot|apos);/g, '')).not.toContain(
+      '&',
+    );
+  }
+});
+
+test('buildEligibleSkillCatalog carries credential ids the prompt drops', () => {
+  const withCredentials = makeSkill({
+    name: 'calendar',
+    manifest: {
+      ...makeManifest(),
+      requiredCredentials: [
+        {
+          id: 'google-oauth',
+          kind: 'oauth',
+          required: true,
+          secretRef: { provider: 'env', key: 'GOOGLE_TOKEN' },
+          scope: 'calendar.events',
+          howToObtain: 'Run the Google OAuth flow.',
+        },
+      ],
+    },
+  });
+  const withoutCredentials = makeSkill({ name: 'pdf' });
+
+  const catalog = buildEligibleSkillCatalog([
+    withCredentials,
+    withoutCredentials,
+  ]);
+
+  expect(catalog[0].requiredCredentials).toEqual(['google-oauth']);
+  expect(catalog[1]).not.toHaveProperty('requiredCredentials');
+  expect(buildSkillsPrompt([withCredentials])).not.toContain('google-oauth');
 });
 
 test('buildSystemPromptFromHooks uses the provided workspace path in runtime metadata', () => {


### PR DESCRIPTION
## Summary

- preserve every eligible skill name and location before allocating prompt space to descriptions
- compact descriptions uniformly and report prompt compaction or identity omissions in both the prompt and structured logs
- add a read-only `skills_list` recovery tool backed by the complete policy-filtered session catalog
- pass that catalog through host, container, chat, bootstrap, and scheduled-task runtimes
- document the progressive-disclosure and recovery behavior

## Root cause

The skill prompt serialized verbose manifest metadata in category/name order and stopped at a fixed 30,000-character limit. Skills after the cutoff disappeared silently, so a late-sorted skill such as `pdf` could not be selected from a natural-language request.

## Impact

Large skill catalogs keep their routing identities discoverable. When the minimum identity catalog itself cannot fit, omission is explicit and recoverable through `skills_list`.

## Validation

- full workspace lint passed
- targeted skill prompt and `skills_list` tests: 23 passed
- full unit suite completed with one environment-only failure in `host-runner.redaction.test.ts`: the temporary worktree's symlinked dependency layout resolved `agent-browser` from root `node_modules` instead of `container/node_modules`
