### PR TITLE
fix(email): drop an unusable caller-supplied parent instead of threading on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Email replies stay in their thread**: An agent that supplies its own parent
+  message id when answering mail no longer breaks threading when that value is
+  not a message id — for example an identifier read out of the subject line.
+  Unusable parents are rejected and the thread the runtime already tracked is
+  used instead, so the reply keeps its `Re:` subject and lands in the original
+  conversation rather than starting an untitled one.
+
 ## [0.28.7](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.7) - 2026-08-17
 
 ### Added

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -4250,7 +4250,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
           inReplyTo: {
             type: 'string',
             description:
-              'Optional parent message id for threaded replies when supported by the active channel.',
+              'Optional parent message id for threaded replies when supported by the active channel. Pass only an id the channel itself reported for an existing message — on email that is an RFC 5322 Message-ID such as "<abc@example.com>". Never derive one from a subject line, body text, or run identifier. Omit it to keep replying in the current thread, which is the right choice unless you are deliberately answering a different message.',
           },
           references: {
             type: ['string', 'array'],
@@ -4258,7 +4258,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
               type: 'string',
             },
             description:
-              'Optional ordered parent message id chain for threaded replies when supported by the active channel.',
+              'Optional ordered parent message id chain for threaded replies when supported by the active channel. Same rules as inReplyTo: channel-reported ids only, never invented ones.',
           },
           filePath: {
             type: 'string',

--- a/src/channels/email/delivery.ts
+++ b/src/channels/email/delivery.ts
@@ -152,9 +152,26 @@ export function renderEmailHtml(text: string): string | undefined {
   ].join('');
 }
 
+// RFC 5322: msg-id = "<" id-left "@" id-right ">". Senders vary on the angle
+// brackets, so accept either form, but require the `@` — a value without one
+// is not a message id and can never match a message in any mailbox.
+const MESSAGE_ID_RE = /^<?[^\s<>@]+@[^\s<>@]+>?$/;
+
+/**
+ * Return *raw* if it can be a Message-ID, otherwise null.
+ *
+ * Callers may pass a parent they constructed themselves — an agent answering
+ * a mail can hand over a run id it read out of the subject line rather than
+ * the message's own id. Forwarding that verbatim ships a threading header
+ * that matches nothing, orphaning the reply out of its thread and (because a
+ * supplied parent suppresses the known thread context) dropping the reply
+ * subject with it. Rejecting the value instead lets the caller fall back to
+ * the thread the runtime already tracked.
+ */
 function normalizeMessageId(raw: string | null | undefined): string | null {
   const normalized = String(raw || '').trim();
-  return normalized || null;
+  if (!normalized) return null;
+  return MESSAGE_ID_RE.test(normalized) ? normalized : null;
 }
 
 function normalizeMessageIdList(raw: string[] | null | undefined): string[] {

--- a/tests/email.channel.test.ts
+++ b/tests/email.channel.test.ts
@@ -706,6 +706,75 @@ describe('email delivery helpers', () => {
     });
   });
 
