### PR TITLE
fix: quiet recovered transcription fallbacks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,6 +242,11 @@ hybridclaw gateway status             # gateway liveness, PID, build/version dia
 
 - Before diagnosing gateway/runtime issues, inspect the actual checkout, the
   running process, runtime state, logs, and `hybridclaw gateway status`.
+- The coding agent's shell Node version is not evidence about the gateway
+  runtime. If the CLI bootstrap rejects the shell's Node version, invoke the
+  installed CLI with the live gateway's Node 22 binary (discovered from the
+  running process) and continue silently. Report a Node runtime mismatch only
+  when the live gateway process itself is using the wrong version.
 - Use `hybridclaw gateway status` to compare the PID file, API-reported PID,
   entrypoint, package root, Node version, Git commit/branch, and
   source-vs-build freshness before concluding that a gateway is stale.

--- a/console/src/routes/chat/dictation-control.tsx
+++ b/console/src/routes/chat/dictation-control.tsx
@@ -67,7 +67,7 @@ export function DictationControl(props: {
   onTranscript: (text: string) => void;
   token: string;
 }) {
-  const copy = useMemo(() => getSpeechCopy(navigator.language), []);
+  const copy = useMemo(() => getSpeechCopy(document.documentElement.lang), []);
   const capabilities = useMediaCapabilities(props.token);
   const browserSupported = canRecord();
   const available = browserSupported && capabilities?.dictation === true;

--- a/console/src/routes/chat/read-aloud-control.test.tsx
+++ b/console/src/routes/chat/read-aloud-control.test.tsx
@@ -42,6 +42,7 @@ describe('ReadAloudControl', () => {
     mocks.capabilities = { dictation: true, readAloud: true };
     mocks.playback.mockReset();
     mocks.unlockAudio.mockReset();
+    document.documentElement.lang = 'en';
     vi.stubGlobal('Audio', class {});
   });
 
@@ -124,6 +125,28 @@ describe('ReadAloudControl', () => {
         })
         .hasAttribute('disabled'),
     ).toBe(true);
