### PR TITLE
fix(console): resolve chat approval cards instead of leaving stale buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Chat approval prompts resolve instead of lingering**: Acting on an
+  approval card marks it handled instead of leaving live buttons behind, a
+  card superseded by a newer request or past its expiry says so instead of
+  offering a dead-end action, and pending approvals that arrive as plain text
+  — after a reload, or from a command's output — regain Allow/Cancel actions.
+
 ## [0.28.7](https://github.com/HybridAIOne/hybridclaw/tree/v0.28.7) - 2026-08-17
 
 ### Added

--- a/console/src/lib/chat-helpers.ts
+++ b/console/src/lib/chat-helpers.ts
@@ -90,6 +90,30 @@ export function buildApprovalSummary(
   return lines.join('\n');
 }
 
+const APPROVAL_ID_RE = /Approval ID:\s*([A-Za-z0-9_-]+)/;
+
+// Approvals that surface as plain chat text — a `**Pending Approval**` info
+// block from a slash command, or an approval-role message whose structured
+// payload didn't survive a history restore — carry no buttons of their own.
+// This recognizes that text (mirroring the gateway's own heuristic) and pulls
+// the approval id back out so the UI can offer actions anyway.
+export function parseApprovalAnnouncement(
+  content: string,
+): { approvalId: string } | null {
+  const text = String(content ?? '').trim();
+  if (!text) return null;
+  const looksLikeApproval =
+    text.startsWith('Approval needed for:') ||
+    text.startsWith('**Pending Approval**') ||
+    text.startsWith('I need your approval before I ') ||
+    text.includes('Approval expires in') ||
+    text.includes('Reply `yes` to approve once.');
+  if (!looksLikeApproval) return null;
+  const match = text.match(APPROVAL_ID_RE);
+  const approvalId = match?.[1]?.trim();
+  return approvalId ? { approvalId } : null;
+}
+
 const APPROVAL_COMMAND_MAP: Record<ApprovalAction, string> = {
   once: '/approve yes',
   session: '/approve session',

--- a/console/src/routes/chat/approval-card.test.tsx
+++ b/console/src/routes/chat/approval-card.test.tsx
@@ -63,4 +63,77 @@ describe('ApprovalCard', () => {
     expect(onAction).toHaveBeenCalledWith('session', 'approve123');
     expect(screen.queryByRole('button', { name: 'Trust agent' })).toBeNull();
   });
+
+  it('hides the action buttons and explains why for a responded card', () => {
+    const onAction = vi.fn();
+
+    render(
+      <ApprovalCard
+        approval={makeApproval()}
+        busy={false}
+        onAction={onAction}
+        status="responded"
+        respondedAction="session"
+      />,
+    );
+
+    expect(screen.getByText('Approved for this session.')).not.toBeNull();
+    expect(screen.queryByRole('button', { name: 'Allow once' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Trust session' })).toBeNull();
+  });
+
+  it.each([
+    ['once', 'Approved — the agent will continue.'],
+    ['agent', 'Approved for this agent.'],
+    ['all', 'Always allowed.'],
+    ['deny', 'Cancelled.'],
+  ] as const)('captions a responded %s action correctly', (action, caption) => {
+    render(
+      <ApprovalCard
+        approval={makeApproval()}
+        busy={false}
+        onAction={vi.fn()}
+        status="responded"
+        respondedAction={action}
+      />,
+    );
+    expect(screen.getByText(caption)).not.toBeNull();
+  });
+
+  it('hides the action buttons and explains a superseded card', () => {
+    render(
+      <ApprovalCard
+        approval={makeApproval()}
+        busy={false}
+        onAction={vi.fn()}
+        status="superseded"
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        'No longer pending — superseded by a newer approval request.',
+      ),
+    ).not.toBeNull();
+    expect(screen.queryByRole('button', { name: 'Allow once' })).toBeNull();
+  });
+
+  it('hides the action buttons and explains an expired card', () => {
+    render(
+      <ApprovalCard
+        approval={makeApproval()}
+        busy={false}
+        onAction={vi.fn()}
+        status="expired"
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        'Expired — ask the agent to retry if you still want this.',
+      ),
+    ).not.toBeNull();
+    expect(screen.queryByRole('button', { name: 'Allow once' })).toBeNull();
+  });
 });

