### PR TITLE
fix: ignore manifestless plugin directories

### DIFF
--- a/src/plugins/plugin-manager.ts
+++ b/src/plugins/plugin-manager.ts
@@ -1064,6 +1064,7 @@ export class PluginManager {
       .map((entry) => path.join(dir, entry.name));
     const out: PluginCandidate[] = [];
     for (const entry of entries) {
+      if (!fs.existsSync(path.join(entry, MANIFEST_FILE_NAME))) continue;
       try {
         out.push(this.scanPluginDir(entry, source));
       } catch (error) {

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -886,6 +886,39 @@ test('plugin manager auto-discovers plugins from project directories without con
   ).resolves.toBe('workspace-auto:true:hello');
 });
 
+test('plugin manager ignores manifestless directories during automatic discovery', async () => {
+  const homeDir = makeTempDir('hybridclaw-plugin-home-');
+  const cwd = makeTempDir('hybridclaw-plugin-project-');
+  const stalePluginDir = path.join(
+    cwd,
+    '.hybridclaw',
+    'plugins',
+    'whatsapp',
+  );
+  fs.mkdirSync(path.join(stalePluginDir, 'dist'), { recursive: true });
+  fs.mkdirSync(path.join(stalePluginDir, 'node_modules'), { recursive: true });
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
+  const config = loadRuntimeConfig();
+  config.plugins.list = [];
+
+  const { PluginManager } = await import('../src/plugins/plugin-manager.js');
+  const manager = new PluginManager({
+    homeDir,
+    cwd,
+    getRuntimeConfig: () => config,
+    logger: logger as never,
+  });
+
+  await expect(manager.discoverPlugins(config)).resolves.toEqual([]);
+  expect(logger.warn).not.toHaveBeenCalled();
+});
+
 test('plugin manager allows only one external memory provider plugin', async () => {
   const homeDir = makeTempDir('hybridclaw-plugin-home-');
   const cwd = makeTempDir('hybridclaw-plugin-project-');


### PR DESCRIPTION
## Summary

- ignore directories without `hybridclaw.plugin.yaml` during automatic plugin discovery
- preserve validation errors for explicit plugin paths and malformed manifests
- add regression coverage for stale plugin directories containing only `dist/` and `node_modules/`

## Root cause

The bundled WhatsApp plugin was moved out of this repository, but ignored build artifacts could leave `plugins/whatsapp/` behind in an existing checkout. Automatic discovery treated every child directory as a plugin candidate, attempted to scan the orphan, and emitted a warning with a `Missing hybridclaw.plugin.yaml` stack trace during gateway startup.

## Impact

Gateway startup no longer emits an invalid-plugin warning for manifestless build or cache directories. Valid plugin directories and explicit configuration failures retain their existing behavior.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `vitest run tests/plugin-manager.test.ts --configLoader runner` (36 tests)
- live compiled discovery smoke check (zero warnings after stale artifact cleanup)