+  });
+
+  it('uses the console language instead of the browser preference', () => {
+    const languageDescriptor = Object.getOwnPropertyDescriptor(
+      navigator,
+      'language',
+    );
+    Object.defineProperty(navigator, 'language', {
+      configurable: true,
+      value: 'de-DE',
+    });
+
+    try {
+      render(<ReadAloudControl text="English UI" token="test-token" />);
+      expect(
+        screen.getByRole('button', { name: 'Read response aloud' }),
+      ).toBeTruthy();
+    } finally {
+      if (languageDescriptor) {
+        Object.defineProperty(navigator, 'language', languageDescriptor);
+      }
+    }
   });
 
   it('turns rendered markdown into natural speech text', () => {

--- a/console/src/routes/chat/read-aloud-control.tsx
+++ b/console/src/routes/chat/read-aloud-control.tsx
@@ -36,7 +36,7 @@ export function textFromRenderedMarkdown(html: string): string {
 
 export function ReadAloudControl(props: { text: string; token: string }) {
   const id = useId();
-  const copy = useMemo(() => getSpeechCopy(navigator.language), []);
+  const copy = useMemo(() => getSpeechCopy(document.documentElement.lang), []);
   const capabilities = useMediaCapabilities(props.token);
   const browserSupported = typeof window.Audio === 'function';
   const available = capabilities?.readAloud === true;

--- a/console/src/routes/chat/speech-copy.ts
+++ b/console/src/routes/chat/speech-copy.ts
@@ -1,8 +1,8 @@
 /**
  * Webchat speech copy — the localized labels and status text for audio UX.
  *
- * Locale selection follows the browser because the console has no global
- * translation runtime; the same locale is also passed to speech synthesis.
+ * Locale selection follows the console document because the console has no
+ * global translation runtime; browser preferences do not override UI copy.
  *
  * NOT a general console i18n registry; it deliberately covers only dictation
  * and read-aloud controls.

--- a/src/media/audio-transcription-backends.ts
+++ b/src/media/audio-transcription-backends.ts
@@ -985,6 +985,8 @@ export async function transcribeAudioWithFallback(params: {
   if (!stat.isFile()) return null;
 
   let fileBuffer: Buffer | null = null;
+  const failedBackends: string[] = [];
+  let lastError: unknown;
 
   for (const entry of models) {
     if (params.abortSignal?.aborted) break;
@@ -1014,16 +1016,23 @@ export async function transcribeAudioWithFallback(params: {
         abortSignal: params.abortSignal,
       });
     } catch (error) {
-      logger.warn(
-        {
-          error,
-          backend: entry.type === 'cli' ? entry.command : entry.provider,
-          fileName: params.fileName,
-          filePath: params.filePath,
-        },
-        'Audio transcription backend failed; trying next backend',
+      failedBackends.push(
+        entry.type === 'cli' ? entry.command : entry.provider,
       );
+      lastError = error;
     }
+  }
+
+  if (failedBackends.length > 0 && !params.abortSignal?.aborted) {
+    logger.warn(
+      {
+        error: lastError,
+        failedBackends,
+        fileName: params.fileName,
+        filePath: params.filePath,
+      },
+      'All audio transcription backends failed',
+    );
   }
 
   return null;

--- a/tests/audio-transcription-backends.test.ts
+++ b/tests/audio-transcription-backends.test.ts
@@ -6,6 +6,7 @@ import {
   resolveAudioTranscriptionModels,
   transcribeAudioWithFallback,
 } from '../src/media/audio-transcription-backends.js';
+import { logger } from '../src/logger.js';
 import { useCleanMocks, useTempDir } from './test-utils.ts';
 
 const ORIGINAL_PATH = process.env.PATH;
@@ -152,4 +153,82 @@ test('hybridai leads the auto-detected provider order', async () => {
 
   expect(providers[0]).toBe('hybridai');
   expect(providers).toContain('openai');
+});
+
+test('does not warn when a later audio backend recovers the request', async () => {
+  const audioDir = makeTempDir('hybridclaw-audio-fallback-');
+  const audioPath = path.join(audioDir, 'voice-note.ogg');
+  fs.writeFileSync(audioPath, 'audio-bytes', 'utf8');
+  const warnSpy = vi
+    .spyOn(logger, 'warn')
+    .mockImplementation(() => undefined);
+
+  try {
+    const transcript = await transcribeAudioWithFallback({
+      filePath: audioPath,
+      fileName: 'voice-note.ogg',
+      mimeType: 'audio/ogg',
+      config: DEFAULT_AUDIO_CONFIG,
+      models: [
+        {
+          type: 'cli',
+          command: process.execPath,
+          args: ['-e', 'process.exit(1)'],
+        },
+        {
+          type: 'cli',
+          command: process.execPath,
+          args: ['-e', 'process.stdout.write("fallback transcript")'],
+        },
+      ],
+    });
+
+    expect(transcript).toEqual({
+      text: 'fallback transcript',
+      backend: `cli:${path.basename(process.execPath)}`,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  } finally {
+    warnSpy.mockRestore();
+  }
+});
+
+test('warns once only after every audio backend fails', async () => {
+  const audioDir = makeTempDir('hybridclaw-audio-failure-');
+  const audioPath = path.join(audioDir, 'voice-note.ogg');
+  fs.writeFileSync(audioPath, 'audio-bytes', 'utf8');
+  const warnSpy = vi
+    .spyOn(logger, 'warn')
+    .mockImplementation(() => undefined);
+
+  try {
+    await expect(
+      transcribeAudioWithFallback({
+        filePath: audioPath,
+        fileName: 'voice-note.ogg',
+        mimeType: 'audio/ogg',
+        config: DEFAULT_AUDIO_CONFIG,
+        models: [
+          {
+            type: 'cli',
+            command: process.execPath,
+            args: ['-e', 'process.exit(1)'],
+          },
+        ],
+      }),
+    ).resolves.toBeNull();
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.any(Error),
+        failedBackends: [process.execPath],
+        fileName: 'voice-note.ogg',
+        filePath: audioPath,
+      }),
+      'All audio transcription backends failed',
+    );
+  } finally {
+    warnSpy.mockRestore();
+  }
 });


### PR DESCRIPTION
## Summary

- keep individual transcription backend failures internal when a later fallback succeeds
- emit one terminal warning only when every eligible transcription backend fails
- align dictation and read-aloud copy with the console document language instead of the browser preference
- clarify that an agent shell's Node version is not evidence about the live gateway runtime

## Root cause

An installed `whisper` executable was auto-detected and attempted before provider-backed transcription. Its failure was logged immediately as a WARN with a full stack trace even though HybridAI successfully recovered the request. Separately, speech controls used `navigator.language`, which made an English console show German status copy for browsers configured with a German locale.

## Impact

Successful transcription fallbacks no longer surface alarming errors, while complete backend exhaustion still produces one actionable warning. The English console now consistently displays English speech status text.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `vitest run tests/audio-transcription-backends.test.ts tests/webchat-dictation.test.ts` (11 tests)
- console speech/composer Vitest suites (56 tests)