--- a/console/src/routes/chat/approval-card.tsx
+++ b/console/src/routes/chat/approval-card.tsx
@@ -2,7 +2,30 @@ import { useMemo } from 'react';
 import type { ChatStreamApproval } from '../../api/chat-types';
 import { Button } from '../../components/button';
 import type { ApprovalAction } from '../../lib/chat-helpers';
+import { cx } from '../../lib/cx';
+import type { ApprovalItemStatus } from './approval-lifecycle';
 import css from './chat-page.module.css';
+
+const RESPONDED_CAPTION: Record<ApprovalAction, string> = {
+  once: 'Approved — the agent will continue.',
+  session: 'Approved for this session.',
+  agent: 'Approved for this agent.',
+  all: 'Always allowed.',
+  deny: 'Cancelled.',
+};
+
+function inactiveCaption(
+  status: Exclude<ApprovalItemStatus, 'active'>,
+  respondedAction?: ApprovalAction,
+): string {
+  if (status === 'responded') {
+    return respondedAction ? RESPONDED_CAPTION[respondedAction] : 'Resolved.';
+  }
+  if (status === 'superseded') {
+    return 'No longer pending — superseded by a newer approval request.';
+  }
+  return 'Expired — ask the agent to retry if you still want this.';
+}
 
 const TRUST_APPROVAL_BUTTONS: ReadonlyArray<{
   label: string;
@@ -140,8 +163,12 @@ export function ApprovalCard(props: {
   approval: ChatStreamApproval;
   busy: boolean;
   onAction: (action: ApprovalAction, approvalId: string) => void;
+  status?: ApprovalItemStatus;
+  respondedAction?: ApprovalAction;
 }) {
   const { approval } = props;
+  const status = props.status ?? 'active';
+  const isActive = status === 'active';
   const rows = useMemo(() => buildApprovalRows(approval), [approval]);
   const intro = useMemo(() => buildApprovalIntro(approval), [approval]);
   const availableTrustButtons = TRUST_APPROVAL_BUTTONS.filter((btn) =>
@@ -154,7 +181,9 @@ export function ApprovalCard(props: {
   };
 
   return (
-    <div className={css.approvalCard}>
+    <div
+      className={cx(css.approvalCard, !isActive && css.approvalCardInactive)}
+    >
       <div className={css.approvalHeader}>
         {tierLabel ? (
           <span className={css.approvalTier}>{tierLabel}</span>
@@ -175,39 +204,47 @@ export function ApprovalCard(props: {
           ))}
         </dl>
       ) : null}
-      <div className={css.approvalPrimaryActions}>
-        <Button
-          size="sm"
-          disabled={props.busy}
-          onClick={() => handleAction('once')}
-        >
-          Allow once
-        </Button>
-        <Button
-          variant="danger"
-          size="sm"
-          disabled={props.busy}
-          onClick={() => handleAction('deny')}
-        >
-          Cancel
-        </Button>
-      </div>
-      {availableTrustButtons.length > 0 ? (
-        <div className={css.approvalTrustActions}>
-          {availableTrustButtons.map((btn) => (
+      {isActive ? (
+        <>
+          <div className={css.approvalPrimaryActions}>
             <Button
-              key={btn.action}
-              variant="outline"
               size="sm"
-              className={css.approvalAllow}
               disabled={props.busy}
-              onClick={() => handleAction(btn.action)}
+              onClick={() => handleAction('once')}
             >
-              {btn.label}
+              Allow once
             </Button>
-          ))}
-        </div>
-      ) : null}
+            <Button
+              variant="danger"
+              size="sm"
+              disabled={props.busy}
+              onClick={() => handleAction('deny')}
+            >
+              Cancel
+            </Button>
+          </div>
+          {availableTrustButtons.length > 0 ? (
+            <div className={css.approvalTrustActions}>
+              {availableTrustButtons.map((btn) => (
+                <Button
+                  key={btn.action}
+                  variant="outline"
+                  size="sm"
+                  className={css.approvalAllow}
+                  disabled={props.busy}
+                  onClick={() => handleAction(btn.action)}
+                >
+                  {btn.label}
+                </Button>
+              ))}
+            </div>
+          ) : null}
+        </>
+      ) : (
+        <p className={css.approvalStatusLine}>
+          {inactiveCaption(status, props.respondedAction)}
+        </p>
+      )}
     </div>
   );
 }

--- a/console/src/routes/chat/approval-lifecycle.test.ts
+++ b/console/src/routes/chat/approval-lifecycle.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest';
+import type { ChatStreamApproval } from '../../api/chat-types';
+import type { ApprovalAction } from '../../lib/chat-helpers';
+import { deriveApprovalStates } from './approval-lifecycle';
+import type { ChatUiMessage } from './chat-ui-message';
+
+function structuredApproval(
+  overrides: Partial<ChatStreamApproval> = {},
+): ChatStreamApproval {
+  return {
+    type: 'approval',
+    approvalId: 'approve-1',
+    prompt: 'Trigger a thumbnail snapshot.\nApproval ID: approve-1',
+    expiresAt: null,
+    ...overrides,
+  };
+}
+
+function approvalMessage(
+  id: string,
+  overrides: Partial<ChatUiMessage> = {},
+): ChatUiMessage {
+  return {
+    id,
+    role: 'approval',
+    content: '',
+    sessionId: 'session-a',
+    pendingApproval: structuredApproval({ approvalId: id }),
+    ...overrides,
+  } as ChatUiMessage;
+}
+
+function textAnnouncementMessage(
+  id: string,
+  approvalId: string,
+  role: 'assistant' | 'command' = 'assistant',
+): ChatUiMessage {
+  return {
+    id,
+    role,
+    content: [
+      'Approval needed for: trigger a thumbnail snapshot',
+      `Approval ID: ${approvalId}`,
+      'Reply `yes` to approve once.',
+    ].join('\n'),
+    sessionId: 'session-a',
+  } as ChatUiMessage;
+}
+
+const NO_RESOLUTIONS: ReadonlyMap<string, ApprovalAction> = new Map();
+
+describe('deriveApprovalStates', () => {
+  it('marks the newest approval item active when nothing has been resolved', () => {
+    const messages = [
+      approvalMessage('m1', {
+        pendingApproval: structuredApproval({ approvalId: 'a1' }),
+      }),
+    ];
+    const states = deriveApprovalStates(messages, NO_RESOLUTIONS, Date.now());
+    expect(states.get('m1')).toMatchObject({
+      approvalId: 'a1',
+      status: 'active',
+    });
+  });
+
+  it('supersedes an older approval once a newer one arrives', () => {
+    const messages = [
+      approvalMessage('m1', {
+        pendingApproval: structuredApproval({ approvalId: 'a1' }),
+      }),
+      approvalMessage('m2', {
+        pendingApproval: structuredApproval({ approvalId: 'a2' }),
+      }),
+    ];
+    const states = deriveApprovalStates(messages, NO_RESOLUTIONS, Date.now());
+    expect(states.get('m1')).toMatchObject({
+      approvalId: 'a1',
+      status: 'superseded',
+    });
+    expect(states.get('m2')).toMatchObject({
+      approvalId: 'a2',
+      status: 'active',
+    });
+  });
+
+  it('marks an approval responded once its id is in resolvedApprovals, even if newest', () => {
+    const messages = [
+      approvalMessage('m1', {
+        pendingApproval: structuredApproval({ approvalId: 'a1' }),
+      }),
+    ];
+    const resolved = new Map<string, ApprovalAction>([['a1', 'session']]);
+    const states = deriveApprovalStates(messages, resolved, Date.now());
+    expect(states.get('m1')).toMatchObject({
+      approvalId: 'a1',
+      status: 'responded',
+      respondedAction: 'session',
+    });
+  });
+
+  it('responded takes priority over superseded for an older, acted-on item', () => {
+    const messages = [
+      approvalMessage('m1', {
+        pendingApproval: structuredApproval({ approvalId: 'a1' }),
+      }),
+      approvalMessage('m2', {
+        pendingApproval: structuredApproval({ approvalId: 'a2' }),
+      }),
+    ];
+    const resolved = new Map<string, ApprovalAction>([['a1', 'deny']]);
+    const states = deriveApprovalStates(messages, resolved, Date.now());
+    expect(states.get('m1')).toMatchObject({
+      status: 'responded',
+      respondedAction: 'deny',
+    });
+    expect(states.get('m2')).toMatchObject({ status: 'active' });
+  });
+
+  it('expires a structured approval once its expiresAt is in the past', () => {
+    const now = Date.now();
+    const messages = [
+      approvalMessage('m1', {
+        pendingApproval: structuredApproval({
+          approvalId: 'a1',
+          expiresAt: now - 1000,
+        }),
+      }),
+    ];
+    const states = deriveApprovalStates(messages, NO_RESOLUTIONS, now);
+    expect(states.get('m1')).toMatchObject({
+      approvalId: 'a1',
+      status: 'expired',
+    });
+  });
+
+  it('keeps older items superseded even when the newest one expired', () => {
+    // Each new request replaces the previous pending one on the gateway, so
+    // an older item must never become actionable again.
+    const now = Date.now();
+    const messages = [
+      approvalMessage('m1', {
+        pendingApproval: structuredApproval({ approvalId: 'a1' }),
+      }),
+      approvalMessage('m2', {
+        pendingApproval: structuredApproval({
+          approvalId: 'a2',
+          expiresAt: now - 1000,
+        }),
+      }),
+    ];
+    const states = deriveApprovalStates(messages, NO_RESOLUTIONS, now);
+    expect(states.get('m2')).toMatchObject({ status: 'expired' });
+    expect(states.get('m1')).toMatchObject({ status: 'superseded' });
+  });
+
+  it('treats a payloadless approval-role message as a text item using its content', () => {
+    const messages = [
+      {
+        id: 'm1',
+        role: 'approval',
+        content: 'Approval needed for: run a scan\nApproval ID: a1',
+        sessionId: 'session-a',
+        pendingApproval: null,
+      } as ChatUiMessage,
+    ];
+    const states = deriveApprovalStates(messages, NO_RESOLUTIONS, Date.now());
+    expect(states.get('m1')).toMatchObject({
+      approvalId: 'a1',
+      status: 'active',
+    });
+  });
+
+  it('treats an assistant text announcement as an approval item', () => {
+    const messages = [textAnnouncementMessage('m1', 'a1', 'assistant')];
+    const states = deriveApprovalStates(messages, NO_RESOLUTIONS, Date.now());
+    expect(states.get('m1')).toMatchObject({
+      approvalId: 'a1',
+      status: 'active',
+    });
+  });
+
+  it('treats a command text announcement (e.g. **Pending Approval**) as an approval item', () => {
+    const messages: ChatUiMessage[] = [
+      {
+        id: 'm1',
+        role: 'command',
+        content: '**Pending Approval**\nRun a scan.\nApproval ID: a1',
+        sessionId: 'session-a',
+      } as ChatUiMessage,
+    ];
+    const states = deriveApprovalStates(messages, NO_RESOLUTIONS, Date.now());
+    expect(states.get('m1')).toMatchObject({
+      approvalId: 'a1',
+      status: 'active',
+    });
+  });
+
+  it('ignores plain assistant text that is not an approval announcement', () => {
+    const messages: ChatUiMessage[] = [
+      {
+        id: 'm1',
+        role: 'assistant',
+        content: 'Just a normal reply.',
+        sessionId: 'session-a',
+      } as ChatUiMessage,
+    ];
+    const states = deriveApprovalStates(messages, NO_RESOLUTIONS, Date.now());
+    expect(states.size).toBe(0);
+  });
+
+  it('a text announcement can be superseded by a later structured approval', () => {
+    const messages = [
+      textAnnouncementMessage('m1', 'a1'),
+      approvalMessage('m2', {
+        pendingApproval: structuredApproval({ approvalId: 'a2' }),
+      }),
+    ];
+    const states = deriveApprovalStates(messages, NO_RESOLUTIONS, Date.now());
+    expect(states.get('m1')).toMatchObject({ status: 'superseded' });
+    expect(states.get('m2')).toMatchObject({ status: 'active' });
+  });
+});

--- a/console/src/routes/chat/approval-lifecycle.ts
+++ b/console/src/routes/chat/approval-lifecycle.ts
@@ -1,0 +1,117 @@
+/**
+ * Derives per-message approval lifecycle state so stale approval cards stop
+ * being clickable once they're acted on, expire, or get superseded by a
+ * newer request.
+ *
+ * The gateway keeps at most one pending approval per session, so "only the
+ * newest approval item is actionable" mirrors server semantics exactly.
+ */
+
+import type { ApprovalAction } from '../../lib/chat-helpers';
+import { parseApprovalAnnouncement } from '../../lib/chat-helpers';
+import type { ChatUiMessage } from './chat-ui-message';
+
+export type ApprovalItemStatus =
+  | 'active'
+  | 'responded'
+  | 'superseded'
+  | 'expired';
+
+export interface ApprovalItemState {
+  approvalId: string;
+  status: ApprovalItemStatus;
+  respondedAction?: ApprovalAction;
+  /** Only known for structured (streamed) approvals; text announcements don't carry it. */
+  expiresAt?: number | null;
+}
+
+interface ApprovalItem {
+  messageId: string;
+  approvalId: string;
+  expiresAt: number | null;
+}
+
+function extractApprovalItem(msg: ChatUiMessage): ApprovalItem | null {
+  if (msg.role === 'approval' && msg.pendingApproval) {
+    return {
+      messageId: msg.id,
+      approvalId: msg.pendingApproval.approvalId,
+      expiresAt: msg.pendingApproval.expiresAt ?? null,
+    };
+  }
+  if (
+    msg.role === 'approval' ||
+    msg.role === 'assistant' ||
+    msg.role === 'command'
+  ) {
+    const parsed = parseApprovalAnnouncement(msg.content);
+    if (parsed)
+      return {
+        messageId: msg.id,
+        approvalId: parsed.approvalId,
+        expiresAt: null,
+      };
+  }
+  return null;
+}
+
+/**
+ * Only the newest approval item can be actionable: each new request replaces
+ * the previous pending one on the gateway, so an older item is gone even when
+ * the newest expired unanswered. The newest item is active unless it was
+ * responded to or is past its expiry; every older item is responded (acted
+ * on) or superseded.
+ */
+export function deriveApprovalStates(
+  messages: readonly ChatUiMessage[],
+  resolvedApprovals: ReadonlyMap<string, ApprovalAction>,
+  now: number,
+): Map<string, ApprovalItemState> {
+  const items: ApprovalItem[] = [];
+  for (const msg of messages) {
+    const item = extractApprovalItem(msg);
+    if (item) items.push(item);
+  }
+
+  const result = new Map<string, ApprovalItemState>();
+
+  for (let i = 0; i < items.length; i += 1) {
+    const item = items[i];
+    if (!item) continue;
+    const respondedAction = resolvedApprovals.get(item.approvalId);
+    if (respondedAction !== undefined) {
+      result.set(item.messageId, {
+        approvalId: item.approvalId,
+        status: 'responded',
+        respondedAction,
+      });
+      continue;
+    }
+
+    const isNewest = i === items.length - 1;
+    if (!isNewest) {
+      result.set(item.messageId, {
+        approvalId: item.approvalId,
+        status: 'superseded',
+      });
+      continue;
+    }
+
+    const isExpired =
+      item.expiresAt != null &&
+      Number.isFinite(item.expiresAt) &&
+      item.expiresAt < now;
+    result.set(
+      item.messageId,
+      isExpired
+        ? { approvalId: item.approvalId, status: 'expired' }
+        : {
+            approvalId: item.approvalId,
+            status: 'active',
+            expiresAt: item.expiresAt,
+          },
+    );
+  }
+
+  return result;
+}

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -1234,6 +1234,25 @@ aside[data-state="collapsed"] .chatSidebarContent {
   color: var(--success);
 }
 
+.approvalCardInactive {
+  opacity: 0.68;
+  filter: saturate(0.7);
+}
+
+.approvalStatusLine {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 0.82rem;
+  font-style: italic;
+}
+
+.approvalTextActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
 .artifactCard {
   display: flex;
   flex-direction: column;

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -66,6 +66,7 @@ import { CHAT_UI_CONFIG } from '../../lib/chat-ui-config';
 import { getErrorMessage } from '../../lib/error-message';
 import { useDebouncedValue } from '../../lib/use-debounced-value';
 import { findAgentMentions } from './agent-mention-display';
+import { deriveApprovalStates } from './approval-lifecycle';
 import {
   type ChatHistoryUiData,
   chatHistoryQueryKey,
@@ -93,6 +94,7 @@ const ERROR_BANNER_VISIBLE_MS = 5000;
 const ERROR_BANNER_FADE_MS = 200;
 const BOOTSTRAP_AUTOSTART_THINKING_ID = 'bootstrap-autostart-thinking';
 const BOOTSTRAP_AUTOSTART_REFETCH_MS = 1500;
+const APPROVAL_EXPIRY_TICK_MS = 30_000;
 const DEFAULT_EMPTY_CHAT_HEADER = 'Ready to claw through your to-do list?';
 type RecentChatScope = 'user' | 'all';
 
@@ -229,6 +231,12 @@ export function ChatPage() {
   const [errorExiting, setErrorExiting] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [approvalBusy, setApprovalBusy] = useState(false);
+  // approvalId -> action taken, so an acted-on card stops looking pending
+  // even before the next history refresh confirms it server-side.
+  const [resolvedApprovals, setResolvedApprovals] = useState<
+    Map<string, ApprovalAction>
+  >(() => new Map());
+  const [approvalNow, setApprovalNow] = useState(() => Date.now());
   const [mobileQr, setMobileQr] = useState<ChatMobileQrResponse | null>(null);
   const [mobileQrBusy, setMobileQrBusy] = useState(false);
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(
@@ -539,6 +547,32 @@ export function ChatPage() {
       },
     ];
   }, [isBootstrapAutostartStarting, messages, sessionId]);
+  const approvalStates = useMemo(
+    () => deriveApprovalStates(messages, resolvedApprovals, approvalNow),
+    [messages, resolvedApprovals, approvalNow],
+  );
+  // Only the active approval's expiry can flip a card's state, and only when
+  // it has a real deadline — no point ticking a clock nothing is watching.
+  const activeApprovalExpiresAt = useMemo(() => {
+    for (const state of approvalStates.values()) {
+      if (
+        state.status === 'active' &&
+        state.expiresAt != null &&
+        Number.isFinite(state.expiresAt)
+      ) {
+        return state.expiresAt;
+      }
+    }
+    return null;
+  }, [approvalStates]);
+  useEffect(() => {
+    if (activeApprovalExpiresAt == null) return;
+    if (activeApprovalExpiresAt <= approvalNow) return;
+    const interval = window.setInterval(() => {
+      setApprovalNow(Date.now());
+    }, APPROVAL_EXPIRY_TICK_MS);
+    return () => window.clearInterval(interval);
+  }, [activeApprovalExpiresAt, approvalNow]);
   const branchFamilies =
     historyQuery.data?.branchFamilies ?? EMPTY_BRANCH_FAMILIES;
   const effectiveAgentId =
@@ -800,7 +834,17 @@ export function ChatPage() {
       setApprovalBusy(true);
       try {
         jumpToBottom();
-        await stream.sendMessage(cmd, [], { hideUser: true });
+        const sent = await stream.sendMessage(cmd, [], { hideUser: true });
+        // Mark it handled only once the send succeeds — a failed send (e.g.
+        // another run already in flight) leaves it unresolved so the user
+        // can retry.
+        if (sent) {
+          setResolvedApprovals((prev) => {
+            const next = new Map(prev);
+            next.set(approvalId, action);
+            return next;
+          });
+        }
       } finally {
         setApprovalBusy(false);
       }
@@ -1353,6 +1397,7 @@ export function ChatPage() {
                       skillInvocationTargets={skillInvocationTargets}
                       onApprovalAction={handleApprovalAction}
                       approvalBusy={approvalBusy}
+                      approvalState={approvalStates.get(msg.id)}
                       branchInfo={branchInfoMap.get(msg.id) ?? null}
                       onBranchNav={handleBranchNav}
                     />

--- a/console/src/routes/chat/message-block.test.tsx
+++ b/console/src/routes/chat/message-block.test.tsx
@@ -1209,3 +1209,95 @@ describe('MessageBlock code-block copy button', () => {
     }
   });
 });
+
+describe('MessageBlock text-announced approvals', () => {
+  beforeEach(() => {
+    renderMarkdownMock.mockReset();
+    renderMarkdownMock.mockImplementation((content) => `<p>${content}</p>`);
+  });
+
+  const announcementText = [
+    'Approval needed for: trigger a thumbnail snapshot',
+    'Approval ID: approve123',
+    'Reply `yes` to approve once.',
+  ].join('\n');
+
+  it('renders Allow/Cancel actions for an active text approval item and dispatches the parsed id', () => {
+    const onApprovalAction = vi.fn();
+    render(
+      <MessageBlock
+        message={makeMessage([], {
+          role: 'assistant',
+          content: announcementText,
+        })}
+        token="test-token"
+        isStreaming={false}
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={onApprovalAction}
+        approvalBusy={false}
+        approvalState={{ approvalId: 'approve123', status: 'active' }}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Allow once' }));
+    expect(onApprovalAction).toHaveBeenCalledWith('once', 'approve123');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onApprovalAction).toHaveBeenCalledWith('deny', 'approve123');
+  });
+
+  it('renders no actions for a resolved (non-active) text approval item', () => {
+    render(
+      <MessageBlock
+        message={makeMessage([], {
+          role: 'assistant',
+          content: announcementText,
+        })}
+        token="test-token"
+        isStreaming={false}
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={vi.fn()}
+        approvalBusy={false}
+        approvalState={{
+          approvalId: 'approve123',
+          status: 'responded',
+          respondedAction: 'once',
+        }}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Allow once' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull();
+  });
+
+  it('renders no actions for plain assistant text with no approval state', () => {
+    render(
+      <MessageBlock
+        message={makeMessage([], {
+          role: 'assistant',
+          content: 'Just a normal reply.',
+        })}
+        token="test-token"
+        isStreaming={false}
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        onApprovalAction={vi.fn()}
+        approvalBusy={false}
+        branchInfo={null}
+        onBranchNav={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Allow once' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull();
+  });
+});

--- a/console/src/routes/chat/message-block.tsx
+++ b/console/src/routes/chat/message-block.tsx
@@ -30,6 +30,7 @@ import { renderMarkdown } from '../../lib/markdown';
 import { A2ADeliveryChip } from './a2a-delivery-chip';
 import { findAgentMentions } from './agent-mention-display';
 import { ApprovalCard } from './approval-card';
+import type { ApprovalItemState } from './approval-lifecycle';
 import css from './chat-page.module.css';
 import type { ChatUiMessage } from './chat-ui-message';
 import {
@@ -402,6 +403,8 @@ export const MessageBlock = memo(function MessageBlock(props: {
   skillInvocationTargets?: ReadonlyMap<string, string>;
   onApprovalAction: (action: ApprovalAction, approvalId: string) => void;
   approvalBusy: boolean;
+  /** Lifecycle state for this message's approval item, if it has one. */
+  approvalState?: ApprovalItemState;
   branchInfo: { current: number; total: number } | null;
   onBranchNav: (message: ChatMessage, direction: -1 | 1) => void;
 }) {
@@ -437,6 +440,13 @@ export const MessageBlock = memo(function MessageBlock(props: {
   const isDraft = msg.role === 'draft';
   const isA2ADeliveryStatus = Boolean(msg.a2aDelivery);
   const shouldRenderApprovalCard = isApproval && Boolean(msg.pendingApproval);
+  // A text-rendered approval item (role 'approval' without its structured
+  // payload, or an assistant/command message announcing one in plain text) —
+  // chat-page has already worked out whether it's still actionable.
+  const isTextApprovalItem =
+    Boolean(props.approvalState) && !shouldRenderApprovalCard;
+  const showApprovalTextActions =
+    isTextApprovalItem && props.approvalState?.status === 'active';
   const isMarkdownMessage =
     !isA2ADeliveryStatus &&
     (msg.role === 'assistant' ||
@@ -541,14 +551,47 @@ export const MessageBlock = memo(function MessageBlock(props: {
               approval={msg.pendingApproval}
               busy={props.approvalBusy}
               onAction={props.onApprovalAction}
+              status={props.approvalState?.status}
+              respondedAction={props.approvalState?.respondedAction}
             />
           ) : isMarkdownMessage ? (
-            <div
-              ref={markdownRef}
-              className={css.markdownContent}
-              // biome-ignore lint/security/noDangerouslySetInnerHtml: markdown output is rendered by marked and sanitized through sanitize-html
-              dangerouslySetInnerHTML={{ __html: renderedHtml }}
-            />
+            <>
+              <div
+                ref={markdownRef}
+                className={css.markdownContent}
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: markdown output is rendered by marked and sanitized through sanitize-html
+                dangerouslySetInnerHTML={{ __html: renderedHtml }}
+              />
+              {showApprovalTextActions ? (
+                <div className={css.approvalTextActions}>
+                  <Button
+                    size="sm"
+                    disabled={props.approvalBusy}
+                    onClick={() =>
+                      props.onApprovalAction(
+                        'once',
+                        props.approvalState?.approvalId ?? '',
+                      )
+                    }
+                  >
+                    Allow once
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    disabled={props.approvalBusy}
+                    onClick={() =>
+                      props.onApprovalAction(
+                        'deny',
+                        props.approvalState?.approvalId ?? '',
+                      )
+                    }
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              ) : null}
+            </>
           ) : isUser ? (
             <UserMessageContent
               content={stripAppBuildDirective(msg.content)}


### PR DESCRIPTION
## Summary

- derive a lifecycle for every approval shown in the chat window: the newest request is active; everything else is responded, superseded, or expired
- non-active cards keep their details but lose their buttons and show one status line saying why they can no longer be acted on
- acting on a card marks it responded immediately (per action: approved once / for session / for agent / always / cancelled), so it stops inviting a second click
- pending approvals that surface as plain text — a command's "Pending Approval" output, or a history-restored approval message that lost its structured payload — get a compact Allow once / Cancel row while they are the active request
- expiry flips live via a low-frequency tick that only runs while the active approval has a real deadline

## Root cause

The chat window rendered a fully interactive `ApprovalCard` for every `approval`-role message forever. The gateway keeps at most one pending approval per session, so after a response, an expiry, or a newer request, those buttons were dead ends: clicking one sent an `/approve` for a stale id and the reply was "No pending approval found". Conversely, approvals announced only as message text had no buttons at all, forcing users to hand-type `approve <id>`.

## Impact

Only the request the gateway will actually accept is clickable; every stale card explains its state instead of failing after a click, and text-announced approvals become one-click actionable. Derivation lives in one pure helper (`approval-lifecycle.ts`) mirroring the server's one-pending-per-session rule — an older request never becomes actionable again, even when the newest expires unanswered.

## Validation

- console unit suite: 103 files, 925 tests passed
- new coverage: lifecycle derivation (12 cases incl. supersede/responded precedence, expiry, payloadless and text announcements), card rendering per status, text-item action row dispatch
- console typecheck and biome clean