### PR TITLE
fix(db): self-heal a corrupted main database file at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Fixed
+
+- **A corrupted main database file no longer bricks the gateway either**:
+  Startup now runs a full integrity check (catching a silently diverged
+  index that used to slip past the quicker check and return wrong query
+  results) and, if the main database file itself is damaged, self-heals in
+  two stages instead of refusing to boot. Index-only damage is repaired
+  losslessly by rebuilding the affected indexes; damage in the table data
+  itself is repaired by rebuilding the database from every row that can
+  still be read, dropping and logging the rows that can't. The damaged
+  original is preserved beside the database as `*.corrupt-<timestamp>` for
+  inspection either way.
+
 ## [0.29.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.0) - 2026-08-20
 
 ### Added

--- a/src/memory/database.ts
+++ b/src/memory/database.ts
@@ -68,9 +68,17 @@ type CheckedOpen =
   | { ok: false; database: Database.Database | null };
 
 /**
- * Open dbPath and report whether `PRAGMA quick_check` passes. On corruption
- * the (still open) connection is returned so the caller can dispose of it
- * safely; non-corruption errors are rethrown.
+ * Open dbPath and report whether `PRAGMA integrity_check` passes. On
+ * corruption the (still open) connection is returned so the caller can
+ * dispose of it safely; non-corruption errors are rethrown.
+ *
+ * This uses the full integrity_check rather than quick_check: quick_check
+ * skips verifying that index content matches table content, so an index
+ * that has silently diverged from its table (missing or stale entries,
+ * which makes index-scan queries return wrong results) passes quick_check
+ * silently. integrity_check catches it — and now that startup can heal that
+ * class of damage with REINDEX (see openDatabaseWithWalRecovery), detecting
+ * it here is strictly better than staying blind to it.
  */
 function openCheckedConnection(dbPath: string): CheckedOpen {
   let database: Database.Database | undefined;
@@ -81,7 +89,7 @@ function openCheckedConnection(dbPath: string): CheckedOpen {
     // running migrations or accepting writes on this writable connection.
     database.pragma('foreign_keys = ON');
     database.pragma('busy_timeout = 5000');
-    const rows = database.pragma('quick_check(1)') as Array<
+    const rows = database.pragma('integrity_check(1)') as Array<
       Record<string, unknown>
     >;
     if (rows.length === 1 && Object.values(rows[0] ?? {})[0] === 'ok') {
@@ -100,6 +108,515 @@ function openCheckedConnection(dbPath: string): CheckedOpen {
   return { ok: false, database: database ?? null };
 }
 
+const ROWID_WALK_BATCH = 256;
+const MAX_CONSECUTIVE_ROW_SKIPS = 10_000;
+
+interface RebuildSummary {
+  droppedRows: number;
+  droppedByTable: Record<string, number>;
+  skippedSchemaObjects: string[];
+}
+
+interface SchemaObjectRow {
+  type: string;
+  name: string;
+  tbl_name: string;
+  sql: string;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Whether `sql` mentions any of `skippedTables` as a bare identifier. */
+function referencesSkippedTable(
+  sql: string,
+  skippedTables: Set<string>,
+): boolean {
+  for (const table of skippedTables) {
+    if (new RegExp(`\\b${escapeRegExp(table)}\\b`).test(sql)) return true;
+  }
+  return false;
+}
+
+/**
+ * Copy every row of `table` from the ATTACHed `src` database into `dest`.
+ * Tries a single bulk statement first; if that throws (a corrupt page
+ * anywhere in the table poisons the whole statement), starts over with a
+ * walk over SOURCE rowids: fetch the next batch of readable rowids, copy
+ * them one row at a time, and when even a single-rowid fetch throws, step
+ * the cursor forward by one until the b-tree seek escapes the corrupt leaf
+ * page's key range and lands on the next healthy page. The cursor tracks
+ * source rowids only — the destination assigns fresh rowids for tables
+ * without an INTEGER PRIMARY KEY alias, so destination state says nothing
+ * about how far the source scan has progressed.
+ *
+ * Caveat: for a table lacking an INTEGER PRIMARY KEY alias the rowids
+ * themselves are not preserved. Every real table in this schema carries an
+ * explicit id column, and the one rowid-linked structure (the FTS index) is
+ * skipped here and rebuilt from `messages` by the schema migrations.
+ */
+function copyTableData(
+  dest: Database.Database,
+  table: string,
+  summary: RebuildSummary,
+): void {
+  const quoted = `"${table.replace(/"/g, '""')}"`;
+  try {
+    dest.exec(`INSERT INTO main.${quoted} SELECT * FROM src.${quoted}`);
+    return;
+  } catch (error) {
+    logger.warn(
+      { table, error },
+      'Bulk copy of table failed during database salvage; falling back to a row-by-row scan',
+    );
+  }
+
+  let dropped = 0;
+  try {
+    // Prepare before deleting anything: if the table can't be addressed by
+    // rowid at all (prepare throws), the bulk copy's partial rows are all
+    // we'll ever get and must survive.
+    const fetchIdsStmt = dest.prepare(
+      `SELECT rowid AS r FROM src.${quoted} WHERE rowid > ? ORDER BY rowid LIMIT ?`,
+    );
+    const insertRowStmt = dest.prepare(
+      `INSERT INTO main.${quoted} SELECT * FROM src.${quoted} WHERE rowid = ?`,
+    );
+
+    // journal_mode=OFF gives no statement-level rollback guarantee, so the
+    // failed bulk copy may have left a partial prefix behind. Start clean —
+    // the walk below re-reads everything readable from the source.
+    dest.exec(`DELETE FROM main.${quoted}`);
+
+    let cursor = Number.MIN_SAFE_INTEGER;
+    let batch = ROWID_WALK_BATCH;
+    let consecutiveSkips = 0;
+
+    for (;;) {
+      let ids: number[];
+      try {
+        ids = (fetchIdsStmt.all(cursor, batch) as Array<{ r: number }>).map(
+          (row) => row.r,
+        );
+      } catch {
+        if (batch > 1) {
+          batch = 1;
+          continue;
+        }
+        // Even a single-rowid fetch just past `cursor` is unreadable — step
+        // over it. Once `cursor` passes the corrupt leaf page's key range,
+        // the seek lands on the next healthy page and the fetch recovers.
+        cursor += 1;
+        dropped += 1;
+        consecutiveSkips += 1;
+        if (consecutiveSkips >= MAX_CONSECUTIVE_ROW_SKIPS) {
+          logger.warn(
+            { table, cursor },
+            'Too many consecutive unreadable rows during database salvage; abandoning the rest of this table',
+          );
+          break;
+        }
+        continue;
+      }
+
+      consecutiveSkips = 0;
+      if (ids.length === 0) break; // end of table
+      for (const id of ids) {
+        try {
+          insertRowStmt.run(id);
+        } catch {
+          dropped += 1;
+        }
+      }
+      cursor = ids[ids.length - 1] as number;
+      batch = ROWID_WALK_BATCH;
+    }
+  } catch (error) {
+    // A table that can't be walked at all (e.g. WITHOUT ROWID — none exist
+    // in this schema today) keeps whatever the bulk copy managed; losing
+    // one table's tail must not abort the whole rebuild.
+    logger.warn(
+      { table, error },
+      'Row-by-row salvage of table failed; keeping the partial copy',
+    );
+    summary.droppedByTable[table] = summary.droppedByTable[table] ?? 0;
+  }
+
+  if (dropped > 0) {
+    summary.droppedByTable[table] =
+      (summary.droppedByTable[table] ?? 0) + dropped;
+    summary.droppedRows += dropped;
+  }
+}
+
+/**
+ * Rebuild dbPath from scratch: recreate every schema object it still knows
+ * about and copy across whatever rows are still readable, dropping (and
+ * counting) the rest. This is the lossy, last-resort repair for damage that
+ * REINDEX cannot fix — corrupted table pages, not just index pages.
+ *
+ * Virtual tables (and their shadow tables) are skipped rather than copied:
+ * the only virtual table in this schema is `recent_chat_message_search`, an
+ * FTS5 index over `messages` that the schema-migration layer detects as
+ * missing and recreates + backfills at startup, so skipping it here is
+ * lossless — it comes back on its own right after this function returns.
+ *
+ * Returns null (with dbPath and any scratch files it created cleaned up by
+ * the caller) if the source can't be read at all or the rebuilt copy still
+ * fails its integrity check.
+ */
+function attemptRebuildRepair(
+  dbPath: string,
+  ts: number,
+): { database: Database.Database; summary: RebuildSummary } | null {
+  const rebuildPath = `${dbPath}.rebuild-${ts}`;
+  fs.rmSync(rebuildPath, { force: true });
+
+  let source: Database.Database | undefined;
+  let dest: Database.Database | undefined;
+  const summary: RebuildSummary = {
+    droppedRows: 0,
+    droppedByTable: {},
+    skippedSchemaObjects: [],
+  };
+
+  try {
+    try {
+      source = new Database(dbPath, { readonly: true });
+    } catch {
+      // Header trashed (SQLITE_NOTADB) or similarly unreadable — there is
+      // nothing left to salvage rows from.
+      return null;
+    }
+
+    let schemaRows: SchemaObjectRow[];
+    try {
+      schemaRows = source
+        .prepare(
+          'SELECT type, name, tbl_name, sql FROM sqlite_master WHERE sql IS NOT NULL',
+        )
+        .all() as SchemaObjectRow[];
+    } catch {
+      return null;
+    }
+
+    // Virtual tables and their FTS5 shadow tables ("<name>_*") are skipped;
+    // everything else whose tbl_name points at a skipped table (its indexes,
+    // triggers, views) is skipped too.
+    const skippedTables = new Set<string>();
+    for (const row of schemaRows) {
+      if (row.name.startsWith('sqlite_')) continue;
+      if (row.type === 'table' && /^CREATE VIRTUAL TABLE/i.test(row.sql)) {
+        skippedTables.add(row.name);
+      }
+    }
+    for (const row of schemaRows) {
+      if (row.type !== 'table' || row.name.startsWith('sqlite_')) continue;
+      for (const virtualTable of skippedTables) {
+        if (row.name.startsWith(`${virtualTable}_`)) {
+          skippedTables.add(row.name);
+        }
+      }
+    }
+
+    const objects = schemaRows.filter((row) => {
+      if (row.name.startsWith('sqlite_')) return false;
+      if (skippedTables.has(row.name) || skippedTables.has(row.tbl_name)) {
+        summary.skippedSchemaObjects.push(row.name);
+        return false;
+      }
+      // A trigger's tbl_name is the table it fires ON, not the tables its
+      // body references — e.g. the FTS5 shadow triggers fire on `messages`
+      // but INSERT/DELETE into the skipped virtual table inside their body.
+      // Recreating such a trigger without its target leaves a schema object
+      // that fails not just when it fires, but on any later DDL that has to
+      // resolve every trigger/view in the schema (observed: ALTER TABLE
+      // RENAME on an unrelated table failing with "no such table"). Skip
+      // any trigger/view whose body mentions a skipped table by name.
+      if (
+        (row.type === 'trigger' || row.type === 'view') &&
+        referencesSkippedTable(row.sql, skippedTables)
+      ) {
+        summary.skippedSchemaObjects.push(row.name);
+        return false;
+      }
+      return true;
+    });
+    const tables = objects.filter((o) => o.type === 'table');
+    const indexes = objects.filter((o) => o.type === 'index');
+    const others = objects.filter(
+      (o) => o.type === 'trigger' || o.type === 'view',
+    );
+
+    dest = new Database(rebuildPath);
+    // This is a scratch file we verify before it ever becomes dbPath, so
+    // durability during the copy doesn't matter — only speed does. Foreign
+    // keys stay off so table creation/copy order doesn't have to satisfy
+    // them.
+    dest.pragma('journal_mode = OFF');
+    dest.pragma('synchronous = OFF');
+    dest.pragma('foreign_keys = OFF');
+
+    const createdTables = new Set<string>();
+    for (const table of tables) {
+      try {
+        dest.exec(table.sql);
+        createdTables.add(table.name);
+      } catch (error) {
+        logger.warn(
+          { table: table.name, error },
+          'Failed to recreate table during database salvage; skipping it',
+        );
+      }
+    }
+
+    // Copy data before creating indexes/triggers/views: indexes populate
+    // automatically as rows land, and triggers must not fire on the copy
+    // itself, so they're created afterward.
+    source.close();
+    source = undefined;
+    const escapedSrcPath = dbPath.replace(/'/g, "''");
+    dest.exec(`ATTACH DATABASE '${escapedSrcPath}' AS src`);
+    for (const table of tables) {
+      if (!createdTables.has(table.name)) continue;
+      copyTableData(dest, table.name, summary);
+    }
+    try {
+      // Preserve AUTOINCREMENT counters even for tables whose highest rowid
+      // was among the rows we couldn't copy.
+      dest.exec(
+        'DELETE FROM main.sqlite_sequence; INSERT INTO main.sqlite_sequence SELECT * FROM src.sqlite_sequence',
+      );
+    } catch {
+      // Neither side has AUTOINCREMENT tables (no sqlite_sequence table) —
+      // nothing to preserve.
+    }
+    dest.exec('DETACH DATABASE src');
+
+    for (const index of indexes) {
+      if (!createdTables.has(index.tbl_name)) continue;
+      try {
+        dest.exec(index.sql);
+      } catch (error) {
+        logger.warn(
+          { index: index.name, error },
+          'Failed to recreate index during database salvage; skipping it',
+        );
+      }
+    }
+    for (const other of others) {
+      // A trigger's tbl_name is the table it fires on — skip triggers whose
+      // table didn't make it. A view's tbl_name is the view's own name, so
+      // the gate must not apply to views (ones referencing skipped tables
+      // were already filtered out above).
+      if (other.type === 'trigger' && !createdTables.has(other.tbl_name)) {
+        continue;
+      }
+      try {
+        dest.exec(other.sql);
+      } catch (error) {
+        logger.warn(
+          { name: other.name, type: other.type, error },
+          'Failed to recreate schema object during database salvage; skipping it',
+        );
+      }
+    }
+
+    const check = dest.pragma('integrity_check') as Array<
+      Record<string, unknown>
+    >;
+    if (check.length !== 1 || Object.values(check[0] ?? {})[0] !== 'ok') {
+      dest.close();
+      dest = undefined;
+      fs.rmSync(rebuildPath, { force: true });
+      return null;
+    }
+    dest.close();
+    dest = undefined;
+
+    // Swap the rebuild in. Forensic copies of the original were already
+    // taken by the caller, so it's safe to delete the corrupt originals.
+    fs.rmSync(dbPath, { force: true });
+    fs.rmSync(`${dbPath}-wal`, { force: true });
+    fs.rmSync(`${dbPath}-shm`, { force: true });
+    fs.renameSync(rebuildPath, dbPath);
+
+    const reopened = openCheckedConnection(dbPath);
+    if (!reopened.ok) {
+      try {
+        reopened.database?.close();
+      } catch {
+        // Ignore; we're already reporting failure.
+      }
+      return null;
+    }
+    return { database: reopened.database, summary };
+  } catch (error) {
+    logger.warn(
+      { error, path: dbPath },
+      'Database rebuild salvage failed unexpectedly',
+    );
+    return null;
+  } finally {
+    try {
+      source?.close();
+    } catch {
+      // Ignore.
+    }
+    try {
+      dest?.close();
+    } catch {
+      // Ignore.
+    }
+  }
+}
+
+/**
+ * Attempt to REINDEX dbPath in place. REINDEX only rebuilds index content
+ * from the table data it indexes, so it losslessly repairs an index that
+ * has diverged from (or was structurally damaged relative to) its table —
+ * the case openCheckedConnection's integrity_check now detects that
+ * quick_check used to miss. On a structurally damaged index btree REINDEX
+ * itself can throw SQLITE_CORRUPT; that's an expected outcome here, not a
+ * bug, so it's swallowed and treated as "this repair didn't work."
+ */
+function attemptReindexRepair(dbPath: string): Database.Database | null {
+  let database: Database.Database | undefined;
+  try {
+    database = new Database(dbPath);
+    database.pragma('journal_mode = WAL');
+    database.pragma('busy_timeout = 5000');
+    try {
+      database.exec('REINDEX');
+    } catch {
+      // Fall through to the checked re-open, which will fail and send us
+      // to the rebuild path.
+    }
+    database.close();
+    database = undefined;
+  } catch {
+    try {
+      database?.close();
+    } catch {
+      // Ignore.
+    }
+    return null;
+  }
+
+  const reopened = openCheckedConnection(dbPath);
+  if (reopened.ok) return reopened.database;
+  try {
+    reopened.database?.close();
+  } catch {
+    // Ignore.
+  }
+  return null;
+}
+
+/**
+ * Attempt to recover a database whose main file itself fails its integrity
+ * check (not merely a stale WAL — see openDatabaseWithWalRecovery). Takes a
+ * forensic snapshot of the current on-disk state first — REINDEX mutates in
+ * place, so the snapshot has to exist before any repair touches the file —
+ * then tries, in order of how much data each preserves:
+ *
+ *  1. REINDEX: lossless. Fixes damaged/diverged indexes without touching
+ *     table content.
+ *  2. Rebuild: lossy. Recreates the schema in a new file and copies every
+ *     row that's still readable, table by table, dropping and counting the
+ *     rest. Handles damaged table pages that REINDEX can't touch.
+ *
+ * Returns the recovered connection, or null if neither repair worked, in
+ * which case dbPath (and its -wal/-shm) is restored byte-for-byte from the
+ * forensic snapshot — the repair attempts mutate the file in place (REINDEX,
+ * and closing a connection checkpoints the WAL), and whoever repairs this by
+ * hand must get the original state, not a half-repaired one. The snapshots
+ * and any `.rebuild-*` scratch file are then removed.
+ */
+function salvageCorruptDatabase(dbPath: string): Database.Database | null {
+  const walPath = `${dbPath}-wal`;
+  const shmPath = `${dbPath}-shm`;
+  const ts = Date.now();
+  const dbSnapshot = `${dbPath}.corrupt-${ts}`;
+  const walSnapshot = `${walPath}.corrupt-${ts}`;
+  const shmSnapshot = `${shmPath}.corrupt-${ts}`;
+  const forensicPaths: string[] = [];
+
+  try {
+    fs.copyFileSync(dbPath, dbSnapshot);
+    forensicPaths.push(dbSnapshot);
+  } catch (error) {
+    logger.warn(
+      { error, path: dbPath },
+      'Failed to snapshot corrupt database before attempting salvage; giving up on salvage',
+    );
+    return null;
+  }
+  if (fs.existsSync(walPath)) {
+    fs.copyFileSync(walPath, walSnapshot);
+    forensicPaths.push(walSnapshot);
+  }
+  if (fs.existsSync(shmPath)) {
+    fs.copyFileSync(shmPath, shmSnapshot);
+    forensicPaths.push(shmSnapshot);
+  }
+
+  const reindexed = attemptReindexRepair(dbPath);
+  if (reindexed) {
+    logger.warn(
+      { path: dbPath, forensic: forensicPaths },
+      'Database self-healed by rebuilding its indexes; rows referenced by the damaged index were preserved',
+    );
+    return reindexed;
+  }
+
+  const rebuilt = attemptRebuildRepair(dbPath, ts);
+  if (rebuilt) {
+    logger.error(
+      {
+        path: dbPath,
+        forensic: forensicPaths,
+        droppedRows: rebuilt.summary.droppedRows,
+        droppedByTable: rebuilt.summary.droppedByTable,
+        skippedSchemaObjects: rebuilt.summary.skippedSchemaObjects,
+      },
+      'Database salvaged by rebuilding it from readable rows; some rows were lost',
+    );
+    return rebuilt.database;
+  }
+
+  // Both repairs failed. They mutated dbPath in place (REINDEX writes, and
+  // closing a connection checkpoints the WAL), so put the original bytes
+  // back from the snapshot before cleaning up — manual repair must start
+  // from the state this function found, not from a half-repaired one. A
+  // -wal/-shm that only appeared during the repair attempts is removed.
+  try {
+    fs.copyFileSync(dbSnapshot, dbPath);
+    if (forensicPaths.includes(walSnapshot)) {
+      fs.copyFileSync(walSnapshot, walPath);
+    } else {
+      fs.rmSync(walPath, { force: true });
+    }
+    if (forensicPaths.includes(shmSnapshot)) {
+      fs.copyFileSync(shmSnapshot, shmPath);
+    } else {
+      fs.rmSync(shmPath, { force: true });
+    }
+  } catch (error) {
+    logger.warn(
+      { error, path: dbPath, forensic: forensicPaths },
+      'Failed to restore the database from its forensic snapshot; keeping the snapshot files',
+    );
+    return null;
+  }
+  for (const forensicPath of forensicPaths) {
+    fs.rmSync(forensicPath, { force: true });
+  }
+  fs.rmSync(`${dbPath}.rebuild-${ts}`, { force: true });
+  return null;
+}
+
 /**
  * Open the database, verifying integrity first. If the combination of main
  * file + WAL is corrupt but the main file alone is intact, quarantine the
@@ -112,6 +629,12 @@ function openCheckedConnection(dbPath: string): CheckedOpen {
  * WAL sits next to the database, the failure survives restarts until the
  * WAL is removed. Losing the WAL's tail is strictly better than an
  * unbootable gateway; the quarantined files are kept for inspection.
+ *
+ * If the main file itself fails its check — either because there was no WAL
+ * to discard, or because discarding the WAL didn't fix it — this falls back
+ * to salvageCorruptDatabase() before giving up: first REINDEX (lossless),
+ * then a full rebuild from readable rows (lossy). Only if both of those
+ * fail does this throw and leave the database for manual repair.
  */
 function openDatabaseWithWalRecovery(dbPath: string): Database.Database {
   const walPath = `${dbPath}-wal`;
@@ -127,6 +650,8 @@ function openDatabaseWithWalRecovery(dbPath: string): Database.Database {
     } catch {
       // Failing anyway.
     }
+    const salvaged = salvageCorruptDatabase(dbPath);
+    if (salvaged) return salvaged;
     throw new Error(
       `Database at ${dbPath} failed its integrity check and there is no WAL to discard; manual repair required`,
     );
@@ -178,6 +703,12 @@ function openDatabaseWithWalRecovery(dbPath: string): Database.Database {
     fs.copyFileSync(shmQuarantine, shmPath);
     fs.rmSync(shmQuarantine, { force: true });
   }
+
+  // Salvage against the restored state, not the WAL-discarded one: the WAL
+  // may hold committed recent data, and reads through SQLite replay it.
+  const salvaged = salvageCorruptDatabase(dbPath);
+  if (salvaged) return salvaged;
+
   throw new Error(
     `Database at ${dbPath} failed its integrity check even without its WAL; manual repair required`,
   );

--- a/tests/database-wal-selfheal.integration.test.ts
+++ b/tests/database-wal-selfheal.integration.test.ts
@@ -18,6 +18,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import Database from 'better-sqlite3';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 let tmpDir: string;
@@ -124,6 +125,60 @@ function listQuarantineFiles(dbPath: string): string[] {
     .filter((name) => name.includes('.corrupt-'));
 }
 
+function listRebuildFiles(dbPath: string): string[] {
+  return fs
+    .readdirSync(path.dirname(dbPath))
+    .filter((name) => name.includes('.rebuild-'));
+}
+
+/** True once a fresh connection's full integrity_check reports something
+ * other than a single 'ok' row — used to confirm a corruption fixture
+ * actually broke something before relying on it in an assertion. */
+function integrityCheckFails(dbPath: string): boolean {
+  const check = new Database(dbPath, { readonly: true });
+  try {
+    // Severe enough corruption can make integrity_check itself throw
+    // (e.g. SQLITE_CORRUPT) rather than return rows describing the damage
+    // — that's still a failed check, not a passed one.
+    const rows = check.pragma('integrity_check') as Array<
+      Record<string, unknown>
+    >;
+    return !(rows.length === 1 && Object.values(rows[0] ?? {})[0] === 'ok');
+  } catch {
+    return true;
+  } finally {
+    check.close();
+  }
+}
+
+/** Byte offset of every occurrence of `needle` in the file at `filePath`. */
+function findAllOffsets(filePath: string, needle: Buffer): number[] {
+  const data = fs.readFileSync(filePath);
+  const offsets: number[] = [];
+  let from = 0;
+  for (;;) {
+    const at = data.indexOf(needle, from);
+    if (at === -1) break;
+    offsets.push(at);
+    from = at + 1;
+  }
+  return offsets;
+}
+
+function overwriteAt(filePath: string, offset: number, bytes: Buffer): void {
+  const fd = fs.openSync(filePath, 'r+');
+  fs.writeSync(fd, bytes, 0, bytes.length, offset);
+  fs.closeSync(fd);
+}
+
+function zeroPage(filePath: string, pageIndex0Based: number): void {
+  overwriteAt(
+    filePath,
+    pageIndex0Based * PAGE_SIZE,
+    Buffer.alloc(PAGE_SIZE, 0),
+  );
+}
+
 describe('database WAL self-heal', () => {
   it('closes cleanly leaving no WAL behind', () => {
     const dbPath = freshDbPath('clean-close');
@@ -186,11 +241,185 @@ describe('database WAL self-heal', () => {
     fs.writeSync(fd, garbage, 0, garbage.length, 0);
     fs.closeSync(fd);
 
+    const dbBytesBefore = fs.readFileSync(dbPath);
+    const walBytesBefore = fs.readFileSync(`${dbPath}-wal`);
+
     expect(() => initDatabase({ dbPath, quiet: true })).toThrow(
       /manual repair required/,
     );
-    // The WAL was put back so nothing is lost for hand-repair.
+    // The WAL was put back so nothing is lost for hand-repair, and the main
+    // file is byte-for-byte what the failed boot found — the salvage
+    // attempts must restore their in-place mutations from the forensic
+    // snapshot before giving up.
     expect(fs.existsSync(`${dbPath}-wal`)).toBe(true);
+    expect(fs.readFileSync(dbPath).equals(dbBytesBefore)).toBe(true);
+    expect(fs.readFileSync(`${dbPath}-wal`).equals(walBytesBefore)).toBe(true);
     expect(listQuarantineFiles(dbPath)).toEqual([]);
+    expect(listRebuildFiles(dbPath)).toEqual([]);
+  });
+
+  it('self-heals silent index divergence via REINDEX', () => {
+    const dbPath = freshDbPath('index-divergence');
+    initDatabase({ dbPath, quiet: true });
+    withMemoryDatabase((database) => {
+      database.prepare('CREATE TABLE t (x TEXT)').run();
+      database.prepare('CREATE INDEX idx_t_x ON t (x)').run();
+      const insert = database.prepare('INSERT INTO t VALUES (?)');
+      for (let i = 0; i < 50; i++) insert.run(`filler-${i}`);
+      insert.run('A'.repeat(64));
+    });
+    closeDatabase();
+
+    // Locate the rootpage of the table vs. the index so we corrupt the
+    // TABLE's copy of the distinctive value, not the index's — that's what
+    // makes the index and table content disagree without either one alone
+    // looking corrupt.
+    const inspect = new Database(dbPath, { readonly: true });
+    const rootpages = inspect
+      .prepare(
+        "SELECT name, rootpage FROM sqlite_master WHERE name IN ('t', 'idx_t_x')",
+      )
+      .all() as Array<{ name: string; rootpage: number }>;
+    inspect.close();
+    const tableRootpage = rootpages.find((r) => r.name === 't')?.rootpage;
+    expect(tableRootpage).toBeDefined();
+
+    const needle = Buffer.from('A'.repeat(64));
+    const offsets = findAllOffsets(dbPath, needle);
+    expect(offsets.length).toBeGreaterThan(0);
+    const tableOffset = offsets.find(
+      (offset) => Math.floor(offset / PAGE_SIZE) + 1 === tableRootpage,
+    );
+    expect(tableOffset).toBeDefined();
+
+    // Overwrite only the table's copy of the value (same length, so no
+    // structural change) — the index still points at a value the table no
+    // longer contains.
+    overwriteAt(dbPath, tableOffset as number, Buffer.from('B'.repeat(64)));
+
+    expect(integrityCheckFails(dbPath)).toBe(true);
+
+    initDatabase({ dbPath, quiet: true });
+    const count = withMemoryDatabase(
+      (database) =>
+        database
+          .prepare('SELECT COUNT(*) AS n FROM t WHERE x = ?')
+          .get('B'.repeat(64)) as { n: number },
+    );
+    expect(count.n).toBe(1);
+
+    expect(
+      listQuarantineFiles(dbPath).some((name) =>
+        name.startsWith('hybridclaw.db.corrupt-'),
+      ),
+    ).toBe(true);
+  });
+
+  it('rebuilds from readable rows when a table page is damaged', () => {
+    const dbPath = freshDbPath('table-damage');
+    initDatabase({ dbPath, quiet: true });
+    withMemoryDatabase((database) => {
+      database
+        .prepare('CREATE TABLE big (id INTEGER PRIMARY KEY, v TEXT)')
+        .run();
+      const insert = database.prepare('INSERT INTO big (id, v) VALUES (?, ?)');
+      for (let i = 0; i < 2000; i++) {
+        insert.run(i, `val-${i}-${'x'.repeat(90)}`);
+      }
+    });
+    closeDatabase();
+
+    // Find a page holding a known row's value and zero the whole page —
+    // damages the table btree without touching the header or schema.
+    const target = `val-1000-${'x'.repeat(90)}`;
+    const offsets = findAllOffsets(dbPath, Buffer.from(target));
+    expect(offsets.length).toBeGreaterThan(0);
+    const pageIndex0Based = Math.floor(offsets[0] / PAGE_SIZE);
+    zeroPage(dbPath, pageIndex0Based);
+
+    expect(integrityCheckFails(dbPath)).toBe(true);
+
+    initDatabase({ dbPath, quiet: true });
+    const count = withMemoryDatabase(
+      (database) =>
+        database.prepare('SELECT COUNT(*) AS n FROM big').get() as {
+          n: number;
+        },
+    );
+    // Only the rows on the zeroed page may be lost (~40 rows of this size
+    // per 4KB page) — the walk must resume past the damage, not abandon the
+    // rest of the table.
+    expect(count.n).toBeLessThan(2000);
+    expect(count.n).toBeGreaterThanOrEqual(1900);
+    const lastRow = withMemoryDatabase(
+      (database) =>
+        database.prepare('SELECT v FROM big WHERE id = 1999').get() as
+          | { v: string }
+          | undefined,
+    );
+    expect(lastRow?.v).toBe(`val-1999-${'x'.repeat(90)}`);
+
+    // Migrations recreate the FTS index that virtual-table skipping dropped.
+    const ftsTable = withMemoryDatabase(
+      (database) =>
+        database
+          .prepare(
+            "SELECT name FROM sqlite_master WHERE name = 'recent_chat_message_search'",
+          )
+          .get() as { name: string } | undefined,
+    );
+    expect(ftsTable?.name).toBe('recent_chat_message_search');
+
+    expect(
+      listQuarantineFiles(dbPath).some((name) =>
+        name.startsWith('hybridclaw.db.corrupt-'),
+      ),
+    ).toBe(true);
+    expect(listRebuildFiles(dbPath)).toEqual([]);
+  });
+
+  it('keeps indexes and triggers when rebuilding from readable rows', () => {
+    const dbPath = freshDbPath('schema-preserved');
+    initDatabase({ dbPath, quiet: true });
+    withMemoryDatabase((database) => {
+      database
+        .prepare('CREATE TABLE s (id INTEGER PRIMARY KEY, v TEXT)')
+        .run();
+      database.prepare('CREATE INDEX idx_s_v ON s (v)').run();
+      database
+        .prepare(
+          `CREATE TRIGGER trg_s_touch AFTER INSERT ON s
+           BEGIN UPDATE s SET v = v WHERE id = new.id; END`,
+        )
+        .run();
+      const insert = database.prepare('INSERT INTO s (id, v) VALUES (?, ?)');
+      for (let i = 0; i < 300; i++) {
+        insert.run(i, `row-${i}-${'y'.repeat(90)}`);
+      }
+    });
+    closeDatabase();
+
+    const target = `row-150-${'y'.repeat(90)}`;
+    const offsets = findAllOffsets(dbPath, Buffer.from(target));
+    expect(offsets.length).toBeGreaterThan(0);
+    zeroPage(dbPath, Math.floor(offsets[0] / PAGE_SIZE));
+
+    expect(integrityCheckFails(dbPath)).toBe(true);
+
+    initDatabase({ dbPath, quiet: true });
+    const schemaObjects = withMemoryDatabase(
+      (database) =>
+        database
+          .prepare(
+            "SELECT type, name FROM sqlite_master WHERE name IN ('idx_s_v', 'trg_s_touch')",
+          )
+          .all() as Array<{ type: string; name: string }>,
+    );
+    expect(schemaObjects.some((o) => o.name === 'idx_s_v' && o.type === 'index')).toBe(
+      true,
+    );
+    expect(
+      schemaObjects.some((o) => o.name === 'trg_s_touch' && o.type === 'trigger'),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

A database whose **main file** fails its integrity check stops the gateway at boot with `manual repair required` — an unbootable installation until someone repairs the SQLite file by hand. #1408 added self-healing for the *stale-WAL* case, but main-file damage still hard-fails.

Worse, this kind of damage sits dormant: startup ran `quick_check`, which skips verifying that index content matches table content. A silently diverged index (wrong query results on index scans) or garbled rows on rarely-scanned pages go unnoticed for weeks — until the first strict look at the file turns them into a boot failure. Both damage shapes have been observed in real installations.

## Fix

Startup now runs the full `integrity_check`, and when the main file itself is damaged it repairs in two stages before giving up:

1. **REINDEX (lossless)** — rebuilds all indexes from table content. Fixes diverged or structurally damaged indexes without touching a single row.
2. **Rebuild (lossy, last resort)** — recreates the schema in a fresh file and copies every row that is still readable. The copy walks *source* rowids in shrinking batches (256 → 1), so a corrupt page costs only the rows on that page, then the walk steps past the damaged leaf and continues; dropped rows are counted and logged. Virtual tables, their shadow tables, and the triggers/views referencing them are skipped — the only virtual table in this schema is the FTS index over `messages`, which the schema migrations detect as missing and recreate + backfill on the very same boot.

Safety properties:

- A forensic snapshot (`*.corrupt-<timestamp>`) of db/-wal/-shm is taken **before** any repair touches the file.
- If both repairs fail, the database is restored **byte-for-byte** from the snapshot and the previous error is thrown — hand repair starts from exactly the state the failed boot found (the repair attempts themselves mutate the file: REINDEX writes, and closing a connection checkpoints the WAL).
- The rebuild is verified with a full `integrity_check` before it ever replaces the original.

Also of note: skipping a virtual table must also skip triggers/views that reference it *in their body* (a trigger's `tbl_name` is the table it fires on, not what it touches) — recreating such a trigger leaves a schema object that breaks unrelated later DDL ("no such table" on any `ALTER TABLE ... RENAME`, because SQLite revalidates every trigger body).

## Tests

Extends the byte-level fixture suite from #1408 (`tests/database-wal-selfheal.integration.test.ts`), 6 tests:

- silent index divergence: a table cell is byte-patched so the index points at a value the table no longer holds — passes `quick_check`, fails `integrity_check`, heals via REINDEX with zero data loss
- zeroed table page: rebuild keeps the rows before **and after** the damage (last row asserted present; exactly one page's worth of rows lost) and the FTS index is back after boot
- schema survival: indexes and triggers exist in the rebuilt file
- hopeless case (trashed header): still throws, and the db + WAL bytes after the throw equal the bytes before it
- the two original WAL self-heal tests, unchanged

`vitest` 6/6, `npm run typecheck` clean, biome clean.