### PR TITLE
fix(console): trim v0.28.6 release highlight to the 48-char limit

### DIFF
--- a/console/src/release-notes.ts
+++ b/console/src/release-notes.ts
@@ -1,7 +1,7 @@
 export const LATEST_RELEASE_NOTES = {
   version: '0.28.6',
   highlights: [
-    'Reliable Teams text, streaming, and file delivery.',
+    'Reliable Teams text, streaming, file delivery.',
     'Agent settings persist with change attribution.',
     'Dependencies ship without known npm advisories.',
     'LINE and WhatsApp install only when enabled.',


### PR DESCRIPTION
## Summary

`main` has been red since the v0.28.6 release (`625e9402`). The release notes shipped a highlight two characters over the limit that `console/src/release-notes.test.ts` enforces, so `test` fails on main and on every open PR branched from it.

## Root cause

`release-notes.test.ts > keeps the popup copy ultra short` caps each highlight at 48 characters. The v0.28.6 copy:

```
 50  Reliable Teams text, streaming, and file delivery.   <- over by 2
 47  Agent settings persist with change attribution.
 47  Dependencies ship without known npm advisories.
 44  LINE and WhatsApp install only when enabled.
```

```
AssertionError: expected 50 to be less than or equal to 48
 ❯ src/release-notes.test.ts:13:32
```

The file is hand-maintained (no generator), so the copy itself is the fix.

## Change

Drop the Oxford `and` so the highlight reads as the three-item list it already is — text, streaming, file delivery. 46 characters, meaning unchanged.

## Impact

Unblocks `test` on main and on every PR currently branched from it, including #1392.

## Validation

- `npm --workspace console run test -- src/release-notes.test.ts`: 2 passed
- lint clean on the changed file
- no other reference to the old string anywhere in the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)