### PR TITLE
fix(plugins): start channel integrations when a plugin reload adds a transport

### DIFF
--- a/src/channels/channel-plugin-catalog.ts
+++ b/src/channels/channel-plugin-catalog.ts
@@ -65,3 +65,35 @@ export function getChannelPluginStatuses(): ChannelPluginStatus[] {
     };
   });
 }
+
+export interface ChannelPluginAvailabilityChange {
+  channel: ChannelKind;
+  available: boolean;
+}
+
+export type ChannelPluginAvailabilitySnapshot = ReadonlyMap<
+  ChannelKind,
+  boolean
+>;
+
+export function snapshotChannelPluginTransportAvailability(): ChannelPluginAvailabilitySnapshot {
+  return new Map(
+    Object.keys(CHANNEL_PLUGIN_CATALOG).map((channel) => [
+      channel as ChannelKind,
+      hasChannelTransport(channel as ChannelKind),
+    ]),
+  );
+}
+
+export function diffChannelPluginTransportAvailability(
+  before: ChannelPluginAvailabilitySnapshot,
+  after: ChannelPluginAvailabilitySnapshot,
+): ChannelPluginAvailabilityChange[] {
+  const changes: ChannelPluginAvailabilityChange[] = [];
+  for (const [channel, available] of after) {
+    if ((before.get(channel) ?? false) !== available) {
+      changes.push({ channel, available });
+    }
+  }
+  return changes;
+}

--- a/src/gateway/gateway-plugin-service.ts
+++ b/src/gateway/gateway-plugin-service.ts
@@ -1,6 +1,12 @@
 import { randomUUID } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import { getChannelPluginCatalogEntryByPluginId } from '../channels/channel-plugin-catalog.js';
+import {
+  type ChannelPluginAvailabilityChange,
+  type ChannelPluginAvailabilitySnapshot,
+  diffChannelPluginTransportAvailability,
+  getChannelPluginCatalogEntryByPluginId,
+  snapshotChannelPluginTransportAvailability,
+} from '../channels/channel-plugin-catalog.js';
 import { sendWebhookJson, WebhookHttpError } from '../channels/webhook-http.js';
 import { parseIdArg, parseLowerArg } from '../command-parsing.js';
 import {
@@ -391,22 +397,64 @@ function isDependencyApprovalRequiredError(error: unknown): error is {
   );
 }
 
