### PR TITLE
fix: indicate automatic model routing

### DIFF
--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -118,9 +118,16 @@ export interface ChatContextSnapshot {
   completionTokens: number | null;
 }
 
+export interface ChatModelRoutingContext {
+  active: boolean;
+  startTier: string | null;
+  startModel: string | null;
+}
+
 export interface ChatContextResponse {
   sessionId: string;
   snapshot: ChatContextSnapshot | null;
+  routing?: ChatModelRoutingContext | null;
 }
 
 export interface ChatCommandSuggestion {

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -1481,6 +1481,7 @@ export function ChatPage() {
             onAgentSwitch={(agentId) => void handleAgentSwitch(agentId)}
             models={modelOptions}
             selectedModelId={selectedModelId}
+            modelRouting={contextQuery.data?.routing}
             onModelSwitch={(modelId) => void handleModelSwitch(modelId)}
             initialValue={initialComposerPrompt}
             voiceAvailable={voiceCapabilityQuery.data?.available === true}

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -18,7 +18,11 @@ import {
   useState,
 } from 'react';
 import { fetchChatCommands } from '../../api/chat';
-import type { ChatCommandSuggestion, MediaItem } from '../../api/chat-types';
+import type {
+  ChatCommandSuggestion,
+  ChatModelRoutingContext,
+  MediaItem,
+} from '../../api/chat-types';
 import { Popover, PopoverAnchor } from '../../components/popover';
 import { extractClipboardFiles } from '../../lib/chat-helpers';
 import { cx } from '../../lib/cx';
@@ -88,6 +92,7 @@ export function Composer(props: {
   onAgentSwitch?: (agentId: string) => void;
   models?: ModelSwitchEntry[];
   selectedModelId?: string;
+  modelRouting?: ChatModelRoutingContext | null;
   onModelSwitch?: (modelId: string) => void;
   initialValue?: string;
   voiceAvailable?: boolean;
@@ -649,6 +654,7 @@ export function Composer(props: {
               <ModelSwitchSelect
                 models={modelOptions}
                 selectedModelId={selectedModelId}
+                routing={props.modelRouting}
                 disabled={props.isStreaming}
                 onSwitch={(modelId) => props.onModelSwitch?.(modelId)}
               />

--- a/console/src/routes/chat/model-switch-select.module.css
+++ b/console/src/routes/chat/model-switch-select.module.css
@@ -1,3 +1,17 @@
+.headerStack {
+  display: grid;
+  gap: 8px;
+}
+
+.routingNotice {
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  color: var(--muted-foreground);
+  font-size: 0.76rem;
+  line-height: 1.35;
+}
+
 .search {
   display: flex;
   align-items: center;

--- a/console/src/routes/chat/model-switch-select.test.ts
+++ b/console/src/routes/chat/model-switch-select.test.ts
@@ -110,6 +110,50 @@ describe('parseModel', () => {
     expect(trigger.textContent).not.toContain('Qwen3.6 27b Fp8');
   });
 
+  it('labels automatic routing and lets the displayed default be explicitly pinned', () => {
+    const onSwitch = vi.fn();
+    render(
+      createElement(ModelSwitchSelect, {
+        models: [
+          model({
+            id: 'openai-codex/gpt-5.6-luna',
+            provider: 'codex',
+          }),
+          model({
+            id: 'haigpu2/google/gemma-4-e4b-it',
+            provider: 'vllm',
+            backend: 'vllm',
+          }),
+        ],
+        selectedModelId: 'openai-codex/gpt-5.6-luna',
+        routing: {
+          active: true,
+          startTier: 'economy',
+          startModel: 'haigpu2/google/gemma-4-e4b-it',
+        },
+        onSwitch,
+      }),
+    );
+
+    const trigger = screen.getByRole('combobox', {
+      name: 'Switch model, automatic routing active',
+    });
+    expect(trigger.textContent).toContain('Auto · Economy');
+    expect(trigger.title).toContain('Starts at Economy with Gemma 4 E4b It');
+
+    fireEvent.click(trigger);
+    expect(
+      screen.getByText(/Automatic routing is active/).textContent,
+    ).toContain('Select a model to pin this chat.');
+    fireEvent.click(
+      document.querySelector<HTMLElement>(
+        '[data-value="openai-codex/gpt-5.6-luna"]',
+      ) as HTMLElement,
+    );
+
+    expect(onSwitch).toHaveBeenCalledWith('openai-codex/gpt-5.6-luna');
+  });
+
   it('disambiguates duplicate local model names by route in the dropdown', () => {
     render(
       createElement(ModelSwitchSelect, {

--- a/console/src/routes/chat/model-switch-select.tsx
+++ b/console/src/routes/chat/model-switch-select.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from 'react';
 import type { GatewayModelProviderKey } from '../../../../src/gateway/model-provider-keys.js';
+import type { ChatModelRoutingContext } from '../../api/chat-types';
 import type { ChatModel } from '../../api/types';
 import {
   Local as LocalIcon,
@@ -521,6 +522,7 @@ function modelMatchesQuery(model: ParsedModel, query: string): boolean {
 export function ModelSwitchSelect(props: {
   models: ModelSwitchEntry[];
   selectedModelId: string;
+  routing?: ChatModelRoutingContext | null;
   disabled?: boolean;
   onSwitch: (modelId: string) => void;
 }) {
@@ -574,6 +576,24 @@ export function ModelSwitchSelect(props: {
   const selected =
     parsed.find((m) => m.id === selectedModelId) ??
     (selectedFallback ? parseModel(selectedFallback) : undefined);
+  const routing = props.routing?.active ? props.routing : null;
+  const routingModelId = routing?.startModel?.trim() ?? '';
+  const routingModelFallback = buildSelectedModelFallback(routingModelId);
+  const routingModel =
+    parsed.find((model) => model.id === routingModelId) ??
+    (routingModelFallback ? parseModel(routingModelFallback) : undefined);
+  const triggerModel = routingModel ?? selected;
+  const routingTierLabel = routing?.startTier
+    ? pretty(routing.startTier, {})
+    : 'Routing';
+  const triggerLabel = routing
+    ? `Auto · ${routingTierLabel}`
+    : selected?.displayName || '';
+  const routingDescription = routing
+    ? `Automatic routing is active. Starts at ${routingTierLabel}${
+        routingModel ? ` with ${routingModel.displayName}` : ''
+      }. Select a model to pin this chat.`
+    : null;
 
   if (props.models.length === 0 && !selected) return null;
 
@@ -582,38 +602,43 @@ export function ModelSwitchSelect(props: {
       value={selected ? selected.id : ''}
       disabled={props.disabled}
       onValueChange={(next) => {
-        if (!next || next === selectedModelId) return;
+        if (!next || (!routing && next === selectedModelId)) return;
         props.onSwitch(next);
       }}
     >
       <SelectTrigger
-        aria-label="Switch model"
-        title="Switch model"
+        aria-label={
+          routing ? 'Switch model, automatic routing active' : 'Switch model'
+        }
+        title={routingDescription ?? 'Switch model'}
         className={cx(css.composerPill, chrome.triggerPill)}
       >
-        {selected ? (
+        {triggerModel ? (
           <span aria-hidden="true" className={chrome.triggerLogo}>
             <VendorIcon
-              vendor={selected.vendor}
-              fallbackProvider={selected.provider}
+              vendor={triggerModel.vendor}
+              fallbackProvider={triggerModel.provider}
               size={16}
             />
           </span>
         ) : null}
-        <SelectValue placeholder="Select model">
-          {selected ? selected.displayName : ''}
-        </SelectValue>
+        <SelectValue placeholder="Select model">{triggerLabel}</SelectValue>
         <SelectIcon />
       </SelectTrigger>
       <SelectContent
         align="start"
         header={
-          <Search
-            value={query}
-            onValueChange={setQuery}
-            placeholder="Search models…"
-            aria-label="Search models"
-          />
+          <div className={chrome.headerStack}>
+            {routingDescription ? (
+              <div className={chrome.routingNotice}>{routingDescription}</div>
+            ) : null}
+            <Search
+              value={query}
+              onValueChange={setQuery}
+              placeholder="Search models…"
+              aria-label="Search models"
+            />
+          </div>
         }
         rail={
           <Rail>

--- a/docs/content/reference/model-selection.md
+++ b/docs/content/reference/model-selection.md
@@ -139,6 +139,9 @@ Routing follows these rules:
 
 - an explicit request model or `/model set` session override remains a hard pin
   and bypasses the ladder
+- in web chat, an unpinned routed session is labeled `Auto · <tier>` in the
+  model switcher; opening the switcher shows its starting model, and selecting
+  any concrete model pins that session
 - an agent's configured model chooses its starting tier when that model appears
   in the ladder; otherwise `routing.defaultStart` applies
 - heartbeat, scheduler, and full-auto turns start at the lowest tier

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -4260,6 +4260,7 @@ function handleApiChatContext(res: ServerResponse, url: URL): void {
   sendJson(res, 200, {
     sessionId: result.sessionId,
     snapshot: result.snapshot,
+    routing: result.routing,
   });
 }
 

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -1,3 +1,10 @@
+/**
+ * Gateway application service — authoritative host operations shared by transports.
+ *
+ * It resolves persisted runtime/session state but does not authenticate callers;
+ * HTTP authorization and response shaping belong to gateway-http-server.ts.
+ */
+
 import { spawnSync } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
 import fs from 'node:fs';
@@ -11136,19 +11143,49 @@ function buildGatewaySessionContextUsageSnapshot(
   });
 }
 
+export interface GatewaySessionModelRouting {
+  active: boolean;
+  startTier: string | null;
+  startModel: string | null;
+}
+
+function buildGatewaySessionModelRouting(
+  session: Session,
+): GatewaySessionModelRouting {
+  const routing = getRuntimeConfig().routing;
+  if (!routing.enabled || session.model?.trim()) {
+    return { active: false, startTier: null, startModel: null };
+  }
+
+  const agentModel = resolveAgentModel(resolveAgentConfig(session.agent_id));
+  const startTier =
+    (agentModel
+      ? routing.tiers.find((tier) => tier.models.includes(agentModel))
+      : undefined) ??
+    routing.tiers.find((tier) => tier.name === routing.defaultStart);
+
+  return {
+    active: true,
+    startTier: startTier?.name ?? null,
+    startModel: startTier?.models[0]?.trim() || null,
+  };
+}
+
 export function getGatewaySessionContextUsage(sessionId: string): {
   status: 'ok' | 'not_found';
   sessionId: string;
   snapshot: ReturnType<typeof buildContextUsageSnapshot> | null;
+  routing: GatewaySessionModelRouting | null;
 } {
   const session = memoryService.getSessionById(sessionId);
   if (!session) {
-    return { status: 'not_found', sessionId, snapshot: null };
+    return { status: 'not_found', sessionId, snapshot: null, routing: null };
   }
   return {
     status: 'ok',
     sessionId: session.id,
     snapshot: buildGatewaySessionContextUsageSnapshot(session),
+    routing: buildGatewaySessionModelRouting(session),
   };
 }
 

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -872,10 +872,24 @@ async function importFreshHealth(options?: {
     result: '',
     toolExecutions: [],
   }));
-  const getGatewaySessionContextUsage = vi.fn((sessionId: string) => ({
-    sessionId,
-    snapshot: null,
-  }));
+  const getGatewaySessionContextUsage = vi.fn(
+    (
+      sessionId: string,
+    ): {
+      status: 'ok';
+      sessionId: string;
+      snapshot: Record<string, unknown> | null;
+      routing?: {
+        active: boolean;
+        startTier: string | null;
+        startModel: string | null;
+      } | null;
+    } => ({
+      status: 'ok',
+      sessionId,
+      snapshot: null,
+    }),
+  );
   const readSystemPromptMessage = vi.fn(
     (messages: Array<{ role?: string; content?: unknown }>) => {
       const first = messages[0];
@@ -6989,6 +7003,36 @@ describe('gateway HTTP server', () => {
           createdCount: 2,
           deletedCount: 1,
         },
+      },
+    });
+  });
+
+  test('returns session-scoped model routing metadata for chat context', async () => {
+    const state = await importFreshHealth();
+    state.getGatewaySessionContextUsage.mockReturnValueOnce({
+      status: 'ok',
+      sessionId: 's1',
+      snapshot: { sessionId: 's1', model: 'openai/gpt-5.6-luna' },
+      routing: {
+        active: true,
+        startTier: 'economy',
+        startModel: 'vllm/google/gemma-4-e4b-it',
+      },
+    });
+    const req = makeRequest({ url: '/api/chat/context?sessionId=s1' });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      sessionId: 's1',
+      snapshot: { sessionId: 's1', model: 'openai/gpt-5.6-luna' },
+      routing: {
+        active: true,
+        startTier: 'economy',
+        startModel: 'vllm/google/gemma-4-e4b-it',
       },
     });
   });

--- a/tests/gateway-service.tier-routing.test.ts
+++ b/tests/gateway-service.tier-routing.test.ts
@@ -39,8 +39,12 @@ async function createFixture() {
   const { handleGatewayMessage } = await import(
     '../src/gateway/gateway-chat-service.ts'
   );
+  const { getGatewaySessionContextUsage } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
   const { memoryService } = await import('../src/memory/memory-service.ts');
   return {
+    getGatewaySessionContextUsage,
     handleGatewayMessage,
     homeDir,
     memoryService,
@@ -59,6 +63,26 @@ useCleanMocks({
     delete process.env.HYBRIDCLAW_DISABLE_CONFIG_WATCHER;
   },
   resetModules: true,
+});
+
+test('session context reports automatic routing until a model is pinned', async () => {
+  const fixture = await createFixture();
+  const sessionId = 'session-tier-indicator';
+  fixture.memoryService.getOrCreateSession(sessionId, null, 'web');
+
+  expect(fixture.getGatewaySessionContextUsage(sessionId).routing).toEqual({
+    active: true,
+    startTier: 'economy',
+    startModel: 'lmstudio/test-cheap',
+  });
+
+  fixture.updateSessionModel(sessionId, 'lmstudio/pinned');
+
+  expect(fixture.getGatewaySessionContextUsage(sessionId).routing).toEqual({
+    active: false,
+    startTier: null,
+    startModel: null,
+  });
 });
 
 test('gateway escalates once, emits route telemetry, and hides failed deltas', async () => {


### PR DESCRIPTION
## Summary

- expose active session routing and its starting tier/model through the chat context API
- label routed chats as Auto · tier in the model switcher and explain the starting model
- let selecting any concrete model, including the displayed default, pin the chat
- document and test the routed versus pinned states

## Validation

- npm run typecheck
- npm run lint
- npm run format
- Node 22: console model-switch-select tests (10 passed)
- Node 22: gateway tier-routing tests (4 passed)
- gateway HTTP routing-context boundary test (1 passed)