### PR TITLE
feat(voice): realtime speech-to-speech voice mode for phone calls (Twilio + Vonage) and web console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@
   needed. Consulted requests run as ordinary web chat turns and appear in the
   session transcript; the button only shows when an `OPENAI_API_KEY` is
   configured.
+- **Realtime mode for the Vonage Voice plugin**: `plugin config vonage-voice
+  mode realtime` runs Vonage calls as the same speech-to-speech conversations
+  over Vonage websocket audio, reusing the core realtime engine and
+  `voice.realtime.*` settings while keeping Vonage credentials in the plugin.
+  Built on two new plugin API seams — `registerWebsocketWebhook` and
+  `createRealtimeVoiceSession` — available to any channel plugin.
+- **Live progress during realtime voice consults**: While the realtime model
+  consults the full agent, long-running turns speak short "still working"
+  updates naming the current tool activity (never over the caller), and the
+  web console's live-call capsule shows what the agent is doing, for example
+  `Checking — web search…`.
 
 ## [0.28.7](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.7) - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
   to the full gateway agent via a `consult_agent` tool, so tools, approvals,
   and session persistence keep working. Configure via `voice.realtime.*`;
   requires an `OPENAI_API_KEY`.
+- **Voice mode in the web console chat**: A microphone button in the composer
+  starts a realtime speech-to-speech session in the browser using the same
+  OpenAI Realtime engine and `voice.realtime.*` settings — no Twilio setup
+  needed. Consulted requests run as ordinary web chat turns and appear in the
+  session transcript; the button only shows when an `OPENAI_API_KEY` is
+  configured.
 
 ## [0.28.6](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.6) - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+- **Realtime voice mode for phone calls**: `voice.mode: "realtime"` runs
+  Twilio calls through the OpenAI Realtime API as natural speech-to-speech
+  conversations with barge-in, instead of the turn-based ConversationRelay
+  flow. The realtime model fronts the call and forwards substantive requests
+  to the full gateway agent via a `consult_agent` tool, so tools, approvals,
+  and session persistence keep working. Configure via `voice.realtime.*`;
+  requires an `OPENAI_API_KEY`.
+
 ### Changed
 
 - **LINE is now an install-on-demand channel plugin**: The unofficial LINEJS

