### PR TITLE
fix(email): stop hammering the mail server after repeated auth failures

### DIFF
--- a/src/channels/email/connection.ts
+++ b/src/channels/email/connection.ts
@@ -10,7 +10,19 @@ import {
 } from '../../utils/transport-errors.js';
 
 const INITIAL_RECONNECT_DELAY_MS = 1_000;
-const MAX_RECONNECT_DELAY_MS = 60_000;
+// Reconnect ceiling for transport-level failures. A short cap (this used to be
+// 60s) makes every gateway retry against an unreachable or refusing mail host
+// once a minute forever, which providers read as hostile traffic; five minutes
+// keeps recovery reasonable without that connection pressure.
+const MAX_RECONNECT_DELAY_MS = 300_000;
+// Spread reconnects so a fleet of gateways sharing one egress IP does not
+// retry against the mail host in lockstep.
+const RECONNECT_JITTER_RATIO = 0.2;
+// Failed logins are what mail-server intrusion detection (fail2ban and
+// provider-side abuse handling) counts. Wrong credentials never fix themselves
+// by retrying, so give up quickly and stay stopped until the gateway restarts
+// or the email config changes.
+const MAX_CONSECUTIVE_AUTH_FAILURES = 3;
 const EMAIL_CURSOR_STATE_DIR = path.join(DATA_DIR, 'email');
 const EMAIL_CURSOR_STATE_VERSION = 1;
 // Cursor seeding runs inside `channels email setup`, which platforms exec with
@@ -24,9 +36,33 @@ export interface EmailFetchedMessage {
   raw: Buffer;
 }
 
+export interface EmailConnectionStatus {
+  authFailed: boolean;
+  consecutiveAuthFailures: number;
+}
+
 export interface EmailConnectionManager {
   start: () => Promise<void>;
   stop: () => Promise<void>;
+  getStatus: () => EmailConnectionStatus;
+}
+
+export function isEmailAuthenticationError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const candidate = error as {
+    authenticationFailed?: unknown;
+    serverResponseCode?: unknown;
+  };
+  if (candidate.authenticationFailed === true) return true;
+  return (
+    String(candidate.serverResponseCode || '').toUpperCase() ===
+    'AUTHENTICATIONFAILED'
+  );
+}
+
+function applyReconnectJitter(delayMs: number): number {
+  const jitterSpan = delayMs * RECONNECT_JITTER_RATIO;
+  return Math.round(delayMs - jitterSpan + Math.random() * 2 * jitterSpan);
 }
 
 type EmailConnectionConfig = Pick<
