### PR TITLE
fix(imessage): validate BlueBubbles server URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Incomplete BlueBubbles configuration is actionable before startup**:
+  `hybridclaw config check` rejects an enabled BlueBubbles backend without a
+  real server URL, and the gateway reports setup and disable commands without
+  emitting an initialization stack trace.
+
 ## [0.28.6](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.6) - 2026-08-14
 
 ### Added

--- a/src/doctor/checks/config.ts
+++ b/src/doctor/checks/config.ts
@@ -332,6 +332,31 @@ function getDeploymentConfigIssues(rawConfig: Record<string, unknown>): {
   return { missingFields, invalidFields };
 }
 
+function isEnabledBlueBubblesServerUrlMissing(
+  rawConfig: Record<string, unknown>,
+): boolean {
+  const rawIMessage = rawConfig.imessage;
+  if (
+    !rawIMessage ||
+    typeof rawIMessage !== 'object' ||
+    Array.isArray(rawIMessage)
+  ) {
+    return false;
+  }
+
+  const imessage = rawIMessage as Record<string, unknown>;
+  if (imessage.enabled !== true || imessage.backend !== 'bluebubbles') {
+    return false;
+  }
+
+  const serverUrl =
+    typeof imessage.serverUrl === 'string' ? imessage.serverUrl.trim() : '';
+  return (
+    !serverUrl ||
+    serverUrl.replace(/\/+$/, '') === 'https://bluebubbles.example.com'
+  );
+}
+
 export async function checkConfigFile(): Promise<DiagResult[]> {
   const filePath = runtimeConfigPath();
   const displayPath = shortenHomePath(filePath);
@@ -383,6 +408,11 @@ export async function checkConfigFile(): Promise<DiagResult[]> {
   ].filter(Boolean) as string[];
   const deploymentIssues = getDeploymentConfigIssues(rawConfig);
   missingFields.push(...deploymentIssues.missingFields);
+  if (isEnabledBlueBubblesServerUrlMissing(rawConfig)) {
+    missingFields.push(
+      'imessage.serverUrl (required when the BlueBubbles backend is enabled)',
+    );
+  }
 
   if (missingFields.length > 0 || deploymentIssues.invalidFields.length > 0) {
     const detail = [

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -3372,6 +3372,15 @@ async function startIMessageIntegration(): Promise<boolean> {
     logger.info('iMessage integration disabled in config');
     return false;
   }
+  if (
+    imessageConfig.backend === 'bluebubbles' &&
+    !imessageConfig.serverUrl.trim()
+  ) {
+    logger.warn(
+      'iMessage integration not started: imessage.serverUrl is required for the BlueBubbles backend. Configure it with `hybridclaw channels imessage setup --backend remote --server-url <url>` or disable iMessage with `hybridclaw config set imessage.enabled false`.',
+    );
+    return false;
+  }
 
   try {
     await initIMessage(

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -26,6 +26,7 @@ function createGatewayMainTestState(options?: {
   emailPassword?: string;
   imessageInitError?: Error;
   imessageEnabled?: boolean;
+  imessageServerUrl?: string;
   lineEnabled?: boolean;
   slackEnabled?: boolean;
   slackInitError?: Error;
@@ -170,6 +171,8 @@ function createGatewayMainTestState(options?: {
       imessage: {
         enabled: options?.imessageEnabled ?? false,
         backend: 'bluebubbles',
+        serverUrl:
+          options?.imessageServerUrl ?? 'https://bluebubbles.test',
         webhookPath: '/api/imessage/webhook',
       },
       whatsapp: {
@@ -346,6 +349,7 @@ async function importFreshGatewayMain(options?: {
   discordInitError?: Error;
   imessageInitError?: Error;
   imessageEnabled?: boolean;
+  imessageServerUrl?: string;
   lineEnabled?: boolean;
   slackEnabled?: boolean;
   hasSlackCredentials?: boolean;
@@ -1011,6 +1015,28 @@ describe('gateway bootstrap', () => {
       'Gateway channels',
       expect.objectContaining({
         imessage: true,
+      }),
+    );
+  });
+
+  test('does not initialize BlueBubbles without a server URL', async () => {
+    const state = await importFreshGatewayMain({
+      imessageEnabled: true,
+      imessageServerUrl: '',
+    });
+
+    expect(state.initIMessage).not.toHaveBeenCalled();
+    expect(state.imessageMessageHandler).toBeNull();
+    expect(state.loggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'imessage.serverUrl is required for the BlueBubbles backend',
+      ),
+    );
+    expectInfoLog(
+      state,
+      'Gateway channels',
+      expect.objectContaining({
+        imessage: false,
       }),
     );
   });

--- a/tests/imessage.config.test.ts
+++ b/tests/imessage.config.test.ts
@@ -1,0 +1,110 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { useTempDir } from './test-utils.ts';
+
+const makeTempDir = useTempDir();
+const ORIGINAL_DATA_DIR = process.env.HYBRIDCLAW_DATA_DIR;
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_DISABLE_CONFIG_WATCHER =
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
+
+let homeDir: string;
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+async function writeIMessageConfig(options: {
+  enabled: boolean;
+  serverUrl: string;
+}): Promise<void> {
+  const runtimeConfig = await import('../src/config/runtime-config.js');
+  const configPath = runtimeConfig.runtimeConfigPath();
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as Record<
+    string,
+    unknown
+  >;
+  config.imessage = {
+    ...(config.imessage as Record<string, unknown>),
+    enabled: options.enabled,
+    backend: 'bluebubbles',
+    serverUrl: options.serverUrl,
+  };
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+}
+
+beforeEach(() => {
+  homeDir = makeTempDir();
+  process.env.HOME = homeDir;
+  process.env.HYBRIDCLAW_DATA_DIR = path.join(homeDir, '.hybridclaw', 'data');
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.resetModules();
+  restoreEnvVar('HOME', ORIGINAL_HOME);
+  restoreEnvVar('HYBRIDCLAW_DATA_DIR', ORIGINAL_DATA_DIR);
+  restoreEnvVar(
+    'HYBRIDCLAW_DISABLE_CONFIG_WATCHER',
+    ORIGINAL_DISABLE_CONFIG_WATCHER,
+  );
+});
+
+describe('iMessage runtime config checks', () => {
+  test.each([
+    '',
+    'https://bluebubbles.example.com',
+    'https://bluebubbles.example.com/',
+  ])(
+    'rejects an enabled BlueBubbles backend without a real server URL (%s)',
+    async (serverUrl) => {
+      await writeIMessageConfig({ enabled: true, serverUrl });
+      const { checkConfigFile } = await import(
+        '../src/doctor/checks/config.js'
+      );
+
+      const results = await checkConfigFile();
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.severity).toBe('error');
+      expect(results[0]?.message).toContain('imessage.serverUrl');
+    },
+  );
+
+  test('accepts an enabled BlueBubbles backend with a server URL', async () => {
+    await writeIMessageConfig({
+      enabled: true,
+      serverUrl: 'https://bluebubbles.test',
+    });
+    const { checkConfigFile } = await import(
+      '../src/doctor/checks/config.js'
+    );
+
+    const results = await checkConfigFile();
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        label: 'Config',
+        severity: 'ok',
+      }),
+    ]);
+  });
+
+  test('allows a disabled BlueBubbles backend without a server URL', async () => {
+    await writeIMessageConfig({ enabled: false, serverUrl: '' });
+    const { checkConfigFile } = await import(
+      '../src/doctor/checks/config.js'
+    );
+
+    const results = await checkConfigFile();
+
+    expect(results[0]?.severity).toBe('ok');
+  });
+});


### PR DESCRIPTION
## Summary

- reject enabled BlueBubbles configurations that have an empty or documentation-only server URL during `hybridclaw config check`
- short-circuit gateway initialization with actionable setup/disable commands instead of logging an exception stack
- cover valid, disabled, missing, placeholder, and gateway startup boundaries
- document the behavior in the changelog

## Root cause

The legacy BlueBubbles example URL migration correctly normalized `https://bluebubbles.example.com` to an empty value, but an already-enabled channel remained enabled. Gateway startup then delegated validation to the backend, where the missing URL threw and produced a recurring warning with a stack trace.

## Impact

Operators now get the configuration error before startup, and gateway startup remains healthy while reporting exactly how to configure or disable the incomplete channel. Valid BlueBubbles endpoints, disabled iMessage channels, and local iMessage behavior are unchanged.

## Risk / security boundaries

- no network, credential, approval, or permission behavior changes
- the preflight only skips an enabled BlueBubbles backend whose normalized URL is empty
- valid and disabled configurations have explicit boundary coverage
- unexpected backend initialization failures remain on the existing non-fatal catch path

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint`
- focused tests: 98 passed across `gateway-main`, `imessage.config`, and `doctor`
- full unit run: 5,466 passed; 4 unrelated failures remained in `discord-webhook` and `transformers-embedding-provider` module-initialization flakes, `plugin-manager.singleton` timeout, and `host-runner.redaction` resolving the shared root dependency path instead of a container-local dependency path