--- a/config.example.json
+++ b/config.example.json
@@ -293,6 +293,7 @@
   "voice": {
     "enabled": false,
     "provider": "twilio",
+    "mode": "relay",
     "twilio": {
       "accountSid": "",
       "authToken": "",
@@ -305,6 +306,12 @@
       "language": "en-US",
       "interruptible": true,
       "welcomeGreeting": "Hello! How can I help you today?"
+    },
+    "realtime": {
+      "model": "gpt-realtime",
+      "voice": "marin",
+      "greeting": "Hello! How can I help you today?",
+      "instructions": ""
     },
     "webhookPath": "/voice",
     "maxConcurrentCalls": 8

--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -10,6 +10,12 @@ export interface ChatRecentResponse {
   sessions: ChatRecentSession[];
 }
 
+export interface ChatVoiceCapabilityResponse {
+  available: boolean;
+  model: string;
+  voice: string;
+}
+
 export interface ChatCleanupResponse {
   deletedCount: number;
   deletedSessionIds: string[];

--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -67,6 +67,8 @@ export interface ChatHistoryMessage {
   artifacts?: ChatArtifact[];
   assistantPresentation?: AssistantPresentation | null;
   activityTrace?: ChatActivityTrace | null;
+  /** Provenance of the turn, e.g. 'voice' for realtime speech transcripts. */
+  source?: string | null;
 }
 
 export type ResponseRatingValue = 'up' | 'down';
@@ -290,4 +292,6 @@ export interface ChatMessage {
   responseRating?: ResponseRatingValue | null;
   branchKey?: string | null;
   a2aDelivery?: A2ADeliveryDescriptor | null;
+  /** Provenance of the turn, e.g. 'voice' for realtime speech transcripts. */
+  source?: string | null;
 }

--- a/console/src/api/chat.ts
+++ b/console/src/api/chat.ts
@@ -6,6 +6,7 @@ import type {
   ChatHistoryResponse,
   ChatMobileQrResponse,
   ChatRecentResponse,
+  ChatVoiceCapabilityResponse,
   MediaUploadResponse,
   RateResponseRequest,
   RateResponseResponse,
@@ -88,6 +89,12 @@ export function fetchChatContext(
     `/api/chat/context?${params.toString()}`,
     { token },
   );
+}
+
+export function fetchChatVoiceCapability(
+  token: string,
+): Promise<ChatVoiceCapabilityResponse> {
+  return requestJson<ChatVoiceCapabilityResponse>('/api/chat/voice', { token });
 }
 
 export function fetchChatCommands(

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -725,6 +725,14 @@ export function stopAdminTerminal(
   );
 }
 
+export function chatVoiceSocketUrl(): string {
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return new URL(
+    '/api/chat/voice/stream',
+    `${protocol}//${window.location.host}`,
+  ).toString();
+}
+
 export function adminTerminalSocketUrl(
   _token: string,
   sessionId: string,

--- a/console/src/generated/settings-registry.ts
+++ b/console/src/generated/settings-registry.ts
@@ -2736,6 +2736,12 @@ export const GENERATED_SETTINGS_REGISTRY: ReadonlyArray<GeneratedSettingEntry> =
       defaultValue: 'gpt-realtime',
     },
     {
+      path: 'voice.realtime.provider',
+      section: 'voice',
+      kind: 'string',
+      defaultValue: 'openai',
+    },
+    {
       path: 'voice.realtime.voice',
       section: 'voice',
       kind: 'string',

--- a/console/src/generated/settings-registry.ts
+++ b/console/src/generated/settings-registry.ts
@@ -2706,10 +2706,40 @@ export const GENERATED_SETTINGS_REGISTRY: ReadonlyArray<GeneratedSettingEntry> =
       defaultValue: 8,
     },
     {
+      path: 'voice.mode',
+      section: 'voice',
+      kind: 'string',
+      defaultValue: 'relay',
+    },
+    {
       path: 'voice.provider',
       section: 'voice',
       kind: 'string',
       defaultValue: 'twilio',
+    },
+    {
+      path: 'voice.realtime.greeting',
+      section: 'voice',
+      kind: 'string',
+      defaultValue: 'Hello! How can I help you today?',
+    },
+    {
+      path: 'voice.realtime.instructions',
+      section: 'voice',
+      kind: 'string',
+      defaultValue: '',
+    },
+    {
+      path: 'voice.realtime.model',
+      section: 'voice',
+      kind: 'string',
+      defaultValue: 'gpt-realtime',
+    },
+    {
+      path: 'voice.realtime.voice',
+      section: 'voice',
+      kind: 'string',
+      defaultValue: 'marin',
     },
     {
       path: 'voice.relay.interruptible',

--- a/console/src/routes/chat/chat-history-query.ts
+++ b/console/src/routes/chat/chat-history-query.ts
@@ -204,6 +204,7 @@ export function buildChatHistoryUiData(
           : null,
       a2aDelivery:
         msg.role === 'assistant' ? hydrateA2ADelivery(msg.content) : null,
+      source: msg.source ?? null,
     };
     if (msg.role === 'assistant') {
       const trace = hydrateActivityTrace(msg.activityTrace, resolvedSessionId);

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -2337,79 +2337,135 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 .voiceModeButtonActive {
-  background: var(--accent);
-  color: var(--primary-foreground);
   animation: voicePulse 1.6s ease-in-out infinite;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .voiceModeButtonActive {
-    animation: none;
-  }
-}
-
-.voicePanel {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin: 0 0 8px;
-  padding: 10px 14px;
-  border: 1px solid var(--line-strong);
-  border-radius: 12px;
-  background: var(--chat-hover-bg);
-}
-
-.voicePanelHeader {
+/* Live-call capsule: a compact centered pill above the composer while voice
+   mode is active. The waveform mirrors the voice button glyph; its color and
+   motion encode state (primary breathing = listening, success dancing =
+   speaking, muted sweep = thinking). */
+.voiceCapsule {
   display: flex;
   align-items: center;
   gap: 10px;
+  width: max-content;
+  max-width: 100%;
+  margin: 0 auto 8px;
+  padding: 6px 8px 6px 14px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel-bg);
+  box-shadow: var(--shadow-card);
+  color: var(--muted-foreground);
 }
 
-.voiceIndicator {
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-  background: var(--muted-foreground);
+.voiceWave {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  height: 16px;
   flex-shrink: 0;
 }
 
-.voiceIndicatorListening {
-  background: var(--accent);
-  animation: voicePulse 1.6s ease-in-out infinite;
+.voiceWaveBar {
+  width: 3px;
+  height: 8px;
+  border-radius: 2px;
+  background: currentColor;
 }
 
-.voiceIndicatorSpeaking {
-  background: #3fb950;
+.voiceWaveBar:nth-child(2) {
+  height: 12px;
+  animation-delay: 0.12s;
 }
 
-.voiceIndicatorThinking {
-  background: #d29922;
-  animation: voicePulse 1s ease-in-out infinite;
+.voiceWaveBar:nth-child(3) {
+  height: 16px;
+  animation-delay: 0.24s;
 }
 
-.voiceIndicatorError {
-  background: #f85149;
+.voiceWaveBar:nth-child(4) {
+  height: 12px;
+  animation-delay: 0.36s;
+}
+
+.voiceWaveBar:nth-child(5) {
+  animation-delay: 0.48s;
+}
+
+.voiceCapsuleListening {
+  color: var(--primary);
+}
+
+.voiceCapsuleListening .voiceWaveBar {
+  animation-name: voiceWaveBreathe;
+  animation-duration: 1.8s;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+}
+
+.voiceCapsuleSpeaking {
+  color: var(--success);
+}
+
+.voiceCapsuleSpeaking .voiceWaveBar {
+  animation-name: voiceWaveDance;
+  animation-duration: 0.9s;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+}
+
+.voiceCapsuleThinking .voiceWaveBar {
+  animation-name: voiceWaveSweep;
+  animation-duration: 1.4s;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+}
+
+.voiceCapsuleEnded {
+  opacity: 0.85;
+}
+
+.voiceCapsuleError {
+  color: var(--danger);
 }
 
 .voiceStatusLabel {
-  flex: 1;
   font-size: 0.85rem;
+  font-weight: 500;
   color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.voiceCapsuleError .voiceStatusLabel {
+  color: var(--danger);
 }
 
 .voiceEndButton {
-  border: 1px solid var(--line-strong);
+  border: none;
   border-radius: 999px;
-  background: transparent;
+  background: var(--chat-hover-bg);
   color: var(--muted-foreground);
-  padding: 4px 12px;
-  font-size: 0.8rem;
+  padding: 5px 12px;
+  font-size: 0.78rem;
+  font-weight: 600;
   cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    background 0.12s,
+    color 0.12s;
 }
 
 .voiceEndButton:hover {
-  background: var(--chat-hover-bg);
-  color: var(--text);
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.voiceEndButton:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--danger) 55%, transparent);
+  outline-offset: 2px;
 }
 
 /* Spoken turns from realtime voice mode (message source 'voice'). Persisted
@@ -2445,9 +2501,41 @@ aside[data-state="collapsed"] .chatSidebarContent {
   }
 }
 
+@keyframes voiceWaveBreathe {
+  0%,
+  100% {
+    transform: scaleY(0.6);
+    opacity: 0.55;
+  }
+  50% {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+}
+
+@keyframes voiceWaveDance {
+  0%,
+  100% {
+    transform: scaleY(0.4);
+  }
+  50% {
+    transform: scaleY(1.15);
+  }
+}
+
+@keyframes voiceWaveSweep {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .voiceIndicatorListening,
-  .voiceIndicatorThinking {
+  .voiceModeButtonActive,
+  .voiceWaveBar {
     animation: none;
   }
 }

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -2392,9 +2392,9 @@ aside[data-state="collapsed"] .chatSidebarContent {
   color: var(--text);
 }
 
-/* Ephemeral voice turns rendered inline in the conversation. They live only
-   in client memory (never in session history), so they are visually marked
-   and disappear on reload. */
+/* Spoken turns from realtime voice mode (message source 'voice'). Persisted
+   like any other message; the tag and dashed border distinguish speech from
+   typed chat, e.g. next to the consult turns of the same exchange. */
 .bubbleVoice {
   opacity: 0.92;
   border-style: dashed;

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -2224,3 +2224,110 @@ aside[data-state="collapsed"] .chatSidebarContent {
     animation: none;
   }
 }
+
+/* Realtime voice mode */
+.voiceButtonActive {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: var(--accent);
+}
+
+.voicePanel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0 0 8px;
+  padding: 10px 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: 12px;
+  background: var(--chat-hover-bg);
+}
+
+.voicePanelHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.voiceIndicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--muted-foreground);
+  flex-shrink: 0;
+}
+
+.voiceIndicatorListening {
+  background: var(--accent);
+  animation: voicePulse 1.6s ease-in-out infinite;
+}
+
+.voiceIndicatorSpeaking {
+  background: #3fb950;
+}
+
+.voiceIndicatorThinking {
+  background: #d29922;
+  animation: voicePulse 1s ease-in-out infinite;
+}
+
+.voiceIndicatorError {
+  background: #f85149;
+}
+
+.voiceStatusLabel {
+  flex: 1;
+  font-size: 0.85rem;
+  color: var(--text);
+}
+
+.voiceEndButton {
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted-foreground);
+  padding: 4px 12px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.voiceEndButton:hover {
+  background: var(--chat-hover-bg);
+  color: var(--text);
+}
+
+.voiceTranscripts {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 120px;
+  overflow-y: auto;
+  font-size: 0.8rem;
+  color: var(--muted-foreground);
+}
+
+.voiceTranscriptLine {
+  display: flex;
+  gap: 8px;
+}
+
+.voiceTranscriptRole {
+  flex-shrink: 0;
+  font-weight: 600;
+}
+
+@keyframes voicePulse {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .voiceIndicatorListening,
+  .voiceIndicatorThinking {
+    animation: none;
+  }
+}

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1753,6 +1753,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 
 .attachButton,
 .dictationButton,
+.voiceModeButton,
 .sendButton {
   display: flex;
   align-items: center;
@@ -1770,6 +1771,7 @@ aside[data-state="collapsed"] .chatSidebarContent {
 
 .attachButton:focus-visible,
 .dictationButton:focus-visible,
+.voiceModeButton:focus-visible,
 .sendButton:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
   outline-offset: 2px;
@@ -2323,9 +2325,27 @@ aside[data-state="collapsed"] .chatSidebarContent {
 }
 
 /* Realtime voice mode */
-.voiceButtonActive {
-  background: color-mix(in srgb, var(--accent) 18%, transparent);
-  color: var(--accent);
+/* Realtime voice mode: filled accent circle with a waveform glyph, sitting
+   between the dictation mic and send (ChatGPT-style pairing). */
+.voiceModeButton {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+
+.voiceModeButton:hover {
+  background: color-mix(in srgb, var(--primary) 85%, var(--foreground) 15%);
+}
+
+.voiceModeButtonActive {
+  background: var(--accent);
+  color: var(--primary-foreground);
+  animation: voicePulse 1.6s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .voiceModeButtonActive {
+    animation: none;
+  }
 }
 
 .voicePanel {

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -2392,24 +2392,27 @@ aside[data-state="collapsed"] .chatSidebarContent {
   color: var(--text);
 }
 
-.voiceTranscripts {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  max-height: 120px;
-  overflow-y: auto;
-  font-size: 0.8rem;
-  color: var(--muted-foreground);
+/* Ephemeral voice turns rendered inline in the conversation. They live only
+   in client memory (never in session history), so they are visually marked
+   and disappear on reload. */
+.bubbleVoice {
+  opacity: 0.92;
+  border-style: dashed;
 }
 
-.voiceTranscriptLine {
-  display: flex;
-  gap: 8px;
+.bubbleUser.bubbleVoice {
+  border: 1px dashed
+    color-mix(in srgb, var(--primary-foreground) 45%, transparent);
 }
 
-.voiceTranscriptRole {
-  flex-shrink: 0;
-  font-weight: 600;
+.voiceBubbleTag {
+  display: block;
+  margin-bottom: 2px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.65;
 }
 
 @keyframes voicePulse {

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -17,6 +17,7 @@ import {
   fetchAppStatus,
   fetchChatContext,
   fetchChatRecent,
+  fetchChatVoiceCapability,
   rateChatResponse,
   uploadMedia,
 } from '../../api/chat';
@@ -81,6 +82,7 @@ import { EditInline, MessageBlock } from './message-block';
 import { useChatSession } from './use-chat-session';
 import { useChatStream } from './use-chat-stream';
 import { useStickToBottom } from './use-stick-to-bottom';
+import { VoicePanel } from './voice-panel';
 
 type BranchInfo = {
   current: number;
@@ -341,6 +343,22 @@ export function ChatPage() {
     staleTime: 30_000,
     enabled: chatApiReady,
   });
+
+  const voiceCapabilityQuery = useQuery({
+    queryKey: ['chat-voice-capability', auth.token],
+    queryFn: () => fetchChatVoiceCapability(auth.token),
+    staleTime: Infinity,
+    enabled: chatApiReady,
+  });
+  const [voiceOpen, setVoiceOpen] = useState(false);
+  const handleVoiceAssistantTurn = useCallback(() => {
+    // Consulted voice turns persist as ordinary web chat messages; refetch so
+    // they appear in the transcript without leaving voice mode.
+    void queryClient.invalidateQueries({
+      queryKey: chatHistoryQueryKey(auth.token, getSessionId()),
+    });
+    refreshRecent();
+  }, [queryClient, auth.token, getSessionId, refreshRecent]);
 
   const modelsQuery = useQuery({
     queryKey: ['models', auth.token],
@@ -1383,6 +1401,14 @@ export function ChatPage() {
             </div>
           ) : null}
 
+          {voiceOpen ? (
+            <VoicePanel
+              sessionId={sessionId}
+              agentId={effectiveAgentId}
+              onAssistantTurn={handleVoiceAssistantTurn}
+              onClose={() => setVoiceOpen(false)}
+            />
+          ) : null}
           <Composer
             isStreaming={stream.isStreaming}
             onSend={handleSendMessage}
@@ -1396,6 +1422,9 @@ export function ChatPage() {
             selectedModelId={selectedModelId}
             onModelSwitch={(modelId) => void handleModelSwitch(modelId)}
             initialValue={initialComposerPrompt}
+            voiceAvailable={voiceCapabilityQuery.data?.available === true}
+            voiceActive={voiceOpen}
+            onVoiceToggle={() => setVoiceOpen((open) => !open)}
           />
         </div>
         <Dialog

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -1421,6 +1421,7 @@ export function ChatPage() {
             <VoicePanel
               status={voiceSession.status}
               error={voiceSession.error}
+              consultActivity={voiceSession.consultActivity}
               onClose={() => setVoiceOpen(false)}
             />
           ) : null}

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -64,6 +64,7 @@ import {
   readStoredUserId,
 } from '../../lib/chat-helpers';
 import { CHAT_UI_CONFIG } from '../../lib/chat-ui-config';
+import { cx } from '../../lib/cx';
 import { getErrorMessage } from '../../lib/error-message';
 import { useDebouncedValue } from '../../lib/use-debounced-value';
 import { findAgentMentions } from './agent-mention-display';
@@ -82,6 +83,7 @@ import { EditInline, MessageBlock } from './message-block';
 import { useChatSession } from './use-chat-session';
 import { useChatStream } from './use-chat-stream';
 import { useStickToBottom } from './use-stick-to-bottom';
+import { useVoiceSession } from './use-voice-session';
 import { VoicePanel } from './voice-panel';
 
 type BranchInfo = {
@@ -568,6 +570,20 @@ export function ChatPage() {
     agentOptions
       .find((agent) => agent.id.toLowerCase() === effectiveAgentId)
       ?.emptyChatHeader?.trim() || DEFAULT_EMPTY_CHAT_HEADER;
+
+  const voiceSession = useVoiceSession({
+    sessionId,
+    agentId: effectiveAgentId,
+    onAssistantTurn: handleVoiceAssistantTurn,
+  });
+  const { start: startVoice, stop: stopVoice } = voiceSession;
+  useEffect(() => {
+    if (voiceOpen) {
+      void startVoice();
+    } else {
+      stopVoice();
+    }
+  }, [voiceOpen, startVoice, stopVoice]);
 
   const deleteSessionMutation = useMutation({
     mutationFn: (targetSessionId: string) =>
@@ -1250,7 +1266,8 @@ export function ChatPage() {
     [branchFamilies, handleOpenSession],
   );
 
-  const isEmpty = visibleMessages.length === 0;
+  const isEmpty =
+    visibleMessages.length === 0 && voiceSession.transcripts.length === 0;
   const isSwitchingSession = historyQuery.isFetching;
 
   const sidebarProps = {
@@ -1376,6 +1393,30 @@ export function ChatPage() {
                     />
                   ),
                 )}
+                {voiceSession.transcripts.map((entry) => (
+                  <div
+                    key={`voice-${entry.id}`}
+                    className={cx(
+                      css.messageBlock,
+                      entry.role === 'user'
+                        ? css.messageBlockUser
+                        : css.messageBlockAssistant,
+                    )}
+                  >
+                    <div
+                      className={cx(
+                        css.bubble,
+                        entry.role === 'user'
+                          ? css.bubbleUser
+                          : css.bubbleAssistant,
+                        css.bubbleVoice,
+                      )}
+                    >
+                      <span className={css.voiceBubbleTag}>Voice</span>
+                      {entry.text}
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
           )}
@@ -1403,9 +1444,8 @@ export function ChatPage() {
 
           {voiceOpen ? (
             <VoicePanel
-              sessionId={sessionId}
-              agentId={effectiveAgentId}
-              onAssistantTurn={handleVoiceAssistantTurn}
+              status={voiceSession.status}
+              error={voiceSession.error}
               onClose={() => setVoiceOpen(false)}
             />
           ) : null}

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -64,7 +64,6 @@ import {
   readStoredUserId,
 } from '../../lib/chat-helpers';
 import { CHAT_UI_CONFIG } from '../../lib/chat-ui-config';
-import { cx } from '../../lib/cx';
 import { getErrorMessage } from '../../lib/error-message';
 import { useDebouncedValue } from '../../lib/use-debounced-value';
 import { findAgentMentions } from './agent-mention-display';
@@ -353,9 +352,10 @@ export function ChatPage() {
     enabled: chatApiReady,
   });
   const [voiceOpen, setVoiceOpen] = useState(false);
-  const handleVoiceAssistantTurn = useCallback(() => {
-    // Consulted voice turns persist as ordinary web chat messages; refetch so
-    // they appear in the transcript without leaving voice mode.
+  const handleVoiceTranscript = useCallback(() => {
+    // The gateway persists every spoken turn (and consulted turns) as
+    // ordinary web chat messages; refetch so they appear in the conversation
+    // without leaving voice mode.
     void queryClient.invalidateQueries({
       queryKey: chatHistoryQueryKey(auth.token, getSessionId()),
     });
@@ -574,7 +574,7 @@ export function ChatPage() {
   const voiceSession = useVoiceSession({
     sessionId,
     agentId: effectiveAgentId,
-    onAssistantTurn: handleVoiceAssistantTurn,
+    onTranscript: handleVoiceTranscript,
   });
   const { start: startVoice, stop: stopVoice } = voiceSession;
   useEffect(() => {
@@ -1266,8 +1266,7 @@ export function ChatPage() {
     [branchFamilies, handleOpenSession],
   );
 
-  const isEmpty =
-    visibleMessages.length === 0 && voiceSession.transcripts.length === 0;
+  const isEmpty = visibleMessages.length === 0;
   const isSwitchingSession = historyQuery.isFetching;
 
   const sidebarProps = {
@@ -1393,30 +1392,6 @@ export function ChatPage() {
                     />
                   ),
                 )}
-                {voiceSession.transcripts.map((entry) => (
-                  <div
-                    key={`voice-${entry.id}`}
-                    className={cx(
-                      css.messageBlock,
-                      entry.role === 'user'
-                        ? css.messageBlockUser
-                        : css.messageBlockAssistant,
-                    )}
-                  >
-                    <div
-                      className={cx(
-                        css.bubble,
-                        entry.role === 'user'
-                          ? css.bubbleUser
-                          : css.bubbleAssistant,
-                        css.bubbleVoice,
-                      )}
-                    >
-                      <span className={css.voiceBubbleTag}>Voice</span>
-                      {entry.text}
-                    </div>
-                  </div>
-                ))}
               </div>
             </div>
           )}

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -670,6 +670,9 @@ export function Composer(props: {
                   aria-label={
                     props.voiceActive ? 'End voice mode' : 'Start voice mode'
                   }
+                  title={
+                    props.voiceActive ? 'End voice mode' : 'Start voice mode'
+                  }
                   aria-pressed={props.voiceActive === true}
                 >
                   <svg

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -82,6 +82,9 @@ export function Composer(props: {
   selectedModelId?: string;
   onModelSwitch?: (modelId: string) => void;
   initialValue?: string;
+  voiceAvailable?: boolean;
+  voiceActive?: boolean;
+  onVoiceToggle?: () => void;
 }) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -597,6 +600,36 @@ export function Composer(props: {
               >
                 +
               </button>
+              {props.voiceAvailable ? (
+                <button
+                  type="button"
+                  className={cx(
+                    css.attachButton,
+                    props.voiceActive && css.voiceButtonActive,
+                  )}
+                  onClick={() => props.onVoiceToggle?.()}
+                  aria-label={
+                    props.voiceActive ? 'End voice mode' : 'Start voice mode'
+                  }
+                  aria-pressed={props.voiceActive === true}
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    width="16"
+                    height="16"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <rect x="9" y="3" width="6" height="11" rx="3" />
+                    <path d="M5 11a7 7 0 0 0 14 0" />
+                    <path d="M12 18v3" />
+                  </svg>
+                </button>
+              ) : null}
               <AgentSwitchSelect
                 agents={agentOptions}
                 selectedAgentId={selectedAgentId}

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -633,36 +633,6 @@ export function Composer(props: {
               >
                 +
               </button>
-              {props.voiceAvailable ? (
-                <button
-                  type="button"
-                  className={cx(
-                    css.attachButton,
-                    props.voiceActive && css.voiceButtonActive,
-                  )}
-                  onClick={() => props.onVoiceToggle?.()}
-                  aria-label={
-                    props.voiceActive ? 'End voice mode' : 'Start voice mode'
-                  }
-                  aria-pressed={props.voiceActive === true}
-                >
-                  <svg
-                    viewBox="0 0 24 24"
-                    width="16"
-                    height="16"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden="true"
-                  >
-                    <rect x="9" y="3" width="6" height="11" rx="3" />
-                    <path d="M5 11a7 7 0 0 0 14 0" />
-                    <path d="M12 18v3" />
-                  </svg>
-                </button>
-              ) : null}
               <AgentSwitchSelect
                 agents={agentOptions}
                 selectedAgentId={selectedAgentId}
@@ -689,6 +659,37 @@ export function Composer(props: {
                 disabled={props.isStreaming}
                 onTranscript={insertDictationTranscript}
               />
+              {props.voiceAvailable ? (
+                <button
+                  type="button"
+                  className={cx(
+                    css.voiceModeButton,
+                    props.voiceActive && css.voiceModeButtonActive,
+                  )}
+                  onClick={() => props.onVoiceToggle?.()}
+                  aria-label={
+                    props.voiceActive ? 'End voice mode' : 'Start voice mode'
+                  }
+                  aria-pressed={props.voiceActive === true}
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    width="16"
+                    height="16"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2.2"
+                    strokeLinecap="round"
+                    aria-hidden="true"
+                  >
+                    <path d="M4 10v4" />
+                    <path d="M8 7v10" />
+                    <path d="M12 4v16" />
+                    <path d="M16 7v10" />
+                    <path d="M20 10v4" />
+                  </svg>
+                </button>
+              ) : null}
               <button
                 type="button"
                 className={cx(

--- a/console/src/routes/chat/message-block.tsx
+++ b/console/src/routes/chat/message-block.tsx
@@ -507,6 +507,7 @@ export const MessageBlock = memo(function MessageBlock(props: {
       css.messageBlockAssistant,
   );
 
+  const isVoice = msg.source === 'voice';
   const bubbleClass = cx(
     css.bubble,
     isUser && css.bubbleUser,
@@ -515,6 +516,7 @@ export const MessageBlock = memo(function MessageBlock(props: {
     msg.role === 'system' && css.bubbleSystem,
     msg.role === 'command' && css.bubbleCommand,
     isA2ADeliveryStatus && css.bubbleA2AStatus,
+    isVoice && css.bubbleVoice,
   );
 
   return (
@@ -534,6 +536,7 @@ export const MessageBlock = memo(function MessageBlock(props: {
 
       {shouldRenderBubble ? (
         <div className={bubbleClass}>
+          {isVoice ? <span className={css.voiceBubbleTag}>Voice</span> : null}
           {isA2ADeliveryStatus && msg.a2aDelivery ? (
             <A2ADeliveryChip descriptor={msg.a2aDelivery} token={token} />
           ) : shouldRenderApprovalCard && msg.pendingApproval ? (

--- a/console/src/routes/chat/use-voice-session.ts
+++ b/console/src/routes/chat/use-voice-session.ts
@@ -16,6 +16,9 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { chatVoiceSocketUrl } from '../../api/client';
 import { VoiceAudioPipeline } from './voice-audio';
 
+// ~20s of mic audio at the pipeline's ~171ms chunk cadence.
+const PENDING_AUDIO_LIMIT = 120;
+
 export type VoiceSessionStatus =
   | 'idle'
   | 'connecting'
@@ -63,12 +66,22 @@ export function useVoiceSession(options: {
     setStatus('connecting');
     const pipeline = new VoiceAudioPipeline();
     pipelineRef.current = pipeline;
+    // The mic captures before the gateway session is up; buffer those chunks
+    // and flush on `ready` so speech from the first seconds is not lost.
+    const pendingAudio: string[] = [];
+    let sessionReady = false;
+    const sendAudio = (socket: WebSocket, base64Pcm: string) => {
+      socket.send(JSON.stringify({ type: 'audio', payload: base64Pcm }));
+    };
     try {
       await pipeline.start((base64Pcm) => {
         const socket = socketRef.current;
-        if (socket && socket.readyState === WebSocket.OPEN) {
-          socket.send(JSON.stringify({ type: 'audio', payload: base64Pcm }));
+        if (sessionReady && socket && socket.readyState === WebSocket.OPEN) {
+          sendAudio(socket, base64Pcm);
+          return;
         }
+        pendingAudio.push(base64Pcm);
+        if (pendingAudio.length > PENDING_AUDIO_LIMIT) pendingAudio.shift();
       });
     } catch {
       pipelineRef.current = null;
@@ -96,6 +109,11 @@ export function useVoiceSession(options: {
         return;
       }
       if (frame.type === 'ready') {
+        sessionReady = true;
+        if (socket.readyState === WebSocket.OPEN) {
+          for (const chunk of pendingAudio) sendAudio(socket, chunk);
+        }
+        pendingAudio.length = 0;
         setStatus('listening');
         return;
       }

--- a/console/src/routes/chat/use-voice-session.ts
+++ b/console/src/routes/chat/use-voice-session.ts
@@ -1,7 +1,9 @@
 /**
  * Realtime voice session hook: owns the `/api/chat/voice/stream` websocket
  * lifecycle and wires it to the `VoiceAudioPipeline` — mic chunks up, model
- * audio and barge-in clears down, plus state and transcript frames for the UI.
+ * audio and barge-in clears down, plus status for the UI. Transcript frames
+ * only signal that a turn was persisted; the chat page refetches history to
+ * render it.
  *
  * Guarantees teardown is idempotent (stop, server `ended`, socket close,
  * session switch, and unmount all funnel through one cleanup path) so the mic
@@ -14,8 +16,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { chatVoiceSocketUrl } from '../../api/client';
 import { VoiceAudioPipeline } from './voice-audio';
 
-const TRANSCRIPT_LIMIT = 100;
-
 export type VoiceSessionStatus =
   | 'idle'
   | 'connecting'
@@ -25,29 +25,21 @@ export type VoiceSessionStatus =
   | 'ended'
   | 'error';
 
-export interface VoiceTranscriptEntry {
-  id: number;
-  role: 'user' | 'assistant';
-  text: string;
-}
-
 export function useVoiceSession(options: {
   sessionId: string;
   agentId?: string | null;
-  onAssistantTurn?: () => void;
+  /** Fired per spoken turn; the gateway has already persisted it to history. */
+  onTranscript?: (role: 'user' | 'assistant') => void;
 }): {
   status: VoiceSessionStatus;
   error: string | null;
-  transcripts: VoiceTranscriptEntry[];
   start: () => Promise<void>;
   stop: () => void;
 } {
   const [status, setStatus] = useState<VoiceSessionStatus>('idle');
   const [error, setError] = useState<string | null>(null);
-  const [transcripts, setTranscripts] = useState<VoiceTranscriptEntry[]>([]);
   const socketRef = useRef<WebSocket | null>(null);
   const pipelineRef = useRef<VoiceAudioPipeline | null>(null);
-  const transcriptIdRef = useRef(0);
   const optionsRef = useRef(options);
   optionsRef.current = options;
 
@@ -68,7 +60,6 @@ export function useVoiceSession(options: {
   const start = useCallback(async () => {
     if (socketRef.current) return;
     setError(null);
-    setTranscripts([]);
     setStatus('connecting');
     const pipeline = new VoiceAudioPipeline();
     pipelineRef.current = pipeline;
@@ -132,17 +123,9 @@ export function useVoiceSession(options: {
         typeof frame.text === 'string' &&
         (frame.role === 'user' || frame.role === 'assistant')
       ) {
-        const role: 'user' | 'assistant' =
-          frame.role === 'user' ? 'user' : 'assistant';
-        const text = frame.text;
-        transcriptIdRef.current += 1;
-        const id = transcriptIdRef.current;
-        setTranscripts((current) =>
-          [...current, { id, role, text }].slice(-TRANSCRIPT_LIMIT),
+        optionsRef.current.onTranscript?.(
+          frame.role === 'user' ? 'user' : 'assistant',
         );
-        if (role === 'assistant') {
-          optionsRef.current.onAssistantTurn?.();
-        }
         return;
       }
       if (frame.type === 'error' && typeof frame.message === 'string') {
@@ -164,16 +147,15 @@ export function useVoiceSession(options: {
     });
   }, [stop]);
 
-  // Ephemeral voice turns belong to one chat session: switching sessions (or
-  // unmounting) ends the live session and drops the inline transcript.
+  // A live voice call belongs to one chat session: switching sessions (or
+  // unmounting) ends it.
   const sessionId = options.sessionId;
   // biome-ignore lint/correctness/useExhaustiveDependencies: sessionId intentionally tears down the live call on session switch.
   useEffect(() => {
     return () => {
       stop();
-      setTranscripts([]);
     };
   }, [sessionId, stop]);
 
-  return { status, error, transcripts, start, stop };
+  return { status, error, start, stop };
 }

--- a/console/src/routes/chat/use-voice-session.ts
+++ b/console/src/routes/chat/use-voice-session.ts
@@ -1,0 +1,169 @@
+/**
+ * Realtime voice session hook: owns the `/api/chat/voice/stream` websocket
+ * lifecycle and wires it to the `VoiceAudioPipeline` — mic chunks up, model
+ * audio and barge-in clears down, plus state and transcript frames for the UI.
+ *
+ * Guarantees teardown is idempotent (stop, server `ended`, socket close, and
+ * unmount all funnel through one cleanup path) so the mic never stays hot
+ * after the panel closes.
+ *
+ * NOT the UI: rendering lives in `voice-panel.tsx`.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { chatVoiceSocketUrl } from '../../api/client';
+import { VoiceAudioPipeline } from './voice-audio';
+
+export type VoiceSessionStatus =
+  | 'idle'
+  | 'connecting'
+  | 'listening'
+  | 'speaking'
+  | 'thinking'
+  | 'ended'
+  | 'error';
+
+export interface VoiceTranscriptEntry {
+  id: number;
+  role: 'user' | 'assistant';
+  text: string;
+}
+
+export function useVoiceSession(options: {
+  sessionId: string;
+  agentId?: string | null;
+  onAssistantTurn?: () => void;
+}): {
+  status: VoiceSessionStatus;
+  error: string | null;
+  transcripts: VoiceTranscriptEntry[];
+  start: () => Promise<void>;
+  stop: () => void;
+} {
+  const [status, setStatus] = useState<VoiceSessionStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [transcripts, setTranscripts] = useState<VoiceTranscriptEntry[]>([]);
+  const socketRef = useRef<WebSocket | null>(null);
+  const pipelineRef = useRef<VoiceAudioPipeline | null>(null);
+  const transcriptIdRef = useRef(0);
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const stop = useCallback(() => {
+    const socket = socketRef.current;
+    socketRef.current = null;
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ type: 'stop' }));
+    }
+    socket?.close();
+    pipelineRef.current?.stop();
+    pipelineRef.current = null;
+    setStatus((current) =>
+      current === 'error' || current === 'idle' ? current : 'ended',
+    );
+  }, []);
+
+  const start = useCallback(async () => {
+    if (socketRef.current) return;
+    setError(null);
+    setTranscripts([]);
+    setStatus('connecting');
+    const pipeline = new VoiceAudioPipeline();
+    pipelineRef.current = pipeline;
+    try {
+      await pipeline.start((base64Pcm) => {
+        const socket = socketRef.current;
+        if (socket && socket.readyState === WebSocket.OPEN) {
+          socket.send(JSON.stringify({ type: 'audio', payload: base64Pcm }));
+        }
+      });
+    } catch {
+      pipelineRef.current = null;
+      pipeline.stop();
+      setError('Microphone access was denied.');
+      setStatus('error');
+      return;
+    }
+    const socket = new WebSocket(chatVoiceSocketUrl());
+    socketRef.current = socket;
+    socket.addEventListener('open', () => {
+      socket.send(
+        JSON.stringify({
+          type: 'start',
+          sessionId: optionsRef.current.sessionId,
+          agentId: optionsRef.current.agentId || undefined,
+        }),
+      );
+    });
+    socket.addEventListener('message', (event) => {
+      let frame: { type?: string } & Record<string, unknown>;
+      try {
+        frame = JSON.parse(String(event.data)) as typeof frame;
+      } catch {
+        return;
+      }
+      if (frame.type === 'ready') {
+        setStatus('listening');
+        return;
+      }
+      if (frame.type === 'audio' && typeof frame.payload === 'string') {
+        pipelineRef.current?.playAudio(frame.payload);
+        return;
+      }
+      if (frame.type === 'clear') {
+        pipelineRef.current?.clearPlayback();
+        return;
+      }
+      if (frame.type === 'state' && typeof frame.state === 'string') {
+        const state = frame.state;
+        if (
+          state === 'listening' ||
+          state === 'speaking' ||
+          state === 'thinking'
+        ) {
+          setStatus(state);
+        }
+        return;
+      }
+      if (
+        frame.type === 'transcript' &&
+        typeof frame.text === 'string' &&
+        (frame.role === 'user' || frame.role === 'assistant')
+      ) {
+        const role: 'user' | 'assistant' =
+          frame.role === 'user' ? 'user' : 'assistant';
+        const text = frame.text;
+        transcriptIdRef.current += 1;
+        const id = transcriptIdRef.current;
+        setTranscripts((current) => [...current, { id, role, text }].slice(-8));
+        if (role === 'assistant') {
+          optionsRef.current.onAssistantTurn?.();
+        }
+        return;
+      }
+      if (frame.type === 'error' && typeof frame.message === 'string') {
+        setError(frame.message);
+        return;
+      }
+      if (frame.type === 'ended') {
+        stop();
+      }
+    });
+    socket.addEventListener('close', () => {
+      if (socketRef.current === socket) {
+        stop();
+      }
+    });
+    socket.addEventListener('error', () => {
+      setError('Voice connection failed.');
+      setStatus('error');
+    });
+  }, [stop]);
+
+  useEffect(() => {
+    return () => {
+      stop();
+    };
+  }, [stop]);
+
+  return { status, error, transcripts, start, stop };
+}

--- a/console/src/routes/chat/use-voice-session.ts
+++ b/console/src/routes/chat/use-voice-session.ts
@@ -3,15 +3,18 @@
  * lifecycle and wires it to the `VoiceAudioPipeline` — mic chunks up, model
  * audio and barge-in clears down, plus state and transcript frames for the UI.
  *
- * Guarantees teardown is idempotent (stop, server `ended`, socket close, and
- * unmount all funnel through one cleanup path) so the mic never stays hot
- * after the panel closes.
+ * Guarantees teardown is idempotent (stop, server `ended`, socket close,
+ * session switch, and unmount all funnel through one cleanup path) so the mic
+ * never stays hot after voice mode closes.
  *
- * NOT the UI: rendering lives in `voice-panel.tsx`.
+ * NOT the UI: the status bar lives in `voice-panel.tsx` and transcripts
+ * render inline in the chat page's conversation view.
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { chatVoiceSocketUrl } from '../../api/client';
 import { VoiceAudioPipeline } from './voice-audio';
+
+const TRANSCRIPT_LIMIT = 100;
 
 export type VoiceSessionStatus =
   | 'idle'
@@ -134,7 +137,9 @@ export function useVoiceSession(options: {
         const text = frame.text;
         transcriptIdRef.current += 1;
         const id = transcriptIdRef.current;
-        setTranscripts((current) => [...current, { id, role, text }].slice(-8));
+        setTranscripts((current) =>
+          [...current, { id, role, text }].slice(-TRANSCRIPT_LIMIT),
+        );
         if (role === 'assistant') {
           optionsRef.current.onAssistantTurn?.();
         }
@@ -159,11 +164,16 @@ export function useVoiceSession(options: {
     });
   }, [stop]);
 
+  // Ephemeral voice turns belong to one chat session: switching sessions (or
+  // unmounting) ends the live session and drops the inline transcript.
+  const sessionId = options.sessionId;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: sessionId intentionally tears down the live call on session switch.
   useEffect(() => {
     return () => {
       stop();
+      setTranscripts([]);
     };
-  }, [stop]);
+  }, [sessionId, stop]);
 
   return { status, error, transcripts, start, stop };
 }

--- a/console/src/routes/chat/use-voice-session.ts
+++ b/console/src/routes/chat/use-voice-session.ts
@@ -36,11 +36,14 @@ export function useVoiceSession(options: {
 }): {
   status: VoiceSessionStatus;
   error: string | null;
+  /** Humanized tool label while a consulted agent turn works, else null. */
+  consultActivity: string | null;
   start: () => Promise<void>;
   stop: () => void;
 } {
   const [status, setStatus] = useState<VoiceSessionStatus>('idle');
   const [error, setError] = useState<string | null>(null);
+  const [consultActivity, setConsultActivity] = useState<string | null>(null);
   const socketRef = useRef<WebSocket | null>(null);
   const pipelineRef = useRef<VoiceAudioPipeline | null>(null);
   const optionsRef = useRef(options);
@@ -55,6 +58,7 @@ export function useVoiceSession(options: {
     socket?.close();
     pipelineRef.current?.stop();
     pipelineRef.current = null;
+    setConsultActivity(null);
     setStatus((current) =>
       current === 'error' || current === 'idle' ? current : 'ended',
     );
@@ -133,7 +137,14 @@ export function useVoiceSession(options: {
           state === 'thinking'
         ) {
           setStatus(state);
+          if (state !== 'thinking') setConsultActivity(null);
         }
+        return;
+      }
+      if (frame.type === 'consult') {
+        setConsultActivity(
+          typeof frame.label === 'string' && frame.label ? frame.label : null,
+        );
         return;
       }
       if (
@@ -175,5 +186,5 @@ export function useVoiceSession(options: {
     };
   }, [sessionId, stop]);
 
-  return { status, error, start, stop };
+  return { status, error, consultActivity, start, stop };
 }

--- a/console/src/routes/chat/voice-audio.ts
+++ b/console/src/routes/chat/voice-audio.ts
@@ -1,0 +1,158 @@
+/**
+ * Browser audio pipeline for realtime voice: microphone capture as base64
+ * PCM16 mono 24 kHz chunks, and gapless scheduled playback of the same wire
+ * format, with instant clear-on-barge-in.
+ *
+ * Capture uses a ScriptProcessorNode instead of an AudioWorklet on purpose:
+ * the console ships under `script-src 'self'` and this avoids a separately
+ * emitted worklet asset for ~10 lines of resampling. Swap to a worklet if the
+ * deprecation ever lands in practice.
+ *
+ * NOT the session protocol: websocket frames live in `use-voice-session.ts`.
+ */
+
+export const VOICE_SAMPLE_RATE = 24_000;
+const CAPTURE_BUFFER_SIZE = 4096;
+
+function floatTo16BitPcmBase64(samples: Float32Array): string {
+  const pcm = new Int16Array(samples.length);
+  for (let i = 0; i < samples.length; i += 1) {
+    const s = Math.max(-1, Math.min(1, samples[i]));
+    pcm[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+  }
+  const bytes = new Uint8Array(pcm.buffer);
+  let binary = '';
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}
+
+function base64ToFloat32(base64: string): Float32Array<ArrayBuffer> {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  const pcm = new Int16Array(bytes.buffer, 0, Math.floor(bytes.length / 2));
+  const samples = new Float32Array(pcm.length);
+  for (let i = 0; i < pcm.length; i += 1) {
+    samples[i] = pcm[i] / (pcm[i] < 0 ? 0x8000 : 0x7fff);
+  }
+  return samples;
+}
+
+function resampleLinear(
+  input: Float32Array<ArrayBuffer>,
+  fromRate: number,
+  toRate: number,
+): Float32Array<ArrayBuffer> {
+  if (fromRate === toRate) return input;
+  const outLength = Math.max(1, Math.round((input.length * toRate) / fromRate));
+  const output = new Float32Array(outLength);
+  const step = (input.length - 1) / Math.max(1, outLength - 1);
+  for (let i = 0; i < outLength; i += 1) {
+    const pos = i * step;
+    const low = Math.floor(pos);
+    const high = Math.min(input.length - 1, low + 1);
+    const frac = pos - low;
+    output[i] = input[low] * (1 - frac) + input[high] * frac;
+  }
+  return output;
+}
+
+export class VoiceAudioPipeline {
+  private context: AudioContext | null = null;
+  private stream: MediaStream | null = null;
+  private source: MediaStreamAudioSourceNode | null = null;
+  private processor: ScriptProcessorNode | null = null;
+  private playbackCursor = 0;
+  private readonly playingSources = new Set<AudioBufferSourceNode>();
+
+  async start(onChunk: (base64Pcm: string) => void): Promise<void> {
+    if (this.context) return;
+    this.stream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        channelCount: 1,
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+      },
+    });
+    // Some hardware ignores the requested rate; capture resamples from
+    // context.sampleRate to the 24 kHz wire rate either way.
+    const context = new AudioContext({ sampleRate: VOICE_SAMPLE_RATE });
+    this.context = context;
+    await context.resume();
+    this.source = context.createMediaStreamSource(this.stream);
+    this.processor = context.createScriptProcessor(CAPTURE_BUFFER_SIZE, 1, 1);
+    this.processor.onaudioprocess = (event) => {
+      const input = event.inputBuffer.getChannelData(0);
+      const resampled = resampleLinear(
+        new Float32Array(input),
+        context.sampleRate,
+        VOICE_SAMPLE_RATE,
+      );
+      onChunk(floatTo16BitPcmBase64(resampled));
+    };
+    this.source.connect(this.processor);
+    // Chrome requires the processor to reach the destination to fire
+    // onaudioprocess; a zero-gain node keeps the mic out of the speakers.
+    const mute = context.createGain();
+    mute.gain.value = 0;
+    this.processor.connect(mute);
+    mute.connect(context.destination);
+  }
+
+  playAudio(base64Pcm: string): void {
+    const context = this.context;
+    if (!context) return;
+    const samples = base64ToFloat32(base64Pcm);
+    if (samples.length === 0) return;
+    const wireRateBuffer = context.createBuffer(
+      1,
+      samples.length,
+      VOICE_SAMPLE_RATE,
+    );
+    wireRateBuffer.copyToChannel(samples, 0);
+    const source = context.createBufferSource();
+    source.buffer = wireRateBuffer;
+    source.connect(context.destination);
+    const startAt = Math.max(context.currentTime, this.playbackCursor);
+    source.start(startAt);
+    this.playbackCursor = startAt + wireRateBuffer.duration;
+    this.playingSources.add(source);
+    source.onended = () => {
+      this.playingSources.delete(source);
+    };
+  }
+
+  clearPlayback(): void {
+    for (const source of this.playingSources) {
+      try {
+        source.stop();
+      } catch {
+        // Already ended; nothing to stop.
+      }
+    }
+    this.playingSources.clear();
+    this.playbackCursor = 0;
+  }
+
+  stop(): void {
+    this.clearPlayback();
+    this.processor?.disconnect();
+    this.processor = null;
+    this.source?.disconnect();
+    this.source = null;
+    for (const track of this.stream?.getTracks() || []) {
+      track.stop();
+    }
+    this.stream = null;
+    void this.context?.close().catch(() => {
+      // The context may already be closed by the browser.
+    });
+    this.context = null;
+  }
+}

--- a/console/src/routes/chat/voice-panel.tsx
+++ b/console/src/routes/chat/voice-panel.tsx
@@ -39,8 +39,13 @@ const WAVE_BARS = [0, 1, 2, 3, 4];
 export function VoicePanel(props: {
   status: VoiceSessionStatus;
   error: string | null;
+  consultActivity?: string | null;
   onClose: () => void;
 }) {
+  const label =
+    props.status === 'thinking' && props.consultActivity
+      ? `Checking — ${props.consultActivity}…`
+      : STATUS_LABELS[props.status];
   return (
     <div
       className={cx(css.voiceCapsule, STATUS_CLASSES[props.status])}
@@ -52,9 +57,7 @@ export function VoicePanel(props: {
           <span key={bar} className={css.voiceWaveBar} />
         ))}
       </span>
-      <span className={css.voiceStatusLabel}>
-        {props.error || STATUS_LABELS[props.status]}
-      </span>
+      <span className={css.voiceStatusLabel}>{props.error || label}</span>
       <button
         type="button"
         className={css.voiceEndButton}

--- a/console/src/routes/chat/voice-panel.tsx
+++ b/console/src/routes/chat/voice-panel.tsx
@@ -1,0 +1,83 @@
+/**
+ * Voice mode panel: the visible surface of a realtime voice session, shown
+ * above the composer while the mic is live. Auto-starts its session on mount
+ * and guarantees the session ends when the panel unmounts or the user closes
+ * it, so voice can never keep running invisibly.
+ *
+ * NOT the transport: audio and websocket handling live in
+ * `use-voice-session.ts` / `voice-audio.ts`.
+ */
+import { useEffect } from 'react';
+import { cx } from '../../lib/cx';
+import css from './chat-page.module.css';
+import { useVoiceSession, type VoiceSessionStatus } from './use-voice-session';
+
+const STATUS_LABELS: Record<VoiceSessionStatus, string> = {
+  idle: 'Starting…',
+  connecting: 'Connecting…',
+  listening: 'Listening',
+  speaking: 'Speaking',
+  thinking: 'Checking with the assistant…',
+  ended: 'Voice session ended',
+  error: 'Voice error',
+};
+
+export function VoicePanel(props: {
+  sessionId: string;
+  agentId?: string | null;
+  onAssistantTurn?: () => void;
+  onClose: () => void;
+}) {
+  const session = useVoiceSession({
+    sessionId: props.sessionId,
+    agentId: props.agentId,
+    onAssistantTurn: props.onAssistantTurn,
+  });
+  const { start } = session;
+
+  useEffect(() => {
+    void start();
+  }, [start]);
+
+  return (
+    <div className={css.voicePanel} role="status" aria-live="polite">
+      <div className={css.voicePanelHeader}>
+        <span
+          className={cx(
+            css.voiceIndicator,
+            session.status === 'listening' && css.voiceIndicatorListening,
+            session.status === 'speaking' && css.voiceIndicatorSpeaking,
+            session.status === 'thinking' && css.voiceIndicatorThinking,
+            session.status === 'error' && css.voiceIndicatorError,
+          )}
+          aria-hidden="true"
+        />
+        <span className={css.voiceStatusLabel}>
+          {session.error || STATUS_LABELS[session.status]}
+        </span>
+        <button
+          type="button"
+          className={css.voiceEndButton}
+          onClick={() => {
+            session.stop();
+            props.onClose();
+          }}
+        >
+          End voice
+        </button>
+      </div>
+      {session.transcripts.length > 0 ? (
+        <div className={css.voiceTranscripts}>
+          {session.transcripts.map((entry) => (
+            <div key={entry.id} className={css.voiceTranscriptLine}>
+              <span className={css.voiceTranscriptRole}>
+                {entry.role === 'user' ? 'You' : 'HybridClaw'}
+              </span>
+              <span>{entry.text}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/console/src/routes/chat/voice-panel.tsx
+++ b/console/src/routes/chat/voice-panel.tsx
@@ -1,5 +1,9 @@
 /**
- * Voice mode status bar, shown above the composer while the mic is live.
+ * Voice mode capsule: a compact live-call chip floating above the composer
+ * while the mic is live. Its animated waveform mirrors the composer's voice
+ * button glyph and encodes state — breathing while listening, dancing while
+ * the model speaks, sweeping while it consults the agent.
+ *
  * Purely presentational: the session lifecycle is owned by the chat page,
  * which starts the session when voice mode opens and guarantees it ends when
  * voice mode closes, so voice can never keep running invisibly. Transcripts
@@ -22,35 +26,43 @@ const STATUS_LABELS: Record<VoiceSessionStatus, string> = {
   error: 'Voice error',
 };
 
+const STATUS_CLASSES: Partial<Record<VoiceSessionStatus, string>> = {
+  listening: css.voiceCapsuleListening,
+  speaking: css.voiceCapsuleSpeaking,
+  thinking: css.voiceCapsuleThinking,
+  ended: css.voiceCapsuleEnded,
+  error: css.voiceCapsuleError,
+};
+
+const WAVE_BARS = [0, 1, 2, 3, 4];
+
 export function VoicePanel(props: {
   status: VoiceSessionStatus;
   error: string | null;
   onClose: () => void;
 }) {
   return (
-    <div className={css.voicePanel} role="status" aria-live="polite">
-      <div className={css.voicePanelHeader}>
-        <span
-          className={cx(
-            css.voiceIndicator,
-            props.status === 'listening' && css.voiceIndicatorListening,
-            props.status === 'speaking' && css.voiceIndicatorSpeaking,
-            props.status === 'thinking' && css.voiceIndicatorThinking,
-            props.status === 'error' && css.voiceIndicatorError,
-          )}
-          aria-hidden="true"
-        />
-        <span className={css.voiceStatusLabel}>
-          {props.error || STATUS_LABELS[props.status]}
-        </span>
-        <button
-          type="button"
-          className={css.voiceEndButton}
-          onClick={props.onClose}
-        >
-          End voice
-        </button>
-      </div>
+    <div
+      className={cx(css.voiceCapsule, STATUS_CLASSES[props.status])}
+      role="status"
+      aria-live="polite"
+    >
+      <span className={css.voiceWave} aria-hidden="true">
+        {WAVE_BARS.map((bar) => (
+          <span key={bar} className={css.voiceWaveBar} />
+        ))}
+      </span>
+      <span className={css.voiceStatusLabel}>
+        {props.error || STATUS_LABELS[props.status]}
+      </span>
+      <button
+        type="button"
+        className={css.voiceEndButton}
+        onClick={props.onClose}
+        aria-label="End voice mode"
+      >
+        End
+      </button>
     </div>
   );
 }

--- a/console/src/routes/chat/voice-panel.tsx
+++ b/console/src/routes/chat/voice-panel.tsx
@@ -1,16 +1,16 @@
 /**
- * Voice mode panel: the visible surface of a realtime voice session, shown
- * above the composer while the mic is live. Auto-starts its session on mount
- * and guarantees the session ends when the panel unmounts or the user closes
- * it, so voice can never keep running invisibly.
+ * Voice mode status bar, shown above the composer while the mic is live.
+ * Purely presentational: the session lifecycle is owned by the chat page,
+ * which starts the session when voice mode opens and guarantees it ends when
+ * voice mode closes, so voice can never keep running invisibly. Transcripts
+ * render inline in the conversation, not here.
  *
  * NOT the transport: audio and websocket handling live in
  * `use-voice-session.ts` / `voice-audio.ts`.
  */
-import { useEffect } from 'react';
 import { cx } from '../../lib/cx';
 import css from './chat-page.module.css';
-import { useVoiceSession, type VoiceSessionStatus } from './use-voice-session';
+import type { VoiceSessionStatus } from './use-voice-session';
 
 const STATUS_LABELS: Record<VoiceSessionStatus, string> = {
   idle: 'Starting…',
@@ -23,61 +23,34 @@ const STATUS_LABELS: Record<VoiceSessionStatus, string> = {
 };
 
 export function VoicePanel(props: {
-  sessionId: string;
-  agentId?: string | null;
-  onAssistantTurn?: () => void;
+  status: VoiceSessionStatus;
+  error: string | null;
   onClose: () => void;
 }) {
-  const session = useVoiceSession({
-    sessionId: props.sessionId,
-    agentId: props.agentId,
-    onAssistantTurn: props.onAssistantTurn,
-  });
-  const { start } = session;
-
-  useEffect(() => {
-    void start();
-  }, [start]);
-
   return (
     <div className={css.voicePanel} role="status" aria-live="polite">
       <div className={css.voicePanelHeader}>
         <span
           className={cx(
             css.voiceIndicator,
-            session.status === 'listening' && css.voiceIndicatorListening,
-            session.status === 'speaking' && css.voiceIndicatorSpeaking,
-            session.status === 'thinking' && css.voiceIndicatorThinking,
-            session.status === 'error' && css.voiceIndicatorError,
+            props.status === 'listening' && css.voiceIndicatorListening,
+            props.status === 'speaking' && css.voiceIndicatorSpeaking,
+            props.status === 'thinking' && css.voiceIndicatorThinking,
+            props.status === 'error' && css.voiceIndicatorError,
           )}
           aria-hidden="true"
         />
         <span className={css.voiceStatusLabel}>
-          {session.error || STATUS_LABELS[session.status]}
+          {props.error || STATUS_LABELS[props.status]}
         </span>
         <button
           type="button"
           className={css.voiceEndButton}
-          onClick={() => {
-            session.stop();
-            props.onClose();
-          }}
+          onClick={props.onClose}
         >
           End voice
         </button>
       </div>
-      {session.transcripts.length > 0 ? (
-        <div className={css.voiceTranscripts}>
-          {session.transcripts.map((entry) => (
-            <div key={entry.id} className={css.voiceTranscriptLine}>
-              <span className={css.voiceTranscriptRole}>
-                {entry.role === 'user' ? 'You' : 'HybridClaw'}
-              </span>
-              <span>{entry.text}</span>
-            </div>
-          ))}
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -26,7 +26,9 @@ export default defineConfig({
     host: '127.0.0.1',
     port: 4173,
     proxy: {
-      '/api': 'http://127.0.0.1:9090',
+      // ws:true lets the voice and admin-terminal websockets reach the
+      // gateway from the standalone Vite dev server.
+      '/api': { target: 'http://127.0.0.1:9090', ws: true },
       '/health': 'http://127.0.0.1:9090',
     },
   },

--- a/docs/content/channels/admin-console.md
+++ b/docs/content/channels/admin-console.md
@@ -155,8 +155,9 @@ changes before navigation.
 - the web chat route offers a realtime voice mode (microphone button in the
   composer) when an OpenAI API key is configured: mic audio streams to the
   OpenAI Realtime API for natural speech-to-speech conversation with
-  interruption support, and substantive requests run as ordinary web chat
-  turns via `consult_agent`, so they appear in the session transcript
+  interruption support; spoken turns persist into the conversation as
+  voice-tagged messages, and substantive requests run as ordinary web chat
+  turns via `consult_agent`
 - destructive admin actions use explicit browser confirmation dialogs before
   HybridClaw applies the requested change
 

--- a/docs/content/channels/admin-console.md
+++ b/docs/content/channels/admin-console.md
@@ -159,7 +159,9 @@ changes before navigation.
   audio streams to the realtime API for natural speech-to-speech conversation
   with interruption support; spoken turns persist into the conversation as
   voice-tagged messages, and substantive requests run as ordinary web chat
-  turns via `consult_agent`
+  turns via `consult_agent`; while a consult runs, the live-call capsule shows
+  what the agent is currently doing (for example `Checking — web search…`)
+  and long consults get short spoken progress updates
 - destructive admin actions use explicit browser confirmation dialogs before
   HybridClaw applies the requested change
 

--- a/docs/content/channels/admin-console.md
+++ b/docs/content/channels/admin-console.md
@@ -152,6 +152,11 @@ changes before navigation.
   operators apply persisted thumbs-up/down ratings to assistant responses
 - the web chat route syntax-highlights completed code blocks, shows language
   labels, and keeps copy controls reachable on hover and touch devices
+- the web chat route offers a realtime voice mode (microphone button in the
+  composer) when an OpenAI API key is configured: mic audio streams to the
+  OpenAI Realtime API for natural speech-to-speech conversation with
+  interruption support, and substantive requests run as ordinary web chat
+  turns via `consult_agent`, so they appear in the session transcript
 - destructive admin actions use explicit browser confirmation dialogs before
   HybridClaw applies the requested change
 

--- a/docs/content/channels/admin-console.md
+++ b/docs/content/channels/admin-console.md
@@ -153,9 +153,11 @@ changes before navigation.
 - the web chat route syntax-highlights completed code blocks, shows language
   labels, and keeps copy controls reachable on hover and touch devices
 - the web chat route offers a realtime voice mode (microphone button in the
-  composer) when an OpenAI API key is configured: mic audio streams to the
-  OpenAI Realtime API for natural speech-to-speech conversation with
-  interruption support; spoken turns persist into the conversation as
+  composer) when the configured `voice.realtime.provider` has a credential —
+  an OpenAI API key for `openai`, or the signed-in HybridAI credential for
+  `hybridai` (which routes through the platform's `/v1/realtime` proxy): mic
+  audio streams to the realtime API for natural speech-to-speech conversation
+  with interruption support; spoken turns persist into the conversation as
   voice-tagged messages, and substantive requests run as ordinary web chat
   turns via `consult_agent`
 - destructive admin actions use explicit browser confirmation dialogs before

--- a/docs/content/channels/overview.md
+++ b/docs/content/channels/overview.md
@@ -28,7 +28,7 @@ If you are still in first-run onboarding mode, start with
 | Fax | Fax-to-email inbound PDFs and guarded outbound PDF fax delivery | `hybridclaw channels email setup ...` + `fax-send` skill | [Fax](./fax.md) |
 | WhatsApp | Linked-device QR pairing and phone-based DM tests | `hybridclaw channels whatsapp setup ...` | [WhatsApp](./whatsapp.md) |
 | LINE | Unofficial personal-account QR login and self-chat only | `hybridclaw channels line setup` | [LINE](./line.md) |
-| Twilio Voice | Phone calls when you already have a public HTTPS/WSS endpoint | `/admin/channels` | [Twilio Voice](../guides/twilio-voice.md) |
+| Twilio Voice | Phone calls (turn-based relay or realtime speech-to-speech) over a public HTTPS/WSS endpoint | `/admin/channels` | [Twilio Voice](../guides/twilio-voice.md) |
 | iMessage | Local Mac runtime or remote BlueBubbles relay | `hybridclaw channels imessage setup ...` | [iMessage](./imessage.md) |
 | Microsoft Teams | Entra/Azure bot registration and HTTPS webhook delivery | `hybridclaw auth login msteams ...` | [Microsoft Teams](./msteams.md) |
 

--- a/docs/content/extensibility/plugins.md
+++ b/docs/content/extensibility/plugins.md
@@ -58,7 +58,8 @@ plugin is explicitly enabled.
 
 Vonage Voice is also bundled as an install-on-demand plugin. Its webhook
 runtime, credentials, and outbound calling command stay outside the built-in
-Twilio voice channel.
+Twilio voice channel. Its optional realtime mode reuses the core realtime
+voice engine through the plugin API rather than its own model credentials.
 
 The reinstall command:
 
@@ -121,9 +122,9 @@ or change one top-level `plugins.list[].config` key without editing
   `fromName`, `fromAddress`, and `agentHandles`. The bundled `send_email` tool
   also accepts optional `inReplyTo` and `references` Message-ID headers when
   you need to continue an existing email thread.
-- `vonage-voice` provides signed, turn-based inbound and outbound phone calls
-  through Vonage Voice without adding Vonage configuration to the core voice
-  channel.
+- `vonage-voice` provides signed inbound and outbound phone calls through
+  Vonage Voice without adding Vonage configuration to the core voice channel —
+  turn-based by default, or realtime speech-to-speech with `mode: realtime`.
 
 Example config writes:
 
@@ -367,7 +368,27 @@ plus the parsed `URL`, and can reuse `readWebhookJsonBody(...)`,
 To hand a normalized inbound event back into the standard assistant turn flow,
 plugins can call `api.dispatchInboundMessage(...)`. That runs the same gateway
 turn pipeline used by built-in channels and returns the standard gateway chat
-result so the plugin can deliver the reply through its own transport.
+result so the plugin can deliver the reply through its own transport. The
+request accepts an optional `onToolProgress` callback for live tool activity
+during the turn.
+
+Plugins can also register websocket endpoints on the same route prefix through
+`api.registerWebsocketWebhook({ name, handler })`. The handler receives the
+upgrade request plus `accept()` / `reject(statusCode, message)`; exactly one
+must be called. Like HTTP plugin webhooks, the gateway performs no peer
+authentication on these upgrades — the handler must validate the peer itself
+(for example with a signed single-use token in the URL) before accepting.
+
+Channel plugins that transport live phone audio can open a realtime
+speech-to-speech session with `api.createRealtimeVoiceSession(...)`. The core
+realtime engine (configured by `voice.realtime.*`) fronts the conversation,
+consults the full agent through the plugin dispatch pipeline (so approvals,
+audit, and session history behave like any other turn), and persists spoken
+turns as voice transcripts. Transport audio is 16-bit LE mono PCM at 8 kHz;
+model audio arrives as paced 20 ms frames so barge-in can cut playback
+promptly. `api.isRealtimeVoiceAvailable()` reports whether realtime
+credentials are configured. The bundled `vonage-voice` plugin's realtime mode
+is the reference implementation.
 
 Classifier middleware uses one decision shape for routing, inbound prompt
 preparation, and outbound response inspection:

--- a/docs/content/guides/README.md
+++ b/docs/content/guides/README.md
@@ -27,8 +27,8 @@ These pages focus on common operator workflows after the base install works.
 - [Hatching Task Ideas](./hatching-task-ideas.md) for first-run questions and starter jobs tailored to the user's tools and goals
 - [Twilio Voice](./twilio-voice.md) for phone-channel setup, public webhook
   exposure, testing, and troubleshooting
-- [Vonage Voice Plugin](./vonage-voice.md) for turn-based phone calls through
-  the install-on-demand Vonage integration
+- [Vonage Voice Plugin](./vonage-voice.md) for turn-based or realtime phone
+  calls through the install-on-demand Vonage integration
 - [Voice and TTS](./voice-tts.md) for voice reply and speech backend setup
 - [Optional Office Dependencies](./office-dependencies.md) for host-side
   office tooling

--- a/docs/content/guides/twilio-voice.md
+++ b/docs/content/guides/twilio-voice.md
@@ -151,10 +151,15 @@ tagged `source: 'voice'`, alongside the consulted turns.
 
 Requirements and notes:
 
-- Realtime mode needs an OpenAI API key. Set the `OPENAI_API_KEY` environment
+- Realtime mode needs a realtime credential. With the default
+  `voice.realtime.provider` of `openai`, set the `OPENAI_API_KEY` environment
   variable or store it in the encrypted secret store (same flow as the Twilio
-  auth token, secret name `OPENAI_API_KEY`). The gateway refuses to start the
-  voice channel in realtime mode without it.
+  auth token, secret name `OPENAI_API_KEY`). Set the provider to `hybridai`
+  to route sessions through the HybridAI platform's `/v1/realtime` proxy
+  instead, authenticated with your signed-in HybridAI credential (or
+  `HYBRIDAI_API_KEY`) — no OpenAI key required. The gateway refuses to start
+  the voice channel in realtime mode without the selected provider's
+  credential.
 - `voice.realtime.voice` accepts any OpenAI realtime voice name (for example
   `marin`, `cedar`, `alloy`).
 - `voice.realtime.instructions` is appended to the built-in call instructions;
@@ -164,11 +169,11 @@ Requirements and notes:
 - Realtime API audio is billed by OpenAI per minute of input and output audio
   in addition to Twilio's per-minute call pricing.
 - The same realtime engine also powers voice mode in the web console chat
-  (microphone button in the composer). Browser voice needs only the OpenAI
-  key — it works even when the Twilio voice channel is disabled, and it uses
-  the same `voice.realtime.*` model, voice, greeting, and instructions
-  settings. It is the quickest way to try realtime voice before wiring up a
-  phone number.
+  (microphone button in the composer). Browser voice needs only the realtime
+  credential — it works even when the Twilio voice channel is disabled, and it
+  uses the same `voice.realtime.*` provider, model, voice, greeting, and
+  instructions settings. It is the quickest way to try realtime voice before
+  wiring up a phone number.
 
 ## Store The Twilio Secret
 

--- a/docs/content/guides/twilio-voice.md
+++ b/docs/content/guides/twilio-voice.md
@@ -35,7 +35,16 @@ Important:
 
 ## How The Channel Works
 
-The flow is:
+The channel has two modes, selected with `voice.mode`:
+
+- `relay` (default): turn-based conversation where Twilio owns speech
+  recognition and synthesis.
+- `realtime`: speech-to-speech conversation powered by the OpenAI Realtime
+  API, with barge-in and natural back-and-forth — comparable to advanced
+  voice modes in consumer assistants. See
+  [Realtime Voice Mode](#realtime-voice-mode) below.
+
+The relay flow is:
 
 1. Twilio sends an inbound webhook to HybridClaw.
 2. HybridClaw returns TwiML with `<Connect><ConversationRelay>`.
@@ -46,7 +55,7 @@ The flow is:
 
 For outbound calls, `hybridclaw gateway voice call <number>` tells Twilio to
 dial the destination and point the live call back at the same HybridClaw voice
-webhook.
+webhook. Outbound calls use the same configured mode as inbound calls.
 
 ## Minimum Config
 
@@ -92,11 +101,68 @@ Notes:
 - `ops.gatewayBaseUrl` must be the public URL Twilio sees, not a local one.
 - `voice.webhookPath` controls the base path for:
   - `<webhookPath>/webhook`
-  - `<webhookPath>/relay`
+  - `<webhookPath>/relay` (relay mode)
+  - `<webhookPath>/stream` (realtime mode)
   - `<webhookPath>/action`
 - `voice.twilio.fromNumber` must be an E.164 number like `+14155550123`.
 - leave `voice.twilio.authToken` empty when you store the real token in the
   encrypted secret store.
+
+## Realtime Voice Mode
+
+Set `voice.mode` to `"realtime"` to run calls through the OpenAI Realtime API
+instead of Twilio's turn-based ConversationRelay:
+
+```json
+{
+  "voice": {
+    "enabled": true,
+    "provider": "twilio",
+    "mode": "realtime",
+    "realtime": {
+      "model": "gpt-realtime",
+      "voice": "marin",
+      "greeting": "Hello! How can I help you today?",
+      "instructions": ""
+    }
+  }
+}
+```
+
+The realtime flow is:
+
+1. Twilio sends the same inbound webhook to HybridClaw.
+2. HybridClaw returns TwiML with `<Connect><Stream>` (Twilio Media Streams).
+3. Twilio opens a websocket at `<webhookPath>/stream` and streams the caller's
+   raw audio (8kHz µ-law).
+4. HybridClaw bridges that audio to an OpenAI realtime session, which listens,
+   detects turns, and speaks directly — audio passes through in both
+   directions without transcoding.
+5. When the caller interrupts, the bridge cancels the model's response and
+   flushes Twilio's audio buffer, so the model stops talking immediately.
+
+The realtime model fronts the conversation but is not the agent. It handles
+greetings and small talk itself; for anything that needs the assistant's
+knowledge, memory, or tools it calls a `consult_agent` tool, which runs a
+normal gateway agent turn in the same voice session — with the usual approval
+policy, session persistence, and audit logging — and speaks the reply. Turns
+handled directly by the realtime model are not persisted to the session
+transcript; consulted turns are.
+
+Requirements and notes:
+
+- Realtime mode needs an OpenAI API key. Set the `OPENAI_API_KEY` environment
+  variable or store it in the encrypted secret store (same flow as the Twilio
+  auth token, secret name `OPENAI_API_KEY`). The gateway refuses to start the
+  voice channel in realtime mode without it.
+- `voice.realtime.voice` accepts any OpenAI realtime voice name (for example
+  `marin`, `cedar`, `alloy`).
+- `voice.realtime.instructions` is appended to the built-in call instructions;
+  use it for tone, language, or caller-handling guidance.
+- `voice.relay.*` settings are ignored in realtime mode, and
+  `channelInstructions.voice` still applies to the consulted agent turns.
+- Realtime API audio is billed by OpenAI per minute of input and output audio
+  in addition to Twilio's per-minute call pricing.
 
 ## Store The Twilio Secret
 

--- a/docs/content/guides/twilio-voice.md
+++ b/docs/content/guides/twilio-voice.md
@@ -145,9 +145,9 @@ The realtime model fronts the conversation but is not the agent. It handles
 greetings and small talk itself; for anything that needs the assistant's
 knowledge, memory, or tools it calls a `consult_agent` tool, which runs a
 normal gateway agent turn in the same voice session — with the usual approval
-policy, session persistence, and audit logging — and speaks the reply. Turns
-handled directly by the realtime model are not persisted to the session
-transcript; consulted turns are.
+policy, session persistence, and audit logging — and speaks the reply. Every
+spoken turn is persisted to the session as a regular user/assistant message
+tagged `source: 'voice'`, alongside the consulted turns.
 
 Requirements and notes:
 

--- a/docs/content/guides/twilio-voice.md
+++ b/docs/content/guides/twilio-voice.md
@@ -163,6 +163,12 @@ Requirements and notes:
   `channelInstructions.voice` still applies to the consulted agent turns.
 - Realtime API audio is billed by OpenAI per minute of input and output audio
   in addition to Twilio's per-minute call pricing.
+- The same realtime engine also powers voice mode in the web console chat
+  (microphone button in the composer). Browser voice needs only the OpenAI
+  key — it works even when the Twilio voice channel is disabled, and it uses
+  the same `voice.realtime.*` model, voice, greeting, and instructions
+  settings. It is the quickest way to try realtime voice before wiring up a
+  phone number.
 
 ## Store The Twilio Secret
 

--- a/docs/content/guides/twilio-voice.md
+++ b/docs/content/guides/twilio-voice.md
@@ -145,9 +145,13 @@ The realtime model fronts the conversation but is not the agent. It handles
 greetings and small talk itself; for anything that needs the assistant's
 knowledge, memory, or tools it calls a `consult_agent` tool, which runs a
 normal gateway agent turn in the same voice session — with the usual approval
-policy, session persistence, and audit logging — and speaks the reply. Every
-spoken turn is persisted to the session as a regular user/assistant message
-tagged `source: 'voice'`, alongside the consulted turns.
+policy, session persistence, and audit logging — and speaks the reply. While a
+consult runs, the caller is not left in silence: the model briefly announces
+it is checking, and if the turn takes longer it speaks short "still working"
+updates that mention what the agent is currently doing (from live tool
+activity), never talking over the caller. Every spoken turn is persisted to
+the session as a regular user/assistant message tagged `source: 'voice'`,
+alongside the consulted turns.
 
 Requirements and notes:
 

--- a/docs/content/guides/vonage-voice.md
+++ b/docs/content/guides/vonage-voice.md
@@ -1,6 +1,6 @@
 ---
 title: Vonage Voice Plugin
-description: Install and configure turn-based phone calls through the Vonage Voice API.
+description: Install and configure turn-based or realtime phone calls through the Vonage Voice API.
 sidebar_position: 8
 ---
 
@@ -27,8 +27,8 @@ Configure the plugin:
 Store `VONAGE_PRIVATE_KEY` and `VONAGE_SIGNATURE_SECRET` through HybridClaw's
 credential flow. Do not put either secret in plugin config.
 
-Optional settings are `language`, `welcomeGreeting`, `interruptible`, and
-`maxConcurrentCalls`.
+Optional settings are `mode` (`turn` or `realtime`), `language`,
+`welcomeGreeting`, `interruptible`, and `maxConcurrentCalls`.
 
 ## Vonage Application
 
@@ -40,9 +40,34 @@ Vonage number, and configure these `POST` endpoints:
 
 The plugin places its input callback URL in each NCCO automatically.
 
-Vonage handles speech recognition and text-to-speech. Calls are turn-based:
-the caller speaks, HybridClaw processes the completed transcript, then the
-plugin transfers the live call to an NCCO that speaks the finished reply.
+In the default turn mode, Vonage handles speech recognition and
+text-to-speech. Calls are turn-based: the caller speaks, HybridClaw processes
+the completed transcript, then the plugin transfers the live call to an NCCO
+that speaks the finished reply.
+
+## Realtime Mode
+
+```text
+/plugin config vonage-voice mode realtime
+```
+
+Realtime mode runs calls as natural speech-to-speech conversations with
+instant barge-in, using the gateway's realtime voice engine — the same
+`voice.realtime.*` settings (provider, model, voice, instructions) and
+credential (`OPENAI_API_KEY` or the HybridAI provider) that power the Twilio
+realtime mode and the web console voice mode. The Twilio channel itself can
+stay disabled. Answered calls where no realtime credential is configured are
+declined with a spoken notice instead of connecting silently.
+
+The answer webhook connects the call's audio to a plugin websocket at
+`/api/plugin-webhooks/vonage-voice/stream`, carrying linear PCM at 8 kHz in
+both directions. Each call's websocket URL embeds a single-use stream token
+that expires after 30 seconds, since Vonage does not sign websocket upgrades.
+The realtime model fronts the conversation and forwards substantive requests
+to the full agent, so approvals, audit, and session history keep working;
+spoken turns persist into the call's session transcript. In realtime mode the
+`interruptible` setting is ignored (barge-in is always on) and DTMF digits are
+not delivered.
 
 ## Verify And Call
 

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -256,10 +256,14 @@ saved revision history directly.
   `EMAIL_PASSWORD` or `email.password` via SecretRef instead of plaintext
   config, and note that `email.pollIntervalMs` defaults to `30000`
   milliseconds and is clamped to a minimum of `1000`
-- `voice.*` for the Twilio ConversationRelay channel, including webhook path,
-  concurrency, relay voice/STT options, and Twilio number/account settings;
-  the auth token can stay empty in config when you store `TWILIO_AUTH_TOKEN`
-  in the encrypted runtime secret store or use a SecretRef-backed
+- `voice.*` for the Twilio phone channel, including webhook path, concurrency,
+  and Twilio number/account settings; `voice.mode` selects `relay`
+  (ConversationRelay, `voice.relay.*` voice/STT options) or `realtime`
+  (OpenAI Realtime speech-to-speech over Twilio Media Streams, configured via
+  `voice.realtime.model`, `voice.realtime.voice`, `voice.realtime.greeting`,
+  and `voice.realtime.instructions`; requires an `OPENAI_API_KEY`). The auth
+  token can stay empty in config when you store `TWILIO_AUTH_TOKEN` in the
+  encrypted runtime secret store or use a SecretRef-backed
   `voice.twilio.authToken`
 - `deployment.mode`, `deployment.public_url`, `deployment.a2a_local_mode`,
   `deployment.a2a_e2ee_required`, `deployment.tunnel.provider`, and

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -261,7 +261,9 @@ saved revision history directly.
   (ConversationRelay, `voice.relay.*` voice/STT options) or `realtime`
   (OpenAI Realtime speech-to-speech over Twilio Media Streams, configured via
   `voice.realtime.model`, `voice.realtime.voice`, `voice.realtime.greeting`,
-  and `voice.realtime.instructions`; requires an `OPENAI_API_KEY`). The auth
+  and `voice.realtime.instructions`; requires an `OPENAI_API_KEY`). The
+  `voice.realtime.*` settings also drive web console voice mode, which needs
+  only the OpenAI key and works with the Twilio channel disabled. The auth
   token can stay empty in config when you store `TWILIO_AUTH_TOKEN` in the
   encrypted runtime secret store or use a SecretRef-backed
   `voice.twilio.authToken`

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -263,9 +263,13 @@ saved revision history directly.
   (ConversationRelay, `voice.relay.*` voice/STT options) or `realtime`
   (OpenAI Realtime speech-to-speech over Twilio Media Streams, configured via
   `voice.realtime.model`, `voice.realtime.voice`, `voice.realtime.greeting`,
-  and `voice.realtime.instructions`; requires an `OPENAI_API_KEY`). The
-  `voice.realtime.*` settings also drive web console voice mode, which needs
-  only the OpenAI key and works with the Twilio channel disabled. The auth
+  and `voice.realtime.instructions`). `voice.realtime.provider` selects the
+  realtime backend: `openai` (the default; requires an `OPENAI_API_KEY`) or
+  `hybridai` (the HybridAI platform's `/v1/realtime` proxy at
+  `HYBRIDAI_BASE_URL`, authenticated with your signed-in HybridAI credential
+  or `HYBRIDAI_API_KEY` — no OpenAI key needed). The `voice.realtime.*`
+  settings also drive web console voice mode, which needs only the realtime
+  credential and works with the Twilio channel disabled. The auth
   token can stay empty in config when you store `TWILIO_AUTH_TOKEN` in the
   encrypted runtime secret store or use a SecretRef-backed
   `voice.twilio.authToken`

--- a/plugins/vonage-voice/hybridclaw.plugin.yaml
+++ b/plugins/vonage-voice/hybridclaw.plugin.yaml
@@ -2,7 +2,7 @@ id: vonage-voice
 name: Vonage Voice
 version: 0.1.0
 kind: channel
-description: Turn-based inbound and outbound phone calls through the Vonage Voice API.
+description: Inbound and outbound phone calls through the Vonage Voice API, turn-based or realtime speech-to-speech.
 entrypoint: src/index.js
 requires:
   node: 22.x
@@ -26,6 +26,10 @@ configSchema:
     publicBaseUrl:
       type: string
       pattern: '^https://'
+    mode:
+      type: string
+      enum: [turn, realtime]
+      default: turn
     language:
       type: string
       default: en-US
@@ -43,6 +47,8 @@ configSchema:
 configUiHints:
   applicationId:
     label: Application ID
+  mode:
+    label: Call Mode
   fromNumber:
     label: Vonage Number
     placeholder: '+14155550123'

--- a/plugins/vonage-voice/src/config.js
+++ b/plugins/vonage-voice/src/config.js
@@ -23,12 +23,17 @@ export function resolveConfig(api) {
   }
   if (!privateKey) throw new Error('VONAGE_PRIVATE_KEY is required.');
   if (!signatureSecret) throw new Error('VONAGE_SIGNATURE_SECRET is required.');
+  const mode = String(config.mode || 'turn').trim() || 'turn';
+  if (mode !== 'turn' && mode !== 'realtime') {
+    throw new Error('Vonage mode must be "turn" or "realtime".');
+  }
   return {
     applicationId,
     fromNumber,
     publicBaseUrl,
     privateKey,
     signatureSecret,
+    mode,
     language: String(config.language || 'en-US').trim() || 'en-US',
     welcomeGreeting:
       String(config.welcomeGreeting || '').trim() ||

--- a/plugins/vonage-voice/src/index.js
+++ b/plugins/vonage-voice/src/index.js
@@ -16,17 +16,25 @@ export default {
       handler: (ctx) => runtime.handleAnswer(ctx),
     });
     api.registerInboundWebhook({
-      name: 'input',
-      method: 'POST',
-      description: 'Vonage speech input callback',
-      handler: (ctx) => runtime.handleInput(ctx),
-    });
-    api.registerInboundWebhook({
       name: 'event',
       method: 'POST',
       description: 'Vonage call status callback',
       handler: (ctx) => runtime.handleEvent(ctx),
     });
+    if (config.mode === 'realtime') {
+      api.registerWebsocketWebhook({
+        name: 'stream',
+        description: 'Vonage realtime call audio stream',
+        handler: (ctx) => runtime.handleStreamUpgrade(ctx),
+      });
+    } else {
+      api.registerInboundWebhook({
+        name: 'input',
+        method: 'POST',
+        description: 'Vonage speech input callback',
+        handler: (ctx) => runtime.handleInput(ctx),
+      });
+    }
     api.registerService({
       id: 'vonage-voice-runtime',
       stop: () => runtime.stop(),
@@ -39,6 +47,7 @@ export default {
         if (subcommand === 'info' || subcommand === 'status') {
           return [
             'Vonage Voice plugin is ready.',
+            `Mode: ${config.mode === 'realtime' ? 'realtime speech-to-speech' : 'turn-based'}`,
             `Answer webhook: ${runtime.answerUrl}`,
             `Event webhook: ${runtime.eventUrl}`,
             'Usage: /vonage call <e164-number>',

--- a/plugins/vonage-voice/src/ncco.js
+++ b/plugins/vonage-voice/src/ncco.js
@@ -87,6 +87,31 @@ export function buildGoodbyeNcco(params) {
     bargeIn: false,
   });
 }
+/**
+ * Realtime mode: hand the call's audio to our websocket endpoint as linear
+ * PCM at 8 kHz (matches the µ-law realtime session sample rate — no
+ * resampling anywhere). The goodbye talk plays once the websocket leg ends.
+ */
+export function buildRealtimeConnectNcco(params) {
+  return [
+    {
+      action: 'connect',
+      endpoint: [
+        {
+          type: 'websocket',
+          uri: params.websocketUri,
+          'content-type': 'audio/l16;rate=8000',
+          headers: { callUuid: params.callUuid },
+        },
+      ],
+    },
+    ...buildTalkActions({
+      text: 'Goodbye.',
+      language: params.language,
+      bargeIn: false,
+    }),
+  ];
+}
 function readString(record, key) {
   const value = record[key];
   return typeof value === 'string' ? value.trim() : '';

--- a/plugins/vonage-voice/src/realtime.js
+++ b/plugins/vonage-voice/src/realtime.js
@@ -1,0 +1,127 @@
+/**
+ * Realtime-mode websocket leg: pairs a Vonage `connect`-to-websocket call leg
+ * with a core realtime voice session (api.createRealtimeVoiceSession).
+ *
+ * Upgrades authenticate with a single-use stream token minted by the answer
+ * webhook — Vonage does not sign websocket upgrades, so possession of a
+ * fresh token minted for that call is the auth. Binary frames are 16-bit LE
+ * mono PCM at 8 kHz in both directions.
+ *
+ * NOT the call-state owner: the answer/event webhooks in runtime.js own the
+ * session table, capacity, and teardown signaling.
+ */
+import { randomBytes } from 'node:crypto';
+import { buildVoiceSessionKey } from './utils.js';
+
+const STREAM_TOKEN_TTL_MS = 30_000;
+const WS_OPEN = 1;
+
+export function createVonageRealtimeStreams(api, config) {
+  const tokens = new Map();
+  const activeStreams = new Set();
+  const agentId = api.config.agents?.defaultAgentId || 'main';
+
+  function pruneTokens() {
+    const now = Date.now();
+    for (const [token, entry] of tokens) {
+      if (entry.expiresAt <= now) tokens.delete(token);
+    }
+  }
+
+  return {
+    mintStreamToken(call) {
+      pruneTokens();
+      const token = randomBytes(24).toString('base64url');
+      tokens.set(token, {
+        call,
+        expiresAt: Date.now() + STREAM_TOKEN_TTL_MS,
+      });
+      return token;
+    },
+
+    websocketUri(token) {
+      const wsBase = config.publicBaseUrl.replace(/^https:\/\//i, 'wss://');
+      return `${wsBase}/api/plugin-webhooks/vonage-voice/stream?token=${token}`;
+    },
+
+    async handleStreamUpgrade(ctx) {
+      pruneTokens();
+      const token = String(ctx.url.searchParams.get('token') || '');
+      const entry = token ? tokens.get(token) : undefined;
+      if (!entry) {
+        ctx.logger.warn(
+          { webhook: ctx.webhookName },
+          'Vonage stream upgrade rejected: missing or stale token',
+        );
+        ctx.reject(401, 'Invalid stream token');
+        return;
+      }
+      tokens.delete(token);
+      const call = entry.call;
+      const ws = await ctx.accept();
+      let session;
+      try {
+        session = api.createRealtimeVoiceSession({
+          caller: { from: call.from, to: call.to },
+          greeting: config.welcomeGreeting,
+          session: {
+            sessionId: buildVoiceSessionKey(agentId, call.uuid),
+            channelId: `voice:${call.uuid}`,
+            userId: call.from || call.uuid,
+            username: call.from || call.uuid,
+          },
+          sendAudio: (frame) => {
+            if (ws.readyState === WS_OPEN) ws.send(frame);
+          },
+          onError: (message) => {
+            ctx.logger.warn(
+              { callUuid: call.uuid, message },
+              'Vonage realtime session error',
+            );
+          },
+          onClosed: () => {
+            ws.close();
+          },
+        });
+      } catch (error) {
+        ctx.logger.warn(
+          { callUuid: call.uuid, error },
+          'Vonage realtime session failed to start',
+        );
+        ws.close(1011, 'Realtime session unavailable');
+        return;
+      }
+      const stream = { session, ws };
+      activeStreams.add(stream);
+      ws.on('message', (data, isBinary) => {
+        if (isBinary) {
+          session.handleCallerAudio(
+            Buffer.isBuffer(data) ? data : Buffer.from(data),
+          );
+          return;
+        }
+        // Text frames are Vonage lifecycle events (websocket:connected);
+        // nothing to act on.
+      });
+      ws.on('close', () => {
+        activeStreams.delete(stream);
+        session.close();
+      });
+      ws.on('error', (error) => {
+        ctx.logger.warn(
+          { callUuid: call.uuid, error },
+          'Vonage stream websocket error',
+        );
+      });
+    },
+
+    stop() {
+      tokens.clear();
+      for (const stream of activeStreams) {
+        stream.session.close();
+        stream.ws.close();
+      }
+      activeStreams.clear();
+    },
+  };
+}

--- a/plugins/vonage-voice/src/runtime.js
+++ b/plugins/vonage-voice/src/runtime.js
@@ -7,12 +7,15 @@ import {
 import {
   buildGoodbyeNcco,
   buildParkNcco,
+  buildRealtimeConnectNcco,
   buildReplyNcco,
   parseVonageAnswerWebhook,
   parseVonageEventWebhook,
   parseVonageInputWebhook,
   VONAGE_TERMINAL_CALL_STATUSES,
 } from './ncco.js';
+import { createVonageRealtimeStreams } from './realtime.js';
+import { buildVoiceSessionKey } from './utils.js';
 
 const MAX_BODY_BYTES = 256 * 1024;
 const MAX_SILENT_TIMEOUTS = 3;
@@ -41,25 +44,16 @@ async function readRawJson(req) {
   }
 }
 
-function buildVoiceSessionKey(agentId, callUuid) {
-  return [
-    'agent',
-    encodeURIComponent(agentId),
-    'channel',
-    'voice',
-    'chat',
-    'dm',
-    'peer',
-    encodeURIComponent(callUuid),
-  ].join(':');
-}
-
 export function createVonageRuntime(api, config) {
   const sessions = new Map();
   const replayCache = new Map();
   const agentId = api.config.agents?.defaultAgentId || 'main';
   const webhookBase = `${config.publicBaseUrl}/api/plugin-webhooks/vonage-voice`;
   const inputEventUrl = `${webhookBase}/input`;
+  const realtimeStreams =
+    config.mode === 'realtime'
+      ? createVonageRealtimeStreams(api, config)
+      : null;
 
   function validateWebhook(ctx, rawBody) {
     const token = extractBearerToken(ctx.req.headers.authorization);
@@ -164,11 +158,44 @@ export function createVonageRuntime(api, config) {
         );
         return;
       }
+      if (realtimeStreams && !api.isRealtimeVoiceAvailable()) {
+        ctx.logger.warn(
+          { callUuid: answer.uuid },
+          'Vonage realtime call refused: realtime voice is not configured',
+        );
+        sendJson(
+          ctx.res,
+          200,
+          buildGoodbyeNcco({
+            message:
+              'The voice assistant is not available right now. Please try again later.',
+            language: config.language,
+          }),
+        );
+        return;
+      }
       sessions.set(answer.uuid, {
         ...answer,
         busy: false,
         silentTimeouts: 0,
       });
+      if (realtimeStreams) {
+        const token = realtimeStreams.mintStreamToken({
+          uuid: answer.uuid,
+          from: answer.from,
+          to: answer.to,
+        });
+        sendJson(
+          ctx.res,
+          200,
+          buildRealtimeConnectNcco({
+            websocketUri: realtimeStreams.websocketUri(token),
+            callUuid: answer.uuid,
+            language: config.language,
+          }),
+        );
+        return;
+      }
       sendJson(
         ctx.res,
         200,
@@ -235,9 +262,18 @@ export function createVonageRuntime(api, config) {
       sendJson(ctx.res, 200, {});
     },
 
+    handleStreamUpgrade(ctx) {
+      if (!realtimeStreams) {
+        ctx.reject(404, 'Realtime mode is not enabled');
+        return;
+      }
+      return realtimeStreams.handleStreamUpgrade(ctx);
+    },
+
     stop() {
       sessions.clear();
       replayCache.clear();
+      realtimeStreams?.stop();
     },
   };
 }

--- a/plugins/vonage-voice/src/utils.js
+++ b/plugins/vonage-voice/src/utils.js
@@ -1,3 +1,16 @@
 export function isRecord(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
+
+export function buildVoiceSessionKey(agentId, callUuid) {
+  return [
+    'agent',
+    encodeURIComponent(agentId),
+    'channel',
+    'voice',
+    'chat',
+    'dm',
+    'peer',
+    encodeURIComponent(callUuid),
+  ].join(':');
+}

--- a/src/channels/voice/audio-codec.ts
+++ b/src/channels/voice/audio-codec.ts
@@ -1,0 +1,66 @@
+/**
+ * G.711 µ-law ↔ 16-bit linear PCM companding for 8 kHz telephony audio.
+ *
+ * Pure per-sample transforms — no resampling, no buffering, no I/O — so a
+ * transport speaking linear PCM (Vonage websocket L16) can bridge to a
+ * realtime session speaking `audio/pcmu` without quality-degrading rate
+ * conversion. Buffers are 16-bit little-endian mono.
+ *
+ * NOT a media pipeline: pacing, framing, and base64 wrapping belong to the
+ * transport owners (`plugin-realtime-voice.ts`, channel runtimes).
+ */
+
+const BIAS = 0x84;
+const CLIP = 32_635;
+
+const ENCODE_EXPONENT_TABLE = new Uint8Array(256);
+for (let i = 0; i < 256; i++) {
+  if (i < 2) ENCODE_EXPONENT_TABLE[i] = 0;
+  else if (i < 4) ENCODE_EXPONENT_TABLE[i] = 1;
+  else if (i < 8) ENCODE_EXPONENT_TABLE[i] = 2;
+  else if (i < 16) ENCODE_EXPONENT_TABLE[i] = 3;
+  else if (i < 32) ENCODE_EXPONENT_TABLE[i] = 4;
+  else if (i < 64) ENCODE_EXPONENT_TABLE[i] = 5;
+  else if (i < 128) ENCODE_EXPONENT_TABLE[i] = 6;
+  else ENCODE_EXPONENT_TABLE[i] = 7;
+}
+
+export function muLawEncodeSample(sample: number): number {
+  let value = Math.max(-32_768, Math.min(32_767, Math.round(sample)));
+  const sign = value < 0 ? 0x80 : 0;
+  if (value < 0) value = -value;
+  if (value > CLIP) value = CLIP;
+  value += BIAS;
+  const exponent = ENCODE_EXPONENT_TABLE[(value >> 7) & 0xff];
+  const mantissa = (value >> (exponent + 3)) & 0x0f;
+  return ~(sign | (exponent << 4) | mantissa) & 0xff;
+}
+
+export function muLawDecodeSample(byte: number): number {
+  const inverted = ~byte & 0xff;
+  const sign = inverted & 0x80;
+  const exponent = (inverted >> 4) & 0x07;
+  const mantissa = inverted & 0x0f;
+  const magnitude = (((mantissa << 3) + BIAS) << exponent) - BIAS;
+  // The negative-zero code (0x7f) decodes to plain 0, not -0.
+  return sign && magnitude ? -magnitude : magnitude;
+}
+
+/** 16-bit LE mono PCM → µ-law, one byte per sample. */
+export function pcm16ToMuLaw(pcm: Buffer): Buffer {
+  const sampleCount = Math.floor(pcm.length / 2);
+  const out = Buffer.allocUnsafe(sampleCount);
+  for (let i = 0; i < sampleCount; i++) {
+    out[i] = muLawEncodeSample(pcm.readInt16LE(i * 2));
+  }
+  return out;
+}
+
+/** µ-law → 16-bit LE mono PCM, two bytes per sample. */
+export function muLawToPcm16(mulaw: Buffer): Buffer {
+  const out = Buffer.allocUnsafe(mulaw.length * 2);
+  for (let i = 0; i < mulaw.length; i++) {
+    out.writeInt16LE(muLawDecodeSample(mulaw[i]), i * 2);
+  }
+  return out;
+}

--- a/src/channels/voice/media-stream.ts
+++ b/src/channels/voice/media-stream.ts
@@ -1,0 +1,179 @@
+/**
+ * Twilio Media Streams wire protocol — raw-audio counterpart to
+ * `conversation-relay.ts` (which carries text turns, never audio).
+ *
+ * Guarantees every inbound frame is validated JSON of a known event type
+ * (`connected`/`start`/`media`/`dtmf`/`mark`/`stop`) and every outbound frame
+ * is a well-formed `media`/`clear`/`mark` message carrying base64 8kHz µ-law.
+ * Audio payloads pass through opaque — this module never decodes, transcodes,
+ * or buffers audio, and it never talks to a speech provider.
+ */
+import type WebSocket from 'ws';
+import { isRecord } from '../../utils/type-guards.js';
+
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function rawDataToString(raw: WebSocket.Data): string {
+  if (typeof raw === 'string') {
+    return raw;
+  }
+  if (Buffer.isBuffer(raw)) {
+    return raw.toString('utf8');
+  }
+  if (Array.isArray(raw)) {
+    return Buffer.concat(raw).toString('utf8');
+  }
+  return Buffer.from(raw).toString('utf8');
+}
+
+export interface MediaStreamConnectedMessage {
+  type: 'connected';
+}
+
+export interface MediaStreamStartMessage {
+  type: 'start';
+  streamSid: string;
+  callSid: string;
+  accountSid: string;
+  customParameters?: Record<string, string>;
+}
+
+export interface MediaStreamMediaMessage {
+  type: 'media';
+  streamSid: string;
+  /** Base64-encoded 8kHz mono µ-law audio. */
+  payload: string;
+}
+
+export interface MediaStreamDtmfMessage {
+  type: 'dtmf';
+  streamSid: string;
+  digit: string;
+}
+
+export interface MediaStreamMarkMessage {
+  type: 'mark';
+  streamSid: string;
+  name: string;
+}
+
+export interface MediaStreamStopMessage {
+  type: 'stop';
+  streamSid: string;
+  callSid: string;
+}
+
+export type MediaStreamInboundMessage =
+  | MediaStreamConnectedMessage
+  | MediaStreamStartMessage
+  | MediaStreamMediaMessage
+  | MediaStreamDtmfMessage
+  | MediaStreamMarkMessage
+  | MediaStreamStopMessage;
+
+export function parseMediaStreamMessage(
+  raw: WebSocket.Data,
+): MediaStreamInboundMessage {
+  const decoded = rawDataToString(raw).trim();
+  if (!decoded) {
+    throw new Error('Media stream message was empty.');
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decoded) as unknown;
+  } catch {
+    throw new Error('Media stream message was not valid JSON.');
+  }
+  if (!isRecord(parsed)) {
+    throw new Error('Media stream message must be a JSON object.');
+  }
+  const event = normalizeString(parsed.event);
+  const streamSid = normalizeString(parsed.streamSid);
+  if (event === 'connected') {
+    return { type: 'connected' };
+  }
+  if (event === 'start') {
+    const start = isRecord(parsed.start) ? parsed.start : {};
+    return {
+      type: 'start',
+      streamSid: streamSid || normalizeString(start.streamSid),
+      callSid: normalizeString(start.callSid),
+      accountSid: normalizeString(start.accountSid),
+      customParameters: isRecord(start.customParameters)
+        ? Object.fromEntries(
+            Object.entries(start.customParameters).map(([name, value]) => [
+              name,
+              normalizeString(value),
+            ]),
+          )
+        : undefined,
+    };
+  }
+  if (event === 'media') {
+    const media = isRecord(parsed.media) ? parsed.media : {};
+    return {
+      type: 'media',
+      streamSid,
+      payload: normalizeString(media.payload),
+    };
+  }
+  if (event === 'dtmf') {
+    const dtmf = isRecord(parsed.dtmf) ? parsed.dtmf : {};
+    return {
+      type: 'dtmf',
+      streamSid,
+      digit: normalizeString(dtmf.digit),
+    };
+  }
+  if (event === 'mark') {
+    const mark = isRecord(parsed.mark) ? parsed.mark : {};
+    return {
+      type: 'mark',
+      streamSid,
+      name: normalizeString(mark.name),
+    };
+  }
+  if (event === 'stop') {
+    const stop = isRecord(parsed.stop) ? parsed.stop : {};
+    return {
+      type: 'stop',
+      streamSid,
+      callSid: normalizeString(stop.callSid),
+    };
+  }
+  throw new Error(`Unsupported media stream event: ${event || 'unknown'}`);
+}
+
+export function buildMediaStreamMediaPayload(
+  streamSid: string,
+  base64Audio: string,
+): Record<string, unknown> {
+  return {
+    event: 'media',
+    streamSid,
+    media: { payload: base64Audio },
+  };
+}
+
+/** Flushes Twilio's buffered outbound audio — the barge-in primitive. */
+export function buildMediaStreamClearPayload(
+  streamSid: string,
+): Record<string, unknown> {
+  return {
+    event: 'clear',
+    streamSid,
+  };
+}
+
+export function buildMediaStreamMarkPayload(
+  streamSid: string,
+  name: string,
+): Record<string, unknown> {
+  return {
+    event: 'mark',
+    streamSid,
+    mark: { name },
+  };
+}

--- a/src/channels/voice/openai-realtime.ts
+++ b/src/channels/voice/openai-realtime.ts
@@ -173,6 +173,18 @@ export class OpenAIRealtimeClient {
     });
   }
 
+  /**
+   * Speaks a one-off status line without appending it to the conversation —
+   * the GA out-of-band response shape (`conversation: 'none'`), used for
+   * "still working" reassurance while a function call is outstanding.
+   */
+  createOutOfBandResponse(instructions: string): void {
+    this.sendEvent({
+      type: 'response.create',
+      response: { conversation: 'none', instructions },
+    });
+  }
+
   cancelResponse(): void {
     if (!this.responseActive) return;
     this.sendEvent({ type: 'response.cancel' });

--- a/src/channels/voice/openai-realtime.ts
+++ b/src/channels/voice/openai-realtime.ts
@@ -13,7 +13,6 @@
 import WebSocket from 'ws';
 import { isRecord } from '../../utils/type-guards.js';
 
-const OPENAI_REALTIME_URL = 'wss://api.openai.com/v1/realtime';
 const SOCKET_OPEN = 1;
 
 /** Wire format for both directions of the realtime session. */
@@ -67,6 +66,8 @@ function normalizeString(value: unknown): string {
 }
 
 export interface OpenAIRealtimeClientOptions {
+  /** Realtime endpoint without the model query, e.g. from `resolveRealtimeConnection`. */
+  url: string;
   apiKey: string;
   model: string;
   voice: string;
@@ -92,7 +93,7 @@ export class OpenAIRealtimeClient {
   constructor(options: OpenAIRealtimeClientOptions) {
     this.callbacks = options.callbacks;
     const factory = options.socketFactory || defaultSocketFactory;
-    const url = `${OPENAI_REALTIME_URL}?model=${encodeURIComponent(options.model)}`;
+    const url = `${options.url}?model=${encodeURIComponent(options.model)}`;
     this.socket = factory(url, {
       Authorization: `Bearer ${options.apiKey}`,
     });

--- a/src/channels/voice/openai-realtime.ts
+++ b/src/channels/voice/openai-realtime.ts
@@ -77,11 +77,17 @@ export interface OpenAIRealtimeClientOptions {
   socketFactory?: RealtimeSocketFactory;
 }
 
+// Caller audio arriving before the realtime socket is ready is queued and
+// flushed on open, so speech from the first seconds of a call is not lost.
+// Rolling cap: ~5s of 20ms phone frames, ~40s of 171ms web chunks.
+const PENDING_AUDIO_LIMIT = 250;
+
 export class OpenAIRealtimeClient {
   private readonly socket: RealtimeSocket;
   private readonly callbacks: OpenAIRealtimeCallbacks;
   private responseActive = false;
   private closed = false;
+  private pendingAudio: string[] = [];
 
   constructor(options: OpenAIRealtimeClientOptions) {
     this.callbacks = options.callbacks;
@@ -117,6 +123,7 @@ export class OpenAIRealtimeClient {
           tool_choice: 'auto',
         },
       });
+      this.flushPendingAudio();
     });
     this.socket.on('message', (data) => {
       this.handleServerEvent(data);
@@ -139,8 +146,23 @@ export class OpenAIRealtimeClient {
   }
 
   appendAudio(base64Audio: string): void {
-    if (!base64Audio) return;
+    if (!base64Audio || this.closed) return;
+    if (this.socket.readyState !== SOCKET_OPEN) {
+      this.pendingAudio.push(base64Audio);
+      if (this.pendingAudio.length > PENDING_AUDIO_LIMIT) {
+        this.pendingAudio.shift();
+      }
+      return;
+    }
     this.sendEvent({ type: 'input_audio_buffer.append', audio: base64Audio });
+  }
+
+  private flushPendingAudio(): void {
+    const pending = this.pendingAudio;
+    this.pendingAudio = [];
+    for (const audio of pending) {
+      this.sendEvent({ type: 'input_audio_buffer.append', audio });
+    }
   }
 
   createResponse(instructions?: string): void {

--- a/src/channels/voice/openai-realtime.ts
+++ b/src/channels/voice/openai-realtime.ts
@@ -1,0 +1,262 @@
+/**
+ * OpenAI Realtime API websocket client for speech-to-speech phone calls.
+ *
+ * Owns the upstream socket lifecycle and the GA realtime event vocabulary
+ * (`session.update`, `input_audio_buffer.append`, `response.*`), surfacing a
+ * typed callback seam so callers never touch raw realtime JSON. Audio stays
+ * base64 µ-law end to end — this module never transcodes.
+ *
+ * NOT the call bridge (`realtime-bridge.ts` decides *what* to do with events);
+ * this module only guarantees a validated, ordered event stream.
+ */
+import WebSocket from 'ws';
+import { isRecord } from '../../utils/type-guards.js';
+
+const OPENAI_REALTIME_URL = 'wss://api.openai.com/v1/realtime';
+const SOCKET_OPEN = 1;
+
+export interface RealtimeFunctionTool {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}
+
+export interface RealtimeFunctionCall {
+  callId: string;
+  name: string;
+  arguments: string;
+}
+
+export interface OpenAIRealtimeCallbacks {
+  onReady: () => void;
+  onAudioDelta: (base64Audio: string) => void;
+  onSpeechStarted: () => void;
+  onInputTranscript: (transcript: string) => void;
+  onOutputTranscript: (transcript: string) => void;
+  onFunctionCall: (call: RealtimeFunctionCall) => void;
+  onError: (message: string) => void;
+  onClosed: () => void;
+}
+
+export interface RealtimeSocket {
+  on(event: 'open', listener: () => void): void;
+  on(event: 'message', listener: (data: WebSocket.Data) => void): void;
+  on(event: 'close', listener: () => void): void;
+  on(event: 'error', listener: (error: Error) => void): void;
+  send(data: string, cb?: (error?: Error) => void): void;
+  close(): void;
+  readyState: number;
+}
+
+export type RealtimeSocketFactory = (
+  url: string,
+  headers: Record<string, string>,
+) => RealtimeSocket;
+
+const defaultSocketFactory: RealtimeSocketFactory = (url, headers) =>
+  new WebSocket(url, { headers }) as unknown as RealtimeSocket;
+
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+export interface OpenAIRealtimeClientOptions {
+  apiKey: string;
+  model: string;
+  voice: string;
+  instructions: string;
+  tools: RealtimeFunctionTool[];
+  callbacks: OpenAIRealtimeCallbacks;
+  socketFactory?: RealtimeSocketFactory;
+}
+
+export class OpenAIRealtimeClient {
+  private readonly socket: RealtimeSocket;
+  private readonly callbacks: OpenAIRealtimeCallbacks;
+  private responseActive = false;
+  private closed = false;
+
+  constructor(options: OpenAIRealtimeClientOptions) {
+    this.callbacks = options.callbacks;
+    const factory = options.socketFactory || defaultSocketFactory;
+    const url = `${OPENAI_REALTIME_URL}?model=${encodeURIComponent(options.model)}`;
+    this.socket = factory(url, {
+      Authorization: `Bearer ${options.apiKey}`,
+    });
+    this.socket.on('open', () => {
+      this.sendEvent({
+        type: 'session.update',
+        session: {
+          type: 'realtime',
+          output_modalities: ['audio'],
+          instructions: options.instructions,
+          audio: {
+            input: {
+              format: { type: 'audio/pcmu' },
+              transcription: { model: 'gpt-4o-mini-transcribe' },
+              turn_detection: { type: 'server_vad' },
+            },
+            output: {
+              format: { type: 'audio/pcmu' },
+              voice: options.voice,
+            },
+          },
+          tools: options.tools.map((tool) => ({
+            type: 'function',
+            name: tool.name,
+            description: tool.description,
+            parameters: tool.parameters,
+          })),
+          tool_choice: 'auto',
+        },
+      });
+    });
+    this.socket.on('message', (data) => {
+      this.handleServerEvent(data);
+    });
+    this.socket.on('close', () => {
+      this.closed = true;
+      this.callbacks.onClosed();
+    });
+    this.socket.on('error', (error) => {
+      this.callbacks.onError(error.message);
+    });
+  }
+
+  get isOpen(): boolean {
+    return !this.closed && this.socket.readyState === SOCKET_OPEN;
+  }
+
+  get hasActiveResponse(): boolean {
+    return this.responseActive;
+  }
+
+  appendAudio(base64Audio: string): void {
+    if (!base64Audio) return;
+    this.sendEvent({ type: 'input_audio_buffer.append', audio: base64Audio });
+  }
+
+  createResponse(instructions?: string): void {
+    this.sendEvent({
+      type: 'response.create',
+      ...(instructions ? { response: { instructions } } : {}),
+    });
+  }
+
+  cancelResponse(): void {
+    if (!this.responseActive) return;
+    this.sendEvent({ type: 'response.cancel' });
+    this.responseActive = false;
+  }
+
+  sendFunctionCallOutput(callId: string, output: string): void {
+    this.sendEvent({
+      type: 'conversation.item.create',
+      item: {
+        type: 'function_call_output',
+        call_id: callId,
+        output,
+      },
+    });
+    this.createResponse();
+  }
+
+  sendUserText(text: string): void {
+    this.sendEvent({
+      type: 'conversation.item.create',
+      item: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text }],
+      },
+    });
+    this.createResponse();
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.socket.close();
+  }
+
+  private sendEvent(event: Record<string, unknown>): void {
+    if (this.closed || this.socket.readyState !== SOCKET_OPEN) {
+      return;
+    }
+    this.socket.send(JSON.stringify(event), (error) => {
+      if (error) {
+        this.callbacks.onError(error.message);
+      }
+    });
+  }
+
+  private handleServerEvent(data: WebSocket.Data): void {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(
+        typeof data === 'string'
+          ? data
+          : Buffer.from(data as Buffer).toString('utf8'),
+      ) as unknown;
+    } catch {
+      this.callbacks.onError('Realtime server event was not valid JSON.');
+      return;
+    }
+    if (!isRecord(parsed)) {
+      this.callbacks.onError('Realtime server event was not a JSON object.');
+      return;
+    }
+    const type = normalizeString(parsed.type);
+    if (type === 'session.updated') {
+      this.callbacks.onReady();
+      return;
+    }
+    if (type === 'response.created') {
+      this.responseActive = true;
+      return;
+    }
+    if (type === 'response.done') {
+      this.responseActive = false;
+      return;
+    }
+    if (type === 'response.output_audio.delta') {
+      const delta = normalizeString(parsed.delta);
+      if (delta) {
+        this.callbacks.onAudioDelta(delta);
+      }
+      return;
+    }
+    if (type === 'input_audio_buffer.speech_started') {
+      this.callbacks.onSpeechStarted();
+      return;
+    }
+    if (type === 'conversation.item.input_audio_transcription.completed') {
+      const transcript = normalizeString(parsed.transcript).trim();
+      if (transcript) {
+        this.callbacks.onInputTranscript(transcript);
+      }
+      return;
+    }
+    if (type === 'response.output_audio_transcript.done') {
+      const transcript = normalizeString(parsed.transcript).trim();
+      if (transcript) {
+        this.callbacks.onOutputTranscript(transcript);
+      }
+      return;
+    }
+    if (type === 'response.function_call_arguments.done') {
+      this.callbacks.onFunctionCall({
+        callId: normalizeString(parsed.call_id),
+        name: normalizeString(parsed.name),
+        arguments: normalizeString(parsed.arguments),
+      });
+      return;
+    }
+    if (type === 'error') {
+      const error = isRecord(parsed.error) ? parsed.error : {};
+      this.callbacks.onError(
+        normalizeString(error.message) || 'Unknown realtime error',
+      );
+    }
+  }
+}

--- a/src/channels/voice/openai-realtime.ts
+++ b/src/channels/voice/openai-realtime.ts
@@ -1,10 +1,11 @@
 /**
- * OpenAI Realtime API websocket client for speech-to-speech phone calls.
+ * OpenAI Realtime API websocket client for speech-to-speech conversations.
  *
  * Owns the upstream socket lifecycle and the GA realtime event vocabulary
  * (`session.update`, `input_audio_buffer.append`, `response.*`), surfacing a
  * typed callback seam so callers never touch raw realtime JSON. Audio stays
- * base64 µ-law end to end — this module never transcodes.
+ * base64 in the caller-chosen wire format (µ-law for phone calls, PCM16 for
+ * browsers) end to end — this module never transcodes.
  *
  * NOT the call bridge (`realtime-bridge.ts` decides *what* to do with events);
  * this module only guarantees a validated, ordered event stream.
@@ -14,6 +15,11 @@ import { isRecord } from '../../utils/type-guards.js';
 
 const OPENAI_REALTIME_URL = 'wss://api.openai.com/v1/realtime';
 const SOCKET_OPEN = 1;
+
+/** Wire format for both directions of the realtime session. */
+export type RealtimeAudioFormat =
+  | { type: 'audio/pcmu' }
+  | { type: 'audio/pcm'; rate: 24000 };
 
 export interface RealtimeFunctionTool {
   name: string;
@@ -64,6 +70,7 @@ export interface OpenAIRealtimeClientOptions {
   apiKey: string;
   model: string;
   voice: string;
+  audioFormat: RealtimeAudioFormat;
   instructions: string;
   tools: RealtimeFunctionTool[];
   callbacks: OpenAIRealtimeCallbacks;
@@ -92,12 +99,12 @@ export class OpenAIRealtimeClient {
           instructions: options.instructions,
           audio: {
             input: {
-              format: { type: 'audio/pcmu' },
+              format: options.audioFormat,
               transcription: { model: 'gpt-4o-mini-transcribe' },
               turn_detection: { type: 'server_vad' },
             },
             output: {
-              format: { type: 'audio/pcmu' },
+              format: options.audioFormat,
               voice: options.voice,
             },
           },

--- a/src/channels/voice/openai-realtime.ts
+++ b/src/channels/voice/openai-realtime.ts
@@ -261,6 +261,11 @@ export class OpenAIRealtimeClient {
     }
     if (type === 'error') {
       const error = isRecord(parsed.error) ? parsed.error : {};
+      // Benign barge-in race: the response finished server-side before our
+      // response.cancel arrived. Nothing to surface.
+      if (normalizeString(error.code) === 'response_cancel_not_active') {
+        return;
+      }
       this.callbacks.onError(
         normalizeString(error.message) || 'Unknown realtime error',
       );

--- a/src/channels/voice/realtime-bridge.ts
+++ b/src/channels/voice/realtime-bridge.ts
@@ -1,24 +1,23 @@
 /**
- * Per-call bridge between a Twilio media stream and an OpenAI realtime
- * session — the speech-to-speech counterpart of `dispatchPromptToHandler`.
+ * Per-conversation bridge between a caller-facing audio transport (Twilio
+ * media stream or browser websocket) and an OpenAI realtime session — the
+ * speech-to-speech counterpart of `dispatchPromptToHandler`.
  *
- * Guarantees barge-in stays coherent (caller speech always clears Twilio's
- * audio buffer and cancels the active model response) and that at most one
- * `consult_agent` gateway turn runs per call at a time. The realtime model
- * only fronts the conversation; anything requiring tools, memory, or actions
- * is forwarded to the full gateway agent via the consult callback.
+ * Guarantees barge-in stays coherent (caller speech always clears queued
+ * playback and cancels the active model response) and that at most one
+ * `consult_agent` gateway turn runs per conversation at a time. The realtime
+ * model only fronts the conversation; anything requiring tools, memory, or
+ * actions is forwarded to the full gateway agent via the consult callback.
  *
- * NOT a transport: Twilio frame parsing lives in `media-stream.ts` and the
+ * NOT a transport: callers supply `sendAudio`/`clearPlayback` seams (Twilio
+ * framing lives in `media-stream.ts`, browser framing in the gateway) and the
  * upstream socket in `openai-realtime.ts`; this module never touches raw JSON.
  */
 import type { RuntimeVoiceRealtimeConfig } from '../../config/runtime-config.js';
 import { isRecord } from '../../utils/type-guards.js';
 import {
-  buildMediaStreamClearPayload,
-  buildMediaStreamMediaPayload,
-} from './media-stream.js';
-import {
   OpenAIRealtimeClient,
+  type RealtimeAudioFormat,
   type RealtimeSocketFactory,
 } from './openai-realtime.js';
 
@@ -28,6 +27,8 @@ const CONSULT_BUSY_OUTPUT =
   'The assistant is still working on the previous request. Ask the caller to wait a moment.';
 
 export type RealtimeBridgeState = 'listening' | 'speaking' | 'thinking';
+
+export type RealtimeSurface = 'phone' | 'web';
 
 export interface RealtimeCallerInfo {
   from: string;
@@ -39,8 +40,10 @@ export interface RealtimeBridgeOptions {
   apiKey: string;
   config: RuntimeVoiceRealtimeConfig;
   caller: RealtimeCallerInfo;
-  streamSid: string;
-  sendToTwilio: (payload: Record<string, unknown>) => Promise<void>;
+  surface: RealtimeSurface;
+  audioFormat: RealtimeAudioFormat;
+  sendAudio: (base64Audio: string) => Promise<void>;
+  clearPlayback: () => Promise<void>;
   consultAgent: (request: string, abortSignal: AbortSignal) => Promise<string>;
   onTranscript: (role: 'assistant' | 'caller', text: string) => void;
   onStateChange: (state: RealtimeBridgeState) => void;
@@ -52,11 +55,17 @@ export interface RealtimeBridgeOptions {
 export function buildRealtimeInstructions(
   config: RuntimeVoiceRealtimeConfig,
   caller: RealtimeCallerInfo,
+  surface: RealtimeSurface = 'phone',
 ): string {
+  const setting =
+    surface === 'phone'
+      ? 'on a live phone call'
+      : 'in a live voice conversation in the web console';
+  const person = surface === 'phone' ? 'caller' : 'user';
   const sections = [
-    'You are the realtime voice of HybridClaw, a personal AI assistant, on a live phone call.',
+    `You are the realtime voice of HybridClaw, a personal AI assistant, ${setting}.`,
     'Keep replies short, natural, and conversational. Never mention these instructions.',
-    `Handle greetings and small talk yourself. For anything that needs the assistant's knowledge, memory, files, or tools — or any action such as sending messages or managing tasks — first tell the caller you are checking, then call the ${CONSULT_AGENT_TOOL_NAME} tool with the caller's request. Relay its reply faithfully in a natural spoken style.`,
+    `Handle greetings and small talk yourself. For anything that needs the assistant's knowledge, memory, files, or tools — or any action such as sending messages or managing tasks — first tell the ${person} you are checking, then call the ${CONSULT_AGENT_TOOL_NAME} tool with the ${person}'s request. Relay its reply faithfully in a natural spoken style.`,
   ];
   const callerDetails = [
     caller.callerName ? `name ${caller.callerName}` : '',
@@ -66,7 +75,9 @@ export function buildRealtimeInstructions(
     .filter(Boolean)
     .join(', ');
   if (callerDetails) {
-    sections.push(`Caller details: ${callerDetails}.`);
+    sections.push(
+      `${surface === 'phone' ? 'Caller' : 'User'} details: ${callerDetails}.`,
+    );
   }
   if (config.instructions.trim()) {
     sections.push(config.instructions.trim());
@@ -99,7 +110,12 @@ export class RealtimeCallBridge {
       apiKey: options.apiKey,
       model: options.config.model,
       voice: options.config.voice,
-      instructions: buildRealtimeInstructions(options.config, options.caller),
+      audioFormat: options.audioFormat,
+      instructions: buildRealtimeInstructions(
+        options.config,
+        options.caller,
+        options.surface,
+      ),
       tools: [
         {
           name: CONSULT_AGENT_TOOL_NAME,
@@ -126,26 +142,20 @@ export class RealtimeCallBridge {
         },
         onAudioDelta: (base64Audio) => {
           this.options.onStateChange('speaking');
-          void this.options
-            .sendToTwilio(
-              buildMediaStreamMediaPayload(options.streamSid, base64Audio),
-            )
-            .catch((error) => {
-              this.options.onError(
-                `Failed to forward audio to Twilio: ${String(
-                  error instanceof Error ? error.message : error,
-                )}`,
-              );
-            });
+          void this.options.sendAudio(base64Audio).catch((error) => {
+            this.options.onError(
+              `Failed to forward audio to the caller: ${String(
+                error instanceof Error ? error.message : error,
+              )}`,
+            );
+          });
         },
         onSpeechStarted: () => {
           this.options.onStateChange('listening');
           this.client.cancelResponse();
-          void this.options
-            .sendToTwilio(buildMediaStreamClearPayload(options.streamSid))
-            .catch(() => {
-              // The stream is gone; the close handler tears the call down.
-            });
+          void this.options.clearPlayback().catch(() => {
+            // The transport is gone; the close handler tears the session down.
+          });
         },
         onInputTranscript: (transcript) => {
           this.options.onTranscript('caller', transcript);

--- a/src/channels/voice/realtime-bridge.ts
+++ b/src/channels/voice/realtime-bridge.ts
@@ -20,6 +20,7 @@ import {
   type RealtimeAudioFormat,
   type RealtimeSocketFactory,
 } from './openai-realtime.js';
+import type { RealtimeConnection } from './realtime-credentials.js';
 
 export const CONSULT_AGENT_TOOL_NAME = 'consult_agent';
 
@@ -37,7 +38,7 @@ export interface RealtimeCallerInfo {
 }
 
 export interface RealtimeBridgeOptions {
-  apiKey: string;
+  connection: RealtimeConnection;
   config: RuntimeVoiceRealtimeConfig;
   caller: RealtimeCallerInfo;
   surface: RealtimeSurface;
@@ -107,7 +108,8 @@ export class RealtimeCallBridge {
   constructor(options: RealtimeBridgeOptions) {
     this.options = options;
     this.client = new OpenAIRealtimeClient({
-      apiKey: options.apiKey,
+      url: options.connection.url,
+      apiKey: options.connection.apiKey,
       model: options.config.model,
       voice: options.config.voice,
       audioFormat: options.audioFormat,

--- a/src/channels/voice/realtime-bridge.ts
+++ b/src/channels/voice/realtime-bridge.ts
@@ -8,6 +8,9 @@
  * `consult_agent` gateway turn runs per conversation at a time. The realtime
  * model only fronts the conversation; anything requiring tools, memory, or
  * actions is forwarded to the full gateway agent via the consult callback.
+ * Long consults stay audibly attended: tool progress from the consulted turn
+ * feeds spoken out-of-band reassurances (never over caller speech or an
+ * active response) and a live activity label for UI surfaces.
  *
  * NOT a transport: callers supply `sendAudio`/`clearPlayback` seams (Twilio
  * framing lives in `media-stream.ts`, browser framing in the gateway) and the
@@ -27,6 +30,13 @@ export const CONSULT_AGENT_TOOL_NAME = 'consult_agent';
 const CONSULT_BUSY_OUTPUT =
   'The assistant is still working on the previous request. Ask the caller to wait a moment.';
 
+// 7s/12s (PR #1395 call, 2026-08-19): the first reassurance lands before the
+// caller starts wondering whether the line dropped; repeats stay sparse so a
+// long consult sounds attended, not robotic. Tuning deferred to live-call
+// feedback.
+const CONSULT_REASSURE_FIRST_MS = 7_000;
+const CONSULT_REASSURE_INTERVAL_MS = 12_000;
+
 export type RealtimeBridgeState = 'listening' | 'speaking' | 'thinking';
 
 export type RealtimeSurface = 'phone' | 'web';
@@ -37,6 +47,23 @@ export interface RealtimeCallerInfo {
   callerName: string;
 }
 
+export interface RealtimeConsultToolProgress {
+  toolName: string;
+  phase: 'start' | 'finish';
+}
+
+export interface RealtimeConsultHooks {
+  abortSignal: AbortSignal;
+  onToolProgress: (event: RealtimeConsultToolProgress) => void;
+}
+
+/** "web_search" → "web search", for spoken status and UI labels. */
+export function humanizeConsultToolName(toolName: string): string {
+  return String(toolName || '')
+    .replace(/[_-]+/g, ' ')
+    .trim();
+}
+
 export interface RealtimeBridgeOptions {
   connection: RealtimeConnection;
   config: RuntimeVoiceRealtimeConfig;
@@ -45,9 +72,17 @@ export interface RealtimeBridgeOptions {
   audioFormat: RealtimeAudioFormat;
   sendAudio: (base64Audio: string) => Promise<void>;
   clearPlayback: () => Promise<void>;
-  consultAgent: (request: string, abortSignal: AbortSignal) => Promise<string>;
+  consultAgent: (
+    request: string,
+    hooks: RealtimeConsultHooks,
+  ) => Promise<string>;
   onTranscript: (role: 'assistant' | 'caller', text: string) => void;
   onStateChange: (state: RealtimeBridgeState) => void;
+  /**
+   * Live consult activity for UI surfaces: a humanized tool label while the
+   * consulted agent works, then null when the consult resolves.
+   */
+  onConsultActivity?: (label: string | null) => void;
   onError: (message: string) => void;
   onClosed: () => void;
   socketFactory?: RealtimeSocketFactory;
@@ -103,6 +138,9 @@ export class RealtimeCallBridge {
   private readonly options: RealtimeBridgeOptions;
   private readonly consultAbort = new AbortController();
   private consultInFlight = false;
+  private consultActivity: string | null = null;
+  private reassureTimer: NodeJS.Timeout | null = null;
+  private callerSpeaking = false;
   private closed = false;
 
   constructor(options: RealtimeBridgeOptions) {
@@ -153,6 +191,7 @@ export class RealtimeCallBridge {
           });
         },
         onSpeechStarted: () => {
+          this.callerSpeaking = true;
           this.options.onStateChange('listening');
           this.client.cancelResponse();
           void this.options.clearPlayback().catch(() => {
@@ -160,6 +199,7 @@ export class RealtimeCallBridge {
           });
         },
         onInputTranscript: (transcript) => {
+          this.callerSpeaking = false;
           this.options.onTranscript('caller', transcript);
         },
         onOutputTranscript: (transcript) => {
@@ -199,8 +239,41 @@ export class RealtimeCallBridge {
   close(): void {
     if (this.closed) return;
     this.closed = true;
+    this.stopReassurance();
     this.consultAbort.abort();
     this.client.close();
+  }
+
+  /**
+   * Speaks a short out-of-band "still working" line while a consult runs, but
+   * only into silence: never over the caller's speech or an active response.
+   */
+  private scheduleReassurance(delayMs: number): void {
+    this.stopReassurance();
+    this.reassureTimer = setTimeout(() => {
+      this.reassureTimer = null;
+      if (this.closed || !this.consultInFlight || !this.client.isOpen) {
+        return;
+      }
+      if (!this.callerSpeaking && !this.client.hasActiveResponse) {
+        const activity = this.consultActivity
+          ? ` It is currently busy with: ${this.consultActivity}.`
+          : '';
+        this.client.createOutOfBandResponse(
+          `The assistant is still working on the request.${activity} Briefly reassure the ${
+            this.options.surface === 'phone' ? 'caller' : 'user'
+          } in one short natural sentence. Do not call tools.`,
+        );
+      }
+      this.scheduleReassurance(CONSULT_REASSURE_INTERVAL_MS);
+    }, delayMs);
+  }
+
+  private stopReassurance(): void {
+    if (this.reassureTimer) {
+      clearTimeout(this.reassureTimer);
+      this.reassureTimer = null;
+    }
   }
 
   private handleFunctionCall(
@@ -225,9 +298,20 @@ export class RealtimeCallBridge {
       return;
     }
     this.consultInFlight = true;
+    this.consultActivity = null;
     this.options.onStateChange('thinking');
+    this.scheduleReassurance(CONSULT_REASSURE_FIRST_MS);
     void this.options
-      .consultAgent(request, this.consultAbort.signal)
+      .consultAgent(request, {
+        abortSignal: this.consultAbort.signal,
+        onToolProgress: (event) => {
+          if (this.closed || !this.consultInFlight) return;
+          if (event.phase === 'start') {
+            this.consultActivity = humanizeConsultToolName(event.toolName);
+            this.options.onConsultActivity?.(this.consultActivity);
+          }
+        },
+      })
       .then((reply) => {
         return reply.trim() || 'The assistant returned no reply.';
       })
@@ -244,6 +328,9 @@ export class RealtimeCallBridge {
       })
       .then((output) => {
         this.consultInFlight = false;
+        this.consultActivity = null;
+        this.stopReassurance();
+        this.options.onConsultActivity?.(null);
         if (this.closed || !output) {
           return;
         }

--- a/src/channels/voice/realtime-bridge.ts
+++ b/src/channels/voice/realtime-bridge.ts
@@ -1,0 +1,242 @@
+/**
+ * Per-call bridge between a Twilio media stream and an OpenAI realtime
+ * session — the speech-to-speech counterpart of `dispatchPromptToHandler`.
+ *
+ * Guarantees barge-in stays coherent (caller speech always clears Twilio's
+ * audio buffer and cancels the active model response) and that at most one
+ * `consult_agent` gateway turn runs per call at a time. The realtime model
+ * only fronts the conversation; anything requiring tools, memory, or actions
+ * is forwarded to the full gateway agent via the consult callback.
+ *
+ * NOT a transport: Twilio frame parsing lives in `media-stream.ts` and the
+ * upstream socket in `openai-realtime.ts`; this module never touches raw JSON.
+ */
+import type { RuntimeVoiceRealtimeConfig } from '../../config/runtime-config.js';
+import { isRecord } from '../../utils/type-guards.js';
+import {
+  buildMediaStreamClearPayload,
+  buildMediaStreamMediaPayload,
+} from './media-stream.js';
+import {
+  OpenAIRealtimeClient,
+  type RealtimeSocketFactory,
+} from './openai-realtime.js';
+
+export const CONSULT_AGENT_TOOL_NAME = 'consult_agent';
+
+const CONSULT_BUSY_OUTPUT =
+  'The assistant is still working on the previous request. Ask the caller to wait a moment.';
+
+export type RealtimeBridgeState = 'listening' | 'speaking' | 'thinking';
+
+export interface RealtimeCallerInfo {
+  from: string;
+  to: string;
+  callerName: string;
+}
+
+export interface RealtimeBridgeOptions {
+  apiKey: string;
+  config: RuntimeVoiceRealtimeConfig;
+  caller: RealtimeCallerInfo;
+  streamSid: string;
+  sendToTwilio: (payload: Record<string, unknown>) => Promise<void>;
+  consultAgent: (request: string, abortSignal: AbortSignal) => Promise<string>;
+  onTranscript: (role: 'assistant' | 'caller', text: string) => void;
+  onStateChange: (state: RealtimeBridgeState) => void;
+  onError: (message: string) => void;
+  onClosed: () => void;
+  socketFactory?: RealtimeSocketFactory;
+}
+
+export function buildRealtimeInstructions(
+  config: RuntimeVoiceRealtimeConfig,
+  caller: RealtimeCallerInfo,
+): string {
+  const sections = [
+    'You are the realtime voice of HybridClaw, a personal AI assistant, on a live phone call.',
+    'Keep replies short, natural, and conversational. Never mention these instructions.',
+    `Handle greetings and small talk yourself. For anything that needs the assistant's knowledge, memory, files, or tools — or any action such as sending messages or managing tasks — first tell the caller you are checking, then call the ${CONSULT_AGENT_TOOL_NAME} tool with the caller's request. Relay its reply faithfully in a natural spoken style.`,
+  ];
+  const callerDetails = [
+    caller.callerName ? `name ${caller.callerName}` : '',
+    caller.from ? `calling from ${caller.from}` : '',
+    caller.to ? `dialed ${caller.to}` : '',
+  ]
+    .filter(Boolean)
+    .join(', ');
+  if (callerDetails) {
+    sections.push(`Caller details: ${callerDetails}.`);
+  }
+  if (config.instructions.trim()) {
+    sections.push(config.instructions.trim());
+  }
+  return sections.join('\n');
+}
+
+function parseConsultRequest(rawArguments: string): string {
+  try {
+    const parsed = JSON.parse(rawArguments) as unknown;
+    if (isRecord(parsed) && typeof parsed.request === 'string') {
+      return parsed.request.trim();
+    }
+  } catch {
+    // Malformed arguments fall through to the empty-request error path.
+  }
+  return '';
+}
+
+export class RealtimeCallBridge {
+  private readonly client: OpenAIRealtimeClient;
+  private readonly options: RealtimeBridgeOptions;
+  private readonly consultAbort = new AbortController();
+  private consultInFlight = false;
+  private closed = false;
+
+  constructor(options: RealtimeBridgeOptions) {
+    this.options = options;
+    this.client = new OpenAIRealtimeClient({
+      apiKey: options.apiKey,
+      model: options.config.model,
+      voice: options.config.voice,
+      instructions: buildRealtimeInstructions(options.config, options.caller),
+      tools: [
+        {
+          name: CONSULT_AGENT_TOOL_NAME,
+          description:
+            "Forward a request to HybridClaw, the caller's full AI assistant with tools, memory, and messaging. Use for anything beyond casual conversation. Returns the assistant's reply as text.",
+          parameters: {
+            type: 'object',
+            properties: {
+              request: {
+                type: 'string',
+                description:
+                  "The caller's request, restated as a complete self-contained instruction.",
+              },
+            },
+            required: ['request'],
+          },
+        },
+      ],
+      callbacks: {
+        onReady: () => {
+          this.client.createResponse(
+            `Greet the caller by saying: "${options.config.greeting}"`,
+          );
+        },
+        onAudioDelta: (base64Audio) => {
+          this.options.onStateChange('speaking');
+          void this.options
+            .sendToTwilio(
+              buildMediaStreamMediaPayload(options.streamSid, base64Audio),
+            )
+            .catch((error) => {
+              this.options.onError(
+                `Failed to forward audio to Twilio: ${String(
+                  error instanceof Error ? error.message : error,
+                )}`,
+              );
+            });
+        },
+        onSpeechStarted: () => {
+          this.options.onStateChange('listening');
+          this.client.cancelResponse();
+          void this.options
+            .sendToTwilio(buildMediaStreamClearPayload(options.streamSid))
+            .catch(() => {
+              // The stream is gone; the close handler tears the call down.
+            });
+        },
+        onInputTranscript: (transcript) => {
+          this.options.onTranscript('caller', transcript);
+        },
+        onOutputTranscript: (transcript) => {
+          this.options.onTranscript('assistant', transcript);
+        },
+        onFunctionCall: (call) => {
+          this.handleFunctionCall(call.callId, call.name, call.arguments);
+        },
+        onError: (message) => {
+          this.options.onError(message);
+        },
+        onClosed: () => {
+          this.closed = true;
+          this.options.onClosed();
+        },
+      },
+      socketFactory: options.socketFactory,
+    });
+  }
+
+  get isOpen(): boolean {
+    return !this.closed && this.client.isOpen;
+  }
+
+  handleCallerAudio(base64Audio: string): void {
+    this.client.appendAudio(base64Audio);
+  }
+
+  handleDtmf(digit: string): void {
+    const normalized = String(digit || '').trim();
+    if (!normalized) return;
+    this.client.sendUserText(
+      `The caller pressed the keypad digit "${normalized}".`,
+    );
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.consultAbort.abort();
+    this.client.close();
+  }
+
+  private handleFunctionCall(
+    callId: string,
+    name: string,
+    rawArguments: string,
+  ): void {
+    if (name !== CONSULT_AGENT_TOOL_NAME) {
+      this.client.sendFunctionCallOutput(callId, `Unknown tool: ${name}`);
+      return;
+    }
+    const request = parseConsultRequest(rawArguments);
+    if (!request) {
+      this.client.sendFunctionCallOutput(
+        callId,
+        'The request argument was missing. Ask the caller to rephrase.',
+      );
+      return;
+    }
+    if (this.consultInFlight) {
+      this.client.sendFunctionCallOutput(callId, CONSULT_BUSY_OUTPUT);
+      return;
+    }
+    this.consultInFlight = true;
+    this.options.onStateChange('thinking');
+    void this.options
+      .consultAgent(request, this.consultAbort.signal)
+      .then((reply) => {
+        return reply.trim() || 'The assistant returned no reply.';
+      })
+      .catch((error) => {
+        if (this.consultAbort.signal.aborted) {
+          return '';
+        }
+        this.options.onError(
+          `Agent consult failed: ${String(
+            error instanceof Error ? error.message : error,
+          )}`,
+        );
+        return 'The assistant hit an error while working on that. Apologize to the caller and offer to try again.';
+      })
+      .then((output) => {
+        this.consultInFlight = false;
+        if (this.closed || !output) {
+          return;
+        }
+        this.options.onStateChange('listening');
+        this.client.sendFunctionCallOutput(callId, output);
+      });
+  }
+}

--- a/src/channels/voice/realtime-credentials.ts
+++ b/src/channels/voice/realtime-credentials.ts
@@ -1,0 +1,75 @@
+/**
+ * Resolves which upstream serves realtime voice sessions.
+ *
+ * `voice.realtime.provider` selects between OpenAI directly (`openai`, the
+ * default, using OPENAI_API_KEY) and the HybridAI platform's `/v1/realtime`
+ * proxy (`hybridai`, using the signed-in HybridAI credential and
+ * HYBRIDAI_BASE_URL). Both speak the same realtime protocol, so everything
+ * past the connection URL and bearer token is provider-agnostic.
+ *
+ * Shared by the Twilio phone path and the web console path so the two
+ * surfaces cannot drift on provider selection or error wording.
+ */
+import { readHybridAIApiKey } from '../../auth/hybridai-auth.js';
+import { HYBRIDAI_BASE_URL, OPENAI_API_KEY } from '../../config/config.js';
+import type { RuntimeVoiceRealtimeProvider } from '../../config/runtime-config.js';
+
+export const OPENAI_REALTIME_URL = 'wss://api.openai.com/v1/realtime';
+
+export interface RealtimeConnection {
+  url: string;
+  apiKey: string;
+}
+
+export function hybridaiRealtimeUrl(baseUrl: string): string {
+  const trimmed = String(baseUrl || '')
+    .trim()
+    .replace(/\/+$/, '');
+  const wsBase = trimmed
+    .replace(/^https:\/\//, 'wss://')
+    .replace(/^http:\/\//, 'ws://');
+  return `${wsBase}/v1/realtime`;
+}
+
+/**
+ * The connection for the configured provider, or an explanation of the
+ * missing credential. Never throws: both call sites report the error into a
+ * live socket rather than to a caller that could recover.
+ */
+export function resolveRealtimeConnection(
+  provider: RuntimeVoiceRealtimeProvider,
+):
+  | { connection: RealtimeConnection; error: null }
+  | {
+      connection: null;
+      error: string;
+    } {
+  if (provider === 'hybridai') {
+    const apiKey = String(readHybridAIApiKey() || '').trim();
+    if (!apiKey) {
+      return {
+        connection: null,
+        error:
+          'Realtime voice via the hybridai provider requires a HybridAI API key (sign in or set HYBRIDAI_API_KEY).',
+      };
+    }
+    return {
+      connection: { url: hybridaiRealtimeUrl(HYBRIDAI_BASE_URL), apiKey },
+      error: null,
+    };
+  }
+  const apiKey = String(OPENAI_API_KEY || '').trim();
+  if (!apiKey) {
+    return {
+      connection: null,
+      error: 'Realtime voice requires an OpenAI API key (OPENAI_API_KEY).',
+    };
+  }
+  return { connection: { url: OPENAI_REALTIME_URL, apiKey }, error: null };
+}
+
+export function isRealtimeCredentialConfigured(
+  provider: RuntimeVoiceRealtimeProvider,
+): boolean {
+  return resolveRealtimeConnection(provider).connection !== null;
+}

--- a/src/channels/voice/runtime.ts
+++ b/src/channels/voice/runtime.ts
@@ -1,7 +1,11 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Duplex } from 'node:stream';
 import WebSocket, * as wsModule from 'ws';
-import { getConfigSnapshot, TWILIO_AUTH_TOKEN } from '../../config/config.js';
+import {
+  getConfigSnapshot,
+  OPENAI_API_KEY,
+  TWILIO_AUTH_TOKEN,
+} from '../../config/config.js';
 import { logger } from '../../logger.js';
 import type { MediaContextItem } from '../../types/container.js';
 import { VOICE_CAPABILITIES } from '../channel.js';
@@ -13,6 +17,8 @@ import {
   mergePromptFragment,
   parseConversationRelayMessage,
 } from './conversation-relay.js';
+import { parseMediaStreamMessage } from './media-stream.js';
+import { RealtimeCallBridge } from './realtime-bridge.js';
 import { ReplayProtector, validateTwilioSignature } from './security.js';
 import { type VoiceCallSession, VoiceCallSessionStore } from './session.js';
 import { formatTextForVoice } from './text.js';
@@ -25,6 +31,7 @@ import {
   buildConversationRelayTwiml,
   buildEmptyTwiml,
   buildHangupTwiml,
+  buildMediaStreamTwiml,
   readTwilioFormBody,
 } from './webhook.js';
 
@@ -309,12 +316,21 @@ function isReconnectableFailure(params: Record<string, string>): boolean {
   );
 }
 
-function buildRelayTwimlForRequest(
+function buildVoiceTwimlForRequest(
   req: IncomingMessage,
   callSid: string,
 ): string {
   const voiceConfig = getConfigSnapshot().voice;
   const paths = resolveVoiceWebhookPaths(voiceConfig.webhookPath);
+  if (voiceConfig.mode === 'realtime') {
+    return buildMediaStreamTwiml({
+      websocketUrl: buildPublicWsUrl(req, paths.streamPath),
+      actionUrl: buildPublicHttpUrl(req, paths.actionPath),
+      customParameters: {
+        callReference: callSid,
+      },
+    });
+  }
   return buildConversationRelayTwiml({
     websocketUrl: buildPublicWsUrl(req, paths.relayPath),
     actionUrl: buildPublicHttpUrl(req, paths.actionPath),
@@ -586,6 +602,224 @@ function handleWebSocketConnection(ws: WebSocket, remoteIp: string): void {
     logger.debug({ error, callSid, remoteIp }, 'Voice relay websocket error');
   });
 }
+async function dispatchRealtimeConsult(
+  session: VoiceCallSession,
+  content: string,
+  bridgeSignal: AbortSignal,
+): Promise<string> {
+  const handler = voiceMessageHandler;
+  if (!handler) {
+    throw new Error('Voice runtime is unavailable.');
+  }
+  const controller = new AbortController();
+  const onBridgeAbort = () => controller.abort();
+  bridgeSignal.addEventListener('abort', onBridgeAbort, { once: true });
+  sessionStore.setController(session.callSid, controller);
+  const chunks: string[] = [];
+  const responseStream = new ConversationRelayResponseStream(
+    async (payload) => {
+      if (payload.type === 'text' && typeof payload.token === 'string') {
+        chunks.push(payload.token);
+      }
+    },
+    {
+      interruptible: false,
+      language: getConfigSnapshot().voice.relay.language,
+    },
+  );
+  const reply: VoiceReplyFn = async (text) => {
+    await responseStream.reply(formatTextForVoice(text));
+  };
+  try {
+    await handler(
+      session.gatewaySessionId,
+      null,
+      session.channelId,
+      session.userId,
+      session.username,
+      content,
+      [],
+      reply,
+      {
+        abortSignal: controller.signal,
+        callSid: session.callSid,
+        twilioSessionId: session.twilioSessionId || '',
+        remoteIp: session.remoteIp,
+        setupMessage: session.setupMessage,
+        responseStream,
+      },
+    );
+    // The stream buffers its final token until finish(); flush it into the
+    // collector or the reply would lose its last chunk.
+    if (!responseStream.finished) {
+      await responseStream.finish();
+    }
+  } finally {
+    bridgeSignal.removeEventListener('abort', onBridgeAbort);
+    if (session.controller === controller) {
+      sessionStore.setController(session.callSid, null);
+    }
+  }
+  return chunks.join(' ').replace(/\s+/g, ' ').trim();
+}
+
+function teardownRealtimeSession(
+  callSid: string,
+  next: 'ended' | 'failed',
+): void {
+  const session = sessionStore.get(callSid);
+  if (!session) {
+    return;
+  }
+  session.controller?.abort();
+  session.realtimeBridge?.close();
+  session.realtimeBridge = null;
+  transitionSession(callSid, next);
+  sessionStore.remove(callSid);
+}
+
+function handleMediaStreamConnection(ws: WebSocket, remoteIp: string): void {
+  let callSid: string | null = null;
+
+  ws.on('message', (raw) => {
+    void (async () => {
+      try {
+        const message = parseMediaStreamMessage(raw);
+        if (message.type === 'connected' || message.type === 'mark') {
+          return;
+        }
+        if (message.type === 'start') {
+          const reference =
+            message.customParameters?.callReference || message.callSid;
+          const session = reference ? sessionStore.get(reference) : undefined;
+          if (!session) {
+            throw new Error(
+              `Media stream started for unknown voice call ${reference || 'unknown'}`,
+            );
+          }
+          callSid = session.callSid;
+          const apiKey = String(OPENAI_API_KEY || '').trim();
+          if (!apiKey) {
+            throw new Error(
+              'Realtime voice mode requires an OpenAI API key (OPENAI_API_KEY).',
+            );
+          }
+          const voiceConfig = getConfigSnapshot().voice;
+          const bridge = new RealtimeCallBridge({
+            apiKey,
+            config: voiceConfig.realtime,
+            caller: {
+              from: session.from,
+              to: session.to,
+              callerName: session.callerName,
+            },
+            streamSid: message.streamSid,
+            sendToTwilio: async (payload) => {
+              if (!session.ws || session.ws.readyState !== WebSocket.OPEN) {
+                throw new Error('Voice websocket is not connected.');
+              }
+              await sendWsPayload(session.ws, payload);
+            },
+            consultAgent: (request, abortSignal) =>
+              dispatchRealtimeConsult(session, request, abortSignal),
+            onTranscript: (role, text) => {
+              logger.debug(
+                {
+                  callSid: session.callSid,
+                  role,
+                  transcriptLength: text.length,
+                },
+                'Voice realtime transcript',
+              );
+            },
+            onStateChange: (state) => {
+              transitionSession(session.callSid, state);
+            },
+            onError: (errorMessage) => {
+              logger.warn(
+                { callSid: session.callSid, errorMessage },
+                'Voice realtime bridge error',
+              );
+            },
+            onClosed: () => {
+              // Upstream loss is unrecoverable; end the Twilio stream so the
+              // caller is not left in silence.
+              if (session.ws && session.ws.readyState === WebSocket.OPEN) {
+                session.ws.close();
+              }
+            },
+          });
+          sessionStore.attachMediaStream({
+            callSid: session.callSid,
+            streamSid: message.streamSid,
+            ws,
+            bridge,
+          });
+          transitionSession(session.callSid, 'listening');
+          logger.info(
+            {
+              callSid: session.callSid,
+              streamSid: message.streamSid,
+              remoteIp,
+            },
+            'Voice media stream started',
+          );
+          return;
+        }
+        if (!callSid) {
+          throw new Error('Media stream frame arrived before start.');
+        }
+        const session = sessionStore.get(callSid);
+        if (!session?.realtimeBridge) {
+          throw new Error(`Unknown voice session for call ${callSid}`);
+        }
+        if (message.type === 'media') {
+          session.realtimeBridge.handleCallerAudio(message.payload);
+          return;
+        }
+        if (message.type === 'dtmf') {
+          logger.info(
+            { callSid, digit: message.digit },
+            'Voice media stream DTMF received',
+          );
+          session.realtimeBridge.handleDtmf(message.digit);
+          return;
+        }
+        logger.info({ callSid }, 'Voice media stream stopped');
+        teardownRealtimeSession(callSid, 'ended');
+      } catch (error) {
+        logger.warn(
+          { error, callSid, remoteIp },
+          'Voice media stream message failed',
+        );
+        if (callSid) {
+          teardownRealtimeSession(callSid, 'failed');
+        }
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.close(1008, 'Invalid voice media stream message');
+        }
+      }
+    })();
+  });
+
+  ws.on('close', (code, reason) => {
+    logger.info(
+      { callSid, remoteIp, code, reason: decodeCloseReason(reason) },
+      'Voice media stream websocket closed',
+    );
+    if (callSid) {
+      teardownRealtimeSession(callSid, 'ended');
+    }
+  });
+
+  ws.on('error', (error) => {
+    logger.debug(
+      { error, callSid, remoteIp },
+      'Voice media stream websocket error',
+    );
+  });
+}
+
 export async function initVoice(
   messageHandler: VoiceMessageHandler,
 ): Promise<void> {
@@ -604,7 +838,16 @@ export async function initVoice(
     capabilities: VOICE_CAPABILITIES,
   });
   websocketServer.on('connection', (ws: WebSocket, req: IncomingMessage) => {
-    handleWebSocketConnection(ws, resolveRemoteIp(req));
+    const remoteIp = resolveRemoteIp(req);
+    const paths = resolveVoiceWebhookPaths(
+      getConfigSnapshot().voice.webhookPath,
+    );
+    const pathname = new URL(req.url || '/', 'http://localhost').pathname;
+    if (pathname === paths.streamPath) {
+      handleMediaStreamConnection(ws, remoteIp);
+      return;
+    }
+    handleWebSocketConnection(ws, remoteIp);
   });
 }
 
@@ -688,7 +931,7 @@ export async function handleVoiceWebhook(
       },
       'Voice webhook accepted',
     );
-    sendXml(res, 200, buildRelayTwimlForRequest(req, callSid));
+    sendXml(res, 200, buildVoiceTwimlForRequest(req, callSid));
     return true;
   }
 
@@ -743,7 +986,7 @@ export async function handleVoiceWebhook(
     ) {
       sessionStore.markReconnectAttempt(callSid);
       transitionSession(callSid, 'relay-connecting');
-      sendXml(res, 200, buildRelayTwimlForRequest(req, callSid));
+      sendXml(res, 200, buildVoiceTwimlForRequest(req, callSid));
       return true;
     }
 
@@ -770,8 +1013,11 @@ export function handleVoiceUpgrade(
   head: Buffer,
   url: URL,
 ): boolean {
-  const paths = resolveVoiceWebhookPaths(getConfigSnapshot().voice.webhookPath);
-  if (url.pathname !== paths.relayPath) {
+  const voiceConfig = getConfigSnapshot().voice;
+  const paths = resolveVoiceWebhookPaths(voiceConfig.webhookPath);
+  const activePath =
+    voiceConfig.mode === 'realtime' ? paths.streamPath : paths.relayPath;
+  if (url.pathname !== activePath) {
     return false;
   }
   const remoteIp = resolveRemoteIp(req);
@@ -832,6 +1078,16 @@ export async function shutdownVoice(opts?: { drain?: boolean }): Promise<void> {
   await Promise.all(
     sessionStore.list().map(async (session) => {
       session.controller?.abort();
+      const isRealtimeSession = session.realtimeBridge !== null;
+      session.realtimeBridge?.close();
+      session.realtimeBridge = null;
+      if (isRealtimeSession) {
+        // Media stream sockets carry raw audio frames; the ConversationRelay
+        // end payload below would be an unknown event to Twilio.
+        session.ws?.close();
+        sessionStore.remove(session.callSid);
+        return;
+      }
       if (session.ws && session.ws.readyState === WebSocket.OPEN) {
         try {
           await sendWsPayload(session.ws, {

--- a/src/channels/voice/runtime.ts
+++ b/src/channels/voice/runtime.ts
@@ -1,11 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Duplex } from 'node:stream';
 import WebSocket, * as wsModule from 'ws';
-import {
-  getConfigSnapshot,
-  OPENAI_API_KEY,
-  TWILIO_AUTH_TOKEN,
-} from '../../config/config.js';
+import { getConfigSnapshot, TWILIO_AUTH_TOKEN } from '../../config/config.js';
 import { logger } from '../../logger.js';
 import type { MediaContextItem } from '../../types/container.js';
 import { VOICE_CAPABILITIES } from '../channel.js';
@@ -23,6 +19,7 @@ import {
   parseMediaStreamMessage,
 } from './media-stream.js';
 import { RealtimeCallBridge } from './realtime-bridge.js';
+import { resolveRealtimeConnection } from './realtime-credentials.js';
 import { ReplayProtector, validateTwilioSignature } from './security.js';
 import { type VoiceCallSession, VoiceCallSessionStore } from './session.js';
 import { formatTextForVoice } from './text.js';
@@ -713,15 +710,15 @@ function handleMediaStreamConnection(ws: WebSocket, remoteIp: string): void {
             );
           }
           callSid = session.callSid;
-          const apiKey = String(OPENAI_API_KEY || '').trim();
-          if (!apiKey) {
-            throw new Error(
-              'Realtime voice mode requires an OpenAI API key (OPENAI_API_KEY).',
-            );
-          }
           const voiceConfig = getConfigSnapshot().voice;
+          const resolved = resolveRealtimeConnection(
+            voiceConfig.realtime.provider,
+          );
+          if (!resolved.connection) {
+            throw new Error(resolved.error);
+          }
           const bridge = new RealtimeCallBridge({
-            apiKey,
+            connection: resolved.connection,
             config: voiceConfig.realtime,
             caller: {
               from: session.from,

--- a/src/channels/voice/runtime.ts
+++ b/src/channels/voice/runtime.ts
@@ -17,7 +17,11 @@ import {
   mergePromptFragment,
   parseConversationRelayMessage,
 } from './conversation-relay.js';
-import { parseMediaStreamMessage } from './media-stream.js';
+import {
+  buildMediaStreamClearPayload,
+  buildMediaStreamMediaPayload,
+  parseMediaStreamMessage,
+} from './media-stream.js';
 import { RealtimeCallBridge } from './realtime-bridge.js';
 import { ReplayProtector, validateTwilioSignature } from './security.js';
 import { type VoiceCallSession, VoiceCallSessionStore } from './session.js';
@@ -713,12 +717,25 @@ function handleMediaStreamConnection(ws: WebSocket, remoteIp: string): void {
               to: session.to,
               callerName: session.callerName,
             },
-            streamSid: message.streamSid,
-            sendToTwilio: async (payload) => {
+            surface: 'phone',
+            audioFormat: { type: 'audio/pcmu' },
+            sendAudio: async (base64Audio) => {
               if (!session.ws || session.ws.readyState !== WebSocket.OPEN) {
                 throw new Error('Voice websocket is not connected.');
               }
-              await sendWsPayload(session.ws, payload);
+              await sendWsPayload(
+                session.ws,
+                buildMediaStreamMediaPayload(message.streamSid, base64Audio),
+              );
+            },
+            clearPlayback: async () => {
+              if (!session.ws || session.ws.readyState !== WebSocket.OPEN) {
+                throw new Error('Voice websocket is not connected.');
+              }
+              await sendWsPayload(
+                session.ws,
+                buildMediaStreamClearPayload(message.streamSid),
+              );
             },
             consultAgent: (request, abortSignal) =>
               dispatchRealtimeConsult(session, request, abortSignal),

--- a/src/channels/voice/runtime.ts
+++ b/src/channels/voice/runtime.ts
@@ -45,6 +45,11 @@ export interface VoiceMessageContext {
   remoteIp: string;
   setupMessage: ConversationRelaySetupMessage | null;
   responseStream: ConversationRelayResponseStream;
+  /** Realtime consults only: live tool activity for spoken reassurance. */
+  onToolProgress?: (event: {
+    toolName: string;
+    phase: 'start' | 'finish';
+  }) => void;
 }
 
 export type VoiceMessageHandler = (
@@ -617,8 +622,15 @@ function handleWebSocketConnection(ws: WebSocket, remoteIp: string): void {
 async function dispatchRealtimeConsult(
   session: VoiceCallSession,
   content: string,
-  bridgeSignal: AbortSignal,
+  hooks: {
+    abortSignal: AbortSignal;
+    onToolProgress: (event: {
+      toolName: string;
+      phase: 'start' | 'finish';
+    }) => void;
+  },
 ): Promise<string> {
+  const bridgeSignal = hooks.abortSignal;
   const handler = voiceMessageHandler;
   if (!handler) {
     throw new Error('Voice runtime is unavailable.');
@@ -659,6 +671,7 @@ async function dispatchRealtimeConsult(
         remoteIp: session.remoteIp,
         setupMessage: session.setupMessage,
         responseStream,
+        onToolProgress: hooks.onToolProgress,
       },
     );
     // The stream buffers its final token until finish(); flush it into the
@@ -745,8 +758,8 @@ function handleMediaStreamConnection(ws: WebSocket, remoteIp: string): void {
                 buildMediaStreamClearPayload(message.streamSid),
               );
             },
-            consultAgent: (request, abortSignal) =>
-              dispatchRealtimeConsult(session, request, abortSignal),
+            consultAgent: (request, hooks) =>
+              dispatchRealtimeConsult(session, request, hooks),
             onTranscript: (role, text) => {
               logger.debug(
                 {

--- a/src/channels/voice/runtime.ts
+++ b/src/channels/voice/runtime.ts
@@ -62,6 +62,16 @@ export type VoiceMessageHandler = (
   context: VoiceMessageContext,
 ) => Promise<void>;
 
+/** Gateway-provided sink that persists realtime spoken turns into history. */
+export type VoiceTranscriptPersister = (params: {
+  sessionId: string;
+  channelId: string;
+  userId: string;
+  username: string | null;
+  role: 'user' | 'assistant';
+  text: string;
+}) => void;
+
 const MAX_PENDING_UPGRADES = 32;
 const MAX_CONNECTIONS_PER_IP = 16;
 const REPLAY_TTL_MS = 30_000;
@@ -74,6 +84,7 @@ const PREINIT_MAX_CONCURRENT_CALLS = 1;
 const replayProtector = new ReplayProtector(REPLAY_TTL_MS);
 let draining = false;
 let voiceMessageHandler: VoiceMessageHandler | null = null;
+let voiceTranscriptPersister: VoiceTranscriptPersister | null = null;
 let missingTwilioAuthTokenLogged = false;
 const sessionStore = new VoiceCallSessionStore(
   PREINIT_MAX_CONCURRENT_CALLS,
@@ -748,6 +759,14 @@ function handleMediaStreamConnection(ws: WebSocket, remoteIp: string): void {
                 },
                 'Voice realtime transcript',
               );
+              voiceTranscriptPersister?.({
+                sessionId: session.gatewaySessionId,
+                channelId: session.channelId,
+                userId: session.userId,
+                username: session.username,
+                role: role === 'caller' ? 'user' : 'assistant',
+                text,
+              });
             },
             onStateChange: (state) => {
               transitionSession(session.callSid, state);
@@ -839,8 +858,10 @@ function handleMediaStreamConnection(ws: WebSocket, remoteIp: string): void {
 
 export async function initVoice(
   messageHandler: VoiceMessageHandler,
+  options?: { transcriptPersister?: VoiceTranscriptPersister },
 ): Promise<void> {
   voiceMessageHandler = messageHandler;
+  voiceTranscriptPersister = options?.transcriptPersister || null;
   draining = false;
   sessionStore.updateLimits(getConfigSnapshot().voice.maxConcurrentCalls);
   if (runtimeInitialized) {
@@ -1124,6 +1145,7 @@ export async function shutdownVoice(opts?: { drain?: boolean }): Promise<void> {
   );
   runtimeInitialized = false;
   voiceMessageHandler = null;
+  voiceTranscriptPersister = null;
   websocketServer.removeAllListeners();
   websocketServer = new WebSocketServerCtor({ noServer: true });
 }

--- a/src/channels/voice/session.ts
+++ b/src/channels/voice/session.ts
@@ -3,6 +3,7 @@ import { DEFAULT_AGENT_ID } from '../../agents/agent-types.js';
 import { buildSessionKey } from '../../session/session-key.js';
 import { buildVoiceChannelId } from './channel-id.js';
 import type { ConversationRelaySetupMessage } from './conversation-relay.js';
+import type { RealtimeCallBridge } from './realtime-bridge.js';
 
 export type VoiceCallState =
   | 'initiated'
@@ -22,9 +23,26 @@ const ALLOWED_TRANSITIONS: Record<VoiceCallState, VoiceCallState[]> = {
   initiated: ['twiml-issued', 'relay-connecting', 'listening', 'failed'],
   'twiml-issued': ['relay-connecting', 'listening', 'failed'],
   'relay-connecting': ['listening', 'failed', 'reconnecting'],
-  listening: ['thinking', 'interrupted', 'ending', 'failed', 'reconnecting'],
+  // Realtime mode speaks without a preceding gateway turn and consults the
+  // agent mid-speech, so listening -> speaking and speaking -> thinking are
+  // legal in addition to the relay-mode cycle.
+  listening: [
+    'thinking',
+    'speaking',
+    'interrupted',
+    'ending',
+    'failed',
+    'reconnecting',
+  ],
   thinking: ['speaking', 'interrupted', 'ending', 'failed', 'reconnecting'],
-  speaking: ['listening', 'interrupted', 'ending', 'failed', 'reconnecting'],
+  speaking: [
+    'listening',
+    'thinking',
+    'interrupted',
+    'ending',
+    'failed',
+    'reconnecting',
+  ],
   interrupted: ['listening', 'thinking', 'ending', 'failed', 'reconnecting'],
   reconnecting: ['relay-connecting', 'failed', 'ended'],
   ending: ['ended', 'failed'],
@@ -49,6 +67,8 @@ export interface VoiceCallSession {
   ws: WebSocket | null;
   controller: AbortController | null;
   setupMessage: ConversationRelaySetupMessage | null;
+  streamSid: string | null;
+  realtimeBridge: RealtimeCallBridge | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -88,6 +108,8 @@ function createSession(params: {
     ws: null,
     controller: null,
     setupMessage: null,
+    streamSid: null,
+    realtimeBridge: null,
     createdAt: timestamp,
     updatedAt: timestamp,
   };
@@ -152,6 +174,21 @@ export class VoiceCallSessionStore {
     });
     this.sessions.set(params.callSid, session);
     this.activeSessions += 1;
+    return session;
+  }
+
+  attachMediaStream(params: {
+    callSid: string;
+    streamSid: string;
+    ws: WebSocket;
+    bridge: RealtimeCallBridge;
+  }): VoiceCallSession | undefined {
+    const session = this.sessions.get(params.callSid);
+    if (!session) return undefined;
+    session.streamSid = params.streamSid;
+    session.ws = params.ws;
+    session.realtimeBridge = params.bridge;
+    session.updatedAt = now();
     return session;
   }
 

--- a/src/channels/voice/twilio-manager.ts
+++ b/src/channels/voice/twilio-manager.ts
@@ -7,6 +7,7 @@ export interface VoiceWebhookPaths {
   basePath: string;
   webhookPath: string;
   relayPath: string;
+  streamPath: string;
   actionPath: string;
 }
 
@@ -44,6 +45,7 @@ export function resolveVoiceWebhookPaths(
     basePath: normalizedBasePath,
     webhookPath: `${normalizedBasePath}/webhook`,
     relayPath: `${normalizedBasePath}/relay`,
+    streamPath: `${normalizedBasePath}/stream`,
     actionPath: `${normalizedBasePath}/action`,
   };
 }

--- a/src/channels/voice/webhook.ts
+++ b/src/channels/voice/webhook.ts
@@ -96,6 +96,24 @@ export function buildConversationRelayTwiml(params: {
   );
 }
 
+export function buildMediaStreamTwiml(params: {
+  websocketUrl: string;
+  actionUrl: string;
+  customParameters?: Record<string, string>;
+}): string {
+  const parameterXml = Object.entries(params.customParameters || {})
+    .map(
+      ([name, value]) => `<Parameter${buildXmlAttributes({ name, value })} />`,
+    )
+    .join('');
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    `<Response><Connect${buildXmlAttributes({ action: params.actionUrl })}>` +
+    `<Stream${buildXmlAttributes({ url: params.websocketUrl })}>${parameterXml}</Stream>` +
+    '</Connect></Response>'
+  );
+}
+
 export function buildHangupTwiml(message: string): string {
   return (
     '<?xml version="1.0" encoding="UTF-8"?>' +

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -629,6 +629,7 @@ export interface RuntimeLineConfig {
 }
 
 export type RuntimeVoiceProvider = 'twilio';
+export type RuntimeVoiceMode = 'realtime' | 'relay';
 export type RuntimeVoiceRelayTtsProvider = 'amazon' | 'default' | 'google';
 export type RuntimeVoiceRelayTranscriptionProvider =
   | 'deepgram'
@@ -650,11 +651,20 @@ export interface RuntimeVoiceRelayConfig {
   welcomeGreeting: string;
 }
 
+export interface RuntimeVoiceRealtimeConfig {
+  model: string;
+  voice: string;
+  greeting: string;
+  instructions: string;
+}
+
 export interface RuntimeVoiceConfig {
   enabled: boolean;
   provider: RuntimeVoiceProvider;
+  mode: RuntimeVoiceMode;
   twilio: RuntimeVoiceTwilioConfig;
   relay: RuntimeVoiceRelayConfig;
+  realtime: RuntimeVoiceRealtimeConfig;
   webhookPath: string;
   maxConcurrentCalls: number;
 }
@@ -1745,6 +1755,7 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   voice: {
     enabled: false,
     provider: 'twilio',
+    mode: 'relay',
     twilio: {
       accountSid: '',
       authToken: '',
@@ -1757,6 +1768,12 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
       language: 'en-US',
       interruptible: true,
       welcomeGreeting: 'Hello! How can I help you today?',
+    },
+    realtime: {
+      model: 'gpt-realtime',
+      voice: 'marin',
+      greeting: 'Hello! How can I help you today?',
+      instructions: '',
     },
     webhookPath: '/voice',
     maxConcurrentCalls: 8,
@@ -3582,6 +3599,18 @@ function normalizeVoiceProvider(
   return fallback;
 }
 
+function normalizeVoiceMode(
+  value: unknown,
+  fallback: RuntimeVoiceMode,
+): RuntimeVoiceMode {
+  if (typeof value !== 'string') return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'relay' || normalized === 'realtime') {
+    return normalized;
+  }
+  return fallback;
+}
+
 function normalizeVoiceRelayTtsProvider(
   value: unknown,
   fallback: RuntimeVoiceRelayTtsProvider,
@@ -3980,9 +4009,11 @@ function normalizeVoiceConfig(
   const raw = isRecord(value) ? value : {};
   const rawTwilio = isRecord(raw.twilio) ? raw.twilio : {};
   const rawRelay = isRecord(raw.relay) ? raw.relay : {};
+  const rawRealtime = isRecord(raw.realtime) ? raw.realtime : {};
   return {
     enabled: normalizeBoolean(raw.enabled, fallback.enabled),
     provider: normalizeVoiceProvider(raw.provider, fallback.provider),
+    mode: normalizeVoiceMode(raw.mode, fallback.mode),
     twilio: {
       accountSid: normalizeString(
         rawTwilio.accountSid,
@@ -4023,6 +4054,24 @@ function normalizeVoiceConfig(
         rawRelay.welcomeGreeting,
         fallback.relay.welcomeGreeting,
         { allowEmpty: false },
+      ),
+    },
+    realtime: {
+      model: normalizeString(rawRealtime.model, fallback.realtime.model, {
+        allowEmpty: false,
+      }),
+      voice: normalizeString(rawRealtime.voice, fallback.realtime.voice, {
+        allowEmpty: false,
+      }),
+      greeting: normalizeString(
+        rawRealtime.greeting,
+        fallback.realtime.greeting,
+        { allowEmpty: false },
+      ),
+      instructions: normalizeString(
+        rawRealtime.instructions,
+        fallback.realtime.instructions,
+        { allowEmpty: true },
       ),
     },
     webhookPath: normalizeApiPath(raw.webhookPath, fallback.webhookPath),

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -631,6 +631,7 @@ export interface RuntimeLineConfig {
 
 export type RuntimeVoiceProvider = 'twilio';
 export type RuntimeVoiceMode = 'realtime' | 'relay';
+export type RuntimeVoiceRealtimeProvider = 'hybridai' | 'openai';
 export type RuntimeVoiceRelayTtsProvider = 'amazon' | 'default' | 'google';
 export type RuntimeVoiceRelayTranscriptionProvider =
   | 'deepgram'
@@ -653,6 +654,7 @@ export interface RuntimeVoiceRelayConfig {
 }
 
 export interface RuntimeVoiceRealtimeConfig {
+  provider: RuntimeVoiceRealtimeProvider;
   model: string;
   voice: string;
   greeting: string;
@@ -1771,6 +1773,7 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
       welcomeGreeting: 'Hello! How can I help you today?',
     },
     realtime: {
+      provider: 'openai',
       model: 'gpt-realtime',
       voice: 'marin',
       greeting: 'Hello! How can I help you today?',
@@ -3612,6 +3615,18 @@ function normalizeVoiceMode(
   return fallback;
 }
 
+function normalizeVoiceRealtimeProvider(
+  value: unknown,
+  fallback: RuntimeVoiceRealtimeProvider,
+): RuntimeVoiceRealtimeProvider {
+  if (typeof value !== 'string') return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'openai' || normalized === 'hybridai') {
+    return normalized;
+  }
+  return fallback;
+}
+
 function normalizeVoiceRelayTtsProvider(
   value: unknown,
   fallback: RuntimeVoiceRelayTtsProvider,
@@ -4058,6 +4073,10 @@ function normalizeVoiceConfig(
       ),
     },
     realtime: {
+      provider: normalizeVoiceRealtimeProvider(
+        rawRealtime.provider,
+        fallback.realtime.provider,
+      ),
       model: normalizeString(rawRealtime.model, fallback.realtime.model, {
         allowEmpty: false,
       }),

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -271,6 +271,7 @@ import { getGatewayAdminLogs } from './gateway-log-service.js';
 import {
   getGatewayAdminPlugins,
   handleGatewayPluginWebhook,
+  handleGatewayPluginWebsocketUpgrade,
   runGatewayPluginTool,
 } from './gateway-plugin-service.js';
 import { requestGatewayRestart } from './gateway-restart.js';
@@ -11379,6 +11380,32 @@ export function startGatewayHttpServer(): GatewayHttpServer {
         userId: resolveGatewayRequestUserId({ req, channelId: 'web' }) || null,
         username: null,
       });
+      return;
+    }
+
+    if (isPluginInboundWebhookPath(url.pathname)) {
+      // Peer auth happens inside the owning plugin handler, mirroring HTTP
+      // plugin webhooks (e.g. signed one-time stream tokens).
+      void handleGatewayPluginWebsocketUpgrade({
+        req,
+        socket,
+        head,
+        url,
+        rejectUpgrade: (statusCode, message) =>
+          writeUpgradeError(socket, statusCode, message),
+      })
+        .then((handled) => {
+          if (!handled) {
+            writeUpgradeError(socket, 404, 'Not Found');
+          }
+        })
+        .catch((error: unknown) => {
+          logger.warn(
+            { error, pathname: url.pathname },
+            'Plugin websocket upgrade failed',
+          );
+          writeUpgradeError(socket, 500, 'Upgrade failed');
+        });
       return;
     }
 

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -436,6 +436,11 @@ import {
   renderTextChannelCommandResult,
   resolveTextChannelSlashCommands,
 } from './text-channel-commands.js';
+import {
+  isWebchatVoiceAvailable,
+  WEBCHAT_VOICE_STREAM_PATH,
+  webchatVoiceManager,
+} from './webchat-voice.js';
 
 const SITE_DIR = resolveInstallPath('docs');
 const CONSOLE_DIST_DIR = resolveInstallPath('console', 'dist');
@@ -10945,6 +10950,15 @@ export function startGatewayHttpServer(): GatewayHttpServer {
             handleApiChatContext(res, url);
             return;
           }
+          if (pathname === '/api/chat/voice' && method === 'GET') {
+            const voiceConfig = getRuntimeConfig().voice.realtime;
+            sendJson(res, 200, {
+              available: isWebchatVoiceAvailable(),
+              model: voiceConfig.model,
+              voice: voiceConfig.voice,
+            });
+            return;
+          }
           if (pathname === '/api/agents' && method === 'GET') {
             await handleApiAgents(res);
             return;
@@ -11173,6 +11187,32 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     }
 
     if (handleVoiceUpgrade(req, socket, head, url)) {
+      return;
+    }
+
+    if (url.pathname === WEBCHAT_VOICE_STREAM_PATH) {
+      // Same browser-auth gate as the admin terminal stream: a signed session
+      // cookie or an authenticated same-origin request (including the
+      // loopback local web session). No query tokens, no API tokens.
+      const voiceSessionPayload = getSessionAuthPayload(req);
+      const voiceRequestAuth = resolveAuthContext(req, url, {
+        allowApiTokens: false,
+        allowQueryToken: false,
+        allowLocalWebSession: true,
+        requireSameOrigin: true,
+      });
+      if (voiceSessionPayload === null && voiceRequestAuth.kind === 'none') {
+        writeUpgradeError(socket, 401, 'Unauthorized');
+        return;
+      }
+      if (!isWebchatVoiceAvailable()) {
+        writeUpgradeError(socket, 503, 'Voice Unavailable');
+        return;
+      }
+      webchatVoiceManager.handleUpgrade(req, socket, head, {
+        userId: resolveGatewayRequestUserId({ req, channelId: 'web' }) || null,
+        username: null,
+      });
       return;
     }
 

--- a/src/gateway/gateway-plugin-service.ts
+++ b/src/gateway/gateway-plugin-service.ts
@@ -1221,6 +1221,36 @@ export async function handleGatewayPluginWebhook(
   }
 }
 
+/**
+ * Routes a websocket upgrade on the plugin webhook path. Returns false when
+ * no plugin websocket webhook owns the path, so the HTTP server can answer
+ * 404; peer auth is the owning plugin handler's responsibility.
+ */
+export async function handleGatewayPluginWebsocketUpgrade(params: {
+  req: IncomingMessage;
+  socket: import('node:stream').Duplex;
+  head: Buffer;
+  url: URL;
+  rejectUpgrade: (statusCode: number, message: string) => void;
+}): Promise<boolean> {
+  const { pluginManager } = await tryEnsurePluginManagerInitializedForGateway({
+    sessionId: `plugin-webhook:${params.url.pathname}`,
+    channelId: params.url.pathname,
+    surface: 'webhook',
+  });
+  if (!pluginManager) {
+    return false;
+  }
+  return pluginManager.handleWebsocketUpgrade({
+    pathname: params.url.pathname,
+    url: params.url,
+    req: params.req,
+    socket: params.socket,
+    head: params.head,
+    rejectUpgrade: params.rejectUpgrade,
+  });
+}
+
 export async function runGatewayPluginTool(params: {
   toolName: string;
   args: Record<string, unknown>;

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -4936,6 +4936,7 @@ export async function getGatewayStatus(
     msteams,
     voice: {
       enabled: runtimeConfig.voice.enabled,
+      mode: runtimeConfig.voice.mode,
       accountSidConfigured: Boolean(
         runtimeConfig.voice.twilio.accountSid.trim(),
       ),
@@ -12735,6 +12736,7 @@ export async function handleGatewayCommand(
             [
               `Enabled: ${voiceConfig.enabled ? 'on' : 'off'}`,
               `Provider: ${voiceConfig.provider}`,
+              `Mode: ${voiceConfig.mode}`,
               `Account SID: ${voiceConfig.twilio.accountSid.trim() ? 'configured' : 'unset'}`,
               `From number: ${voiceConfig.twilio.fromNumber.trim() || '(unset)'}`,
               `Auth token: ${String(TWILIO_AUTH_TOKEN || '').trim() ? 'configured' : 'unset'}`,

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -539,6 +539,7 @@ export interface GatewayStatus {
   };
   voice?: {
     enabled: boolean;
+    mode: 'realtime' | 'relay';
     accountSidConfigured: boolean;
     fromNumberConfigured: boolean;
     authTokenConfigured: boolean;

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -113,6 +113,7 @@ import {
   shutdownThreema,
 } from '../channels/threema/runtime.js';
 import { isThreemaChannelId } from '../channels/threema/target.js';
+import { resolveRealtimeConnection } from '../channels/voice/realtime-credentials.js';
 import { initVoice, shutdownVoice } from '../channels/voice/runtime.js';
 import {
   createVoiceTextStreamFormatter,
@@ -136,7 +137,6 @@ import {
   HEARTBEAT_INTERVAL,
   MSTEAMS_APP_ID,
   MSTEAMS_APP_PASSWORD,
-  OPENAI_API_KEY,
   onConfigChange,
   PROACTIVE_QUEUE_OUTSIDE_HOURS,
   SLACK_APP_TOKEN,
@@ -3179,11 +3179,15 @@ async function startVoiceIntegration(): Promise<boolean> {
     );
     return false;
   }
-  if (voiceConfig.mode === 'realtime' && !String(OPENAI_API_KEY || '').trim()) {
-    logger.warn(
-      'Voice integration disabled: realtime mode requires an OpenAI API key (OPENAI_API_KEY)',
-    );
-    return false;
+  if (voiceConfig.mode === 'realtime') {
+    const resolved = resolveRealtimeConnection(voiceConfig.realtime.provider);
+    if (!resolved.connection) {
+      logger.warn(
+        { provider: voiceConfig.realtime.provider },
+        `Voice integration disabled: ${resolved.error}`,
+      );
+      return false;
+    }
   }
 
   try {

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -3221,6 +3221,9 @@ async function startVoiceIntegration(): Promise<boolean> {
             source: 'voice',
             reply: textReply,
             abortSignal: context.abortSignal,
+            onToolProgress: context.onToolProgress
+              ? (event) => context.onToolProgress?.(event)
+              : undefined,
             onTextDelta: (delta) => {
               const filteredDelta = streamFilter.push(delta);
               if (!filteredDelta) return;

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -144,7 +144,9 @@ import {
   TWILIO_AUTH_TOKEN,
 } from '../config/config.js';
 import {
+  getRuntimeConfig,
   type RuntimeConfig,
+  resolveDefaultAgentId,
   startRuntimeConfigWatcher,
 } from '../config/runtime-config.js';
 import { resolveLocalInstanceId } from '../identity/agent-id.js';
@@ -269,6 +271,7 @@ import {
   renderTextChannelCommandResult,
   resolveTextChannelSlashCommands,
 } from './text-channel-commands.js';
+import { persistVoiceTranscript } from './voice-transcript-store.js';
 
 let detachConfigListener: (() => void) | null = null;
 let proactiveFlushTimer: ReturnType<typeof setInterval> | null = null;
@@ -3304,6 +3307,14 @@ async function startVoiceIntegration(): Promise<boolean> {
             }
           }
         }
+      },
+      {
+        transcriptPersister: (params) => {
+          persistVoiceTranscript({
+            ...params,
+            agentId: resolveDefaultAgentId(getRuntimeConfig()),
+          });
+        },
       },
     );
     logger.info(

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -136,6 +136,7 @@ import {
   HEARTBEAT_INTERVAL,
   MSTEAMS_APP_ID,
   MSTEAMS_APP_PASSWORD,
+  OPENAI_API_KEY,
   onConfigChange,
   PROACTIVE_QUEUE_OUTSIDE_HOURS,
   SLACK_APP_TOKEN,
@@ -3175,6 +3176,12 @@ async function startVoiceIntegration(): Promise<boolean> {
     );
     return false;
   }
+  if (voiceConfig.mode === 'realtime' && !String(OPENAI_API_KEY || '').trim()) {
+    logger.warn(
+      'Voice integration disabled: realtime mode requires an OpenAI API key (OPENAI_API_KEY)',
+    );
+    return false;
+  }
 
   try {
     await initVoice(
@@ -3302,6 +3309,7 @@ async function startVoiceIntegration(): Promise<boolean> {
     logger.info(
       {
         provider: voiceConfig.provider,
+        mode: voiceConfig.mode,
         webhookPath: voiceConfig.webhookPath,
         maxConcurrentCalls: voiceConfig.maxConcurrentCalls,
       },

--- a/src/gateway/voice-transcript-store.ts
+++ b/src/gateway/voice-transcript-store.ts
@@ -1,0 +1,45 @@
+/**
+ * Persists realtime voice transcripts into session history as regular
+ * user/assistant messages tagged `source: 'voice'`, mirrored into the
+ * workspace session transcript. Shared by the webchat voice surface and the
+ * phone-call realtime runtime.
+ */
+
+import { memoryService } from '../memory/memory-service.js';
+import { appendSessionTranscript } from '../session/session-transcripts.js';
+
+export const VOICE_MESSAGE_SOURCE = 'voice';
+
+export function persistVoiceTranscript(params: {
+  sessionId: string;
+  channelId: string;
+  agentId: string;
+  userId: string;
+  username: string | null;
+  role: 'user' | 'assistant';
+  text: string;
+}): void {
+  const { sessionId, channelId, agentId, role, text } = params;
+  const userId = role === 'user' ? params.userId : 'assistant';
+  const username = role === 'user' ? params.username : null;
+  // Spoken turns can arrive before any consult runs, so the session row must
+  // exist even for a voice-first conversation.
+  memoryService.getOrCreateSession(sessionId, null, channelId, agentId);
+  memoryService.storeMessage({
+    sessionId,
+    userId,
+    username,
+    role,
+    content: text,
+    agentId: role === 'assistant' ? agentId : undefined,
+    source: VOICE_MESSAGE_SOURCE,
+  });
+  appendSessionTranscript(agentId, {
+    sessionId,
+    channelId,
+    role,
+    userId,
+    username,
+    content: text,
+  });
+}

--- a/src/gateway/webchat-voice.ts
+++ b/src/gateway/webchat-voice.ts
@@ -1,0 +1,321 @@
+/**
+ * Browser realtime voice sessions for the web console chat surface.
+ *
+ * Owns the `/api/chat/voice/stream` websocket protocol: JSON frames carrying
+ * base64 PCM16 (24 kHz mono) mic audio from the browser into a per-connection
+ * `RealtimeCallBridge`, and model audio, barge-in clears, state, and
+ * transcripts back. `consult_agent` runs an ordinary web chat turn through
+ * `handleGatewayMessage`, so tools, approvals, and session history behave
+ * exactly like typed chat.
+ *
+ * Threat model: the HTTP server authenticates the upgrade (session cookie or
+ * loopback web session) BEFORE handing sockets to this module — nothing here
+ * may run for anonymous peers. This module still enforces its own limits:
+ * bounded frame size, a concurrent-session cap, a start deadline for idle
+ * sockets, and canonical-session-id validation so a client cannot consult
+ * into an arbitrary key shape. Audio payloads are opaque and never logged;
+ * transcripts are logged as lengths only.
+ *
+ * NOT the Twilio path: phone calls live in `src/channels/voice/runtime.ts`.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+import WebSocket, * as wsModule from 'ws';
+import type { RealtimeSocketFactory } from '../channels/voice/openai-realtime.js';
+import {
+  type RealtimeBridgeState,
+  RealtimeCallBridge,
+} from '../channels/voice/realtime-bridge.js';
+import { formatTextForVoice } from '../channels/voice/text.js';
+import { getConfigSnapshot, OPENAI_API_KEY } from '../config/config.js';
+import {
+  getRuntimeConfig,
+  resolveDefaultAgentId,
+} from '../config/runtime-config.js';
+import { logger } from '../logger.js';
+import {
+  buildSessionKey,
+  classifySessionKeyShape,
+} from '../session/session-key.js';
+import { handleGatewayMessage } from './gateway-chat-service.js';
+
+export const WEBCHAT_VOICE_STREAM_PATH = '/api/chat/voice/stream';
+
+const MAX_CONCURRENT_SESSIONS = 4;
+const MAX_FRAME_BYTES = 256 * 1024;
+const START_DEADLINE_MS = 10_000;
+
+export interface WebchatVoiceIdentity {
+  userId: string | null;
+  username: string | null;
+}
+
+export function isWebchatVoiceAvailable(): boolean {
+  return Boolean(String(OPENAI_API_KEY || '').trim());
+}
+
+interface ClientFrame {
+  type: string;
+  payload?: unknown;
+  sessionId?: unknown;
+  agentId?: unknown;
+}
+
+function sendFrame(ws: WebSocket, frame: Record<string, unknown>): void {
+  if (ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify(frame), () => {
+    // Send failures surface through the socket error/close handlers.
+  });
+}
+
+function resolveVoiceSessionId(requested: unknown, agentId: string): string {
+  const candidate = typeof requested === 'string' ? requested.trim() : '';
+  if (
+    candidate &&
+    classifySessionKeyShape(candidate) !== 'canonical_malformed'
+  ) {
+    return candidate;
+  }
+  return buildSessionKey(
+    agentId,
+    'web',
+    'dm',
+    randomUUID().replace(/-/g, '').slice(0, 16),
+  );
+}
+
+export interface WebchatVoiceConnectionOptions {
+  ws: WebSocket;
+  identity: WebchatVoiceIdentity;
+  remoteIp: string;
+  onFinished: () => void;
+  /** Test seam: injected upstream realtime socket factory. */
+  socketFactory?: RealtimeSocketFactory;
+}
+
+export class WebchatVoiceConnection {
+  private bridge: RealtimeCallBridge | null = null;
+  private startTimer: NodeJS.Timeout | null = null;
+  private closed = false;
+  private readonly ws: WebSocket;
+  private readonly identity: WebchatVoiceIdentity;
+  private readonly remoteIp: string;
+  private readonly onFinished: () => void;
+  private readonly socketFactory?: RealtimeSocketFactory;
+
+  constructor(options: WebchatVoiceConnectionOptions) {
+    this.ws = options.ws;
+    this.identity = options.identity;
+    this.remoteIp = options.remoteIp;
+    this.onFinished = options.onFinished;
+    this.socketFactory = options.socketFactory;
+    const ws = this.ws;
+    this.startTimer = setTimeout(() => {
+      this.fail('Voice session was not started in time.', 1008);
+    }, START_DEADLINE_MS);
+    ws.on('message', (raw) => {
+      this.handleFrame(raw);
+    });
+    ws.on('close', () => {
+      this.teardown();
+    });
+    ws.on('error', (error) => {
+      logger.debug(
+        { error, remoteIp: this.remoteIp },
+        'Webchat voice websocket error',
+      );
+    });
+  }
+
+  private handleFrame(raw: WebSocket.Data): void {
+    let frame: ClientFrame;
+    try {
+      const parsed = JSON.parse(String(raw)) as unknown;
+      if (!parsed || typeof parsed !== 'object') {
+        throw new Error('Frame was not a JSON object.');
+      }
+      frame = parsed as ClientFrame;
+    } catch {
+      this.fail('Invalid voice frame.', 1008);
+      return;
+    }
+    if (frame.type === 'start') {
+      this.handleStart(frame);
+      return;
+    }
+    if (frame.type === 'audio') {
+      if (typeof frame.payload === 'string' && this.bridge) {
+        this.bridge.handleCallerAudio(frame.payload);
+      }
+      return;
+    }
+    if (frame.type === 'stop') {
+      sendFrame(this.ws, { type: 'ended' });
+      this.ws.close(1000, 'Voice session ended');
+      return;
+    }
+    this.fail(`Unknown voice frame type: ${String(frame.type)}`, 1008);
+  }
+
+  private handleStart(frame: ClientFrame): void {
+    if (this.bridge) {
+      this.fail('Voice session already started.', 1008);
+      return;
+    }
+    const apiKey = String(OPENAI_API_KEY || '').trim();
+    if (!apiKey) {
+      this.fail(
+        'Realtime voice requires an OpenAI API key (OPENAI_API_KEY).',
+        1011,
+      );
+      return;
+    }
+    if (this.startTimer) {
+      clearTimeout(this.startTimer);
+      this.startTimer = null;
+    }
+    const agentId =
+      (typeof frame.agentId === 'string' && frame.agentId.trim()) ||
+      resolveDefaultAgentId(getRuntimeConfig());
+    const sessionId = resolveVoiceSessionId(frame.sessionId, agentId);
+    const userId = this.identity.userId || sessionId;
+    const username = this.identity.username || 'web';
+    const voiceConfig = getConfigSnapshot().voice.realtime;
+    this.bridge = new RealtimeCallBridge({
+      apiKey,
+      config: voiceConfig,
+      caller: { from: '', to: '', callerName: username },
+      surface: 'web',
+      audioFormat: { type: 'audio/pcm', rate: 24000 },
+      sendAudio: async (base64Audio) => {
+        sendFrame(this.ws, { type: 'audio', payload: base64Audio });
+      },
+      clearPlayback: async () => {
+        sendFrame(this.ws, { type: 'clear' });
+      },
+      consultAgent: async (request, abortSignal) => {
+        const result = await handleGatewayMessage({
+          sessionId,
+          guildId: null,
+          channelId: 'web',
+          userId,
+          username,
+          content: request,
+          agentId,
+          abortSignal,
+          source: 'webchat.voice',
+        });
+        if (result.status !== 'success') {
+          throw new Error(result.error || 'Chat turn failed.');
+        }
+        return formatTextForVoice(result.result || '');
+      },
+      onTranscript: (role, text) => {
+        logger.debug(
+          { sessionId, role, transcriptLength: text.length },
+          'Webchat voice transcript',
+        );
+        sendFrame(this.ws, {
+          type: 'transcript',
+          role: role === 'caller' ? 'user' : 'assistant',
+          text,
+        });
+      },
+      onStateChange: (state: RealtimeBridgeState) => {
+        sendFrame(this.ws, { type: 'state', state });
+      },
+      onError: (message) => {
+        logger.warn(
+          { sessionId, remoteIp: this.remoteIp, message },
+          'Webchat voice bridge error',
+        );
+        sendFrame(this.ws, { type: 'error', message });
+      },
+      onClosed: () => {
+        // Upstream loss is unrecoverable; end the browser session too.
+        sendFrame(this.ws, { type: 'ended' });
+        if (this.ws.readyState === WebSocket.OPEN) {
+          this.ws.close(1011, 'Realtime session closed');
+        }
+      },
+      socketFactory: this.socketFactory,
+    });
+    sendFrame(this.ws, { type: 'ready', sessionId });
+    logger.info(
+      { sessionId, remoteIp: this.remoteIp },
+      'Webchat voice session started',
+    );
+  }
+
+  private fail(message: string, code: number): void {
+    sendFrame(this.ws, { type: 'error', message });
+    if (this.ws.readyState === WebSocket.OPEN) {
+      this.ws.close(code, message.slice(0, 120));
+    }
+    this.teardown();
+  }
+
+  private teardown(): void {
+    if (this.closed) return;
+    this.closed = true;
+    if (this.startTimer) {
+      clearTimeout(this.startTimer);
+      this.startTimer = null;
+    }
+    this.bridge?.close();
+    this.bridge = null;
+    this.onFinished();
+  }
+}
+
+const WebSocketServerCtor = (
+  wsModule as unknown as {
+    WebSocketServer: new (options: {
+      noServer: true;
+      maxPayload: number;
+    }) => {
+      handleUpgrade: (
+        req: IncomingMessage,
+        socket: Duplex,
+        head: Buffer,
+        cb: (ws: WebSocket) => void,
+      ) => void;
+    };
+  }
+).WebSocketServer;
+
+class WebchatVoiceManager {
+  private readonly wss = new WebSocketServerCtor({
+    noServer: true,
+    maxPayload: MAX_FRAME_BYTES,
+  });
+  private activeSessions = 0;
+
+  handleUpgrade(
+    req: IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+    identity: WebchatVoiceIdentity,
+  ): void {
+    const remoteIp = String(req.socket.remoteAddress || 'unknown');
+    this.wss.handleUpgrade(req, socket, head, (ws: WebSocket) => {
+      if (this.activeSessions >= MAX_CONCURRENT_SESSIONS) {
+        ws.close(1013, 'Too many voice sessions');
+        return;
+      }
+      this.activeSessions += 1;
+      new WebchatVoiceConnection({
+        ws,
+        identity,
+        remoteIp,
+        onFinished: () => {
+          this.activeSessions = Math.max(0, this.activeSessions - 1);
+        },
+      });
+    });
+  }
+}
+
+export const webchatVoiceManager = new WebchatVoiceManager();

--- a/src/gateway/webchat-voice.ts
+++ b/src/gateway/webchat-voice.ts
@@ -29,8 +29,12 @@ import {
   type RealtimeBridgeState,
   RealtimeCallBridge,
 } from '../channels/voice/realtime-bridge.js';
+import {
+  isRealtimeCredentialConfigured,
+  resolveRealtimeConnection,
+} from '../channels/voice/realtime-credentials.js';
 import { formatTextForVoice } from '../channels/voice/text.js';
-import { getConfigSnapshot, OPENAI_API_KEY } from '../config/config.js';
+import { getConfigSnapshot } from '../config/config.js';
 import {
   getRuntimeConfig,
   resolveDefaultAgentId,
@@ -55,7 +59,9 @@ export interface WebchatVoiceIdentity {
 }
 
 export function isWebchatVoiceAvailable(): boolean {
-  return Boolean(String(OPENAI_API_KEY || '').trim());
+  return isRealtimeCredentialConfigured(
+    getConfigSnapshot().voice.realtime.provider,
+  );
 }
 
 interface ClientFrame {
@@ -166,12 +172,10 @@ export class WebchatVoiceConnection {
       this.fail('Voice session already started.', 1008);
       return;
     }
-    const apiKey = String(OPENAI_API_KEY || '').trim();
-    if (!apiKey) {
-      this.fail(
-        'Realtime voice requires an OpenAI API key (OPENAI_API_KEY).',
-        1011,
-      );
+    const voiceConfig = getConfigSnapshot().voice.realtime;
+    const resolved = resolveRealtimeConnection(voiceConfig.provider);
+    if (!resolved.connection) {
+      this.fail(resolved.error, 1011);
       return;
     }
     if (this.startTimer) {
@@ -184,9 +188,8 @@ export class WebchatVoiceConnection {
     const sessionId = resolveVoiceSessionId(frame.sessionId, agentId);
     const userId = this.identity.userId || sessionId;
     const username = this.identity.username || 'web';
-    const voiceConfig = getConfigSnapshot().voice.realtime;
     this.bridge = new RealtimeCallBridge({
-      apiKey,
+      connection: resolved.connection,
       config: voiceConfig,
       caller: { from: '', to: '', callerName: username },
       surface: 'web',

--- a/src/gateway/webchat-voice.ts
+++ b/src/gateway/webchat-voice.ts
@@ -4,9 +4,10 @@
  * Owns the `/api/chat/voice/stream` websocket protocol: JSON frames carrying
  * base64 PCM16 (24 kHz mono) mic audio from the browser into a per-connection
  * `RealtimeCallBridge`, and model audio, barge-in clears, state, and
- * transcripts back. `consult_agent` runs an ordinary web chat turn through
- * `handleGatewayMessage`, so tools, approvals, and session history behave
- * exactly like typed chat.
+ * transcripts back. Spoken turns persist into session history as regular
+ * user/assistant messages tagged `source: 'voice'`. `consult_agent` runs an
+ * ordinary web chat turn through `handleGatewayMessage`, so tools, approvals,
+ * and session history behave exactly like typed chat.
  *
  * Threat model: the HTTP server authenticates the upgrade (session cookie or
  * loopback web session) BEFORE handing sockets to this module — nothing here
@@ -40,6 +41,7 @@ import {
   classifySessionKeyShape,
 } from '../session/session-key.js';
 import { handleGatewayMessage } from './gateway-chat-service.js';
+import { persistVoiceTranscript } from './voice-transcript-store.js';
 
 export const WEBCHAT_VOICE_STREAM_PATH = '/api/chat/voice/stream';
 
@@ -217,11 +219,17 @@ export class WebchatVoiceConnection {
           { sessionId, role, transcriptLength: text.length },
           'Webchat voice transcript',
         );
-        sendFrame(this.ws, {
-          type: 'transcript',
-          role: role === 'caller' ? 'user' : 'assistant',
+        const chatRole = role === 'caller' ? 'user' : 'assistant';
+        persistVoiceTranscript({
+          sessionId,
+          channelId: 'web',
+          agentId,
+          userId,
+          username,
+          role: chatRole,
           text,
         });
+        sendFrame(this.ws, { type: 'transcript', role: chatRole, text });
       },
       onStateChange: (state: RealtimeBridgeState) => {
         sendFrame(this.ws, { type: 'state', state });

--- a/src/gateway/webchat-voice.ts
+++ b/src/gateway/webchat-voice.ts
@@ -3,8 +3,8 @@
  *
  * Owns the `/api/chat/voice/stream` websocket protocol: JSON frames carrying
  * base64 PCM16 (24 kHz mono) mic audio from the browser into a per-connection
- * `RealtimeCallBridge`, and model audio, barge-in clears, state, and
- * transcripts back. Spoken turns persist into session history as regular
+ * `RealtimeCallBridge`, and model audio, barge-in clears, state, consult
+ * activity labels, and transcripts back. Spoken turns persist into session history as regular
  * user/assistant messages tagged `source: 'voice'`. `consult_agent` runs an
  * ordinary web chat turn through `handleGatewayMessage`, so tools, approvals,
  * and session history behave exactly like typed chat.
@@ -200,7 +200,7 @@ export class WebchatVoiceConnection {
       clearPlayback: async () => {
         sendFrame(this.ws, { type: 'clear' });
       },
-      consultAgent: async (request, abortSignal) => {
+      consultAgent: async (request, hooks) => {
         const result = await handleGatewayMessage({
           sessionId,
           guildId: null,
@@ -209,13 +209,17 @@ export class WebchatVoiceConnection {
           username,
           content: request,
           agentId,
-          abortSignal,
+          abortSignal: hooks.abortSignal,
+          onToolProgress: (event) => hooks.onToolProgress(event),
           source: 'webchat.voice',
         });
         if (result.status !== 'success') {
           throw new Error(result.error || 'Chat turn failed.');
         }
         return formatTextForVoice(result.result || '');
+      },
+      onConsultActivity: (label) => {
+        sendFrame(this.ws, { type: 'consult', label });
       },
       onTranscript: (role, text) => {
         logger.debug(

--- a/src/memory/memory-service.ts
+++ b/src/memory/memory-service.ts
@@ -175,6 +175,7 @@ export interface MemoryBackend {
     content: string,
     agentId?: string | null,
     artifacts?: ArtifactMetadata[] | null,
+    source?: string | null,
   ) => number;
   storeSemanticMemory: (params: {
     sessionId: string;
@@ -731,6 +732,7 @@ export class MemoryService {
     content: string;
     agentId?: string | null;
     artifacts?: ArtifactMetadata[] | null;
+    source?: string | null;
   }): number {
     return this.backend.storeMessage(
       params.sessionId,
@@ -740,6 +742,7 @@ export class MemoryService {
       params.content,
       params.agentId,
       params.artifacts,
+      params.source,
     );
   }
 

--- a/src/memory/messages.ts
+++ b/src/memory/messages.ts
@@ -147,6 +147,7 @@ export function storeMessage(
   content: string,
   agentId?: string | null,
   artifacts?: ArtifactMetadata[] | null,
+  source?: string | null,
 ): number {
   const resolvedSessionId = resolveSessionIdCompat(sessionId);
   const normalizedAgentId = agentId?.trim() || null;
@@ -161,8 +162,9 @@ export function storeMessage(
          agent_id,
          content,
          artifacts_json,
+         source,
          created_at
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%d %H:%M:%f', 'now'))`,
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%d %H:%M:%f', 'now'))`,
     )
     .run(
       resolvedSessionId,
@@ -172,6 +174,7 @@ export function storeMessage(
       normalizedAgentId,
       content,
       artifactsJson,
+      source?.trim() || null,
     );
 
   getMessageDatabase()

--- a/src/memory/schema/migrations.ts
+++ b/src/memory/schema/migrations.ts
@@ -21,7 +21,7 @@ import {
 } from '../../session/session-key.js';
 import type { CanonicalSessionMessage, Session } from '../../types/session.js';
 
-export const DATABASE_SCHEMA_VERSION = 53;
+export const DATABASE_SCHEMA_VERSION = 54;
 const AGENT_CANONICAL_ID_COLLISION_LIMIT = 20;
 const AUDIT_ACTOR_MIGRATION_BATCH_SIZE = 500;
 const ACTOR_ID_MAX_LENGTH =
@@ -970,6 +970,7 @@ function migrateV1(database: Database.Database): void {
       content TEXT NOT NULL,
       artifacts_json TEXT,
       activity_trace_json TEXT,
+      source TEXT,
       created_at TEXT DEFAULT (datetime('now'))
     );
     CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id);
@@ -3402,6 +3403,27 @@ function migrateV53(
   recordMigration(database, 53, 'Persist archived agent state');
 }
 
+function messageSourceNeedMigration(database: Database.Database): boolean {
+  return (
+    tableExists(database, 'messages') &&
+    !columnExists(database, 'messages', 'source')
+  );
+}
+
+function migrateV54(
+  database: Database.Database,
+  opts?: InitDatabaseOptions,
+): void {
+  addColumnIfMissing({
+    database,
+    table: 'messages',
+    column: 'source',
+    ddl: 'source TEXT',
+    quiet: opts?.quiet === true,
+  });
+  recordMigration(database, 54, 'Persist message source (e.g. voice turns)');
+}
+
 export function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -3527,6 +3549,9 @@ export function runMigrations(
   if (currentVersion < 51) migrateV51(database);
   if (currentVersion < 53 || agentArchivedNeedMigration(database)) {
     migrateV53(database, opts);
+  }
+  if (currentVersion < 54 || messageSourceNeedMigration(database)) {
+    migrateV54(database, opts);
   }
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);

--- a/src/plugins/plugin-api.ts
+++ b/src/plugins/plugin-api.ts
@@ -19,6 +19,10 @@ import {
   writePluginConfigValue,
 } from './plugin-config.js';
 import type { PluginManager } from './plugin-manager.js';
+import {
+  createPluginRealtimeVoiceSession,
+  isPluginRealtimeVoiceAvailable,
+} from './plugin-realtime-voice.js';
 import type {
   HybridClawPluginApi,
   MemoryLayerPlugin,
@@ -32,10 +36,13 @@ import type {
   PluginMiddlewareSkill,
   PluginOutputGuard,
   PluginPromptHook,
+  PluginRealtimeVoiceSession,
+  PluginRealtimeVoiceSessionOptions,
   PluginRegistrationMode,
   PluginRuntime,
   PluginService,
   PluginToolDefinition,
+  PluginWebsocketWebhookDefinition,
 } from './plugin-types.js';
 
 function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
@@ -149,10 +156,26 @@ export function createPluginApi(params: {
     registerInboundWebhook(webhook: PluginInboundWebhookDefinition): void {
       params.manager.registerInboundWebhook(params.pluginId, webhook);
     },
+    registerWebsocketWebhook(webhook: PluginWebsocketWebhookDefinition): void {
+      params.manager.registerWebsocketWebhook(params.pluginId, webhook);
+    },
     dispatchInboundMessage(
       request: PluginDispatchInboundMessageRequest,
     ): Promise<import('../gateway/gateway-types.js').GatewayChatResult> {
       return params.manager.dispatchInboundMessage(params.pluginId, request);
+    },
+    isRealtimeVoiceAvailable(): boolean {
+      return isPluginRealtimeVoiceAvailable();
+    },
+    createRealtimeVoiceSession(
+      options: PluginRealtimeVoiceSessionOptions,
+    ): PluginRealtimeVoiceSession {
+      return createPluginRealtimeVoiceSession(options, {
+        pluginId: params.pluginId,
+        agentId: resolvePluginSessionAgentId(options.session.sessionId),
+        dispatch: (request) =>
+          params.manager.dispatchInboundMessage(params.pluginId, request),
+      });
     },
     on<K extends PluginHookName>(
       event: K,

--- a/src/plugins/plugin-manager.ts
+++ b/src/plugins/plugin-manager.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { Ajv, type AnySchemaObject, type ErrorObject } from 'ajv';
+import * as wsModule from 'ws';
 import { parse as parseYaml } from 'yaml';
 import {
   type AgentTurnContext,
@@ -81,6 +82,9 @@ import type {
   PluginToolDefinition,
   PluginToolHandlerContext,
   PluginToolSchema,
+  PluginWebsocket,
+  PluginWebsocketWebhookContext,
+  PluginWebsocketWebhookDefinition,
 } from './plugin-types.js';
 import { buildPluginInboundWebhookPath } from './plugin-webhooks.js';
 
@@ -166,6 +170,28 @@ type RegisteredInboundWebhook = {
   logger: PluginLogger;
 };
 
+type RegisteredWebsocketWebhook = {
+  pluginId: string;
+  path: string;
+  webhook: PluginWebsocketWebhookDefinition & { name: string };
+  logger: PluginLogger;
+};
+
+type PluginWebsocketServerLike = {
+  handleUpgrade: (
+    req: import('node:http').IncomingMessage,
+    socket: import('node:stream').Duplex,
+    head: Buffer,
+    cb: (ws: PluginWebsocket) => void,
+  ) => void;
+};
+
+const PLUGIN_WEBSOCKET_MAX_FRAME_BYTES = 256 * 1024;
+// 32 (PR #1395 call, 2026-08-19): plugin websockets are per-call media
+// streams, not fan-out subscriptions; matches the voice runtime's
+// pending-upgrade cap. Raise only with a concrete plugin that needs more.
+const PLUGIN_WEBSOCKET_MAX_ACTIVE = 32;
+
 type RegisteredHook<K extends PluginHookName = PluginHookName> = {
   pluginId: string;
   priority: number;
@@ -204,6 +230,7 @@ type PluginRegistrationSnapshot = {
   middlewares: RegisteredMiddleware[];
   services: RegisteredService[];
   inboundWebhooks: Map<string, RegisteredInboundWebhook>;
+  websocketWebhooks: Map<string, RegisteredWebsocketWebhook>;
   providers: RegisteredProvider[];
   channels: RegisteredChannel[];
   channelTransports: RegisteredChannelTransport[];
@@ -834,6 +861,9 @@ export class PluginManager {
   private tools = new Map<string, RegisteredTool>();
   private services: RegisteredService[] = [];
   private inboundWebhooks = new Map<string, RegisteredInboundWebhook>();
+  private websocketWebhooks = new Map<string, RegisteredWebsocketWebhook>();
+  private activeWebsocketCount = 0;
+  private websocketServer: PluginWebsocketServerLike | null = null;
   private providers: RegisteredProvider[] = [];
   private channels: RegisteredChannel[] = [];
   private channelTransports: RegisteredChannelTransport[] = [];
@@ -1464,6 +1494,29 @@ export class PluginManager {
     });
   }
 
+  registerWebsocketWebhook(
+    pluginId: string,
+    webhook: PluginWebsocketWebhookDefinition,
+  ): void {
+    const normalizedName = safeString(() => webhook.name, '').trim();
+    if (!normalizedName) {
+      throw new Error('Plugin websocket webhook is missing `name`.');
+    }
+    const path = buildPluginInboundWebhookPath(pluginId, normalizedName);
+    if (this.websocketWebhooks.has(path) || this.inboundWebhooks.has(path)) {
+      throw new Error(`Plugin webhook path "${path}" is already registered.`);
+    }
+    this.websocketWebhooks.set(path, {
+      pluginId,
+      path,
+      webhook: { ...webhook, name: normalizedName },
+      logger: this.logger.child({
+        pluginId,
+        webhookName: normalizedName,
+      }) as PluginLogger,
+    });
+  }
+
   registerHook<K extends PluginHookName>(
     pluginId: string,
     name: K,
@@ -1566,6 +1619,7 @@ export class PluginManager {
       middlewares: [...this.middlewares],
       services: [...this.services],
       inboundWebhooks: new Map(this.inboundWebhooks),
+      websocketWebhooks: new Map(this.websocketWebhooks),
       providers: [...this.providers],
       channels: [...this.channels],
       channelTransports: [...this.channelTransports],
@@ -1592,6 +1646,7 @@ export class PluginManager {
     this.recomputeMiddlewareFlags();
     this.services = [...snapshot.services];
     this.inboundWebhooks = new Map(snapshot.inboundWebhooks);
+    this.websocketWebhooks = new Map(snapshot.websocketWebhooks);
     this.providers = [...snapshot.providers];
     for (const entry of this.channelTransports) {
       unregisterChannelTransport(entry.transport.kind);
@@ -1789,6 +1844,99 @@ export class PluginManager {
         params.res.statusCode = 204;
       }
       params.res.end();
+    }
+    return true;
+  }
+
+  /**
+   * Routes a websocket upgrade on the plugin webhook path to its registered
+   * handler. Returns false when no handler owns the path (caller answers
+   * 404). The handler must validate the peer before accepting — the gateway
+   * performs no auth here, mirroring HTTP plugin webhooks.
+   */
+  async handleWebsocketUpgrade(params: {
+    pathname: string;
+    url: URL;
+    req: import('node:http').IncomingMessage;
+    socket: import('node:stream').Duplex;
+    head: Buffer;
+    rejectUpgrade: (statusCode: number, message: string) => void;
+  }): Promise<boolean> {
+    await this.ensureInitialized();
+    const entry = this.websocketWebhooks.get(params.pathname);
+    if (!entry) {
+      return false;
+    }
+    if (this.activeWebsocketCount >= PLUGIN_WEBSOCKET_MAX_ACTIVE) {
+      entry.logger.warn(
+        { path: entry.path },
+        'Plugin websocket upgrade rejected: too many active sockets',
+      );
+      params.rejectUpgrade(503, 'Too many plugin websocket sessions');
+      return true;
+    }
+    this.websocketServer ??= new (
+      wsModule as unknown as {
+        WebSocketServer: new (options: {
+          noServer: true;
+          maxPayload: number;
+        }) => PluginWebsocketServerLike;
+      }
+    ).WebSocketServer({
+      noServer: true,
+      maxPayload: PLUGIN_WEBSOCKET_MAX_FRAME_BYTES,
+    });
+    const server = this.websocketServer;
+    let settled = false;
+    const context: PluginWebsocketWebhookContext = {
+      req: params.req,
+      url: params.url,
+      pluginId: entry.pluginId,
+      webhookName: entry.webhook.name,
+      path: entry.path,
+      logger: entry.logger,
+      accept: () => {
+        if (settled) {
+          return Promise.reject(
+            new Error('Plugin websocket upgrade already settled.'),
+          );
+        }
+        settled = true;
+        this.activeWebsocketCount += 1;
+        return new Promise<PluginWebsocket>((resolve) => {
+          server.handleUpgrade(params.req, params.socket, params.head, (ws) => {
+            ws.on('close', () => {
+              this.activeWebsocketCount = Math.max(
+                0,
+                this.activeWebsocketCount - 1,
+              );
+            });
+            resolve(ws);
+          });
+        });
+      },
+      reject: (statusCode, message) => {
+        if (settled) return;
+        settled = true;
+        params.rejectUpgrade(statusCode, message);
+      },
+    };
+    try {
+      await entry.webhook.handler(context);
+    } catch (error) {
+      entry.logger.warn(
+        { path: entry.path, error },
+        'Plugin websocket webhook handler failed',
+      );
+      if (!settled) {
+        settled = true;
+        params.rejectUpgrade(500, 'Plugin websocket handler failed');
+      }
+      return true;
+    }
+    if (!settled) {
+      settled = true;
+      params.rejectUpgrade(500, 'Plugin websocket handler did not settle');
     }
     return true;
   }

--- a/src/plugins/plugin-realtime-voice.ts
+++ b/src/plugins/plugin-realtime-voice.ts
@@ -1,0 +1,217 @@
+/**
+ * Realtime speech-to-speech voice sessions for channel plugins.
+ *
+ * Wraps the core `RealtimeCallBridge` behind a linear-PCM transport contract:
+ * plugins hand in 16-bit LE mono 8 kHz caller audio and receive model audio
+ * back as paced 20 ms frames, so a transport without a clear/flush primitive
+ * (Vonage websockets) still gets prompt barge-in — cutting playback only ever
+ * drops ≤1 queued frame plus what the far end already buffered. µ-law
+ * companding to the realtime session's `audio/pcmu` is exact per-sample; no
+ * resampling happens anywhere.
+ *
+ * Consults run through the plugin inbound-message dispatcher, so approvals,
+ * audit, and session history behave exactly like the plugin's turn-based
+ * path, and spoken turns persist as voice transcripts.
+ *
+ * NOT a transport: websocket framing, peer auth, and call signaling stay in
+ * the plugin; this module never sees raw transport messages.
+ */
+import { muLawToPcm16, pcm16ToMuLaw } from '../channels/voice/audio-codec.js';
+import type { RealtimeSocketFactory } from '../channels/voice/openai-realtime.js';
+import { RealtimeCallBridge } from '../channels/voice/realtime-bridge.js';
+import {
+  isRealtimeCredentialConfigured,
+  resolveRealtimeConnection,
+} from '../channels/voice/realtime-credentials.js';
+import { formatTextForVoice } from '../channels/voice/text.js';
+import { getConfigSnapshot } from '../config/config.js';
+import type { GatewayChatResult } from '../gateway/gateway-types.js';
+import { persistVoiceTranscript } from '../gateway/voice-transcript-store.js';
+import { logger } from '../logger.js';
+import type {
+  PluginDispatchInboundMessageRequest,
+  PluginRealtimeVoiceSession,
+  PluginRealtimeVoiceSessionOptions,
+} from './plugin-types.js';
+
+const FRAME_BYTES = 320; // 20 ms of 16-bit mono at 8 kHz
+const FRAME_INTERVAL_MS = 20;
+// 60ms (PR #1395 call, 2026-08-19): a response tail shorter than one frame is
+// zero-padded out after three ticks rather than waiting for the next response.
+const PARTIAL_FLUSH_AFTER_MS = 60;
+// ~5 min of queued model audio (~4.8 MB as PCM16); realtime responses burst
+// faster than playback, so long relayed replies queue — but never this much.
+const MAX_QUEUED_BYTES = 8_000 * 2 * 300;
+
+export interface PluginRealtimeVoiceDeps {
+  pluginId: string;
+  agentId: string;
+  dispatch: (
+    request: PluginDispatchInboundMessageRequest,
+  ) => Promise<GatewayChatResult>;
+  /** Test seam: injected upstream realtime socket factory. */
+  socketFactory?: RealtimeSocketFactory;
+}
+
+export function isPluginRealtimeVoiceAvailable(): boolean {
+  return isRealtimeCredentialConfigured(
+    getConfigSnapshot().voice.realtime.provider,
+  );
+}
+
+export function createPluginRealtimeVoiceSession(
+  options: PluginRealtimeVoiceSessionOptions,
+  deps: PluginRealtimeVoiceDeps,
+): PluginRealtimeVoiceSession {
+  const voiceConfig = getConfigSnapshot().voice.realtime;
+  const resolved = resolveRealtimeConnection(voiceConfig.provider);
+  if (!resolved.connection) {
+    throw new Error(resolved.error);
+  }
+  const greeting = String(options.greeting || '').trim();
+  const identity = options.session;
+
+  let queued: Buffer[] = [];
+  let queuedBytes = 0;
+  let lastAppendAt = 0;
+  let closed = false;
+
+  const sendFrame = (frame: Buffer): void => {
+    try {
+      options.sendAudio(frame);
+    } catch (error) {
+      logger.debug(
+        { pluginId: deps.pluginId, error },
+        'Plugin realtime voice sendAudio failed',
+      );
+    }
+  };
+
+  const pacer = setInterval(() => {
+    if (queuedBytes === 0) return;
+    if (queuedBytes < FRAME_BYTES) {
+      if (Date.now() - lastAppendAt < PARTIAL_FLUSH_AFTER_MS) return;
+      const padded = Buffer.concat([
+        ...queued,
+        Buffer.alloc(FRAME_BYTES - queuedBytes),
+      ]);
+      queued = [];
+      queuedBytes = 0;
+      sendFrame(padded);
+      return;
+    }
+    let frame = Buffer.concat(queued);
+    queued = frame.length > FRAME_BYTES ? [frame.subarray(FRAME_BYTES)] : [];
+    queuedBytes = frame.length - FRAME_BYTES;
+    frame = frame.subarray(0, FRAME_BYTES);
+    sendFrame(frame);
+  }, FRAME_INTERVAL_MS);
+
+  const teardown = (): void => {
+    if (closed) return;
+    closed = true;
+    clearInterval(pacer);
+    queued = [];
+    queuedBytes = 0;
+  };
+
+  const bridge = new RealtimeCallBridge({
+    connection: resolved.connection,
+    config: greeting ? { ...voiceConfig, greeting } : voiceConfig,
+    caller: {
+      from: options.caller.from,
+      to: options.caller.to,
+      callerName: options.caller.callerName || '',
+    },
+    surface: 'phone',
+    audioFormat: { type: 'audio/pcmu' },
+    sendAudio: async (base64Audio) => {
+      const pcm = muLawToPcm16(Buffer.from(base64Audio, 'base64'));
+      if (queuedBytes + pcm.length > MAX_QUEUED_BYTES) {
+        logger.warn(
+          { pluginId: deps.pluginId },
+          'Plugin realtime voice playback queue overflow; dropping audio',
+        );
+        return;
+      }
+      queued.push(pcm);
+      queuedBytes += pcm.length;
+      lastAppendAt = Date.now();
+    },
+    clearPlayback: async () => {
+      queued = [];
+      queuedBytes = 0;
+    },
+    consultAgent: async (request, hooks) => {
+      const result = await deps.dispatch({
+        sessionId: identity.sessionId,
+        sessionMode: 'resume',
+        guildId: null,
+        channelId: identity.channelId,
+        userId: identity.userId,
+        username: identity.username,
+        content: request,
+        agentId: deps.agentId,
+        abortSignal: hooks.abortSignal,
+        onToolProgress: (event) => hooks.onToolProgress(event),
+      });
+      if (result.status !== 'success') {
+        throw new Error(result.error || 'Agent turn failed.');
+      }
+      return formatTextForVoice(result.result || '');
+    },
+    onTranscript: (role, text) => {
+      logger.debug(
+        {
+          pluginId: deps.pluginId,
+          sessionId: identity.sessionId,
+          role,
+          transcriptLength: text.length,
+        },
+        'Plugin realtime voice transcript',
+      );
+      persistVoiceTranscript({
+        sessionId: identity.sessionId,
+        channelId: identity.channelId,
+        agentId: deps.agentId,
+        userId: identity.userId,
+        username: identity.username,
+        role: role === 'caller' ? 'user' : 'assistant',
+        text,
+      });
+    },
+    onStateChange: (state) => {
+      options.onStateChange?.(state);
+    },
+    onError: (message) => {
+      logger.warn(
+        { pluginId: deps.pluginId, sessionId: identity.sessionId, message },
+        'Plugin realtime voice bridge error',
+      );
+      options.onError?.(message);
+    },
+    onClosed: () => {
+      teardown();
+      options.onClosed?.();
+    },
+    socketFactory: deps.socketFactory,
+  });
+
+  return {
+    handleCallerAudio(frame: Buffer): void {
+      if (closed || frame.length === 0) return;
+      bridge.handleCallerAudio(pcm16ToMuLaw(frame).toString('base64'));
+    },
+    handleDtmf(digit: string): void {
+      if (closed) return;
+      bridge.handleDtmf(digit);
+    },
+    close(): void {
+      teardown();
+      bridge.close();
+    },
+    get isOpen(): boolean {
+      return !closed && bridge.isOpen;
+    },
+  };
+}

--- a/src/plugins/plugin-sdk.ts
+++ b/src/plugins/plugin-sdk.ts
@@ -62,6 +62,10 @@ export type {
   PluginOutputGuardOutcome,
   PluginPromptBuildContext,
   PluginPromptHook,
+  PluginRealtimeVoiceCallerInfo,
+  PluginRealtimeVoiceSession,
+  PluginRealtimeVoiceSessionIdentity,
+  PluginRealtimeVoiceSessionOptions,
   PluginRegistrationMode,
   PluginRuntime,
   PluginRuntimeToolDefinition,
@@ -74,6 +78,9 @@ export type {
   PluginToolHookContext,
   PluginToolSchema,
   PluginToolSchemaProperty,
+  PluginWebsocket,
+  PluginWebsocketWebhookContext,
+  PluginWebsocketWebhookDefinition,
 } from './plugin-types.js';
 export {
   buildPluginInboundWebhookPath,

--- a/src/plugins/plugin-types.ts
+++ b/src/plugins/plugin-types.ts
@@ -472,6 +472,13 @@ export interface PluginDispatchInboundMessageRequest {
   onProactiveMessage?: (
     message: PluginInboundProactiveMessage,
   ) => void | Promise<void>;
+  onToolProgress?: (event: {
+    sessionId: string;
+    toolName: string;
+    phase: 'start' | 'finish';
+    preview?: string;
+    durationMs?: number;
+  }) => void;
   abortSignal?: AbortSignal;
 }
 
@@ -493,6 +500,84 @@ export interface PluginInboundWebhookDefinition {
   handler: (context: PluginInboundWebhookContext) => Promise<void> | void;
 }
 
+/** Structural view of a `ws` socket, so plugins never import `ws` directly. */
+export interface PluginWebsocket {
+  on(
+    event: 'message',
+    listener: (data: unknown, isBinary: boolean) => void,
+  ): void;
+  on(event: 'close', listener: (code: number, reason: unknown) => void): void;
+  on(event: 'error', listener: (error: Error) => void): void;
+  send(data: string | Buffer, cb?: (error?: Error) => void): void;
+  close(code?: number, reason?: string): void;
+  readyState: number;
+}
+
+export interface PluginWebsocketWebhookContext {
+  req: IncomingMessage;
+  url: URL;
+  pluginId: string;
+  webhookName: string;
+  path: string;
+  logger: PluginLogger;
+  /**
+   * Completes the upgrade and hands back the socket. Call at most once; a
+   * handler that neither accepts nor rejects fails the upgrade.
+   */
+  accept: () => Promise<PluginWebsocket>;
+  /** Refuses the upgrade with an HTTP status before any socket exists. */
+  reject: (statusCode: number, message: string) => void;
+}
+
+/**
+ * Websocket upgrades on the plugin webhook path. Like HTTP plugin webhooks,
+ * upgrades are NOT authenticated by the gateway — the handler must validate
+ * the peer (signed token, allow-list) before calling `accept()`.
+ */
+export interface PluginWebsocketWebhookDefinition {
+  name: string;
+  description?: string;
+  handler: (context: PluginWebsocketWebhookContext) => Promise<void> | void;
+}
+
+export interface PluginRealtimeVoiceCallerInfo {
+  from: string;
+  to: string;
+  callerName?: string;
+}
+
+export interface PluginRealtimeVoiceSessionIdentity {
+  sessionId: string;
+  channelId: string;
+  userId: string;
+  username: string | null;
+}
+
+/**
+ * A realtime speech-to-speech voice session backed by the core realtime
+ * engine (`voice.realtime.*` config and credentials). Transport audio is
+ * 16-bit LE mono PCM at 8 kHz; model audio is delivered as paced 20 ms
+ * frames so barge-in can cut playback promptly.
+ */
+export interface PluginRealtimeVoiceSessionOptions {
+  caller: PluginRealtimeVoiceCallerInfo;
+  session: PluginRealtimeVoiceSessionIdentity;
+  /** Overrides the configured realtime greeting for this call. */
+  greeting?: string;
+  sendAudio: (frame: Buffer) => void;
+  onStateChange?: (state: 'listening' | 'speaking' | 'thinking') => void;
+  onError?: (message: string) => void;
+  onClosed?: () => void;
+}
+
+export interface PluginRealtimeVoiceSession {
+  /** 16-bit LE mono PCM at 8 kHz from the caller. */
+  handleCallerAudio(frame: Buffer): void;
+  handleDtmf(digit: string): void;
+  close(): void;
+  readonly isOpen: boolean;
+}
+
 export interface HybridClawPluginApi {
   readonly pluginId: string;
   readonly pluginDir: string;
@@ -512,9 +597,21 @@ export interface HybridClawPluginApi {
   registerCommand(cmd: PluginCommandDefinition): void;
   registerService(svc: PluginService): void;
   registerInboundWebhook(webhook: PluginInboundWebhookDefinition): void;
+  registerWebsocketWebhook(webhook: PluginWebsocketWebhookDefinition): void;
   dispatchInboundMessage(
     request: PluginDispatchInboundMessageRequest,
   ): Promise<GatewayChatResult>;
+  /** Whether realtime voice credentials are configured for this gateway. */
+  isRealtimeVoiceAvailable(): boolean;
+  /**
+   * Opens a realtime speech-to-speech session for a live call this plugin
+   * transports. Throws when realtime voice is not configured. Consulted
+   * agent turns run through `dispatchInboundMessage` semantics (approvals,
+   * audit, session history) and spoken turns persist as voice transcripts.
+   */
+  createRealtimeVoiceSession(
+    options: PluginRealtimeVoiceSessionOptions,
+  ): PluginRealtimeVoiceSession;
   on<K extends PluginHookName>(
     event: K,
     handler: PluginHookHandlerMap[K],

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -46,6 +46,8 @@ export interface StoredMessage {
   artifacts?: ArtifactMetadata[];
   /** Web-chat activity trace (thinking + tool calls) for assistant turns. */
   activityTrace?: ActivityTrace;
+  /** Provenance of the turn, e.g. 'voice' for realtime speech transcripts. */
+  source?: string | null;
   created_at: string;
 }
 

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -1010,6 +1010,7 @@ test('getGatewayStatus includes voice Twilio credential status', async () => {
 
   expect(status.voice).toEqual({
     enabled: true,
+    mode: 'relay',
     accountSidConfigured: true,
     fromNumberConfigured: true,
     authTokenConfigured: true,

--- a/tests/memory-service.test.ts
+++ b/tests/memory-service.test.ts
@@ -667,7 +667,7 @@ describe.sequential('schema migrations', () => {
       .all() as Array<{ version: number; description: string }>;
     inspect.close();
 
-    expect(Number(schemaVersion)).toBe(53);
+    expect(Number(schemaVersion)).toBe(DATABASE_SCHEMA_VERSION);
     expect(agentColumns.some((column) => column.name === 'archived')).toBe(true);
     expect(migrations).toEqual([
       {
@@ -676,6 +676,33 @@ describe.sequential('schema migrations', () => {
       },
       { version: 53, description: 'Persist archived agent state' },
     ]);
+  });
+
+  test('adds the message source column to pre-v54 databases', () => {
+    const dbPath = createTempDbPath();
+    initDatabase({ quiet: true, dbPath });
+
+    const collision = new Database(dbPath);
+    collision.exec(`
+      ALTER TABLE messages DROP COLUMN source;
+      DELETE FROM migrations WHERE version = 54;
+      PRAGMA user_version = 53;
+    `);
+    collision.close();
+
+    initDatabase({ quiet: true, dbPath });
+
+    const inspect = new Database(dbPath, { readonly: true });
+    const schemaVersion = inspect.pragma('user_version', { simple: true });
+    const messageColumns = inspect.pragma('table_info(messages)') as Array<{
+      name: string;
+    }>;
+    inspect.close();
+
+    expect(Number(schemaVersion)).toBe(DATABASE_SCHEMA_VERSION);
+    expect(messageColumns.some((column) => column.name === 'source')).toBe(
+      true,
+    );
   });
 
   test('self-heals schema v30 databases from parallel migrations', () => {

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -2033,6 +2033,84 @@ test('plugin manager resolves fixed plugin inbound webhook routes and enforces H
   ).resolves.toBe(false);
 });
 
+test('plugin manager routes websocket webhooks and enforces handler settlement', async () => {
+  const { PluginManager } = await import('../src/plugins/plugin-manager.js');
+  const manager = new PluginManager({
+    getRuntimeConfig: () => {
+      const config = loadRuntimeConfig();
+      config.plugins.list = [];
+      return config;
+    },
+  });
+
+  manager.registerInboundWebhook('demo-plugin', {
+    name: 'answer',
+    async handler() {},
+  });
+  expect(() =>
+    manager.registerWebsocketWebhook('demo-plugin', {
+      name: 'answer',
+      async handler() {},
+    }),
+  ).toThrow('already registered');
+  expect(() =>
+    manager.registerWebsocketWebhook('demo-plugin', {
+      name: '',
+      async handler() {},
+    }),
+  ).toThrow('missing `name`');
+
+  const rejected: Array<{ statusCode: number; message: string }> = [];
+  manager.registerWebsocketWebhook('demo-plugin', {
+    name: 'stream',
+    handler(ctx) {
+      ctx.reject(401, 'Invalid stream token');
+    },
+  });
+  manager.registerWebsocketWebhook('demo-plugin', {
+    name: 'silent',
+    handler() {
+      // Neither accepts nor rejects; the manager must fail the upgrade.
+    },
+  });
+
+  const upgradeParams = (pathname: string) => ({
+    pathname,
+    url: new URL(`http://localhost${pathname}`),
+    req: makeWebhookRequest({ method: 'GET', url: pathname }),
+    socket: {} as never,
+    head: Buffer.alloc(0),
+    rejectUpgrade: (statusCode: number, message: string) => {
+      rejected.push({ statusCode, message });
+    },
+  });
+
+  await expect(
+    manager.handleWebsocketUpgrade(
+      upgradeParams('/api/plugin-webhooks/demo-plugin/missing'),
+    ),
+  ).resolves.toBe(false);
+
+  await expect(
+    manager.handleWebsocketUpgrade(
+      upgradeParams('/api/plugin-webhooks/demo-plugin/stream'),
+    ),
+  ).resolves.toBe(true);
+  expect(rejected).toEqual([
+    { statusCode: 401, message: 'Invalid stream token' },
+  ]);
+
+  await expect(
+    manager.handleWebsocketUpgrade(
+      upgradeParams('/api/plugin-webhooks/demo-plugin/silent'),
+    ),
+  ).resolves.toBe(true);
+  expect(rejected[1]).toEqual({
+    statusCode: 500,
+    message: 'Plugin websocket handler did not settle',
+  });
+});
+
 test('plugin manager rejects unsupported inbound webhook methods', async () => {
   const { PluginManager } = await import('../src/plugins/plugin-manager.js');
   const manager = new PluginManager();

--- a/tests/plugin-realtime-voice.test.ts
+++ b/tests/plugin-realtime-voice.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import {
+  muLawToPcm16,
+  pcm16ToMuLaw,
+} from '../src/channels/voice/audio-codec.js';
+import type { RealtimeSocket } from '../src/channels/voice/openai-realtime.js';
+
+const REALTIME_CONFIG = {
+  provider: 'openai' as const,
+  model: 'gpt-realtime',
+  voice: 'marin',
+  greeting: 'Hello from config!',
+  instructions: '',
+};
+
+class FakeRealtimeSocket implements RealtimeSocket {
+  readyState = 1;
+  url = '';
+  sent: Array<Record<string, unknown>> = [];
+  private listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+  on(event: string, listener: (...args: unknown[]) => void): void {
+    const existing = this.listeners.get(event) || [];
+    existing.push(listener);
+    this.listeners.set(event, existing);
+  }
+
+  send(data: string, cb?: (error?: Error) => void): void {
+    this.sent.push(JSON.parse(data) as Record<string, unknown>);
+    cb?.();
+  }
+
+  close(): void {
+    this.readyState = 3;
+    for (const listener of this.listeners.get('close') || []) listener();
+  }
+
+  open(): void {
+    for (const listener of this.listeners.get('open') || []) listener();
+  }
+
+  serverEvent(event: Record<string, unknown>): void {
+    for (const listener of this.listeners.get('message') || []) {
+      listener(JSON.stringify(event));
+    }
+  }
+
+  sentOfType(type: string): Array<Record<string, unknown>> {
+    return this.sent.filter((event) => event.type === type);
+  }
+}
+
+const dispatch = vi.fn(async () => ({
+  status: 'success' as const,
+  result: 'All **done**.',
+  toolsUsed: [],
+}));
+
+const persistVoiceTranscript = vi.fn();
+
+const SESSION_IDENTITY = {
+  sessionId: 'agent:main:channel:voice:chat:dm:peer:call-1',
+  channelId: 'voice:call-1',
+  userId: '+15550001111',
+  username: '+15550001111',
+};
+
+async function createSession(params?: {
+  apiKey?: string;
+  sentFrames?: Buffer[];
+}) {
+  vi.doMock('../src/config/config.js', () => ({
+    OPENAI_API_KEY: params?.apiKey ?? 'test-key',
+    HYBRIDAI_BASE_URL: 'https://hybridai.example',
+    getConfigSnapshot: () => ({ voice: { realtime: REALTIME_CONFIG } }),
+  }));
+  vi.doMock('../src/gateway/voice-transcript-store.js', () => ({
+    persistVoiceTranscript,
+    VOICE_MESSAGE_SOURCE: 'voice',
+  }));
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+  }));
+  const { createPluginRealtimeVoiceSession } = await import(
+    '../src/plugins/plugin-realtime-voice.js'
+  );
+  const realtime = new FakeRealtimeSocket();
+  const sentFrames = params?.sentFrames ?? [];
+  const session = createPluginRealtimeVoiceSession(
+    {
+      caller: { from: '+15550001111', to: '+15550002222' },
+      greeting: 'Hi from the plugin!',
+      session: SESSION_IDENTITY,
+      sendAudio: (frame) => {
+        sentFrames.push(frame);
+      },
+    },
+    {
+      pluginId: 'vonage-voice',
+      agentId: 'main',
+      dispatch,
+      socketFactory: (url) => {
+        realtime.url = url;
+        return realtime;
+      },
+    },
+  );
+  return { session, realtime, sentFrames };
+}
+
+async function flushAsync(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+afterEach(() => {
+  dispatch.mockClear();
+  persistVoiceTranscript.mockClear();
+  vi.doUnmock('../src/config/config.js');
+  vi.doUnmock('../src/gateway/voice-transcript-store.js');
+  vi.doUnmock('../src/logger.js');
+  vi.resetModules();
+  vi.useRealTimers();
+});
+
+test('opens a µ-law phone session with the plugin greeting', async () => {
+  const { session, realtime } = await createSession();
+  realtime.open();
+
+  const [sessionUpdate] = realtime.sentOfType('session.update');
+  const sessionPayload = sessionUpdate.session as Record<string, unknown>;
+  const audio = sessionPayload.audio as {
+    input: { format: { type: string } };
+    output: { format: { type: string } };
+  };
+  expect(audio.input.format.type).toBe('audio/pcmu');
+  expect(audio.output.format.type).toBe('audio/pcmu');
+
+  realtime.serverEvent({ type: 'session.updated' });
+  const [greeting] = realtime.sentOfType('response.create');
+  expect(greeting.response).toEqual({
+    instructions: 'Greet the caller by saying: "Hi from the plugin!"',
+  });
+  session.close();
+});
+
+test('caller PCM frames go upstream as µ-law', async () => {
+  const { session, realtime } = await createSession();
+  realtime.open();
+
+  const pcm = Buffer.alloc(320);
+  pcm.writeInt16LE(1_000, 0);
+  pcm.writeInt16LE(-1_000, 2);
+  session.handleCallerAudio(pcm);
+
+  const [append] = realtime.sentOfType('input_audio_buffer.append');
+  expect(append.audio).toBe(pcm16ToMuLaw(pcm).toString('base64'));
+  session.close();
+});
+
+test('creating a session without a realtime credential fails closed', async () => {
+  await expect(createSession({ apiKey: '' })).rejects.toThrow(
+    /OpenAI API key/,
+  );
+});
+
+test('model audio is paced into 20ms PCM frames and cleared on barge-in', async () => {
+  vi.useFakeTimers();
+  const { session, realtime, sentFrames } = await createSession();
+  realtime.open();
+
+  // Two frames' worth of silence (320 µ-law bytes → 640 PCM bytes).
+  const mulaw = Buffer.alloc(320, 0xff);
+  realtime.serverEvent({
+    type: 'response.output_audio.delta',
+    delta: mulaw.toString('base64'),
+  });
+  await vi.advanceTimersByTimeAsync(20);
+  expect(sentFrames).toHaveLength(1);
+  expect(sentFrames[0].length).toBe(320);
+  expect(sentFrames[0].equals(muLawToPcm16(mulaw).subarray(0, 320))).toBe(
+    true,
+  );
+
+  await vi.advanceTimersByTimeAsync(20);
+  expect(sentFrames).toHaveLength(2);
+
+  // Queue more audio, then barge in before it plays: nothing further sends.
+  realtime.serverEvent({
+    type: 'response.output_audio.delta',
+    delta: mulaw.toString('base64'),
+  });
+  realtime.serverEvent({ type: 'input_audio_buffer.speech_started' });
+  await vi.advanceTimersByTimeAsync(200);
+  expect(sentFrames).toHaveLength(2);
+  session.close();
+});
+
+test('a sub-frame audio tail is zero-padded out instead of sticking', async () => {
+  vi.useFakeTimers();
+  const { session, realtime, sentFrames } = await createSession();
+  realtime.open();
+
+  const mulaw = Buffer.alloc(100, 0xff); // 200 PCM bytes < one 320-byte frame
+  realtime.serverEvent({
+    type: 'response.output_audio.delta',
+    delta: mulaw.toString('base64'),
+  });
+  await vi.advanceTimersByTimeAsync(40);
+  expect(sentFrames).toHaveLength(0);
+  await vi.advanceTimersByTimeAsync(40);
+  expect(sentFrames).toHaveLength(1);
+  expect(sentFrames[0].length).toBe(320);
+  session.close();
+});
+
+test('consults dispatch through the plugin seam and persist transcripts', async () => {
+  const { session, realtime } = await createSession();
+  realtime.open();
+
+  realtime.serverEvent({
+    type: 'response.function_call_arguments.done',
+    call_id: 'call_1',
+    name: 'consult_agent',
+    arguments: JSON.stringify({ request: 'Summarize my day' }),
+  });
+  await flushAsync();
+
+  expect(dispatch).toHaveBeenCalledWith(
+    expect.objectContaining({
+      sessionId: SESSION_IDENTITY.sessionId,
+      sessionMode: 'resume',
+      channelId: 'voice:call-1',
+      userId: '+15550001111',
+      content: 'Summarize my day',
+      agentId: 'main',
+      abortSignal: expect.any(AbortSignal),
+      onToolProgress: expect.any(Function),
+    }),
+  );
+  const outputs = realtime
+    .sentOfType('conversation.item.create')
+    .map((event) => event.item as Record<string, unknown>);
+  // Voice-formatted: markdown stripped before speech.
+  expect(outputs).toContainEqual(
+    expect.objectContaining({ call_id: 'call_1', output: 'All done.' }),
+  );
+
+  realtime.serverEvent({
+    type: 'conversation.item.input_audio_transcription.completed',
+    transcript: 'What time is it?',
+  });
+  expect(persistVoiceTranscript).toHaveBeenCalledWith(
+    expect.objectContaining({
+      sessionId: SESSION_IDENTITY.sessionId,
+      agentId: 'main',
+      role: 'user',
+      text: 'What time is it?',
+    }),
+  );
+  session.close();
+});
+
+test('close stops the pacer and the upstream socket', async () => {
+  vi.useFakeTimers();
+  const { session, realtime, sentFrames } = await createSession();
+  realtime.open();
+
+  realtime.serverEvent({
+    type: 'response.output_audio.delta',
+    delta: Buffer.alloc(320, 0xff).toString('base64'),
+  });
+  session.close();
+  await vi.advanceTimersByTimeAsync(200);
+
+  expect(sentFrames).toHaveLength(0);
+  expect(session.isOpen).toBe(false);
+  expect(realtime.readyState).toBe(3);
+});

--- a/tests/voice.audio-codec.test.ts
+++ b/tests/voice.audio-codec.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from 'vitest';
+import {
+  muLawDecodeSample,
+  muLawEncodeSample,
+  muLawToPcm16,
+  pcm16ToMuLaw,
+} from '../src/channels/voice/audio-codec.js';
+
+test('known G.711 anchor points', () => {
+  expect(muLawEncodeSample(0)).toBe(0xff);
+  expect(muLawDecodeSample(0xff)).toBe(0);
+  // Full-scale positive clips to the µ-law maximum code (0x80).
+  expect(muLawEncodeSample(32_767)).toBe(0x80);
+  expect(muLawDecodeSample(0x80)).toBe(32_124);
+  expect(muLawDecodeSample(0x00)).toBe(-32_124);
+});
+
+test('every µ-law code survives a decode/encode round trip', () => {
+  for (let code = 0; code < 256; code++) {
+    const sample = muLawDecodeSample(code);
+    const reencoded = muLawEncodeSample(sample);
+    expect(muLawDecodeSample(reencoded)).toBe(sample);
+  }
+});
+
+test('companding is symmetric and monotonic on a ramp', () => {
+  for (let value = 517; value <= 32_000; value += 517) {
+    expect(muLawDecodeSample(muLawEncodeSample(-value))).toBe(
+      -muLawDecodeSample(muLawEncodeSample(value)),
+    );
+  }
+  let previous = Number.NEGATIVE_INFINITY;
+  for (let value = -32_768; value <= 32_767; value += 129) {
+    const decoded = muLawDecodeSample(muLawEncodeSample(value));
+    expect(decoded).toBeGreaterThanOrEqual(previous);
+    previous = decoded;
+  }
+});
+
+test('buffer transforms are inverse-consistent and size-correct', () => {
+  const pcm = Buffer.alloc(8);
+  pcm.writeInt16LE(0, 0);
+  pcm.writeInt16LE(1_000, 2);
+  pcm.writeInt16LE(-1_000, 4);
+  pcm.writeInt16LE(31_000, 6);
+
+  const mulaw = pcm16ToMuLaw(pcm);
+  expect(mulaw.length).toBe(4);
+  const roundTrip = pcm16ToMuLaw(muLawToPcm16(mulaw));
+  expect(roundTrip.equals(mulaw)).toBe(true);
+});

--- a/tests/voice.media-stream.test.ts
+++ b/tests/voice.media-stream.test.ts
@@ -1,0 +1,124 @@
+import { expect, test } from 'vitest';
+import {
+  buildMediaStreamClearPayload,
+  buildMediaStreamMarkPayload,
+  buildMediaStreamMediaPayload,
+  parseMediaStreamMessage,
+} from '../src/channels/voice/media-stream.js';
+import { buildMediaStreamTwiml } from '../src/channels/voice/webhook.js';
+
+test('parseMediaStreamMessage decodes the media stream event lifecycle', () => {
+  const connected = parseMediaStreamMessage(
+    JSON.stringify({ event: 'connected', protocol: 'Call', version: '1.0.0' }),
+  );
+  const start = parseMediaStreamMessage(
+    JSON.stringify({
+      event: 'start',
+      sequenceNumber: '1',
+      streamSid: 'MZ123',
+      start: {
+        streamSid: 'MZ123',
+        accountSid: 'AC123',
+        callSid: 'CA123',
+        tracks: ['inbound'],
+        customParameters: { callReference: 'CA123' },
+        mediaFormat: {
+          encoding: 'audio/x-mulaw',
+          sampleRate: 8000,
+          channels: 1,
+        },
+      },
+    }),
+  );
+  const media = parseMediaStreamMessage(
+    JSON.stringify({
+      event: 'media',
+      streamSid: 'MZ123',
+      media: {
+        track: 'inbound',
+        chunk: '2',
+        timestamp: '20',
+        payload: 'dGVzdA==',
+      },
+    }),
+  );
+  const dtmf = parseMediaStreamMessage(
+    JSON.stringify({
+      event: 'dtmf',
+      streamSid: 'MZ123',
+      dtmf: { track: 'inbound_track', digit: '5' },
+    }),
+  );
+  const mark = parseMediaStreamMessage(
+    JSON.stringify({
+      event: 'mark',
+      streamSid: 'MZ123',
+      mark: { name: 'checkpoint' },
+    }),
+  );
+  const stop = parseMediaStreamMessage(
+    JSON.stringify({
+      event: 'stop',
+      streamSid: 'MZ123',
+      stop: { accountSid: 'AC123', callSid: 'CA123' },
+    }),
+  );
+
+  expect(connected).toEqual({ type: 'connected' });
+  expect(start).toEqual({
+    type: 'start',
+    streamSid: 'MZ123',
+    callSid: 'CA123',
+    accountSid: 'AC123',
+    customParameters: { callReference: 'CA123' },
+  });
+  expect(media).toEqual({
+    type: 'media',
+    streamSid: 'MZ123',
+    payload: 'dGVzdA==',
+  });
+  expect(dtmf).toEqual({ type: 'dtmf', streamSid: 'MZ123', digit: '5' });
+  expect(mark).toEqual({ type: 'mark', streamSid: 'MZ123', name: 'checkpoint' });
+  expect(stop).toEqual({ type: 'stop', streamSid: 'MZ123', callSid: 'CA123' });
+});
+
+test('parseMediaStreamMessage rejects malformed payloads', () => {
+  expect(() => parseMediaStreamMessage('')).toThrow(/empty/);
+  expect(() => parseMediaStreamMessage('not json')).toThrow(/valid JSON/);
+  expect(() => parseMediaStreamMessage('"scalar"')).toThrow(/JSON object/);
+  expect(() =>
+    parseMediaStreamMessage(JSON.stringify({ event: 'unknown-event' })),
+  ).toThrow(/Unsupported media stream event/);
+});
+
+test('outbound media stream payload builders produce Twilio frames', () => {
+  expect(buildMediaStreamMediaPayload('MZ123', 'dGVzdA==')).toEqual({
+    event: 'media',
+    streamSid: 'MZ123',
+    media: { payload: 'dGVzdA==' },
+  });
+  expect(buildMediaStreamClearPayload('MZ123')).toEqual({
+    event: 'clear',
+    streamSid: 'MZ123',
+  });
+  expect(buildMediaStreamMarkPayload('MZ123', 'checkpoint')).toEqual({
+    event: 'mark',
+    streamSid: 'MZ123',
+    mark: { name: 'checkpoint' },
+  });
+});
+
+test('buildMediaStreamTwiml renders a bidirectional Connect Stream', () => {
+  const xml = buildMediaStreamTwiml({
+    websocketUrl: 'wss://voice.example.com/voice/stream',
+    actionUrl: 'https://voice.example.com/voice/action',
+    customParameters: { callReference: 'CA123' },
+  });
+
+  expect(xml).toContain(
+    '<Connect action="https://voice.example.com/voice/action">',
+  );
+  expect(xml).toContain('<Stream url="wss://voice.example.com/voice/stream">');
+  expect(xml).toContain('<Parameter name="callReference" value="CA123" />');
+  expect(xml).toContain('</Connect>');
+});

--- a/tests/voice.realtime-bridge.test.ts
+++ b/tests/voice.realtime-bridge.test.ts
@@ -65,14 +65,16 @@ class FakeRealtimeSocket implements RealtimeSocket {
 function createBridge(overrides?: Partial<RealtimeBridgeOptions>): {
   bridge: RealtimeCallBridge;
   socket: FakeRealtimeSocket;
-  twilioPayloads: Array<Record<string, unknown>>;
+  sentAudio: string[];
+  clears: number[];
   states: RealtimeBridgeState[];
   transcripts: Array<{ role: string; text: string }>;
   errors: string[];
   consultAgent: ReturnType<typeof vi.fn>;
 } {
   const socket = new FakeRealtimeSocket();
-  const twilioPayloads: Array<Record<string, unknown>> = [];
+  const sentAudio: string[] = [];
+  const clears: number[] = [];
   const states: RealtimeBridgeState[] = [];
   const transcripts: Array<{ role: string; text: string }> = [];
   const errors: string[] = [];
@@ -81,9 +83,13 @@ function createBridge(overrides?: Partial<RealtimeBridgeOptions>): {
     apiKey: 'test-key',
     config: REALTIME_CONFIG,
     caller: CALLER,
-    streamSid: 'MZ123',
-    sendToTwilio: async (payload) => {
-      twilioPayloads.push(payload);
+    surface: 'phone',
+    audioFormat: { type: 'audio/pcmu' },
+    sendAudio: async (base64Audio) => {
+      sentAudio.push(base64Audio);
+    },
+    clearPlayback: async () => {
+      clears.push(1);
     },
     consultAgent,
     onTranscript: (role, text) => {
@@ -106,7 +112,8 @@ function createBridge(overrides?: Partial<RealtimeBridgeOptions>): {
   return {
     bridge,
     socket,
-    twilioPayloads,
+    sentAudio,
+    clears,
     states,
     transcripts,
     errors,
@@ -126,6 +133,27 @@ test('buildRealtimeInstructions layers persona, caller details, and extras', () 
   expect(instructions).toContain('name Ada Example');
   expect(instructions).toContain('calling from +15550001111');
   expect(instructions).toContain('Prefer metric units.');
+});
+
+test('web surface swaps the phone framing and PCM16 audio format', () => {
+  const instructions = buildRealtimeInstructions(REALTIME_CONFIG, CALLER, 'web');
+  expect(instructions).toContain('web console');
+  expect(instructions).not.toContain('phone call');
+  expect(instructions).toContain('User details');
+
+  const { socket } = createBridge({
+    surface: 'web',
+    audioFormat: { type: 'audio/pcm', rate: 24000 },
+  });
+  socket.open();
+  const [sessionUpdate] = socket.sentOfType('session.update');
+  const session = sessionUpdate.session as Record<string, unknown>;
+  const audio = session.audio as {
+    input: { format: { type: string; rate?: number } };
+    output: { format: { type: string; rate?: number } };
+  };
+  expect(audio.input.format).toEqual({ type: 'audio/pcm', rate: 24000 });
+  expect(audio.output.format).toEqual({ type: 'audio/pcm', rate: 24000 });
 });
 
 test('bridge configures a µ-law realtime session and speaks the greeting', () => {
@@ -153,8 +181,8 @@ test('bridge configures a µ-law realtime session and speaks the greeting', () =
   });
 });
 
-test('bridge forwards caller audio upstream and model audio to Twilio', () => {
-  const { bridge, socket, twilioPayloads, states } = createBridge();
+test('bridge forwards caller audio upstream and model audio downstream', () => {
+  const { bridge, socket, sentAudio, states } = createBridge();
   socket.open();
 
   bridge.handleCallerAudio('dGVzdA==');
@@ -164,14 +192,12 @@ test('bridge forwards caller audio upstream and model audio to Twilio', () => {
 
   socket.serverEvent({ type: 'response.created' });
   socket.serverEvent({ type: 'response.output_audio.delta', delta: 'bXU=' });
-  expect(twilioPayloads).toEqual([
-    { event: 'media', streamSid: 'MZ123', media: { payload: 'bXU=' } },
-  ]);
+  expect(sentAudio).toEqual(['bXU=']);
   expect(states).toContain('speaking');
 });
 
-test('caller speech clears Twilio audio and cancels the active response', () => {
-  const { socket, twilioPayloads, states } = createBridge();
+test('caller speech clears queued playback and cancels the active response', () => {
+  const { socket, clears, states } = createBridge();
   socket.open();
   socket.serverEvent({ type: 'response.created' });
 
@@ -179,7 +205,7 @@ test('caller speech clears Twilio audio and cancels the active response', () => 
 
   expect(states).toContain('listening');
   expect(socket.sentOfType('response.cancel')).toHaveLength(1);
-  expect(twilioPayloads).toContainEqual({ event: 'clear', streamSid: 'MZ123' });
+  expect(clears).toHaveLength(1);
 
   // A second speech start without an active response must not double-cancel.
   socket.serverEvent({ type: 'input_audio_buffer.speech_started' });

--- a/tests/voice.realtime-bridge.test.ts
+++ b/tests/voice.realtime-bridge.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../src/channels/voice/realtime-bridge.js';
 
 const REALTIME_CONFIG = {
+  provider: 'openai' as const,
   model: 'gpt-realtime',
   voice: 'marin',
   greeting: 'Hi there!',
@@ -80,7 +81,10 @@ function createBridge(overrides?: Partial<RealtimeBridgeOptions>): {
   const errors: string[] = [];
   const consultAgent = vi.fn(async () => 'You have two meetings today.');
   const bridge = new RealtimeCallBridge({
-    apiKey: 'test-key',
+    connection: {
+      url: 'wss://api.openai.com/v1/realtime',
+      apiKey: 'test-key',
+    },
     config: REALTIME_CONFIG,
     caller: CALLER,
     surface: 'phone',

--- a/tests/voice.realtime-bridge.test.ts
+++ b/tests/voice.realtime-bridge.test.ts
@@ -326,6 +326,27 @@ test('malformed tool arguments produce a rephrase prompt', async () => {
   expect(String(output?.output)).toContain('rephrase');
 });
 
+test('late response.cancel rejections stay silent; real errors surface', () => {
+  const { socket, errors } = createBridge();
+  socket.open();
+
+  socket.serverEvent({
+    type: 'error',
+    error: {
+      type: 'invalid_request_error',
+      code: 'response_cancel_not_active',
+      message: 'Cancellation failed: no active response found',
+    },
+  });
+  expect(errors).toHaveLength(0);
+
+  socket.serverEvent({
+    type: 'error',
+    error: { type: 'server_error', message: 'boom' },
+  });
+  expect(errors).toEqual(['boom']);
+});
+
 test('DTMF digits are injected as caller text', () => {
   const { bridge, socket } = createBridge();
   socket.open();

--- a/tests/voice.realtime-bridge.test.ts
+++ b/tests/voice.realtime-bridge.test.ts
@@ -249,7 +249,10 @@ test('consult_agent tool calls run the gateway turn and return its reply', async
 
   expect(consultAgent).toHaveBeenCalledWith(
     'What is on my calendar?',
-    expect.any(AbortSignal),
+    expect.objectContaining({
+      abortSignal: expect.any(AbortSignal),
+      onToolProgress: expect.any(Function),
+    }),
   );
   expect(states).toContain('thinking');
   const outputs = socket
@@ -382,6 +385,104 @@ test('DTMF digits are injected as caller text', () => {
   expect(items).toHaveLength(1);
   const content = items[0].content as Array<{ type: string; text: string }>;
   expect(content[0].text).toContain('"5"');
+});
+
+test('long consults speak out-of-band reassurance with live tool activity', async () => {
+  vi.useFakeTimers();
+  try {
+    let resolveConsult: (reply: string) => void = () => {};
+    let toolProgress: (event: {
+      toolName: string;
+      phase: 'start' | 'finish';
+    }) => void = () => {};
+    const consultAgent = vi.fn(
+      (_request: string, hooks: { onToolProgress: typeof toolProgress }) => {
+        toolProgress = hooks.onToolProgress;
+        return new Promise<string>((resolve) => {
+          resolveConsult = resolve;
+        });
+      },
+    );
+    const consultActivity: Array<string | null> = [];
+    const { socket } = createBridge({
+      consultAgent,
+      onConsultActivity: (label) => {
+        consultActivity.push(label);
+      },
+    });
+    socket.open();
+    socket.serverEvent({
+      type: 'response.function_call_arguments.done',
+      call_id: 'call_1',
+      name: 'consult_agent',
+      arguments: JSON.stringify({ request: 'Audit my inbox' }),
+    });
+    await Promise.resolve();
+
+    toolProgress({ toolName: 'web_search', phase: 'start' });
+    expect(consultActivity).toEqual(['web search']);
+
+    await vi.advanceTimersByTimeAsync(7_000);
+    const [first] = socket.sentOfType('response.create');
+    expect(first.response).toEqual({
+      conversation: 'none',
+      instructions: expect.stringContaining('web search'),
+    });
+
+    // Repeats stay out-of-band on the follow-up cadence.
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(socket.sentOfType('response.create')).toHaveLength(2);
+
+    resolveConsult('Inbox is clean.');
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(consultActivity).toEqual(['web search', null]);
+
+    // No further reassurance once the consult resolved.
+    await vi.advanceTimersByTimeAsync(30_000);
+    const reassurances = socket
+      .sentOfType('response.create')
+      .filter(
+        (event) =>
+          (event.response as { conversation?: string } | undefined)
+            ?.conversation === 'none',
+      );
+    expect(reassurances).toHaveLength(2);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('reassurance stays silent while the caller speaks or the model talks', async () => {
+  vi.useFakeTimers();
+  try {
+    const consultAgent = vi.fn(() => new Promise<string>(() => {}));
+    const { socket } = createBridge({ consultAgent });
+    socket.open();
+    socket.serverEvent({
+      type: 'response.function_call_arguments.done',
+      call_id: 'call_1',
+      name: 'consult_agent',
+      arguments: JSON.stringify({ request: 'Slow request' }),
+    });
+    await Promise.resolve();
+
+    // Caller starts speaking before the first reassurance fires.
+    socket.serverEvent({ type: 'input_audio_buffer.speech_started' });
+    await vi.advanceTimersByTimeAsync(7_000);
+    expect(socket.sentOfType('response.create')).toHaveLength(0);
+
+    // Their utterance is transcribed; the next tick may speak again.
+    socket.serverEvent({
+      type: 'conversation.item.input_audio_transcription.completed',
+      transcript: 'Take your time.',
+    });
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(socket.sentOfType('response.create')).toHaveLength(1);
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 test('transcripts are surfaced per role and close aborts consults', () => {

--- a/tests/voice.realtime-bridge.test.ts
+++ b/tests/voice.realtime-bridge.test.ts
@@ -196,6 +196,25 @@ test('bridge forwards caller audio upstream and model audio downstream', () => {
   expect(states).toContain('speaking');
 });
 
+test('caller audio from before the socket opens is flushed after setup', () => {
+  const { bridge, socket } = createBridge();
+  socket.readyState = 0;
+
+  bridge.handleCallerAudio('ZWFybHk=');
+  expect(socket.sentOfType('input_audio_buffer.append')).toHaveLength(0);
+
+  socket.readyState = 1;
+  socket.open();
+
+  const types = socket.sent.map((event) => event.type);
+  expect(types.indexOf('session.update')).toBeLessThan(
+    types.indexOf('input_audio_buffer.append'),
+  );
+  expect(socket.sentOfType('input_audio_buffer.append')).toEqual([
+    { type: 'input_audio_buffer.append', audio: 'ZWFybHk=' },
+  ]);
+});
+
 test('caller speech clears queued playback and cancels the active response', () => {
   const { socket, clears, states } = createBridge();
   socket.open();

--- a/tests/voice.realtime-bridge.test.ts
+++ b/tests/voice.realtime-bridge.test.ts
@@ -1,0 +1,337 @@
+import { expect, test, vi } from 'vitest';
+import type { RealtimeSocket } from '../src/channels/voice/openai-realtime.js';
+import {
+  buildRealtimeInstructions,
+  RealtimeCallBridge,
+  type RealtimeBridgeOptions,
+  type RealtimeBridgeState,
+} from '../src/channels/voice/realtime-bridge.js';
+
+const REALTIME_CONFIG = {
+  model: 'gpt-realtime',
+  voice: 'marin',
+  greeting: 'Hi there!',
+  instructions: 'Prefer metric units.',
+};
+
+const CALLER = {
+  from: '+15550001111',
+  to: '+15550002222',
+  callerName: 'Ada Example',
+};
+
+class FakeRealtimeSocket implements RealtimeSocket {
+  readyState = 1;
+  url = '';
+  headers: Record<string, string> = {};
+  sent: Array<Record<string, unknown>> = [];
+  private listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+  on(event: string, listener: (...args: unknown[]) => void): void {
+    const existing = this.listeners.get(event) || [];
+    existing.push(listener);
+    this.listeners.set(event, existing);
+  }
+
+  send(data: string, cb?: (error?: Error) => void): void {
+    this.sent.push(JSON.parse(data) as Record<string, unknown>);
+    cb?.();
+  }
+
+  close(): void {
+    this.readyState = 3;
+    this.emit('close');
+  }
+
+  emit(event: string, ...args: unknown[]): void {
+    for (const listener of this.listeners.get(event) || []) {
+      listener(...args);
+    }
+  }
+
+  open(): void {
+    this.emit('open');
+  }
+
+  serverEvent(event: Record<string, unknown>): void {
+    this.emit('message', JSON.stringify(event));
+  }
+
+  sentOfType(type: string): Array<Record<string, unknown>> {
+    return this.sent.filter((event) => event.type === type);
+  }
+}
+
+function createBridge(overrides?: Partial<RealtimeBridgeOptions>): {
+  bridge: RealtimeCallBridge;
+  socket: FakeRealtimeSocket;
+  twilioPayloads: Array<Record<string, unknown>>;
+  states: RealtimeBridgeState[];
+  transcripts: Array<{ role: string; text: string }>;
+  errors: string[];
+  consultAgent: ReturnType<typeof vi.fn>;
+} {
+  const socket = new FakeRealtimeSocket();
+  const twilioPayloads: Array<Record<string, unknown>> = [];
+  const states: RealtimeBridgeState[] = [];
+  const transcripts: Array<{ role: string; text: string }> = [];
+  const errors: string[] = [];
+  const consultAgent = vi.fn(async () => 'You have two meetings today.');
+  const bridge = new RealtimeCallBridge({
+    apiKey: 'test-key',
+    config: REALTIME_CONFIG,
+    caller: CALLER,
+    streamSid: 'MZ123',
+    sendToTwilio: async (payload) => {
+      twilioPayloads.push(payload);
+    },
+    consultAgent,
+    onTranscript: (role, text) => {
+      transcripts.push({ role, text });
+    },
+    onStateChange: (state) => {
+      states.push(state);
+    },
+    onError: (message) => {
+      errors.push(message);
+    },
+    onClosed: () => {},
+    socketFactory: (url, headers) => {
+      socket.url = url;
+      socket.headers = headers;
+      return socket;
+    },
+    ...overrides,
+  });
+  return {
+    bridge,
+    socket,
+    twilioPayloads,
+    states,
+    transcripts,
+    errors,
+    consultAgent,
+  };
+}
+
+async function flushAsync(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+test('buildRealtimeInstructions layers persona, caller details, and extras', () => {
+  const instructions = buildRealtimeInstructions(REALTIME_CONFIG, CALLER);
+
+  expect(instructions).toContain('realtime voice of HybridClaw');
+  expect(instructions).toContain('consult_agent');
+  expect(instructions).toContain('name Ada Example');
+  expect(instructions).toContain('calling from +15550001111');
+  expect(instructions).toContain('Prefer metric units.');
+});
+
+test('bridge configures a µ-law realtime session and speaks the greeting', () => {
+  const { socket } = createBridge();
+  socket.open();
+
+  expect(socket.url).toContain('model=gpt-realtime');
+  expect(socket.headers.Authorization).toBe('Bearer test-key');
+  const [sessionUpdate] = socket.sentOfType('session.update');
+  const session = sessionUpdate.session as Record<string, unknown>;
+  const audio = session.audio as {
+    input: { format: { type: string } };
+    output: { format: { type: string }; voice: string };
+  };
+  expect(audio.input.format.type).toBe('audio/pcmu');
+  expect(audio.output.format.type).toBe('audio/pcmu');
+  expect(audio.output.voice).toBe('marin');
+  const tools = session.tools as Array<{ name: string }>;
+  expect(tools.map((tool) => tool.name)).toEqual(['consult_agent']);
+
+  socket.serverEvent({ type: 'session.updated' });
+  const [greeting] = socket.sentOfType('response.create');
+  expect(greeting.response).toEqual({
+    instructions: 'Greet the caller by saying: "Hi there!"',
+  });
+});
+
+test('bridge forwards caller audio upstream and model audio to Twilio', () => {
+  const { bridge, socket, twilioPayloads, states } = createBridge();
+  socket.open();
+
+  bridge.handleCallerAudio('dGVzdA==');
+  expect(socket.sentOfType('input_audio_buffer.append')).toEqual([
+    { type: 'input_audio_buffer.append', audio: 'dGVzdA==' },
+  ]);
+
+  socket.serverEvent({ type: 'response.created' });
+  socket.serverEvent({ type: 'response.output_audio.delta', delta: 'bXU=' });
+  expect(twilioPayloads).toEqual([
+    { event: 'media', streamSid: 'MZ123', media: { payload: 'bXU=' } },
+  ]);
+  expect(states).toContain('speaking');
+});
+
+test('caller speech clears Twilio audio and cancels the active response', () => {
+  const { socket, twilioPayloads, states } = createBridge();
+  socket.open();
+  socket.serverEvent({ type: 'response.created' });
+
+  socket.serverEvent({ type: 'input_audio_buffer.speech_started' });
+
+  expect(states).toContain('listening');
+  expect(socket.sentOfType('response.cancel')).toHaveLength(1);
+  expect(twilioPayloads).toContainEqual({ event: 'clear', streamSid: 'MZ123' });
+
+  // A second speech start without an active response must not double-cancel.
+  socket.serverEvent({ type: 'input_audio_buffer.speech_started' });
+  expect(socket.sentOfType('response.cancel')).toHaveLength(1);
+});
+
+test('consult_agent tool calls run the gateway turn and return its reply', async () => {
+  const { socket, states, consultAgent } = createBridge();
+  socket.open();
+
+  socket.serverEvent({
+    type: 'response.function_call_arguments.done',
+    call_id: 'call_1',
+    name: 'consult_agent',
+    arguments: JSON.stringify({ request: 'What is on my calendar?' }),
+  });
+  await flushAsync();
+
+  expect(consultAgent).toHaveBeenCalledWith(
+    'What is on my calendar?',
+    expect.any(AbortSignal),
+  );
+  expect(states).toContain('thinking');
+  const outputs = socket
+    .sentOfType('conversation.item.create')
+    .map((event) => event.item as Record<string, unknown>);
+  expect(outputs).toContainEqual({
+    type: 'function_call_output',
+    call_id: 'call_1',
+    output: 'You have two meetings today.',
+  });
+  expect(socket.sentOfType('response.create').length).toBeGreaterThan(0);
+});
+
+test('concurrent consults are rejected while one is in flight', async () => {
+  let resolveConsult: (reply: string) => void = () => {};
+  const consultAgent = vi.fn(
+    () =>
+      new Promise<string>((resolve) => {
+        resolveConsult = resolve;
+      }),
+  );
+  const { socket } = createBridge({ consultAgent });
+  socket.open();
+
+  socket.serverEvent({
+    type: 'response.function_call_arguments.done',
+    call_id: 'call_1',
+    name: 'consult_agent',
+    arguments: JSON.stringify({ request: 'First request' }),
+  });
+  socket.serverEvent({
+    type: 'response.function_call_arguments.done',
+    call_id: 'call_2',
+    name: 'consult_agent',
+    arguments: JSON.stringify({ request: 'Second request' }),
+  });
+  await flushAsync();
+
+  expect(consultAgent).toHaveBeenCalledTimes(1);
+  const busyOutput = socket
+    .sentOfType('conversation.item.create')
+    .map((event) => event.item as Record<string, unknown>)
+    .find((item) => item.call_id === 'call_2');
+  expect(String(busyOutput?.output)).toContain('still working');
+
+  resolveConsult('Done.');
+  await flushAsync();
+  const firstOutput = socket
+    .sentOfType('conversation.item.create')
+    .map((event) => event.item as Record<string, unknown>)
+    .find((item) => item.call_id === 'call_1');
+  expect(firstOutput?.output).toBe('Done.');
+});
+
+test('consult failures surface an apologetic tool output, not silence', async () => {
+  const consultAgent = vi.fn(async () => {
+    throw new Error('container crashed');
+  });
+  const { socket, errors } = createBridge({ consultAgent });
+  socket.open();
+
+  socket.serverEvent({
+    type: 'response.function_call_arguments.done',
+    call_id: 'call_1',
+    name: 'consult_agent',
+    arguments: JSON.stringify({ request: 'Do the thing' }),
+  });
+  await flushAsync();
+
+  expect(errors.some((entry) => entry.includes('container crashed'))).toBe(
+    true,
+  );
+  const output = socket
+    .sentOfType('conversation.item.create')
+    .map((event) => event.item as Record<string, unknown>)
+    .find((item) => item.call_id === 'call_1');
+  expect(String(output?.output)).toContain('hit an error');
+});
+
+test('malformed tool arguments produce a rephrase prompt', async () => {
+  const { socket, consultAgent } = createBridge();
+  socket.open();
+
+  socket.serverEvent({
+    type: 'response.function_call_arguments.done',
+    call_id: 'call_1',
+    name: 'consult_agent',
+    arguments: 'not-json',
+  });
+  await flushAsync();
+
+  expect(consultAgent).not.toHaveBeenCalled();
+  const output = socket
+    .sentOfType('conversation.item.create')
+    .map((event) => event.item as Record<string, unknown>)
+    .find((item) => item.call_id === 'call_1');
+  expect(String(output?.output)).toContain('rephrase');
+});
+
+test('DTMF digits are injected as caller text', () => {
+  const { bridge, socket } = createBridge();
+  socket.open();
+
+  bridge.handleDtmf('5');
+
+  const items = socket
+    .sentOfType('conversation.item.create')
+    .map((event) => event.item as Record<string, unknown>);
+  expect(items).toHaveLength(1);
+  const content = items[0].content as Array<{ type: string; text: string }>;
+  expect(content[0].text).toContain('"5"');
+});
+
+test('transcripts are surfaced per role and close aborts consults', () => {
+  const { bridge, socket, transcripts } = createBridge();
+  socket.open();
+
+  socket.serverEvent({
+    type: 'conversation.item.input_audio_transcription.completed',
+    transcript: 'What time is it?',
+  });
+  socket.serverEvent({
+    type: 'response.output_audio_transcript.done',
+    transcript: 'It is noon.',
+  });
+
+  expect(transcripts).toEqual([
+    { role: 'caller', text: 'What time is it?' },
+    { role: 'assistant', text: 'It is noon.' },
+  ]);
+
+  bridge.close();
+  expect(bridge.isOpen).toBe(false);
+});

--- a/tests/voice.realtime-credentials.test.ts
+++ b/tests/voice.realtime-credentials.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+afterEach(() => {
+  vi.doUnmock('../src/config/config.js');
+  vi.doUnmock('../src/auth/hybridai-auth.js');
+  vi.resetModules();
+});
+
+async function loadCredentials(params: {
+  openaiKey?: string;
+  hybridaiKey?: string | null;
+  baseUrl?: string;
+}) {
+  vi.doMock('../src/config/config.js', () => ({
+    OPENAI_API_KEY: params.openaiKey ?? '',
+    HYBRIDAI_BASE_URL: params.baseUrl ?? 'https://hybridai.one',
+  }));
+  vi.doMock('../src/auth/hybridai-auth.js', () => ({
+    readHybridAIApiKey: () => params.hybridaiKey ?? null,
+  }));
+  return import('../src/channels/voice/realtime-credentials.js');
+}
+
+test('openai provider connects to api.openai.com with OPENAI_API_KEY', async () => {
+  const credentials = await loadCredentials({ openaiKey: 'sk-test' });
+
+  const resolved = credentials.resolveRealtimeConnection('openai');
+
+  expect(resolved.connection).toEqual({
+    url: 'wss://api.openai.com/v1/realtime',
+    apiKey: 'sk-test',
+  });
+  expect(credentials.isRealtimeCredentialConfigured('openai')).toBe(true);
+});
+
+test('openai provider without a key explains the missing credential', async () => {
+  const credentials = await loadCredentials({ openaiKey: '' });
+
+  const resolved = credentials.resolveRealtimeConnection('openai');
+
+  expect(resolved.connection).toBeNull();
+  expect(resolved.error).toContain('OPENAI_API_KEY');
+  expect(credentials.isRealtimeCredentialConfigured('openai')).toBe(false);
+});
+
+test('hybridai provider derives a wss URL from HYBRIDAI_BASE_URL', async () => {
+  const credentials = await loadCredentials({
+    hybridaiKey: 'hai-key',
+    baseUrl: 'https://hybridai.one/',
+  });
+
+  const resolved = credentials.resolveRealtimeConnection('hybridai');
+
+  expect(resolved.connection).toEqual({
+    url: 'wss://hybridai.one/v1/realtime',
+    apiKey: 'hai-key',
+  });
+});
+
+test('hybridai provider keeps plain ws for http dev base URLs', async () => {
+  const credentials = await loadCredentials({
+    hybridaiKey: 'hai-key',
+    baseUrl: 'http://127.0.0.1:5000',
+  });
+
+  const resolved = credentials.resolveRealtimeConnection('hybridai');
+
+  expect(resolved.connection?.url).toBe('ws://127.0.0.1:5000/v1/realtime');
+});
+
+test('hybridai provider without a signed-in key explains itself', async () => {
+  const credentials = await loadCredentials({
+    hybridaiKey: null,
+    openaiKey: 'sk-unrelated',
+  });
+
+  const resolved = credentials.resolveRealtimeConnection('hybridai');
+
+  expect(resolved.connection).toBeNull();
+  expect(resolved.error).toContain('HybridAI API key');
+  expect(credentials.isRealtimeCredentialConfigured('hybridai')).toBe(false);
+});

--- a/tests/voice.runtime.test.ts
+++ b/tests/voice.runtime.test.ts
@@ -232,6 +232,92 @@ test('handleVoiceWebhook hangs up cleanly when voice runtime is unavailable', as
   await shutdownVoice();
 });
 
+test('handleVoiceWebhook returns media stream TwiML in realtime mode', async () => {
+  const getConfigSnapshot = vi.fn(() => ({
+    voice: {
+      enabled: true,
+      provider: 'twilio',
+      mode: 'realtime',
+      twilio: {
+        accountSid: 'AC123',
+        authToken: '',
+        fromNumber: '+14155550123',
+      },
+      relay: {
+        ttsProvider: 'default',
+        voice: '',
+        transcriptionProvider: 'default',
+        language: 'en-US',
+        interruptible: true,
+        welcomeGreeting: 'Hello! How can I help you today?',
+      },
+      realtime: {
+        model: 'gpt-realtime',
+        voice: 'marin',
+        greeting: 'Hello! How can I help you today?',
+        instructions: '',
+      },
+      webhookPath: '/voice',
+      maxConcurrentCalls: 8,
+    },
+  }));
+
+  vi.doMock('../src/config/config.js', () => ({
+    GATEWAY_BASE_URL: '',
+    OPENAI_API_KEY: 'test-key',
+    TWILIO_AUTH_TOKEN: 'env-voice-token',
+    getConfigSnapshot,
+  }));
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+  }));
+
+  const { handleVoiceWebhook, initVoice, shutdownVoice } = await import(
+    '../src/channels/voice/runtime.js'
+  );
+  await initVoice(async () => {});
+  const body = {
+    CallSid: 'CA123',
+    From: '+15550001111',
+    To: '+15550002222',
+  };
+  const signature = buildTwilioSignature({
+    authToken: 'env-voice-token',
+    url: 'https://voice.example.com/voice/webhook',
+    values: body,
+  });
+  const req = makeFormRequest({
+    url: '/voice/webhook',
+    body,
+    headers: {
+      'x-forwarded-proto': 'https',
+      'x-twilio-signature': signature,
+    },
+  });
+  const res = makeResponse();
+
+  const handled = await handleVoiceWebhook(
+    req as never,
+    res as never,
+    new URL('http://voice.example.com/voice/webhook'),
+  );
+
+  expect(handled).toBe(true);
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toContain(
+    '<Stream url="wss://voice.example.com/voice/stream">',
+  );
+  expect(res.body).toContain('<Parameter name="callReference" value="CA123" />');
+  expect(res.body).not.toContain('<ConversationRelay');
+
+  await shutdownVoice();
+});
+
 test('handleVoiceWebhook rejects duplicate Twilio webhook replays', async () => {
   const getConfigSnapshot = vi.fn(() => ({
     voice: {

--- a/tests/vonage-voice-plugin.realtime.test.ts
+++ b/tests/vonage-voice-plugin.realtime.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { buildRealtimeConnectNcco } from '../plugins/vonage-voice/src/ncco.js';
+import { createVonageRealtimeStreams } from '../plugins/vonage-voice/src/realtime.js';
+
+const CONFIG = {
+  publicBaseUrl: 'https://voice.example.com',
+  welcomeGreeting: 'Hello there!',
+  language: 'en-US',
+};
+
+const CALL = { uuid: 'call-1', from: '+15550001111', to: '+15550002222' };
+
+class FakeStreamSocket {
+  readyState = 1;
+  sent: Buffer[] = [];
+  closeCode: number | null = null;
+  private listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+  on(event: string, listener: (...args: unknown[]) => void): void {
+    const existing = this.listeners.get(event) || [];
+    existing.push(listener);
+    this.listeners.set(event, existing);
+  }
+
+  send(data: Buffer): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number): void {
+    this.readyState = 3;
+    this.closeCode = code ?? 1000;
+    for (const listener of this.listeners.get('close') || []) {
+      listener(this.closeCode, Buffer.alloc(0));
+    }
+  }
+
+  emit(event: string, ...args: unknown[]): void {
+    for (const listener of this.listeners.get(event) || []) listener(...args);
+  }
+}
+
+function createFakeSession() {
+  return {
+    handleCallerAudio: vi.fn(),
+    handleDtmf: vi.fn(),
+    close: vi.fn(),
+    isOpen: true,
+  };
+}
+
+function createApi(session = createFakeSession()) {
+  return {
+    api: {
+      config: { agents: { defaultAgentId: 'main' } },
+      createRealtimeVoiceSession: vi.fn(() => session),
+      isRealtimeVoiceAvailable: () => true,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    },
+    session,
+  };
+}
+
+function createCtx(token: string | null, ws = new FakeStreamSocket()) {
+  const url = new URL(
+    `https://voice.example.com/api/plugin-webhooks/vonage-voice/stream${
+      token ? `?token=${token}` : ''
+    }`,
+  );
+  const rejections: Array<{ statusCode: number; message: string }> = [];
+  const accept = vi.fn(async () => ws);
+  return {
+    ctx: {
+      url,
+      webhookName: 'stream',
+      logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+      accept,
+      reject: (statusCode: number, message: string) => {
+        rejections.push({ statusCode, message });
+      },
+    },
+    ws,
+    accept,
+    rejections,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test('realtime connect NCCO points the call at the stream websocket', () => {
+  const ncco = buildRealtimeConnectNcco({
+    websocketUri: 'wss://voice.example.com/api/plugin-webhooks/vonage-voice/stream?token=abc',
+    callUuid: 'call-1',
+    language: 'en-US',
+  }) as Array<Record<string, unknown>>;
+
+  expect(ncco[0].action).toBe('connect');
+  const endpoint = (ncco[0].endpoint as Array<Record<string, unknown>>)[0];
+  expect(endpoint.type).toBe('websocket');
+  expect(endpoint['content-type']).toBe('audio/l16;rate=8000');
+  expect(endpoint.headers).toEqual({ callUuid: 'call-1' });
+  expect(String(endpoint.uri)).toContain('?token=abc');
+  // The trailing talk ends the call cleanly once the websocket leg closes.
+  expect(ncco.at(-1)?.action).toBe('talk');
+});
+
+test('a minted token upgrades once and wires audio to the realtime session', async () => {
+  const { api, session } = createApi();
+  const streams = createVonageRealtimeStreams(api, CONFIG);
+
+  const token = streams.mintStreamToken(CALL);
+  expect(streams.websocketUri(token)).toBe(
+    `wss://voice.example.com/api/plugin-webhooks/vonage-voice/stream?token=${token}`,
+  );
+
+  const { ctx, ws, accept } = createCtx(token);
+  await streams.handleStreamUpgrade(ctx);
+  expect(accept).toHaveBeenCalled();
+  expect(api.createRealtimeVoiceSession).toHaveBeenCalledWith(
+    expect.objectContaining({
+      caller: { from: CALL.from, to: CALL.to },
+      greeting: CONFIG.welcomeGreeting,
+      session: expect.objectContaining({
+        sessionId: 'agent:main:channel:voice:chat:dm:peer:call-1',
+        channelId: 'voice:call-1',
+        userId: CALL.from,
+      }),
+    }),
+  );
+
+  const frame = Buffer.alloc(320, 1);
+  ws.emit('message', frame, true);
+  expect(session.handleCallerAudio).toHaveBeenCalledWith(frame);
+
+  // Text lifecycle frames are ignored.
+  ws.emit('message', JSON.stringify({ event: 'websocket:connected' }), false);
+  expect(session.handleCallerAudio).toHaveBeenCalledTimes(1);
+
+  // Model audio goes out through the session's sendAudio seam.
+  const sessionOptions = (
+    api.createRealtimeVoiceSession as ReturnType<typeof vi.fn>
+  ).mock.calls[0][0] as { sendAudio: (frame: Buffer) => void };
+  sessionOptions.sendAudio(Buffer.alloc(320, 2));
+  expect(ws.sent).toHaveLength(1);
+
+  ws.close();
+  expect(session.close).toHaveBeenCalled();
+
+  // The token is single-use.
+  const second = createCtx(token);
+  await streams.handleStreamUpgrade(second.ctx);
+  expect(second.rejections).toEqual([
+    { statusCode: 401, message: 'Invalid stream token' },
+  ]);
+});
+
+test('missing and expired tokens are rejected before accept', async () => {
+  vi.useFakeTimers();
+  const { api } = createApi();
+  const streams = createVonageRealtimeStreams(api, CONFIG);
+
+  const missing = createCtx(null);
+  await streams.handleStreamUpgrade(missing.ctx);
+  expect(missing.rejections[0]?.statusCode).toBe(401);
+  expect(missing.accept).not.toHaveBeenCalled();
+
+  const token = streams.mintStreamToken(CALL);
+  vi.advanceTimersByTime(31_000);
+  const stale = createCtx(token);
+  await streams.handleStreamUpgrade(stale.ctx);
+  expect(stale.rejections[0]?.statusCode).toBe(401);
+});
+
+test('a failed session start closes the accepted socket', async () => {
+  const { api } = createApi();
+  (api.createRealtimeVoiceSession as ReturnType<typeof vi.fn>)
+    .mockImplementation(() => {
+      throw new Error('Realtime voice requires an OpenAI API key.');
+    });
+  const streams = createVonageRealtimeStreams(api, CONFIG);
+  const token = streams.mintStreamToken(CALL);
+
+  const { ctx, ws } = createCtx(token);
+  await streams.handleStreamUpgrade(ctx);
+  expect(ws.closeCode).toBe(1011);
+});
+
+test('stop closes all active streams and invalidates tokens', async () => {
+  const { api, session } = createApi();
+  const streams = createVonageRealtimeStreams(api, CONFIG);
+  const token = streams.mintStreamToken(CALL);
+  const { ctx, ws } = createCtx(token);
+  await streams.handleStreamUpgrade(ctx);
+  const unusedToken = streams.mintStreamToken({ ...CALL, uuid: 'call-2' });
+
+  streams.stop();
+
+  expect(session.close).toHaveBeenCalled();
+  expect(ws.readyState).toBe(3);
+  const reuse = createCtx(unusedToken);
+  await streams.handleStreamUpgrade(reuse.ctx);
+  expect(reuse.rejections[0]?.statusCode).toBe(401);
+});

--- a/tests/vonage-voice-plugin.test.ts
+++ b/tests/vonage-voice-plugin.test.ts
@@ -4,10 +4,12 @@ import type {
   PluginCommandDefinition,
   PluginInboundWebhookDefinition,
   PluginService,
+  PluginWebsocketWebhookDefinition,
 } from '../src/plugins/plugin-sdk.js';
 
 function createApi(overrides: Record<string, unknown> = {}) {
   const webhooks: PluginInboundWebhookDefinition[] = [];
+  const websocketWebhooks: PluginWebsocketWebhookDefinition[] = [];
   const commands: PluginCommandDefinition[] = [];
   const services: PluginService[] = [];
   const api = {
@@ -21,27 +23,32 @@ function createApi(overrides: Record<string, unknown> = {}) {
       key === 'VONAGE_PRIVATE_KEY' ? 'test-key' : 'test-secret',
     registerInboundWebhook: (webhook: PluginInboundWebhookDefinition) =>
       webhooks.push(webhook),
+    registerWebsocketWebhook: (webhook: PluginWebsocketWebhookDefinition) =>
+      websocketWebhooks.push(webhook),
     registerCommand: (command: PluginCommandDefinition) =>
       commands.push(command),
     registerService: (service: PluginService) => services.push(service),
     dispatchInboundMessage: vi.fn(),
+    isRealtimeVoiceAvailable: () => true,
+    createRealtimeVoiceSession: vi.fn(),
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     ...overrides,
   } as unknown as HybridClawPluginApi;
-  return { api, webhooks, commands, services };
+  return { api, webhooks, websocketWebhooks, commands, services };
 }
 
 test('registers isolated Vonage webhooks, command, and runtime service', async () => {
-  const { api, webhooks, commands, services } = createApi();
+  const { api, webhooks, websocketWebhooks, commands, services } = createApi();
   const plugin = (await import('../plugins/vonage-voice/src/index.js')).default;
 
   plugin.register(api);
 
   expect(webhooks.map((webhook) => webhook.name)).toEqual([
     'answer',
-    'input',
     'event',
+    'input',
   ]);
+  expect(websocketWebhooks).toHaveLength(0);
   expect(webhooks.every((webhook) => webhook.method === 'POST')).toBe(true);
   expect(commands.map((command) => command.name)).toEqual(['vonage']);
   expect(services.map((service) => service.id)).toEqual([
@@ -49,6 +56,26 @@ test('registers isolated Vonage webhooks, command, and runtime service', async (
   ]);
   await expect(commands[0]?.handler(['info'], {} as never)).resolves.toContain(
     '/api/plugin-webhooks/vonage-voice/answer',
+  );
+});
+
+test('realtime mode swaps the input webhook for a stream websocket', async () => {
+  const { api, webhooks, websocketWebhooks, commands } = createApi({
+    pluginConfig: {
+      applicationId: 'app-id',
+      fromNumber: '+14155550123',
+      publicBaseUrl: 'https://voice.example.com',
+      mode: 'realtime',
+    },
+  });
+  const plugin = (await import('../plugins/vonage-voice/src/index.js')).default;
+
+  plugin.register(api);
+
+  expect(webhooks.map((webhook) => webhook.name)).toEqual(['answer', 'event']);
+  expect(websocketWebhooks.map((webhook) => webhook.name)).toEqual(['stream']);
+  await expect(commands[0]?.handler(['info'], {} as never)).resolves.toContain(
+    'realtime speech-to-speech',
   );
 });
 

--- a/tests/webchat-voice.test.ts
+++ b/tests/webchat-voice.test.ts
@@ -85,6 +85,8 @@ const handleGatewayMessage = vi.fn(async () => ({
   toolsUsed: [],
 }));
 
+const persistVoiceTranscript = vi.fn();
+
 async function createConnection(params?: { apiKey?: string }) {
   vi.doMock('../src/config/config.js', () => ({
     OPENAI_API_KEY: params?.apiKey ?? 'test-key',
@@ -96,6 +98,10 @@ async function createConnection(params?: { apiKey?: string }) {
   }));
   vi.doMock('../src/gateway/gateway-chat-service.js', () => ({
     handleGatewayMessage,
+  }));
+  vi.doMock('../src/gateway/voice-transcript-store.js', () => ({
+    persistVoiceTranscript,
+    VOICE_MESSAGE_SOURCE: 'voice',
   }));
   vi.doMock('../src/logger.js', () => ({
     logger: {
@@ -130,9 +136,11 @@ async function flushAsync(): Promise<void> {
 
 afterEach(() => {
   handleGatewayMessage.mockClear();
+  persistVoiceTranscript.mockClear();
   vi.doUnmock('../src/config/config.js');
   vi.doUnmock('../src/config/runtime-config.js');
   vi.doUnmock('../src/gateway/gateway-chat-service.js');
+  vi.doUnmock('../src/gateway/voice-transcript-store.js');
   vi.doUnmock('../src/logger.js');
   vi.resetModules();
 });
@@ -234,6 +242,39 @@ test('transcripts reach the browser with web roles', async () => {
   expect(browser.sentOfType('transcript')).toEqual([
     { type: 'transcript', role: 'user', text: 'What time is it?' },
     { type: 'transcript', role: 'assistant', text: 'It is noon.' },
+  ]);
+});
+
+test('spoken turns persist into session history as voice messages', async () => {
+  const { browser, realtime } = await createConnection();
+  const sessionId = 'agent:main:channel:web:chat:dm:peer:abc123';
+  browser.clientFrame({ type: 'start', sessionId, agentId: 'main' });
+  realtime.open();
+
+  realtime.serverEvent({
+    type: 'conversation.item.input_audio_transcription.completed',
+    transcript: 'What time is it?',
+  });
+  realtime.serverEvent({
+    type: 'response.output_audio_transcript.done',
+    transcript: 'It is noon.',
+  });
+
+  expect(persistVoiceTranscript.mock.calls.map(([params]) => params)).toEqual([
+    expect.objectContaining({
+      sessionId,
+      channelId: 'web',
+      agentId: 'main',
+      userId: 'user-1',
+      username: 'Ada',
+      role: 'user',
+      text: 'What time is it?',
+    }),
+    expect.objectContaining({
+      sessionId,
+      role: 'assistant',
+      text: 'It is noon.',
+    }),
   ]);
 });
 

--- a/tests/webchat-voice.test.ts
+++ b/tests/webchat-voice.test.ts
@@ -80,10 +80,10 @@ class FakeBrowserSocket {
   }
 }
 
-const handleGatewayMessage = vi.fn(async () => ({
+const handleGatewayMessage = vi.fn(async (_request: unknown) => ({
   status: 'success' as const,
   result: 'You have **two** meetings today.',
-  toolsUsed: [],
+  toolsUsed: [] as string[],
 }));
 
 const persistVoiceTranscript = vi.fn();
@@ -277,6 +277,44 @@ test('spoken turns persist into session history as voice messages', async () => 
       role: 'assistant',
       text: 'It is noon.',
     }),
+  ]);
+});
+
+test('consult tool activity streams to the browser as consult frames', async () => {
+  handleGatewayMessage.mockImplementationOnce(async (request: unknown) => {
+    const req = request as {
+      onToolProgress?: (event: {
+        sessionId: string;
+        toolName: string;
+        phase: 'start' | 'finish';
+      }) => void;
+    };
+    req.onToolProgress?.({
+      sessionId: 'ignored',
+      toolName: 'web_search',
+      phase: 'start',
+    });
+    return {
+      status: 'success' as const,
+      result: 'Found it.',
+      toolsUsed: ['web_search'],
+    };
+  });
+  const { browser, realtime } = await createConnection();
+  browser.clientFrame({ type: 'start' });
+  realtime.open();
+
+  realtime.serverEvent({
+    type: 'response.function_call_arguments.done',
+    call_id: 'call_1',
+    name: 'consult_agent',
+    arguments: JSON.stringify({ request: 'Find the doc' }),
+  });
+  await flushAsync();
+
+  expect(browser.sentOfType('consult')).toEqual([
+    { type: 'consult', label: 'web search' },
+    { type: 'consult', label: null },
   ]);
 });
 

--- a/tests/webchat-voice.test.ts
+++ b/tests/webchat-voice.test.ts
@@ -2,6 +2,7 @@ import { afterEach, expect, test, vi } from 'vitest';
 import type { RealtimeSocket } from '../src/channels/voice/openai-realtime.js';
 
 const REALTIME_CONFIG = {
+  provider: 'openai' as const,
   model: 'gpt-realtime',
   voice: 'marin',
   greeting: 'Hello from voice!',
@@ -90,6 +91,7 @@ const persistVoiceTranscript = vi.fn();
 async function createConnection(params?: { apiKey?: string }) {
   vi.doMock('../src/config/config.js', () => ({
     OPENAI_API_KEY: params?.apiKey ?? 'test-key',
+    HYBRIDAI_BASE_URL: 'https://hybridai.example',
     getConfigSnapshot: () => ({ voice: { realtime: REALTIME_CONFIG } }),
   }));
   vi.doMock('../src/config/runtime-config.js', () => ({

--- a/tests/webchat-voice.test.ts
+++ b/tests/webchat-voice.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import type { RealtimeSocket } from '../src/channels/voice/openai-realtime.js';
+
+const REALTIME_CONFIG = {
+  model: 'gpt-realtime',
+  voice: 'marin',
+  greeting: 'Hello from voice!',
+  instructions: '',
+};
+
+class FakeRealtimeSocket implements RealtimeSocket {
+  readyState = 1;
+  url = '';
+  sent: Array<Record<string, unknown>> = [];
+  private listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+  on(event: string, listener: (...args: unknown[]) => void): void {
+    const existing = this.listeners.get(event) || [];
+    existing.push(listener);
+    this.listeners.set(event, existing);
+  }
+
+  send(data: string, cb?: (error?: Error) => void): void {
+    this.sent.push(JSON.parse(data) as Record<string, unknown>);
+    cb?.();
+  }
+
+  close(): void {
+    this.readyState = 3;
+    for (const listener of this.listeners.get('close') || []) listener();
+  }
+
+  open(): void {
+    for (const listener of this.listeners.get('open') || []) listener();
+  }
+
+  serverEvent(event: Record<string, unknown>): void {
+    for (const listener of this.listeners.get('message') || []) {
+      listener(JSON.stringify(event));
+    }
+  }
+
+  sentOfType(type: string): Array<Record<string, unknown>> {
+    return this.sent.filter((event) => event.type === type);
+  }
+}
+
+class FakeBrowserSocket {
+  readyState = 1;
+  sent: Array<Record<string, unknown>> = [];
+  closeCode: number | null = null;
+  private listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+  on(event: string, listener: (...args: unknown[]) => void): void {
+    const existing = this.listeners.get(event) || [];
+    existing.push(listener);
+    this.listeners.set(event, existing);
+  }
+
+  send(data: string, cb?: (error?: Error) => void): void {
+    this.sent.push(JSON.parse(data) as Record<string, unknown>);
+    cb?.();
+  }
+
+  close(code?: number): void {
+    this.readyState = 3;
+    this.closeCode = code ?? 1000;
+    for (const listener of this.listeners.get('close') || []) listener();
+  }
+
+  clientFrame(frame: Record<string, unknown>): void {
+    for (const listener of this.listeners.get('message') || []) {
+      listener(JSON.stringify(frame));
+    }
+  }
+
+  sentOfType(type: string): Array<Record<string, unknown>> {
+    return this.sent.filter((frame) => frame.type === type);
+  }
+}
+
+const handleGatewayMessage = vi.fn(async () => ({
+  status: 'success' as const,
+  result: 'You have **two** meetings today.',
+  toolsUsed: [],
+}));
+
+async function createConnection(params?: { apiKey?: string }) {
+  vi.doMock('../src/config/config.js', () => ({
+    OPENAI_API_KEY: params?.apiKey ?? 'test-key',
+    getConfigSnapshot: () => ({ voice: { realtime: REALTIME_CONFIG } }),
+  }));
+  vi.doMock('../src/config/runtime-config.js', () => ({
+    getRuntimeConfig: () => ({}),
+    resolveDefaultAgentId: () => 'main',
+  }));
+  vi.doMock('../src/gateway/gateway-chat-service.js', () => ({
+    handleGatewayMessage,
+  }));
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+  }));
+  const { WebchatVoiceConnection } = await import(
+    '../src/gateway/webchat-voice.js'
+  );
+  const browser = new FakeBrowserSocket();
+  const realtime = new FakeRealtimeSocket();
+  const finished = vi.fn();
+  new WebchatVoiceConnection({
+    ws: browser as never,
+    identity: { userId: 'user-1', username: 'Ada' },
+    remoteIp: '127.0.0.1',
+    onFinished: finished,
+    socketFactory: (url) => {
+      realtime.url = url;
+      return realtime;
+    },
+  });
+  return { browser, realtime, finished };
+}
+
+async function flushAsync(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+afterEach(() => {
+  handleGatewayMessage.mockClear();
+  vi.doUnmock('../src/config/config.js');
+  vi.doUnmock('../src/config/runtime-config.js');
+  vi.doUnmock('../src/gateway/gateway-chat-service.js');
+  vi.doUnmock('../src/logger.js');
+  vi.resetModules();
+});
+
+test('start frame opens a PCM16 web realtime session and acks with ready', async () => {
+  const { browser, realtime } = await createConnection();
+
+  browser.clientFrame({ type: 'start' });
+  realtime.open();
+
+  const [sessionUpdate] = realtime.sentOfType('session.update');
+  const session = sessionUpdate.session as Record<string, unknown>;
+  const audio = session.audio as {
+    input: { format: Record<string, unknown> };
+    output: { format: Record<string, unknown> };
+  };
+  expect(audio.input.format).toEqual({ type: 'audio/pcm', rate: 24000 });
+  expect(audio.output.format).toEqual({ type: 'audio/pcm', rate: 24000 });
+  expect(String(session.instructions)).toContain('web console');
+
+  const [ready] = browser.sentOfType('ready');
+  expect(String(ready.sessionId)).toMatch(/^agent:main:channel:web:chat:dm:peer:/);
+});
+
+test('a valid canonical sessionId from the client is kept for consults', async () => {
+  const { browser, realtime } = await createConnection();
+  const sessionId = 'agent:main:channel:web:chat:dm:peer:abc123';
+
+  browser.clientFrame({ type: 'start', sessionId, agentId: 'main' });
+  realtime.open();
+
+  const [ready] = browser.sentOfType('ready');
+  expect(ready.sessionId).toBe(sessionId);
+
+  realtime.serverEvent({
+    type: 'response.function_call_arguments.done',
+    call_id: 'call_1',
+    name: 'consult_agent',
+    arguments: JSON.stringify({ request: 'What is on my calendar?' }),
+  });
+  await flushAsync();
+
+  expect(handleGatewayMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      sessionId,
+      channelId: 'web',
+      userId: 'user-1',
+      content: 'What is on my calendar?',
+      source: 'webchat.voice',
+    }),
+  );
+  const outputs = realtime
+    .sentOfType('conversation.item.create')
+    .map((event) => event.item as Record<string, unknown>);
+  // The reply is voice-formatted (markdown stripped) before going upstream.
+  expect(outputs).toContainEqual(
+    expect.objectContaining({
+      call_id: 'call_1',
+      output: 'You have two meetings today.',
+    }),
+  );
+});
+
+test('audio flows both ways and barge-in clears browser playback', async () => {
+  const { browser, realtime } = await createConnection();
+  browser.clientFrame({ type: 'start' });
+  realtime.open();
+
+  browser.clientFrame({ type: 'audio', payload: 'dGVzdA==' });
+  expect(realtime.sentOfType('input_audio_buffer.append')).toEqual([
+    { type: 'input_audio_buffer.append', audio: 'dGVzdA==' },
+  ]);
+
+  realtime.serverEvent({ type: 'response.created' });
+  realtime.serverEvent({ type: 'response.output_audio.delta', delta: 'bXU=' });
+  expect(browser.sentOfType('audio')).toEqual([
+    { type: 'audio', payload: 'bXU=' },
+  ]);
+
+  realtime.serverEvent({ type: 'input_audio_buffer.speech_started' });
+  expect(browser.sentOfType('clear')).toHaveLength(1);
+  expect(realtime.sentOfType('response.cancel')).toHaveLength(1);
+});
+
+test('transcripts reach the browser with web roles', async () => {
+  const { browser, realtime } = await createConnection();
+  browser.clientFrame({ type: 'start' });
+  realtime.open();
+
+  realtime.serverEvent({
+    type: 'conversation.item.input_audio_transcription.completed',
+    transcript: 'What time is it?',
+  });
+  realtime.serverEvent({
+    type: 'response.output_audio_transcript.done',
+    transcript: 'It is noon.',
+  });
+
+  expect(browser.sentOfType('transcript')).toEqual([
+    { type: 'transcript', role: 'user', text: 'What time is it?' },
+    { type: 'transcript', role: 'assistant', text: 'It is noon.' },
+  ]);
+});
+
+test('malformed frames close the socket with a policy violation', async () => {
+  const { browser, finished } = await createConnection();
+
+  browser.clientFrame({ type: 'bogus' });
+
+  expect(browser.sentOfType('error')).toHaveLength(1);
+  expect(browser.closeCode).toBe(1008);
+  expect(finished).toHaveBeenCalled();
+});
+
+test('stop ends the session and closes the upstream socket', async () => {
+  const { browser, realtime, finished } = await createConnection();
+  browser.clientFrame({ type: 'start' });
+  realtime.open();
+
+  browser.clientFrame({ type: 'stop' });
+
+  expect(browser.sentOfType('ended')).toHaveLength(1);
+  expect(browser.closeCode).toBe(1000);
+  expect(realtime.readyState).toBe(3);
+  expect(finished).toHaveBeenCalled();
+});
+
+test('starting without an OpenAI key fails closed', async () => {
+  const { browser, finished } = await createConnection({ apiKey: '' });
+
+  browser.clientFrame({ type: 'start' });
+
+  const [error] = browser.sentOfType('error');
+  expect(String(error.message)).toContain('OpenAI API key');
+  expect(browser.closeCode).toBe(1011);
+  expect(finished).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary

Adds an advanced voice mode with three surfaces:

1. **Phone calls (Twilio)**: `voice.mode: "realtime"` runs Twilio calls as natural speech-to-speech conversations through the **OpenAI Realtime API** (or the HybridAI `/v1/realtime` proxy) over **Twilio Media Streams**, with server-side VAD and instant barge-in — comparable to consumer advanced voice modes. The default turn-based ConversationRelay flow (`mode: "relay"`) is unchanged.
2. **Web console chat**: a microphone button in the composer starts the same realtime engine in the browser — no Twilio setup needed, which also makes it the quickest way to test the realtime stack end to end.
3. **Phone calls (Vonage plugin)**: `plugin config vonage-voice mode realtime` gives the install-on-demand Vonage channel the same speech-to-speech experience over Vonage websocket audio, reusing the core realtime engine through two new plugin API seams — so every call-capable voice surface in the repo now supports realtime.

Closes a gap surfaced while researching the voice roadmap (R18/R22 cover turn-based and async voice; no realtime/speech-to-speech item existed).

## Architecture

- **Transport (phone, Twilio)** (`src/channels/voice/media-stream.ts`): parser/builders for the Twilio Media Streams websocket protocol (`connected`/`start`/`media`/`dtmf`/`mark`/`stop` in; `media`/`clear`/`mark` out). Audio stays base64 8kHz µ-law end to end — no transcoding, since the Realtime API speaks `audio/pcmu` natively.
- **Transport (browser)** (`src/gateway/webchat-voice.ts` + `console/src/routes/chat/voice-*`): JSON frames over a new `/api/chat/voice/stream` websocket carrying base64 **PCM16 24kHz** both ways (also a native Realtime API format — still no transcoding). The console captures mic audio, schedules gapless playback, and clears it instantly on barge-in.
- **Transport (phone, Vonage)** (`plugins/vonage-voice/src/realtime.js`): realtime mode answers with a `connect`-to-websocket NCCO carrying `audio/l16;rate=8000` both ways into a plugin websocket endpoint. A new G.711 codec (`src/channels/voice/audio-codec.ts`) compands L16 ↔ µ-law **per sample at the same 8kHz rate** — still no resampling anywhere. Because Vonage websockets have no flush primitive, model audio is paced into 20ms frames server-side, so barge-in only ever races ≤1 queued frame.
- **Plugin API seams** (`src/plugins/plugin-realtime-voice.ts`): `api.registerWebsocketWebhook(...)` mounts websocket upgrades on the plugin webhook path (peer auth owned by the plugin handler, mirroring HTTP plugin webhooks), and `api.createRealtimeVoiceSession(...)` opens a core-managed realtime session whose consults run through the plugin dispatch pipeline. Any future call-capable channel plugin gets realtime the same way.
- **Upstream client** (`src/channels/voice/openai-realtime.ts`): GA realtime-API websocket client (`session.update`, `input_audio_buffer.append`, `response.*`, out-of-band responses), typed callback seam, caller-chosen wire format, injectable socket factory for tests.
- **Per-conversation bridge** (`src/channels/voice/realtime-bridge.ts`): transport-neutral (`sendAudio`/`clearPlayback` seams, `phone`/`web` instruction surface); wires caller audio ↔ model audio, speaks the configured greeting, handles DTMF, and enforces barge-in coherence (caller speech cancels the active response and clears queued playback).
- **Agent bridge**: the realtime model fronts the conversation but **is not the agent**. It gets one function tool, `consult_agent`, which forwards substantive requests into a normal gateway agent turn — so skills, tools, **approval policy, session persistence, and audit logging keep working**. On the phone this goes through the existing voice message handler (Twilio) or the plugin dispatch pipeline (Vonage); in the browser it runs an ordinary web chat turn via `handleGatewayMessage`, so **consulted turns land in the chat session transcript** and the UI refreshes to show them. One consult runs per conversation at a time; failures return an apologetic tool output instead of silence.
- **Consult progress UX**: the consult seam carries live tool progress from the gateway turn back into the bridge. Long consults speak short **out-of-band "still working" updates** (`conversation: 'none'` responses) that name the current tool activity — first after 7s, then every 12s, and only into silence: never over caller speech or an active response. The web console's live-call capsule shows the same activity label (`Checking — web search…`) via a new `consult` frame.
- **Runtime wiring** (`runtime.ts`): mode-aware TwiML (`<Connect><Stream>` at `<webhookPath>/stream`), websocket routing by path, session teardown on `stop`/close, shutdown closes upstream sockets.

## Security (high-risk path notes)

- The new `/stream` Twilio websocket upgrade goes through the **same Twilio signature validation** and per-IP pending-connection caps as the relay path; unsigned or over-limit upgrades are rejected before `handleUpgrade`.
- The browser `/api/chat/voice/stream` upgrade uses the **same browser-auth gate as the admin terminal stream** (signed session cookie or authenticated same-origin request incl. loopback local web session; no query/API tokens). The module additionally enforces a bounded frame size (256KB), a concurrent-session cap (4), a 10s start deadline for idle sockets, and canonical-session-id validation.
- Vonage does not sign websocket upgrades, so the plugin's stream endpoint authenticates with a **single-use token minted per call by the (JWT-verified) answer webhook**, expiring after 30s; missing/stale/reused tokens are rejected before the upgrade completes. Plugin websocket webhooks as a class are documented as gateway-unauthenticated (like HTTP plugin webhooks) with peer auth owned by the handler; the manager additionally caps active plugin sockets (32) and frame size (256KB).
- Realtime voice requires the selected provider's credential (`OPENAI_API_KEY`, or the HybridAI credential for `provider: "hybridai"`); phone realtime mode refuses to start without it, the browser capability endpoint reports `available: false` (button hidden), Vonage realtime answers decline with a spoken notice, and the key is never logged.
- Inbound frames on all transports are validated; malformed frames close the socket (1008) and tear the session down.
- Transcript content is not logged (lengths only, at debug). Spoken turns persist to session history as voice-tagged messages on all three surfaces; consulted turns persist through the normal gateway pipeline. Full-call transcript → audit-log wiring remains roadmap R18.4.

## Config

```json
"voice": {
  "mode": "realtime",
  "realtime": { "provider": "openai", "model": "gpt-realtime", "voice": "marin", "greeting": "Hello! How can I help you today?", "instructions": "" }
}
```

Browser voice needs only the realtime credential and reuses `voice.realtime.*`; it works with the Twilio channel disabled and regardless of `voice.mode`. Vonage realtime is `plugin config vonage-voice mode realtime` — it reuses `voice.realtime.*` for the engine while keeping all Vonage credentials in the plugin. New settings surfaced in the generated console registry; docs updated (`docs/content/guides/twilio-voice.md` realtime section, `docs/content/guides/vonage-voice.md` realtime section, `docs/content/extensibility/plugins.md` websocket/realtime plugin APIs, configuration reference, channels overview, admin-console guide) plus CHANGELOG.

## Validation

- `npm run typecheck` (root + console + desktop) ✅
- `npm run lint` ✅ / `npm run check` (biome) ✅ — no new warnings
- Server unit suite: all `tests/voice.*`, `tests/webchat-voice.test.ts`, `tests/plugin-realtime-voice.test.ts` (session setup, µ-law conversion, 20ms pacing + barge-in clear, sub-frame flush, consult dispatch/persistence, fail-closed without key), `tests/voice.audio-codec.test.ts` (G.711 anchor points, 256-code round trip, symmetry/monotonicity), `tests/vonage-voice-plugin.*.test.ts` (realtime NCCO, single-use/expiring stream tokens, audio wiring, teardown), and the plugin-manager websocket-webhook tests pass (109 tests across the touched suites); the 2 known pre-existing environment failures are unchanged.
- Console suite: 904 tests / 102 files ✅
- Not run: live audio sessions against OpenAI/Vonage (need real keys/numbers); the wire protocols are covered by unit tests with fake sockets. The browser surface exists precisely to make the live realtime test cheap.

## Out of scope (follow-ups)

- Full-call transcript → audit log (R18.4)
- Provider-interface extraction (#838) — this PR keeps the Twilio-mode discriminator local to the voice channel; Vonage realtime deliberately goes through the plugin API instead of widening the core provider enum
- DTMF on Vonage realtime calls (Vonage websocket legs don't deliver keypad events; would need the event webhook)
- Mobile-Safari audio-unlock polish (PR #1390's gesture-unlock pattern) if voice mode should run on iOS browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
