### PR TITLE
fix(msteams): stop duplicating inbound text from html attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 
 ### Fixed
 
+- **Microsoft Teams no longer duplicates incoming message text**: Teams
+  delivers rich-composed messages both as plain activity text and as a
+  `text/html` attachment with the same content; the inbound parser now drops
+  attachment snippets that match the primary text instead of appending the
+  message to itself (`question\n\nquestion`).
 - **Cloud admin sessions recover after inactivity**: Expired browser sessions
   reload through HybridAI sign-in instead of showing an unactionable
   `WEB_API_TOKEN` prompt. The self-hosted fallback identifies the exact gateway

--- a/src/channels/msteams/inbound.ts
+++ b/src/channels/msteams/inbound.ts
@@ -264,10 +264,16 @@ export function extractPrimaryText(activity: Partial<Activity>): string {
 }
 
 export function cleanIncomingContent(activity: Partial<Activity>): string {
-  const parts = [
-    extractPrimaryText(activity),
-    ...extractAttachmentText(activity),
-  ].filter((entry) => entry.length > 0);
+  const primaryText = extractPrimaryText(activity);
+  // Teams sends rich-composed messages both as activity.text and as a
+  // text/html attachment with the same content; keep only attachment
+  // snippets that add something beyond the primary text.
+  const attachmentText = extractAttachmentText(activity).filter(
+    (snippet) => snippet !== primaryText,
+  );
+  const parts = [primaryText, ...attachmentText].filter(
+    (entry) => entry.length > 0,
+  );
   return parts.join('\n\n').trim();
 }
 

--- a/tests/msteams.inbound.test.ts
+++ b/tests/msteams.inbound.test.ts
@@ -47,6 +47,39 @@ test('cleanIncomingContent maps Teams mention bodies to agent addresses', async 
   ).toBe('@Research-Agent hi there');
 });
 
+test('cleanIncomingContent drops the html attachment mirroring the text', async () => {
+  const { cleanIncomingContent } = await importInboundModule();
+
+  expect(
+    cleanIncomingContent({
+      text: 'how many fused couplers are we selling per year?',
+      attachments: [
+        {
+          contentType: 'text/html',
+          content:
+            '<p>how many fused couplers are we selling per year?</p>',
+        },
+      ],
+    }),
+  ).toBe('how many fused couplers are we selling per year?');
+});
+
+test('cleanIncomingContent keeps html attachments that add content', async () => {
+  const { cleanIncomingContent } = await importInboundModule();
+
+  expect(
+    cleanIncomingContent({
+      text: 'see the forwarded note',
+      attachments: [
+        {
+          contentType: 'text/html',
+          content: '<p>quarterly numbers attached below</p>',
+        },
+      ],
+    }),
+  ).toBe('see the forwarded note\n\nquarterly numbers attached below');
+});
+
 test('cleanIncomingContent extracts nested Adaptive Card text', async () => {
   const { cleanIncomingContent } = await importInboundModule();
 


### PR DESCRIPTION
## Problem

Messages composed in the Teams rich-text editor arrive with the same content twice: once as plain `activity.text` and once as a `text/html` attachment. `cleanIncomingContent` dedupes attachment snippets only against each other (`appendUniqueSnippet`), never against the primary text, so the agent receives the user's message as:

```
how many fused couplers are we selling per year?

how many fused couplers are we selling per year?
```

The duplication is intermittent from the user's perspective because plain-composed and mobile messages don't carry the html attachment — which made it look like random noise rather than a parser bug.

## Fix

Filter attachment snippets that exactly match the (already html-stripped and normalized) primary text before joining. Attachments with genuinely distinct content are still appended.

## Testing

- New test: html attachment mirroring the activity text is dropped.
- New test: html attachment with distinct content is still appended.
- Existing `cleanIncomingContent` tests unchanged and passing (7/7 in `tests/msteams.inbound.test.ts`), `biome check` and `tsc --noEmit` clean.