### PR TITLE
fix(db): close SQLite cleanly on shutdown and self-heal a stale WAL at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ### Fixed
 
+- **A stale write-ahead log no longer bricks the gateway**: The gateway now
+  checkpoints and closes its SQLite database during shutdown, after the last
+  database writer has stopped — previously it exited without closing, so a
+  container stop or kill during the remaining shutdown work could strand a
+  `-wal` file that no longer matches the database. And at startup, a database
+  that fails its integrity check only because of such a leftover WAL — a hard
+  kill or a backup restored without its sidecar files can produce one — is
+  recovered by setting the WAL aside (kept on disk as `*.corrupt-<timestamp>`
+  for inspection) and continuing from the last checkpoint, instead of
+  crash-looping with `database disk image is malformed` on every start until
+  someone deletes the file by hand. A database whose main file is itself
+  damaged still refuses to start, with the WAL left in place for manual
+  repair.
 - **Email replies stay in their thread**: An agent that supplies its own parent
   message id when answering mail no longer breaks threading when that value is
   not a message id — for example an identifier read out of the subject line.

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -169,6 +169,7 @@ import {
   runMemoryConsolidation,
 } from '../memory/consolidation-runner.js';
 import {
+  closeDatabase,
   deleteQueuedProactiveMessage,
   enqueueProactiveMessage,
   failStaleDelegationJobs,
@@ -3833,6 +3834,9 @@ function setupShutdown(broadcastShutdown: () => void): void {
     await runShutdownStep('stop gateway plugins', stopGatewayPlugins);
     stopScheduler();
     stopMemoryConsolidationScheduler();
+    // Every database writer is stopped by now; checkpoint and close so no
+    // WAL is left behind if the process is killed during the flushes below.
+    await runShutdownStep('close database', closeDatabase);
     await runShutdownStep('shut down OTel', shutdownOtel);
     await runShutdownStep('flush Sentry', shutdownSentry);
     if (proactiveFlushTimer) {

--- a/src/memory/database.ts
+++ b/src/memory/database.ts
@@ -21,17 +21,166 @@ export function initDatabase(opts?: InitDatabaseOptions): void {
   const quiet = opts?.quiet === true;
   const dbPath = path.resolve(opts?.dbPath || DB_PATH);
   fs.mkdirSync(path.dirname(dbPath), { recursive: true });
-  db = new Database(dbPath);
-  db.pragma('journal_mode = WAL');
-  // SQLite foreign-key enforcement is connection-scoped, so enable it before
-  // running migrations or accepting writes on this writable connection.
-  db.pragma('foreign_keys = ON');
-  db.pragma('busy_timeout = 5000');
+  db = openDatabaseWithWalRecovery(dbPath);
   runMigrations(db, opts);
   migrateLegacyTasksToJobsTable();
   ensureDefaultSchedulerJobs();
   databaseInitialized = true;
   if (!quiet) logger.info({ path: dbPath }, 'Database initialized');
+}
+
+/**
+ * Checkpoint and close the database. Call this on shutdown after every
+ * subsystem that writes to the database has stopped: a clean checkpoint +
+ * close flushes the WAL into the main file and removes it, so a later kill
+ * of the process cannot leave a WAL on disk that no longer matches the
+ * database file.
+ */
+export function closeDatabase(): void {
+  if (!databaseInitialized) return;
+  databaseInitialized = false;
+  try {
+    db.pragma('wal_checkpoint(TRUNCATE)');
+  } catch (error) {
+    logger.warn({ error }, 'WAL checkpoint during database close failed');
+  }
+  try {
+    db.close();
+  } catch (error) {
+    logger.warn({ error }, 'Database close failed');
+  }
+}
+
+function isCorruptionError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as { code?: unknown }).code;
+  if (
+    typeof code === 'string' &&
+    (code.startsWith('SQLITE_CORRUPT') || code === 'SQLITE_NOTADB')
+  ) {
+    return true;
+  }
+  return error.message.includes('database disk image is malformed');
+}
+
+type CheckedOpen =
+  | { ok: true; database: Database.Database }
+  | { ok: false; database: Database.Database | null };
+
+/**
+ * Open dbPath and report whether `PRAGMA quick_check` passes. On corruption
+ * the (still open) connection is returned so the caller can dispose of it
+ * safely; non-corruption errors are rethrown.
+ */
+function openCheckedConnection(dbPath: string): CheckedOpen {
+  let database: Database.Database | undefined;
+  try {
+    database = new Database(dbPath);
+    database.pragma('journal_mode = WAL');
+    // SQLite foreign-key enforcement is connection-scoped, so enable it before
+    // running migrations or accepting writes on this writable connection.
+    database.pragma('foreign_keys = ON');
+    database.pragma('busy_timeout = 5000');
+    const rows = database.pragma('quick_check(1)') as Array<
+      Record<string, unknown>
+    >;
+    if (rows.length === 1 && Object.values(rows[0] ?? {})[0] === 'ok') {
+      return { ok: true, database };
+    }
+  } catch (error) {
+    if (!isCorruptionError(error)) {
+      try {
+        database?.close();
+      } catch {
+        // The original error is the one worth surfacing.
+      }
+      throw error;
+    }
+  }
+  return { ok: false, database: database ?? null };
+}
+
+/**
+ * Open the database, verifying integrity first. If the combination of main
+ * file + WAL is corrupt but the main file alone is intact, quarantine the
+ * -wal/-shm files and continue from the last checkpoint.
+ *
+ * A WAL that no longer matches the database file is what a hard kill of the
+ * runtime can leave behind (cached WAL writes lost while checkpointed main
+ * file writes survived). Recovering that stale WAL makes every read fail
+ * with SQLITE_CORRUPT even though the main file is fine — and because the
+ * WAL sits next to the database, the failure survives restarts until the
+ * WAL is removed. Losing the WAL's tail is strictly better than an
+ * unbootable gateway; the quarantined files are kept for inspection.
+ */
+function openDatabaseWithWalRecovery(dbPath: string): Database.Database {
+  const walPath = `${dbPath}-wal`;
+  const shmPath = `${dbPath}-shm`;
+  const hadWalBeforeOpen = fs.existsSync(walPath);
+
+  const first = openCheckedConnection(dbPath);
+  if (first.ok) return first.database;
+
+  if (!hadWalBeforeOpen) {
+    try {
+      first.database?.close();
+    } catch {
+      // Failing anyway.
+    }
+    throw new Error(
+      `Database at ${dbPath} failed its integrity check and there is no WAL to discard; manual repair required`,
+    );
+  }
+
+  // Preserve the WAL and shm for inspection, then empty the WAL BEFORE
+  // closing the failed connection: closing the last connection makes SQLite
+  // checkpoint the WAL into the main file, which would apply the very
+  // corruption being discarded (observed to overwrite and truncate an intact
+  // main file). Against an empty WAL that checkpoint cannot copy anything.
+  const suffix = `.corrupt-${Date.now()}`;
+  const walQuarantine = `${walPath}${suffix}`;
+  const shmQuarantine = `${shmPath}${suffix}`;
+  fs.copyFileSync(walPath, walQuarantine);
+  const hadShm = fs.existsSync(shmPath);
+  if (hadShm) fs.copyFileSync(shmPath, shmQuarantine);
+  fs.truncateSync(walPath, 0);
+  try {
+    first.database?.close();
+  } catch {
+    // The connection already failed its check; carry on with recovery.
+  }
+  fs.rmSync(walPath, { force: true });
+  fs.rmSync(shmPath, { force: true });
+  logger.warn(
+    { path: dbPath, quarantined: walQuarantine },
+    'Database failed its integrity check; retrying without the WAL in case a stale WAL was left behind by a hard kill',
+  );
+
+  const second = openCheckedConnection(dbPath);
+  if (second.ok) {
+    logger.warn(
+      { path: dbPath },
+      'Database recovered by discarding a stale WAL; changes that only existed in the WAL are lost',
+    );
+    return second.database;
+  }
+
+  // The main file itself is damaged — put the WAL back so no state is lost
+  // for whoever repairs this by hand.
+  try {
+    second.database?.close();
+  } catch {
+    // No WAL is present at this point, so closing cannot make things worse.
+  }
+  fs.copyFileSync(walQuarantine, walPath);
+  fs.rmSync(walQuarantine, { force: true });
+  if (hadShm) {
+    fs.copyFileSync(shmQuarantine, shmPath);
+    fs.rmSync(shmQuarantine, { force: true });
+  }
+  throw new Error(
+    `Database at ${dbPath} failed its integrity check even without its WAL; manual repair required`,
+  );
 }
 
 export function isDatabaseInitialized(): boolean {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -18,6 +18,7 @@ export {
 } from './audit.js';
 export * from './canonical-sessions.js';
 export {
+  closeDatabase,
   initDatabase,
   isDatabaseInitialized,
   withMemoryDatabase,

--- a/tests/database-wal-selfheal.integration.test.ts
+++ b/tests/database-wal-selfheal.integration.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Integration test: WAL self-heal at database startup.
+ *
+ * A hard kill (or a backup restored without its sidecar files) can leave a
+ * `-wal` file next to the database that no longer matches the main file.
+ * SQLite recovers such a WAL as long as it is internally consistent, and the
+ * resulting merged view fails with SQLITE_CORRUPT on every read — forever,
+ * because the WAL survives restarts. initDatabase() must detect this at boot,
+ * quarantine the WAL when the main file alone is intact, and refuse loudly
+ * when it is not.
+ *
+ * The poisoned WAL is crafted byte-by-byte per the documented WAL format: a
+ * single committed frame rewriting page 1 with a "database size" far smaller
+ * than the real file, which truncates the recovered view and makes ordinary
+ * reads hit invalid page references.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+let tmpDir: string;
+let initDatabase: typeof import('../src/memory/db.js').initDatabase;
+let closeDatabase: typeof import('../src/memory/db.js').closeDatabase;
+let withMemoryDatabase: typeof import('../src/memory/db.js').withMemoryDatabase;
+
+const PAGE_SIZE = 4096;
+
+beforeAll(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-wal-selfheal-'));
+
+  // Point the runtime home at our temp dir so side-effecty config imports
+  // resolve harmlessly.
+  process.env.HYBRIDCLAW_DATA_DIR = tmpDir;
+  process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER = '1';
+
+  vi.resetModules();
+  const dbMod = await import('../src/memory/db.js');
+  initDatabase = dbMod.initDatabase;
+  closeDatabase = dbMod.closeDatabase;
+  withMemoryDatabase = dbMod.withMemoryDatabase;
+});
+
+afterEach(() => {
+  closeDatabase();
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function freshDbPath(name: string): string {
+  const dir = fs.mkdtempSync(path.join(tmpDir, `${name}-`));
+  return path.join(dir, 'hybridclaw.db');
+}
+
+/**
+ * The WAL checksum: a cumulative Fletcher-style sum over 32-bit words, two
+ * words per step. Magic 0x377f0682 selects little-endian word order.
+ */
+function walChecksum(
+  data: Buffer,
+  seed: [number, number] = [0, 0],
+): [number, number] {
+  let [s0, s1] = seed;
+  for (let i = 0; i < data.length; i += 8) {
+    s0 = (s0 + data.readUInt32LE(i) + s1) >>> 0;
+    s1 = (s1 + data.readUInt32LE(i + 4) + s0) >>> 0;
+  }
+  return [s0, s1];
+}
+
+/**
+ * Write a syntactically valid WAL beside dbPath containing one committed
+ * frame: a copy of the database's real page 1 whose header claims the whole
+ * database is only `claimedPages` pages long. Recovering it truncates the
+ * reader's view of the database — the poisoned-WAL state a hard kill can
+ * leave behind.
+ */
+function writePoisonedWal(dbPath: string, claimedPages: number): void {
+  const page1 = Buffer.alloc(PAGE_SIZE);
+  const fd = fs.openSync(dbPath, 'r');
+  fs.readSync(fd, page1, 0, PAGE_SIZE, 0);
+  fs.closeSync(fd);
+
+  // Rewrite the in-page header: db size in pages, with the change counter
+  // and version-valid-for bumped in lockstep so the header stays credible.
+  const changeCounter = page1.readUInt32BE(24) + 1;
+  page1.writeUInt32BE(changeCounter, 24);
+  page1.writeUInt32BE(claimedPages, 28);
+  page1.writeUInt32BE(changeCounter, 92);
+
+  const salt1 = 0x11111111;
+  const salt2 = 0x22222222;
+
+  const header = Buffer.alloc(32);
+  header.writeUInt32BE(0x377f0682, 0); // magic, little-endian checksums
+  header.writeUInt32BE(3007000, 4); // format version
+  header.writeUInt32BE(PAGE_SIZE, 8);
+  header.writeUInt32BE(0, 12); // checkpoint sequence
+  header.writeUInt32BE(salt1, 16);
+  header.writeUInt32BE(salt2, 20);
+  let sum = walChecksum(header.subarray(0, 24));
+  header.writeUInt32BE(sum[0], 24);
+  header.writeUInt32BE(sum[1], 28);
+
+  const frameHeader = Buffer.alloc(24);
+  frameHeader.writeUInt32BE(1, 0); // page number
+  frameHeader.writeUInt32BE(claimedPages, 4); // commit: db size after txn
+  frameHeader.writeUInt32BE(salt1, 8);
+  frameHeader.writeUInt32BE(salt2, 12);
+  sum = walChecksum(frameHeader.subarray(0, 8), sum);
+  sum = walChecksum(page1, sum);
+  frameHeader.writeUInt32BE(sum[0], 16);
+  frameHeader.writeUInt32BE(sum[1], 20);
+
+  fs.writeFileSync(`${dbPath}-wal`, Buffer.concat([header, frameHeader, page1]));
+}
+
+function listQuarantineFiles(dbPath: string): string[] {
+  return fs
+    .readdirSync(path.dirname(dbPath))
+    .filter((name) => name.includes('.corrupt-'));
+}
+
+describe('database WAL self-heal', () => {
+  it('closes cleanly leaving no WAL behind', () => {
+    const dbPath = freshDbPath('clean-close');
+    initDatabase({ dbPath, quiet: true });
+    withMemoryDatabase((database) => {
+      database.prepare('CREATE TABLE t (x)').run();
+      database.prepare('INSERT INTO t VALUES (1)').run();
+    });
+    expect(fs.existsSync(`${dbPath}-wal`)).toBe(true);
+
+    closeDatabase();
+    expect(fs.existsSync(`${dbPath}-wal`)).toBe(false);
+  });
+
+  it('quarantines a stale WAL and boots from the intact main file', () => {
+    const dbPath = freshDbPath('selfheal');
+    initDatabase({ dbPath, quiet: true });
+    withMemoryDatabase((database) => {
+      database.prepare('CREATE TABLE t (x)').run();
+      const insert = database.prepare('INSERT INTO t VALUES (?)');
+      for (let i = 0; i < 500; i++) insert.run(`row-${i}`);
+    });
+    closeDatabase();
+
+    const realPages = fs.statSync(dbPath).size / PAGE_SIZE;
+    expect(realPages).toBeGreaterThan(4);
+    writePoisonedWal(dbPath, 2);
+
+    initDatabase({ dbPath, quiet: true });
+    const count = withMemoryDatabase(
+      (database) =>
+        database.prepare('SELECT COUNT(*) AS n FROM t').get() as { n: number },
+    );
+    expect(count.n).toBe(500);
+
+    // The quarantine must actually have triggered (proving the crafted WAL
+    // really corrupted the merged view), and the poisoned WAL is preserved
+    // for inspection rather than deleted.
+    const quarantined = listQuarantineFiles(dbPath);
+    expect(
+      quarantined.some((name) => name.startsWith('hybridclaw.db-wal.corrupt-')),
+    ).toBe(true);
+    // The main database file was never rewritten by the recovery.
+    expect(fs.statSync(dbPath).size / PAGE_SIZE).toBe(realPages);
+  });
+
+  it('restores the WAL and throws when the main file itself is corrupt', () => {
+    const dbPath = freshDbPath('hopeless');
+    initDatabase({ dbPath, quiet: true });
+    withMemoryDatabase((database) => {
+      database.prepare('CREATE TABLE t (x)').run();
+      database.prepare('INSERT INTO t VALUES (1)').run();
+    });
+    closeDatabase();
+
+    writePoisonedWal(dbPath, 2);
+    // Trash the main file's header — no amount of WAL-dropping can fix this.
+    const garbage = Buffer.alloc(100, 0xab);
+    const fd = fs.openSync(dbPath, 'r+');
+    fs.writeSync(fd, garbage, 0, garbage.length, 0);
+    fs.closeSync(fd);
+
+    expect(() => initDatabase({ dbPath, quiet: true })).toThrow(
+      /manual repair required/,
+    );
+    // The WAL was put back so nothing is lost for hand-repair.
+    expect(fs.existsSync(`${dbPath}-wal`)).toBe(true);
+    expect(listQuarantineFiles(dbPath)).toEqual([]);
+  });
+});

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -642,6 +642,7 @@ async function importFreshGatewayMain(options?: {
     },
   }));
   vi.doMock('../src/memory/db.js', () => ({
+    closeDatabase: vi.fn(),
     deleteQueuedProactiveMessage: vi.fn(),
     enqueueProactiveMessage: vi.fn(() => ({ dropped: 0, queued: 1 })),
     failStaleDelegationJobs: state.failStaleDelegationJobs,


### PR DESCRIPTION
## Problem

The gateway never closes its SQLite database. Shutdown ends in `process.exit(0)` with the connection open, so a container stop or kill during the remaining shutdown work (channel drains, telemetry flushes) can strand a `-wal` file on disk that no longer matches the main database file.

SQLite recovers such a WAL as long as it is internally consistent — and the recovered view then fails with `SQLITE_CORRUPT: database disk image is malformed` on **every** read. Because the WAL sits next to the database file, this survives restarts: the gateway crash-loops on startup forever until someone deletes the WAL by hand. A backup of the `.db` file restored without its sidecar files produces the same state. We debugged a production instance bricked exactly this way for six days (the on-disk WAL had gone stale relative to the main file after a hard kill; the main file itself was fully intact).

## Fix

**1. Close the database on shutdown.** After the last database-writing subsystem stops (scheduler, memory consolidation, token-usage buffer, …) and before the network-bound flush steps, the shutdown path now runs `PRAGMA wal_checkpoint(TRUNCATE)` and closes the connection. A clean close removes the WAL entirely, so a kill later in shutdown cannot strand WAL state.

**2. Self-heal a stale WAL at startup.** `initDatabase()` now runs `PRAGMA quick_check` before migrations:

- check passes → boots exactly as before;
- check fails **and** a WAL is present → the WAL/shm are preserved as `*.corrupt-<timestamp>` for inspection, discarded from the live path, and the database reopens from its last checkpoint (re-verified with `quick_check`). Loud warnings are logged; only changes that existed solely in the stale WAL are lost — strictly better than an unbootable gateway;
- the main file itself is damaged → startup still fails loudly, with the WAL restored so no state is lost for manual repair.

A subtle hazard handled explicitly: closing the last connection makes SQLite checkpoint the WAL into the main file — which would *apply* the very corruption being discarded (observed: it overwrites and truncates an intact main file). The failed connection's WAL is therefore emptied before that close, making the close-time checkpoint a no-op.

## Tests

New integration test crafts a poisoned WAL byte-by-byte per the WAL file format (single committed frame rewriting page 1 to claim a far smaller database size — the exact stale-WAL signature) and verifies:

- clean close leaves no `-wal` behind,
- a poisoned WAL is quarantined and the gateway boots with all data from the last checkpoint, the main file untouched,
- a damaged main file still refuses to start, with the WAL put back and no quarantine files left.

`tsc --noEmit --noUnusedLocals --noUnusedParameters` and `biome check` are clean; database integration tests pass.