+  // Regression: a caller (an agent calling the message-send tool) can supply
+  // any string as the parent. Lifting the run id out of the inbound Subject
+  // and passing it as the parent produced `In-Reply-To: <b5f8b8885a84>` on the
+  // wire — syntactically not a msg-id (RFC 5322 requires `id-left@id-right`),
+  // so it matches nothing in any client, and the reply orphans out of its
+  // thread. The known thread context must win over an unusable parent.
+  test('ignores a caller-supplied parent that is not a Message-ID', async () => {
+    vi.doMock('../src/config/config.ts', () => ({
+      APP_VERSION: '0.7.1',
+      DATA_DIR: path.join(os.tmpdir(), 'hybridclaw-test-data'),
+      EMAIL_TEXT_CHUNK_LIMIT: 50000,
+    }));
+    const { sendEmail } = await import('../src/channels/email/delivery.js');
+    const transport = {
+      sendMail: vi.fn(async () => ({
+        messageId: '<sent-orphan@example.com>',
+      })),
+    };
+
+    await sendEmail({
+      transport,
+      to: 'boss@example.com',
+      body: 'Received, thanks.',
+      selfAddress: 'agent@example.com',
+      threadContext: {
+        subject: 'weekly status b5f8b8885a84',
+        messageId: '<178634181362.1410672.119560@example.com>',
+        references: [],
+      },
+      inReplyTo: 'b5f8b8885a84',
+    });
+
+    expect(transport.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'Re: weekly status b5f8b8885a84',
+        inReplyTo: '<178634181362.1410672.119560@example.com>',
+        references: '<178634181362.1410672.119560@example.com>',
+      }),
+    );
+  });
+
+  test('drops an unusable parent when no thread context is known', async () => {
+    vi.doMock('../src/config/config.ts', () => ({
+      APP_VERSION: '0.7.1',
+      DATA_DIR: path.join(os.tmpdir(), 'hybridclaw-test-data'),
+      EMAIL_TEXT_CHUNK_LIMIT: 50000,
+    }));
+    const { sendEmail } = await import('../src/channels/email/delivery.js');
+    const transport = {
+      sendMail: vi.fn(async () => ({
+        messageId: '<sent-no-thread@example.com>',
+      })),
+    };
+
+    await sendEmail({
+      transport,
+      to: 'boss@example.com',
+      body: 'Received, thanks.',
+      subject: 'Status',
+      selfAddress: 'agent@example.com',
+      threadContext: null,
+      inReplyTo: 'b5f8b8885a84',
+    });
+
+    expect(transport.sendMail.mock.calls[0]?.[0]?.inReplyTo).toBeUndefined();
+    expect(transport.sendMail.mock.calls[0]?.[0]?.references).toBeUndefined();
+    expect(transport.sendMail.mock.calls[0]?.[0]?.subject).toBe('Status');
+  });
+
   test('extracts inline subject prefixes and attaches files', async () => {
     vi.doMock('../src/config/config.ts', () => ({
       APP_VERSION: '0.7.1',
@@ -944,6 +1013,117 @@ describe('email runtime', () => {
       expect.any(Buffer),
       ['\\Seen'],
       expect.any(Date),
+    );
+  });
+
+  // End-to-end shape of the bug: the agent answers an inbound mail by
+  // addressing the sender and supplying its own parent id, taken from the
+  // inbound Subject rather than from the Message-ID. The runtime already
+  // remembered the real thread for that sender, so the reply must still land
+  // in it instead of starting an untitled one.
+  test('keeps a reply in its thread when the agent supplies an unusable parent', async () => {
+    vi.doMock('../src/config/config.ts', () => ({
+      APP_VERSION: '0.7.1',
+      DATA_DIR: path.join(os.tmpdir(), 'hybridclaw-test-data'),
+      EMAIL_PASSWORD: 'email-app-password',
+      EMAIL_TEXT_CHUNK_LIMIT: 50_000,
+      getConfigSnapshot: () => ({
+        email: BASE_EMAIL_CONFIG,
+      }),
+    }));
+
+    const sendMail = vi.fn(async () => ({
+      messageId: '<sent-reply@example.com>',
+    }));
+    const createTransport = vi.fn(() => ({
+      close: vi.fn(async () => {}),
+      verify: vi.fn(async () => {}),
+      sendMail,
+    }));
+    const callbacks = new Map<
+      string,
+      (
+        messages: Array<{ folder: string; raw: Buffer; uid: number }>,
+      ) => Promise<void>
+    >();
+
+    vi.doMock('nodemailer', () => ({ default: { createTransport } }));
+    vi.doMock('imapflow', () => ({
+      ImapFlow: class {
+        mailbox = { path: 'Sent' };
+        connect = vi.fn(async () => {});
+        logout = vi.fn(async () => {});
+        close = vi.fn(() => {});
+        list = vi.fn(async () => [
+          { path: 'Sent', name: 'Sent', flags: new Set<string>() },
+        ]);
+        getMailboxLock = vi.fn(async (folder: string) => ({
+          path: folder,
+          release: vi.fn(),
+        }));
+        search = vi.fn(async () => []);
+        append = vi.fn(async () => ({ destination: 'Sent', uid: 7 }));
+      },
+    }));
+    vi.doMock('../src/channels/email/connection.ts', () => ({
+      createEmailConnectionManager: vi.fn(
+        (
+          config: { address: string },
+          _password: string,
+          callback: (
+            messages: Array<{ folder: string; raw: Buffer; uid: number }>,
+          ) => Promise<void>,
+        ) => {
+          callbacks.set(config.address, callback);
+          return { start: vi.fn(async () => {}), stop: vi.fn(async () => {}) };
+        },
+      ),
+    }));
+    vi.doMock('../src/channels/email/inbound.ts', () => ({
+      cleanupEmailInboundMedia: vi.fn(async () => {}),
+      processInboundEmail: vi.fn(async () => ({
+        sessionId: 'agent:main:channel:email:chat:dm:peer:boss%40example.com',
+        agentId: 'main',
+        guildId: null,
+        channelId: 'boss@example.com',
+        userId: 'boss@example.com',
+        username: 'Boss',
+        content: 'Please reply in-thread with a short confirmation.',
+        media: [],
+        senderAddress: 'boss@example.com',
+        senderName: 'Boss',
+        subject: 'weekly status b5f8b8885a84',
+        threadContext: {
+          subject: 'weekly status b5f8b8885a84',
+          messageId: '<178634181362.1410672.119560@example.com>',
+          references: [],
+        },
+      })),
+    }));
+
+    const { createEmailRuntime } = await import(
+      '../src/channels/email/runtime.js'
+    );
+    const runtime = createEmailRuntime();
+
+    await runtime.initEmail(async (...args) => {
+      // The agent addresses the sender itself and hands over a "parent" it
+      // lifted out of the subject line instead of the real Message-ID.
+      await runtime.sendToEmail('boss@example.com', 'Received, thanks.', {
+        inReplyTo: 'b5f8b8885a84',
+      });
+      void args;
+    });
+    await callbacks.get('agent@example.com')?.([
+      { folder: 'INBOX', raw: Buffer.from('raw'), uid: 1 },
+    ]);
+
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'boss@example.com',
+        subject: 'Re: weekly status b5f8b8885a84',
+        inReplyTo: '<178634181362.1410672.119560@example.com>',
+      }),
     );
   });
 


### PR DESCRIPTION
## Problem

An agent replying to an email intermittently sent its answer as a brand-new
conversation: subject `HybridClaw` instead of `Re: <original subject>`, and an
`In-Reply-To` that matched no message in the recipient's mailbox. The same agent,
same prompt, same model got it right on other runs — so the reply either landed in
the thread or vanished from it, apparently at random.

The nondeterminism is on the model side, but the damage is ours. Two shapes of answer
reach delivery:

* **plain text** — the channel replies through its own path, using the thread context
  the runtime tracked. Correct subject, correct `In-Reply-To`. This is the run that
  looks fine.
* **a `message` tool call with `inReplyTo` supplied** — the model volunteers a parent
  id. When it constructs that value instead of quoting one the channel reported (in
  the case that surfaced this, an identifier it had read out of the subject line), we
  accepted it verbatim: `normalizeMessageId` only trimmed.

Accepting it costs twice over, because in `sendEmailMessage` an explicitly supplied
parent also *suppresses* the known thread context:

```ts
const explicitThreadHeaders = resolveExplicitThreadHeaders(params);
const subjectThreadContext = explicitThreadHeaders ? null : params.threadContext;
```

So one unusable value both writes a dead `In-Reply-To` **and** drops the `Re:` subject
that would otherwise have kept the mail visibly in its thread. Every downstream
heuristic a mail client has for threading is gone at once.

## Fix

Validate against the RFC 5322 msg-id shape before accepting a caller-supplied parent:

```ts
const MESSAGE_ID_RE = /^<?[^\s<>@]+@[^\s<>@]+>?$/;
```

Angle brackets are optional because senders vary, but the `@` is required — a value
without one is not a message id and cannot address a message in any mailbox, so
forwarding it can only ever produce a broken header. Rejecting it lets delivery fall
back to the thread the runtime already tracked, which is exactly what the plain-text
path does and what the caller wanted.

Well-formed ids are untouched: an agent that genuinely wants to answer a different
message still can, and the existing `forwards explicit threading headers on outbound
send` test covers that.

I also tightened the `message` tool's `inReplyTo` / `references` descriptions. They
read *"Optional parent message id for threaded replies when supported by the active
channel"* — true for a channel whose message ids are opaque snowflakes, misleading for
email, and quiet about where a valid id comes from. They now say that only
channel-reported ids are acceptable, that email means an RFC 5322 Message-ID, and that
omitting the field replies in the current thread. That reduces how often the mistake is
made; the delivery-layer check is what makes it harmless when it still is.

## Tests

Three new cases in `tests/email.channel.test.ts`, all of which fail on `main`:

* `ignores a caller-supplied parent that is not a Message-ID` — with a valid thread
  context present, asserts the reply keeps `Re: <subject>` and the real Message-ID
  rather than the supplied token. This is the regression.
* `drops an unusable parent when no thread context is known` — with nothing tracked,
  asserts we emit no threading headers at all instead of a dead one.
* `keeps a reply in its thread when the agent supplies an unusable parent` — the full
  runtime chain: inbound mail is processed, the handler answers via
  `runtime.sendToEmail(..., { inReplyTo: '<constructed value>' })`, and the outbound
  message is asserted on the wire.

Verified: `email.channel` 31/31; `email.connection`, `gateway-admin-email`,
`message.tool-actions-send`, `container.message-tool-normalization` green; full unit
project 5474 passed. `tests/host-runner.redaction.test.ts > HostExecutor exposes the
bundled agent-browser binary` fails, but it fails identically on a pristine `main`
checkout — it needs the bundled browser binary, unrelated to this change. `tsc
--noEmit --noUnusedLocals --noUnusedParameters` and the container typecheck both exit
0; `biome check` clean.

## Left alone

`src/channels/email/threading.ts` has its own trim-only `normalizeMessageId`. It is on
the inbound path, where the ids come from the mail server rather than from an agent, so
it is not implicated here — but it is the same latent gap and worth a follow-up.