@@ -264,6 +300,8 @@ export function createEmailConnectionManager(
   let pollTimer: ReturnType<typeof setTimeout> | null = null;
   let connectingPromise: Promise<void> | null = null;
   let stateLoaded = false;
+  let consecutiveAuthFailures = 0;
+  let authFailed = false;
 
   const clearPollTimer = (): void => {
     if (!pollTimer) return;
@@ -315,11 +353,38 @@ export function createEmailConnectionManager(
   const scheduleReconnect = (reason: string, error?: unknown): void => {
     clearPollTimer();
     void closeClient();
-    if (stopped || reconnectTimer) return;
+    if (stopped || reconnectTimer || authFailed) return;
 
-    const delayMs = reconnectDelayMs;
+    if (error && isEmailAuthenticationError(error)) {
+      consecutiveAuthFailures += 1;
+      if (consecutiveAuthFailures >= MAX_CONSECUTIVE_AUTH_FAILURES) {
+        authFailed = true;
+        childLogger.error(
+          {
+            address: config.address,
+            host: config.imapHost,
+            attempts: consecutiveAuthFailures,
+          },
+          'Email IMAP authentication keeps failing; stopping retries for this mailbox so the mail server does not treat this gateway as a brute-force source. Update the mailbox credentials, then restart the gateway or change the email config.',
+        );
+        return;
+      }
+      childLogger.warn(
+        {
+          address: config.address,
+          host: config.imapHost,
+          attempt: consecutiveAuthFailures,
+          maxAttempts: MAX_CONSECUTIVE_AUTH_FAILURES,
+        },
+        `Email IMAP authentication failed (attempt ${consecutiveAuthFailures}/${MAX_CONSECUTIVE_AUTH_FAILURES}). Retrying connection in ${formatReconnectDelay(reconnectDelayMs)}.`,
+      );
+    }
+
+    const delayMs = applyReconnectJitter(reconnectDelayMs);
     reconnectDelayMs = Math.min(reconnectDelayMs * 2, MAX_RECONNECT_DELAY_MS);
-    if (error && isExpectedTransportError(error)) {
+    if (error && isEmailAuthenticationError(error)) {
+      // Already logged above with attempt context.
+    } else if (error && isExpectedTransportError(error)) {
       childLogger.warn(
         {
           delayMs,
@@ -570,6 +635,7 @@ export function createEmailConnectionManager(
 
       client = nextClient;
       reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+      consecutiveAuthFailures = 0;
       await initializeFolders();
       await pollInbox();
     })()
@@ -602,6 +668,12 @@ export function createEmailConnectionManager(
       persistedCursorState.clear();
       stateLoaded = false;
       await closeClient();
+    },
+    getStatus(): EmailConnectionStatus {
+      return {
+        authFailed,
+        consecutiveAuthFailures,
+      };
     },
   };
 }

--- a/src/channels/email/runtime.ts
+++ b/src/channels/email/runtime.ts
@@ -711,6 +711,11 @@ export function createEmailRuntime() {
       );
     },
     shutdownEmail: runtimeLifecycle.shutdown,
+    getAuthFailedAccountAddresses(): string[] {
+      return [...accountStates.values()]
+        .filter((state) => state.connectionManager?.getStatus().authFailed)
+        .map((state) => state.account.address);
+    },
   };
 }
 
@@ -743,4 +748,13 @@ export async function shutdownEmail(): Promise<void> {
   const runtime = defaultRuntime;
   defaultRuntime = null;
   await runtime?.shutdownEmail();
+}
+
+/**
+ * Addresses of configured email accounts whose IMAP poller gave up after
+ * repeated authentication failures. Surfaced in gateway status so stale
+ * mailbox credentials are visible instead of silently dead.
+ */
+export function getEmailAuthFailedAccountAddresses(): string[] {
+  return defaultRuntime?.getAuthFailedAccountAddresses() ?? [];
 }

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -111,6 +111,7 @@ import {
   fetchLiveAdminEmailMailbox,
   fetchLiveAdminEmailMessage,
 } from '../channels/email/admin-mailbox.js';
+import { getEmailAuthFailedAccountAddresses } from '../channels/email/runtime.js';
 import { getLineAuthStatus } from '../channels/line/auth.js';
 import { getLinePairingState } from '../channels/line/pairing-state.js';
 import {
@@ -4931,7 +4932,10 @@ export async function getGatewayStatus(
     slack,
     slackWebhook,
     telegram,
-    email,
+    email: {
+      ...email,
+      authFailedAccounts: getEmailAuthFailedAccountAddresses(),
+    },
     emailEnabled: runtimeConfig.email.enabled === true,
     imessage,
     msteams,

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -527,6 +527,7 @@ export interface GatewayStatus {
   email?: {
     passwordConfigured: boolean;
     passwordSource: 'config' | 'env' | 'runtime-secrets' | null;
+    authFailedAccounts?: string[];
   };
   emailEnabled?: boolean;
   imessage?: {

--- a/tests/email.connection.test.ts
+++ b/tests/email.connection.test.ts
@@ -419,6 +419,8 @@ describe('email connection manager', () => {
 
   test('keeps expected DNS failures local and logs a readable reconnect warning', async () => {
     const dataDir = makeTempDir('hybridclaw-email-connection-');
+    // Pin jitter to its midpoint so reconnect delays are exact in assertions.
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
     const childLogger = {
       warn: vi.fn(),
       error: vi.fn(),
@@ -485,6 +487,8 @@ describe('email connection manager', () => {
 
   test('keeps IMAP shutdown socket errors local after scheduling reconnect', async () => {
     const dataDir = makeTempDir('hybridclaw-email-connection-');
+    // Pin jitter to its midpoint so reconnect delays are exact in assertions.
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
     const childLogger = {
       warn: vi.fn(),
       error: vi.fn(),
@@ -588,6 +592,8 @@ describe('email connection manager', () => {
 
   test('still rejects unexpected connect failures on initial start', async () => {
     const dataDir = makeTempDir('hybridclaw-email-connection-');
+    // Pin jitter to its midpoint so reconnect delays are exact in assertions.
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
     const childLogger = {
       warn: vi.fn(),
       error: vi.fn(),
@@ -848,5 +854,136 @@ describe('setup-time cursor seeding', () => {
       uidValidity: '2',
       lastProcessedUid: 4,
     });
+  });
+
+  test('stops retrying after repeated authentication failures and reports it', async () => {
+    const dataDir = makeTempDir('hybridclaw-email-connection-');
+    vi.useFakeTimers();
+
+    const connect = vi.fn(async () => {
+      throw Object.assign(new Error('Authentication failed'), {
+        authenticationFailed: true,
+      });
+    });
+
+    vi.doMock('../src/config/config.js', () => ({
+      DATA_DIR: dataDir,
+    }));
+    vi.doMock('imapflow', () => ({
+      ImapFlow: class {
+        connect = connect;
+        logout = vi.fn(async () => {});
+        close = vi.fn(() => {});
+        removeAllListeners = vi.fn(() => {});
+        on = vi.fn(() => this);
+      },
+    }));
+
+    const { createEmailConnectionManager } = await import(
+      '../src/channels/email/connection.js'
+    );
+
+    try {
+      const manager = createEmailConnectionManager(
+        BASE_EMAIL_CONFIG,
+        'wrong-password',
+        async () => {},
+      );
+      await expect(manager.start()).rejects.toThrow('Authentication failed');
+      expect(connect).toHaveBeenCalledTimes(1);
+      expect(manager.getStatus()).toEqual({
+        authFailed: false,
+        consecutiveAuthFailures: 1,
+      });
+
+      // Backoff doubles from 1s with ±20% jitter; 10s covers attempts 2 and 3.
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(connect).toHaveBeenCalledTimes(3);
+      expect(manager.getStatus()).toEqual({
+        authFailed: true,
+        consecutiveAuthFailures: 3,
+      });
+
+      // Terminal: even long after the backoff ceiling, no further logins.
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+      expect(connect).toHaveBeenCalledTimes(3);
+
+      await manager.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('keeps retrying transport-level connect failures without tripping the auth breaker', async () => {
+    const dataDir = makeTempDir('hybridclaw-email-connection-');
+    vi.useFakeTimers();
+
+    const connect = vi.fn(async () => {
+      throw Object.assign(new Error('connect ECONNREFUSED'), {
+        code: 'ECONNREFUSED',
+      });
+    });
+
+    vi.doMock('../src/config/config.js', () => ({
+      DATA_DIR: dataDir,
+    }));
+    vi.doMock('imapflow', () => ({
+      ImapFlow: class {
+        connect = connect;
+        logout = vi.fn(async () => {});
+        close = vi.fn(() => {});
+        removeAllListeners = vi.fn(() => {});
+        on = vi.fn(() => this);
+      },
+    }));
+
+    const { createEmailConnectionManager } = await import(
+      '../src/channels/email/connection.js'
+    );
+
+    try {
+      const manager = createEmailConnectionManager(
+        BASE_EMAIL_CONFIG,
+        'secret',
+        async () => {},
+      );
+      await manager.start().catch(() => {});
+      expect(connect).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(connect.mock.calls.length).toBeGreaterThanOrEqual(4);
+      expect(manager.getStatus()).toEqual({
+        authFailed: false,
+        consecutiveAuthFailures: 0,
+      });
+
+      await manager.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('isEmailAuthenticationError matches ImapFlow auth failures only', async () => {
+    const { isEmailAuthenticationError } = await import(
+      '../src/channels/email/connection.js'
+    );
+    expect(
+      isEmailAuthenticationError(
+        Object.assign(new Error('no'), { authenticationFailed: true }),
+      ),
+    ).toBe(true);
+    expect(
+      isEmailAuthenticationError(
+        Object.assign(new Error('no'), {
+          serverResponseCode: 'AUTHENTICATIONFAILED',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isEmailAuthenticationError(
+        Object.assign(new Error('refused'), { code: 'ECONNREFUSED' }),
+      ),
+    ).toBe(false);
+    expect(isEmailAuthenticationError(null)).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

The IMAP poller treats authentication failures like any transient error: reconnect with exponential backoff **capped at 60 seconds, forever**. A gateway holding stale mailbox credentials therefore retries a failing login about once a minute per account, indefinitely. Mail-server intrusion detection counts exactly this (mailcow's netfilter bans at 10 failed logins per 10 minutes), and on cloud deployments every gateway shares one egress IP — so a few stale-cred accounts make the whole fleet's source IP look like a brute-force attacker.

This is not hypothetical: our production sandbox fleet's egress IP has been blocked by the mail provider since Jul 27, taking down the email channel for every cloud workspace for three weeks before anyone noticed (nothing surfaced it).

## Fix

- **Auth-failure breaker**: after 3 consecutive `authenticationFailed` connect attempts, the account's poller stops (until gateway restart or an email config change, both of which rebuild the connection manager) and logs a clear error naming the mailbox. Wrong credentials never fix themselves by retrying.
- **Gentler transport backoff**: reconnect ceiling raised 60s → 5 min, with ±20% jitter so a fleet sharing one egress IP doesn't retry against the mail host in lockstep.
- **Visibility**: `GET /api/status` now includes `email.authFailedAccounts` so stale credentials show up as a named, actionable state instead of a silently dead channel.

## Testing

- New tests in `tests/email.connection.test.ts`: breaker trips after exactly 3 attempts and stays terminal (fake timers, one hour advanced, no further logins); transport errors (ECONNREFUSED) keep retrying without tripping the breaker; `isEmailAuthenticationError` matches ImapFlow's auth failures only.
- Three existing tests asserting exact reconnect delays now pin `Math.random` to the jitter midpoint.
- `tsc --noEmit` and biome clean; `email.connection` (13), `email.channel` + `gateway-admin-email` (37), and `gateway-status` (75) all pass.

## Follow-ups (separate PRs)

- chat: re-sync mailbox credentials to sandboxes when they rotate (today they're pushed exactly once at provisioning, which is how the stale creds happened).
- Console/doctor surfacing of `authFailedAccounts`.