+type ChannelPluginAvailabilityListener = (
+  changes: ChannelPluginAvailabilityChange[],
+) => Promise<void>;
+
+let channelPluginAvailabilityListener: ChannelPluginAvailabilityListener | null =
+  null;
+
+/**
+ * The gateway registers a listener here so channel integrations can be
+ * started/stopped when a plugin reload changes which channel transports are
+ * installed (e.g. a WhatsApp plugin install from the admin console). Without
+ * this, an installed transport sits registered-but-idle until the next full
+ * gateway restart.
+ */
+export function setChannelPluginAvailabilityListener(
+  listener: ChannelPluginAvailabilityListener | null,
+): void {
+  channelPluginAvailabilityListener = listener;
+}
+
+async function notifyChannelPluginAvailabilityChanges(
+  before: ChannelPluginAvailabilitySnapshot,
+): Promise<void> {
+  const listener = channelPluginAvailabilityListener;
+  if (!listener) return;
+  const changes = diffChannelPluginTransportAvailability(
+    before,
+    snapshotChannelPluginTransportAvailability(),
+  );
+  if (changes.length === 0) return;
+  try {
+    await listener(changes);
+  } catch (error) {
+    logger.warn(
+      { error, changes },
+      'Channel integration refresh failed after plugin runtime reload',
+    );
+  }
+}
+
 export async function reloadPluginRuntime(): Promise<{
   ok: boolean;
   message: string;
 }> {
+  const availabilityBefore = snapshotChannelPluginTransportAvailability();
   try {
     await reloadPluginManager();
-    return {
-      ok: true,
-      message: 'Plugin runtime reloaded.',
-    };
   } catch (error) {
     return {
       ok: false,
       message: `Plugin runtime reload failed: ${error instanceof Error ? error.message : String(error)}.`,
     };
   }
+  await notifyChannelPluginAvailabilityChanges(availabilityBefore);
+  return {
+    ok: true,
+    message: 'Plugin runtime reloaded.',
+  };
 }
 
 async function rollbackPluginRuntimeConfigChange(

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -33,6 +33,7 @@ import {
   startObservabilityIngest,
   stopObservabilityIngest,
 } from '../audit/observability-ingest.js';
+import type { ChannelPluginAvailabilityChange } from '../channels/channel-plugin-catalog.js';
 import { buildResponseText } from '../channels/discord/delivery.js';
 import { rewriteUserMentionsForMessage } from '../channels/discord/mentions.js';
 import {
@@ -227,6 +228,7 @@ import {
 import { startGatewayHttpServer } from './gateway-http-server.js';
 import {
   initGatewayService,
+  setChannelPluginAvailabilityListener,
   stopGatewayPlugins,
 } from './gateway-plugin-service.js';
 import {
@@ -3050,6 +3052,60 @@ async function refreshLineIntegrationForConfigChange(
   await startLineIntegration();
 }
 
+/**
+ * Starts or stops install-on-demand channel integrations when a plugin
+ * runtime reload changes which channel transports are registered. This is
+ * what makes an admin-console plugin install take effect immediately: the
+ * install reloads the plugin manager (registering the transport), and this
+ * hook then brings the channel runtime up without requiring a full gateway
+ * restart. The reverse transition (transport removed by uninstall/disable)
+ * shuts the channel runtime down so it does not keep using a dead transport.
+ */
+async function refreshChannelIntegrationsForPluginAvailability(
+  changes: ChannelPluginAvailabilityChange[],
+): Promise<void> {
+  const externalChannelsEnabled = !isA2ALocalModeEnabled(getConfigSnapshot());
+  for (const change of changes) {
+    logger.info(
+      { channel: change.channel, transportAvailable: change.available },
+      change.available
+        ? 'Channel transport plugin became available; refreshing channel integration'
+        : 'Channel transport plugin became unavailable; stopping channel integration',
+    );
+    switch (change.channel) {
+      case 'whatsapp': {
+        await shutdownWhatsApp().catch((error) => {
+          logger.debug(
+            { error },
+            'Failed to stop WhatsApp runtime during plugin availability refresh',
+          );
+        });
+        if (change.available && externalChannelsEnabled) {
+          await startWhatsAppIntegration();
+        }
+        break;
+      }
+      case 'line': {
+        await shutdownLine().catch((error) => {
+          logger.debug(
+            { error },
+            'Failed to stop LINE runtime during plugin availability refresh',
+          );
+        });
+        if (change.available && externalChannelsEnabled) {
+          await startLineIntegration();
+        }
+        break;
+      }
+      default:
+        logger.warn(
+          { channel: change.channel },
+          'No integration refresh handler for channel plugin availability change',
+        );
+    }
+  }
+}
+
 async function refreshThreemaIntegrationForConfigChange(
   next: ReturnType<typeof getConfigSnapshot>,
   prev: ReturnType<typeof getConfigSnapshot>,
@@ -3595,6 +3651,7 @@ function setupShutdown(broadcastShutdown: () => void): void {
       detachConfigListener();
       detachConfigListener = null;
     }
+    setChannelPluginAvailabilityListener(null);
     await runShutdownStep(
       'set Discord maintenance presence',
       setDiscordMaintenancePresence,
@@ -3990,6 +4047,9 @@ async function main(): Promise<void> {
   void hybridAIProbe.get().catch((err) => {
     logger.warn({ err }, 'Startup warm-up of HybridAI probe failed');
   });
+  setChannelPluginAvailabilityListener(
+    refreshChannelIntegrationsForPluginAvailability,
+  );
   detachConfigListener = onConfigChange((next, prev) => {
     a2aLocalModeTransition = a2aLocalModeTransition
       .then(() => refreshA2ALocalModeForConfigChange(next, prev))

--- a/tests/channel-transport.test.ts
+++ b/tests/channel-transport.test.ts
@@ -8,9 +8,11 @@ import {
   unregisterChannelTransport,
 } from '../src/channels/channel-transport.js';
 import {
+  diffChannelPluginTransportAvailability,
   getChannelPluginCatalogEntry,
   getChannelPluginCatalogEntryByPluginId,
   getChannelPluginStatuses,
+  snapshotChannelPluginTransportAvailability,
 } from '../src/channels/channel-plugin-catalog.js';
 import type { RuntimeConfig } from '../src/config/runtime-config.js';
 import { PluginManager } from '../src/plugins/plugin-manager.js';
@@ -78,6 +80,31 @@ test('channel plugin catalog reports transport availability generically', () => 
       transportAvailable: true,
     }),
   );
+});
+
+test('channel plugin availability snapshot diff reports transitions', () => {
+  const before = snapshotChannelPluginTransportAvailability();
+  expect(before.get('whatsapp')).toBe(false);
+  expect(
+    diffChannelPluginTransportAvailability(
+      before,
+      snapshotChannelPluginTransportAvailability(),
+    ),
+  ).toEqual([]);
+
+  registerChannelTransport(createTransportRegistration());
+  const after = snapshotChannelPluginTransportAvailability();
+  expect(diffChannelPluginTransportAvailability(before, after)).toEqual([
+    { channel: 'whatsapp', available: true },
+  ]);
+
+  unregisterChannelTransport('whatsapp');
+  expect(
+    diffChannelPluginTransportAvailability(
+      after,
+      snapshotChannelPluginTransportAvailability(),
+    ),
+  ).toEqual([{ channel: 'whatsapp', available: false }]);
 });
 
 test('channel plugin catalog resolves the bundled LINE plugin', () => {

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -269,6 +269,7 @@ function createGatewayMainTestState(options?: {
     ),
     failStaleDelegationJobs: vi.fn(() => 0),
     listAgents: vi.fn(() => []),
+    setChannelPluginAvailabilityListener: vi.fn(),
     stopGatewayPlugins: vi.fn(async () => {}),
     listQueuedProactiveMessages: vi.fn(() => []),
     loggerDebug: vi.fn(),
@@ -723,6 +724,8 @@ async function importFreshGatewayMain(options?: {
   }));
   vi.doMock('../src/gateway/gateway-plugin-service.js', () => ({
     initGatewayService: state.initGatewayService,
+    setChannelPluginAvailabilityListener:
+      state.setChannelPluginAvailabilityListener,
     stopGatewayPlugins: state.stopGatewayPlugins,
   }));
   vi.doMock('../src/gateway/gateway-http-server.js', () => ({

--- a/tests/gateway-service.plugins.test.ts
+++ b/tests/gateway-service.plugins.test.ts
@@ -1339,6 +1339,88 @@ test('handleGatewayCommand installs a plugin from a local TUI/web session and re
   expect(result.text).toContain('Plugin runtime reloaded.');
 });
 
+test('handleGatewayCommand plugin install notifies channel availability listener when a transport appears', async () => {
+  setupHome();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  const { setChannelPluginAvailabilityListener } = await import(
+    '../src/gateway/gateway-plugin-service.ts'
+  );
+  const { registerChannelTransport, unregisterChannelTransport } = await import(
+    '../src/channels/channel-transport.js'
+  );
+
+  initDatabase({ quiet: true });
+
+  const listener = vi.fn(async () => {});
+  setChannelPluginAvailabilityListener(listener);
+  reloadPluginManagerMock.mockImplementationOnce(async () => {
+    registerChannelTransport({
+      kind: 'whatsapp',
+      create: () => ({
+        init: async () => {},
+        shutdown: async () => {},
+        sendText: async () => {},
+        sendMedia: async () => {},
+      }),
+    });
+    return pluginManagerMock;
+  });
+
+  try {
+    const result = await handleGatewayCommand({
+      sessionId: 'session-plugin-install-transport',
+      guildId: null,
+      channelId: 'tui',
+      args: ['plugin', 'install', './plugins/qmd-memory', '--yes'],
+    });
+
+    expect(result.kind).toBe('info');
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith([
+      { channel: 'whatsapp', available: true },
+    ]);
+  } finally {
+    setChannelPluginAvailabilityListener(null);
+    unregisterChannelTransport('whatsapp');
+  }
+});
+
+test('handleGatewayCommand plugin install skips channel availability listener when transports are unchanged', async () => {
+  setupHome();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  const { setChannelPluginAvailabilityListener } = await import(
+    '../src/gateway/gateway-plugin-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  const listener = vi.fn(async () => {});
+  setChannelPluginAvailabilityListener(listener);
+
+  try {
+    const result = await handleGatewayCommand({
+      sessionId: 'session-plugin-install-no-transport',
+      guildId: null,
+      channelId: 'tui',
+      args: ['plugin', 'install', './plugins/qmd-memory', '--yes'],
+    });
+
+    expect(result.kind).toBe('info');
+    expect(reloadPluginManagerMock).toHaveBeenCalled();
+    expect(listener).not.toHaveBeenCalled();
+  } finally {
+    setChannelPluginAvailabilityListener(null);
+  }
+});
+
 test('handleGatewayCommand reports missing binary guidance after plugin install', async () => {
   setupHome();
   installPluginMock.mockResolvedValueOnce({


### PR DESCRIPTION
## Problem

Installing a channel plugin (WhatsApp/LINE) from the admin console runs `plugin install … --yes` followed by a plugin-runtime reload. The reload **registers the transport** (so the console starts rendering the pairing panel), but **nothing ever starts the channel integration** — `startWhatsAppIntegration()` only runs at boot or when the channel's own config changes. The result is the state we debugged on a prod cloud workspace yesterday: plugin installed and enabled, `transportAvailable: true`, and the pairing panel stuck on *"Waiting for a fresh QR from the gateway."* forever. The console's "Reload Gateway" button goes through the same path and doesn't help; only a full gateway restart does — and the console never says so (the CLI prints the restart hint, the console swallows it).

## Fix

`reloadPluginRuntime()` now snapshots channel-transport availability (from the channel plugin catalog) before and after the plugin-manager reload and notifies a listener that the gateway registers at startup:

- transport **appeared** (install/enable): the gateway starts that channel's integration immediately — for WhatsApp this kicks off the Baileys connection, so the pairing QR shows up right after the console install with no restart.
- transport **disappeared** (uninstall/disable): the gateway shuts the channel runtime down instead of leaving it pointed at a dead registration.
- availability unchanged: nothing is touched, so unrelated plugin reloads don't drop live channel connections.

All reload entry points converge on `reloadPluginRuntime()` (install, reinstall, enable/disable, plugin config set, output-guard admin, the admin "Reload Gateway" button), so every path now brings the channel up/down consistently. A2A local mode is respected (no external channel starts).

## Testing

- `tests/channel-transport.test.ts`: snapshot/diff helpers report transitions in both directions and no-ops when unchanged.
- `tests/gateway-service.plugins.test.ts`: `plugin install` fires the availability listener when the reload registers a WhatsApp transport, and skips it when transports are unchanged.
- `npx tsc --noEmit`, strict lint tsc, and biome all clean; both test files pass (44 tests).

## Follow-ups (not in this PR)

- Surface core-side WhatsApp init failures (auth lock, init errors) into `pairingError` so the console can never sit on the placeholder text silently.
- Console toast after plugin install could mention the channel is now starting.