### PR TITLE
chore: use HybridAI GmbH legal name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 HybridAIOne
+Copyright (c) 2026 HybridAI GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "description": "macOS wrapper for the HybridClaw chat and admin web surfaces",
-  "author": "HybridAI One",
+  "author": "HybridAI GmbH",
   "main": "dist/main.js",
   "scripts": {
     "build:icon": "node scripts/build-icon.mjs",

--- a/docs/content/internal/provenance.md
+++ b/docs/content/internal/provenance.md
@@ -1,13 +1,13 @@
 # Code Provenance And IP Statement
 
-Status: 2026-07-21. Maintained alongside the compliance tooling
+Status: 2026-08-14. Maintained alongside the compliance tooling
 (`THIRD_PARTY_NOTICES.md`, `npm run sbom`, DCO workflow); update this document
 when the facts below change.
 
 ## Summary
 
 HybridClaw is an independent, from-scratch implementation. All first-party
-code is copyright HybridAIOne and the project contributors, licensed under the
+code is copyright HybridAI GmbH and the project contributors, licensed under the
 MIT License (`LICENSE`). It is not a fork of, and contains no code derived
 from, OpenClaw or any other assistant runtime.
 
@@ -53,7 +53,7 @@ relationship:
 
 Because no OpenClaw code is included, the MIT attribution obligation toward
 the OpenClaw Foundation does not attach; `LICENSE` correctly names only
-HybridAIOne. If OpenClaw code is ever incorporated, its copyright notice must
+HybridAI GmbH. If OpenClaw code is ever incorporated, its copyright notice must
 be added to `THIRD_PARTY_NOTICES.md` at that time.
 
 ## Third-Party Code

--- a/docs/content/reference/faq.md
+++ b/docs/content/reference/faq.md
@@ -110,7 +110,7 @@ Studio, llama.cpp, and vLLM.
 ## Is HybridClaw a fork or a rewrite of OpenClaw?
 
 Neither. HybridClaw is an independent implementation built from scratch (MIT,
-copyright HybridAIOne): its git history starts from its own initial commit,
+copyright HybridAI GmbH): its git history starts from its own initial commit,
 and a line-level comparison of both codebases shows no derived code — under 1%
 of lines overlap, all of them generic TypeScript idioms. The resemblance is
 category-level: both are MIT-licensed personal-AI-assistant runtimes.

--- a/tests/agent-cv.test.ts
+++ b/tests/agent-cv.test.ts
@@ -89,7 +89,7 @@ function buildSkillRunEvent(): SkillRunEvent {
     agent_id: 'main',
     session_id: 'session-1',
     run_id: 'run-1',
-    created_at: '2026-05-15T07:59:30.000Z',
+    created_at: new Date().toISOString(),
     input: { content: 'Use demo-skill.', truncated: false },
     output: { content: 'Done.', truncated: false },
     input_full: null,


### PR DESCRIPTION
## Summary

- update the MIT copyright holder to `HybridAI GmbH`
- align desktop package author metadata with the legal company name
- update the FAQ and code-provenance statement, including its status date
- retain `HybridAIOne`/`hybridaione` where it is an operational identifier such as the GitHub organization, npm scope, Docker image, domain, bundle ID, or fixture account

## Why

The repository used the old `HybridAIOne` / `HybridAI One` wording in human-readable legal and company attributions. The correct legal entity name is `HybridAI GmbH`.

## Impact

Documentation, licensing, and package metadata now consistently identify the correct legal entity. Distribution identifiers and existing URLs remain unchanged.

## Validation

- `npm run lint`
- `npm run format` (no changes; existing advisory warnings only)
- `git diff --check`
- parsed `desktop/package.json` as JSON
- scanned the checkout for remaining standalone old-name references