### PR TITLE
feat(voice): default realtime provider to auto (credential-based selection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Changed
+
+- **Realtime voice picks its backend from the credentials you have**: The
+  default `voice.realtime.provider` is now `auto` — the HybridAI platform's
+  realtime proxy when a HybridAI credential is present (signed in, or
+  `HYBRIDAI_API_KEY`), otherwise OpenAI with `OPENAI_API_KEY`. Previously the
+  default was `openai`, so a signed-in operator without an OpenAI key saw no
+  voice button in the web console and no working realtime phone mode until
+  they discovered the provider setting. This matches how dictation and
+  speech output already resolve their backends; explicit `openai` and
+  `hybridai` settings keep pinning a single backend.
+
 ## [0.29.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.0) - 2026-08-20
 
 ### Added

--- a/console/src/generated/settings-registry.ts
+++ b/console/src/generated/settings-registry.ts
@@ -2739,7 +2739,7 @@ export const GENERATED_SETTINGS_REGISTRY: ReadonlyArray<GeneratedSettingEntry> =
       path: 'voice.realtime.provider',
       section: 'voice',
       kind: 'string',
-      defaultValue: 'openai',
+      defaultValue: 'auto',
     },
     {
       path: 'voice.realtime.voice',

--- a/docs/content/channels/admin-console.md
+++ b/docs/content/channels/admin-console.md
@@ -154,8 +154,8 @@ changes before navigation.
   labels, and keeps copy controls reachable on hover and touch devices
 - the web chat route offers a realtime voice mode (microphone button in the
   composer) when the configured `voice.realtime.provider` has a credential —
-  an OpenAI API key for `openai`, or the signed-in HybridAI credential for
-  `hybridai` (which routes through the platform's `/v1/realtime` proxy): mic
+  by default the signed-in HybridAI credential (routing through the
+  platform's `/v1/realtime` proxy), or an OpenAI API key: mic
   audio streams to the realtime API for natural speech-to-speech conversation
   with interruption support; spoken turns persist into the conversation as
   voice-tagged messages, and substantive requests run as ordinary web chat

--- a/docs/content/guides/twilio-voice.md
+++ b/docs/content/guides/twilio-voice.md
@@ -155,15 +155,16 @@ alongside the consulted turns.
 
 Requirements and notes:
 
-- Realtime mode needs a realtime credential. With the default
-  `voice.realtime.provider` of `openai`, set the `OPENAI_API_KEY` environment
-  variable or store it in the encrypted secret store (same flow as the Twilio
-  auth token, secret name `OPENAI_API_KEY`). Set the provider to `hybridai`
-  to route sessions through the HybridAI platform's `/v1/realtime` proxy
-  instead, authenticated with your signed-in HybridAI credential (or
-  `HYBRIDAI_API_KEY`) — no OpenAI key required. The gateway refuses to start
-  the voice channel in realtime mode without the selected provider's
-  credential.
+- Realtime mode needs a realtime credential. The default
+  `voice.realtime.provider` of `auto` uses the HybridAI platform's
+  `/v1/realtime` proxy when a HybridAI credential is present (signed in, or
+  `HYBRIDAI_API_KEY`), and OpenAI otherwise. Set the provider to `openai` or
+  `hybridai` to pin one backend: `openai` needs the `OPENAI_API_KEY`
+  environment variable or the encrypted secret store (same flow as the
+  Twilio auth token, secret name `OPENAI_API_KEY`); `hybridai` needs only
+  the HybridAI credential — no OpenAI key required. The gateway refuses to
+  start the voice channel in realtime mode without a credential for the
+  selected provider.
 - `voice.realtime.voice` accepts any OpenAI realtime voice name (for example
   `marin`, `cedar`, `alloy`).
 - `voice.realtime.instructions` is appended to the built-in call instructions;

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -264,7 +264,8 @@ saved revision history directly.
   (OpenAI Realtime speech-to-speech over Twilio Media Streams, configured via
   `voice.realtime.model`, `voice.realtime.voice`, `voice.realtime.greeting`,
   and `voice.realtime.instructions`). `voice.realtime.provider` selects the
-  realtime backend: `openai` (the default; requires an `OPENAI_API_KEY`) or
+  realtime backend: `auto` (the default: HybridAI when a HybridAI credential
+  is present, otherwise OpenAI), `openai` (requires an `OPENAI_API_KEY`), or
   `hybridai` (the HybridAI platform's `/v1/realtime` proxy at
   `HYBRIDAI_BASE_URL`, authenticated with your signed-in HybridAI credential
   or `HYBRIDAI_API_KEY` — no OpenAI key needed). The `voice.realtime.*`

--- a/src/channels/voice/realtime-credentials.ts
+++ b/src/channels/voice/realtime-credentials.ts
@@ -49,7 +49,8 @@ export function resolveRealtimeConnection(
       connection: null;
       error: string;
     } {
-  const hybridaiApiKey = String(readHybridAIApiKey() || '').trim();
+  const hybridaiApiKey =
+    provider === 'openai' ? '' : String(readHybridAIApiKey() || '').trim();
   if (provider === 'hybridai' || (provider === 'auto' && hybridaiApiKey)) {
     if (!hybridaiApiKey) {
       return {

--- a/src/channels/voice/realtime-credentials.ts
+++ b/src/channels/voice/realtime-credentials.ts
@@ -1,11 +1,16 @@
 /**
  * Resolves which upstream serves realtime voice sessions.
  *
- * `voice.realtime.provider` selects between OpenAI directly (`openai`, the
- * default, using OPENAI_API_KEY) and the HybridAI platform's `/v1/realtime`
- * proxy (`hybridai`, using the signed-in HybridAI credential and
+ * `voice.realtime.provider` selects between OpenAI directly (`openai`, using
+ * OPENAI_API_KEY) and the HybridAI platform's `/v1/realtime` proxy
+ * (`hybridai`, using the signed-in HybridAI credential and
  * HYBRIDAI_BASE_URL). Both speak the same realtime protocol, so everything
  * past the connection URL and bearer token is provider-agnostic.
+ *
+ * The default is `auto`: HybridAI when a HybridAI credential is present,
+ * otherwise OpenAI — the same signed-in-operator-first order the dictation
+ * and speech backends use, so realtime voice works with whichever credential
+ * the operator already has, with no provider setting to discover.
  *
  * Shared by the Twilio phone path and the web console path so the two
  * surfaces cannot drift on provider selection or error wording.
@@ -44,9 +49,9 @@ export function resolveRealtimeConnection(
       connection: null;
       error: string;
     } {
-  if (provider === 'hybridai') {
-    const apiKey = String(readHybridAIApiKey() || '').trim();
-    if (!apiKey) {
+  const hybridaiApiKey = String(readHybridAIApiKey() || '').trim();
+  if (provider === 'hybridai' || (provider === 'auto' && hybridaiApiKey)) {
+    if (!hybridaiApiKey) {
       return {
         connection: null,
         error:
@@ -54,7 +59,10 @@ export function resolveRealtimeConnection(
       };
     }
     return {
-      connection: { url: hybridaiRealtimeUrl(HYBRIDAI_BASE_URL), apiKey },
+      connection: {
+        url: hybridaiRealtimeUrl(HYBRIDAI_BASE_URL),
+        apiKey: hybridaiApiKey,
+      },
       error: null,
     };
   }
@@ -62,7 +70,10 @@ export function resolveRealtimeConnection(
   if (!apiKey) {
     return {
       connection: null,
-      error: 'Realtime voice requires an OpenAI API key (OPENAI_API_KEY).',
+      error:
+        provider === 'auto'
+          ? 'Realtime voice requires a credential: sign in to HybridAI (or set HYBRIDAI_API_KEY), or set OPENAI_API_KEY.'
+          : 'Realtime voice requires an OpenAI API key (OPENAI_API_KEY).',
     };
   }
   return { connection: { url: OPENAI_REALTIME_URL, apiKey }, error: null };

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -636,7 +636,7 @@ export interface RuntimeLineConfig {
 
 export type RuntimeVoiceProvider = 'twilio';
 export type RuntimeVoiceMode = 'realtime' | 'relay';
-export type RuntimeVoiceRealtimeProvider = 'hybridai' | 'openai';
+export type RuntimeVoiceRealtimeProvider = 'auto' | 'hybridai' | 'openai';
 export type RuntimeVoiceRelayTtsProvider = 'amazon' | 'default' | 'google';
 export type RuntimeVoiceRelayTranscriptionProvider =
   | 'deepgram'
@@ -1778,7 +1778,7 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
       welcomeGreeting: 'Hello! How can I help you today?',
     },
     realtime: {
-      provider: 'openai',
+      provider: 'auto',
       model: 'gpt-realtime',
       voice: 'marin',
       greeting: 'Hello! How can I help you today?',
@@ -3626,7 +3626,11 @@ function normalizeVoiceRealtimeProvider(
 ): RuntimeVoiceRealtimeProvider {
   if (typeof value !== 'string') return fallback;
   const normalized = value.trim().toLowerCase();
-  if (normalized === 'openai' || normalized === 'hybridai') {
+  if (
+    normalized === 'auto' ||
+    normalized === 'openai' ||
+    normalized === 'hybridai'
+  ) {
     return normalized;
   }
   return fallback;

--- a/tests/voice.realtime-credentials.test.ts
+++ b/tests/voice.realtime-credentials.test.ts
@@ -9,6 +9,7 @@ afterEach(() => {
 async function loadCredentials(params: {
   openaiKey?: string;
   hybridaiKey?: string | null;
+  readHybridAI?: () => string | null;
   baseUrl?: string;
 }) {
   vi.doMock('../src/config/config.js', () => ({
@@ -16,13 +17,19 @@ async function loadCredentials(params: {
     HYBRIDAI_BASE_URL: params.baseUrl ?? 'https://hybridai.one',
   }));
   vi.doMock('../src/auth/hybridai-auth.js', () => ({
-    readHybridAIApiKey: () => params.hybridaiKey ?? null,
+    readHybridAIApiKey:
+      params.readHybridAI ?? (() => params.hybridaiKey ?? null),
   }));
   return import('../src/channels/voice/realtime-credentials.js');
 }
 
 test('openai provider connects to api.openai.com with OPENAI_API_KEY', async () => {
-  const credentials = await loadCredentials({ openaiKey: 'sk-test' });
+  const credentials = await loadCredentials({
+    openaiKey: 'sk-test',
+    readHybridAI: () => {
+      throw new Error('HybridAI auth should not be read');
+    },
+  });
 
   const resolved = credentials.resolveRealtimeConnection('openai');
 

--- a/tests/voice.realtime-credentials.test.ts
+++ b/tests/voice.realtime-credentials.test.ts
@@ -80,3 +80,43 @@ test('hybridai provider without a signed-in key explains itself', async () => {
   expect(resolved.error).toContain('HybridAI API key');
   expect(credentials.isRealtimeCredentialConfigured('hybridai')).toBe(false);
 });
+
+test('auto prefers hybridai when a HybridAI credential is present', async () => {
+  const credentials = await loadCredentials({
+    hybridaiKey: 'hai-key',
+    openaiKey: 'sk-unused',
+  });
+
+  const resolved = credentials.resolveRealtimeConnection('auto');
+
+  expect(resolved.connection).toEqual({
+    url: 'wss://hybridai.one/v1/realtime',
+    apiKey: 'hai-key',
+  });
+  expect(credentials.isRealtimeCredentialConfigured('auto')).toBe(true);
+});
+
+test('auto falls back to openai when only OPENAI_API_KEY is set', async () => {
+  const credentials = await loadCredentials({
+    hybridaiKey: null,
+    openaiKey: 'sk-test',
+  });
+
+  const resolved = credentials.resolveRealtimeConnection('auto');
+
+  expect(resolved.connection).toEqual({
+    url: 'wss://api.openai.com/v1/realtime',
+    apiKey: 'sk-test',
+  });
+});
+
+test('auto without any credential names both options', async () => {
+  const credentials = await loadCredentials({ hybridaiKey: null });
+
+  const resolved = credentials.resolveRealtimeConnection('auto');
+
+  expect(resolved.connection).toBeNull();
+  expect(resolved.error).toContain('HYBRIDAI_API_KEY');
+  expect(resolved.error).toContain('OPENAI_API_KEY');
+  expect(credentials.isRealtimeCredentialConfigured('auto')).toBe(false);
+});


### PR DESCRIPTION
## Why

The realtime voice provider defaults to `openai`, so an operator signed in with a HybridAI credential but no `OPENAI_API_KEY` sees no voice button in the web console and gets no realtime phone mode — until they discover `voice.realtime.provider` by reading the code. Meanwhile the two sibling audio surfaces (dictation and speech output) already resolve their backend from whatever credentials are present, HybridAI first, precisely so a signed-in operator needs zero extra configuration.

## What

- `voice.realtime.provider` now defaults to **`auto`**: the HybridAI realtime proxy when a HybridAI credential is present (signed in, or `HYBRIDAI_API_KEY`), otherwise OpenAI with `OPENAI_API_KEY`. This matches the dictation/speech resolution order.
- Explicit `openai` / `hybridai` values keep pinning a single backend, with the existing per-provider error messages; `auto` with no credential at all names both options.
- All consumers (web console voice button gate, Twilio realtime mode, plugin realtime sessions) flow through `resolveRealtimeConnection`, so they inherit the new default with no further changes.
- Docs (configuration reference, Twilio voice guide, admin console), settings registry, tests, and CHANGELOG updated.

## Testing

- `vitest run tests/voice.realtime-credentials.test.ts tests/webchat-voice.test.ts tests/runtime-config*` — all passing, incl. three new `auto` cases (prefers hybridai, falls back to openai, no-credential error names both).
- `tsc --noEmit` and `biome check` clean; settings registry regenerated.