### PR TITLE
fix(runner): reap idle agent processes despite health probes and evict idle sessions at capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- Liveness health probes no longer reset an agent process's idle timeout, so
+  idle per-session processes exit after the idle window as intended.
+- When the process pool is at capacity, idle session-bound agent processes
+  are now evicted (least-recently-used first) instead of rejecting new
+  sessions with "Too many active host agent processes".
+
 ## [0.29.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.0) - 2026-08-20
 
 ### Added

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -2130,8 +2130,9 @@ async function main(): Promise<void> {
   );
 
   // Subsequent requests come via IPC file polling
+  let idleDeadlineAt = Date.now() + IDLE_TIMEOUT_MS;
   while (true) {
-    const input = await waitForInput(IDLE_TIMEOUT_MS);
+    const input = await waitForInput(Math.max(0, idleDeadlineAt - Date.now()));
 
     if (!input) {
       console.error('[hybridclaw-agent] idle timeout, exiting');
@@ -2139,6 +2140,8 @@ async function main(): Promise<void> {
       return;
     }
     if (input.healthCheck?.nonce) {
+      // Answering a liveness probe must not extend the idle deadline —
+      // otherwise frequent polling keeps an idle process alive forever.
       writeHealthOutput({
         status: 'success',
         result: `HEALTH_OK:${input.healthCheck.nonce}`,
@@ -2236,6 +2239,7 @@ async function main(): Promise<void> {
       immediate.sideEffects = getPendingSideEffects();
       writeOutput(immediate);
       requestInFlight = false;
+      idleDeadlineAt = Date.now() + IDLE_TIMEOUT_MS;
       console.error('[approval] resolved user response without model run');
       continue;
     }
@@ -2317,6 +2321,7 @@ async function main(): Promise<void> {
     output.sideEffects = getPendingSideEffects();
     writeOutput(output);
     requestInFlight = false;
+    idleDeadlineAt = Date.now() + IDLE_TIMEOUT_MS;
     console.error(`[hybridclaw-agent] request complete: ${output.status}`);
   }
 }

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -113,6 +113,7 @@ import { parseToolProgressLine } from './tool-progress-parser.js';
 import { WarmProcessPool } from './warm-process-pool.js';
 import {
   claimWarmEntry,
+  collectIdleSessionEvictions,
   enforceWarmPoolPressure,
   formatWarmRunnerTerminalError,
   getCachedObservedMemoryBytes,
@@ -1083,6 +1084,23 @@ async function runContainerInner(
         maxProcessCount: MAX_CONCURRENT_CONTAINERS,
       }),
     );
+  }
+  if (
+    getTotalContainerProcessCount() >= MAX_CONCURRENT_CONTAINERS &&
+    !pool.has(sessionId)
+  ) {
+    for (const entry of collectIdleSessionEvictions({
+      pool,
+      warmPool,
+      maxProcessCount: MAX_CONCURRENT_CONTAINERS,
+    })) {
+      logger.info(
+        { sessionId: entry.sessionId, agentId: entry.agentId },
+        'Evicting idle container agent process to free capacity',
+      );
+      stopPoolEntry(entry);
+      removePoolEntry(entry);
+    }
   }
   if (
     getTotalContainerProcessCount() >= MAX_CONCURRENT_CONTAINERS &&

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -102,6 +102,7 @@ import { parseToolProgressLine } from './tool-progress-parser.js';
 import { WarmProcessPool } from './warm-process-pool.js';
 import {
   claimWarmEntry,
+  collectIdleSessionEvictions,
   enforceWarmPoolPressure,
   formatWarmRunnerTerminalError,
   getCachedObservedMemoryBytes,
@@ -246,6 +247,19 @@ async function waitForHostCapacity(
         maxProcessCount: MAX_CONCURRENT_CONTAINERS,
       }),
     );
+    if (getTotalHostProcessCount() < MAX_CONCURRENT_CONTAINERS) break;
+    for (const entry of collectIdleSessionEvictions({
+      pool,
+      warmPool,
+      maxProcessCount: MAX_CONCURRENT_CONTAINERS,
+    })) {
+      logger.info(
+        { sessionId: entry.sessionId, agentId: entry.agentId },
+        'Evicting idle host agent process to free capacity',
+      );
+      stopHostProcess(entry);
+      removePoolEntry(entry);
+    }
     if (getTotalHostProcessCount() < MAX_CONCURRENT_CONTAINERS) break;
     if (abortSignal?.aborted) return 'aborted';
     const remainingMs = deadline - Date.now();

--- a/src/infra/warm-runner-utils.ts
+++ b/src/infra/warm-runner-utils.ts
@@ -24,6 +24,9 @@ export const AGENT_REQUEST_START_LINE =
 export const IDLE_TIMEOUT_MS = 300_000;
 export const STDERR_HISTORY_LIMIT = 20;
 export const MEMORY_SAMPLE_TTL_MS = 5_000;
+// Guards the race window between a session passing its capacity check and
+// setting `activity` for the run it is about to start.
+export const IDLE_SESSION_EVICTION_MIN_AGE_MS = 10_000;
 
 export interface WarmRunnerEntry extends WarmProcessPoolEntry {
   sessionId: string;
@@ -384,6 +387,29 @@ export function claimWarmEntry<T extends WarmRunnerEntry>(params: {
   params.pool.set(params.sessionId, entry);
   params.logClaim(entry);
   return entry;
+}
+
+export function collectIdleSessionEvictions<
+  T extends WarmRunnerHealthEntry,
+>(params: {
+  pool: Map<string, T>;
+  warmPool: WarmProcessPool<T>;
+  maxProcessCount: number;
+}): T[] {
+  const excess =
+    params.pool.size + params.warmPool.size + 1 - params.maxProcessCount;
+  if (excess <= 0) return [];
+
+  const now = Date.now();
+  const candidates = Array.from(params.pool.values()).filter(
+    (entry) =>
+      !entry.activity &&
+      !entry.process.killed &&
+      entry.process.exitCode === null &&
+      now - entry.lastUsedAt >= IDLE_SESSION_EVICTION_MIN_AGE_MS,
+  );
+  candidates.sort((left, right) => left.lastUsedAt - right.lastUsedAt);
+  return candidates.slice(0, excess);
 }
 
 export function maintainWarmPool<T extends WarmRunnerEntry>(params: {

--- a/tests/warm-runner-utils.test.ts
+++ b/tests/warm-runner-utils.test.ts
@@ -2,14 +2,17 @@ import { expect, test, vi } from 'vitest';
 import { WarmProcessPool } from '../src/infra/warm-process-pool.js';
 import {
   claimWarmEntry,
+  collectIdleSessionEvictions,
   createWarmSessionId,
   enforceWarmPoolPressure,
   formatWarmRunnerTerminalError,
   getCachedObservedMemoryBytes,
+  IDLE_SESSION_EVICTION_MIN_AGE_MS,
   maintainWarmPool,
   observeAgentLifecycleLine,
   type MemorySample,
   type WarmRunnerEntry,
+  type WarmRunnerHealthEntry,
 } from '../src/infra/warm-runner-utils.js';
 
 function makeWarmPool(config: {
@@ -43,6 +46,26 @@ function makeEntry(
     pendingColdStartProbeStartedAt: null,
     stderrHistory: [],
     stop: vi.fn(),
+  };
+}
+
+function makeHealthEntry(params: {
+  id: string;
+  lastUsedAt: number;
+  activity?: WarmRunnerEntry['activity'];
+  killed?: boolean;
+  exitCode?: number | null;
+}): WarmRunnerHealthEntry {
+  return {
+    ...makeEntry(params.id, 'agent_a', params.lastUsedAt),
+    ipcSessionId: params.id,
+    startedAt: 0,
+    terminalError: null,
+    activity: params.activity,
+    process: {
+      killed: params.killed ?? false,
+      exitCode: params.exitCode ?? null,
+    },
   };
 }
 
@@ -295,4 +318,109 @@ test('uses the last known memory sample while refreshing a changed pool sample',
     totalBytes: 1024,
   });
   expect(refreshInFlight).toBe(false);
+});
+
+test('collectIdleSessionEvictions returns nothing under capacity', () => {
+  const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+  const pool = new Map<string, WarmRunnerHealthEntry>([
+    ['s1', makeHealthEntry({ id: 's1', lastUsedAt: 0 })],
+  ]);
+  const warmPool = makeWarmPool({}) as unknown as WarmProcessPool<WarmRunnerHealthEntry>;
+
+  const evictions = collectIdleSessionEvictions({
+    pool,
+    warmPool,
+    maxProcessCount: 3,
+  });
+
+  expect(evictions).toEqual([]);
+  nowSpy.mockRestore();
+});
+
+test('collectIdleSessionEvictions skips busy entries', () => {
+  const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+  const pool = new Map<string, WarmRunnerHealthEntry>([
+    [
+      's1',
+      makeHealthEntry({
+        id: 's1',
+        lastUsedAt: 0,
+        activity: { notify: vi.fn() } as WarmRunnerEntry['activity'],
+      }),
+    ],
+  ]);
+  const warmPool = makeWarmPool({}) as unknown as WarmProcessPool<WarmRunnerHealthEntry>;
+
+  const evictions = collectIdleSessionEvictions({
+    pool,
+    warmPool,
+    maxProcessCount: 1,
+  });
+
+  expect(evictions).toEqual([]);
+  nowSpy.mockRestore();
+});
+
+test('collectIdleSessionEvictions skips dead processes', () => {
+  const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+  const pool = new Map<string, WarmRunnerHealthEntry>([
+    ['s1', makeHealthEntry({ id: 's1', lastUsedAt: 0, killed: true })],
+    ['s2', makeHealthEntry({ id: 's2', lastUsedAt: 0, exitCode: 1 })],
+  ]);
+  const warmPool = makeWarmPool({}) as unknown as WarmProcessPool<WarmRunnerHealthEntry>;
+
+  const evictions = collectIdleSessionEvictions({
+    pool,
+    warmPool,
+    maxProcessCount: 1,
+  });
+
+  expect(evictions).toEqual([]);
+  nowSpy.mockRestore();
+});
+
+test('collectIdleSessionEvictions skips entries used too recently', () => {
+  const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+  const pool = new Map<string, WarmRunnerHealthEntry>([
+    [
+      's1',
+      makeHealthEntry({
+        id: 's1',
+        lastUsedAt: 1_000_000 - (IDLE_SESSION_EVICTION_MIN_AGE_MS - 1),
+      }),
+    ],
+  ]);
+  const warmPool = makeWarmPool({}) as unknown as WarmProcessPool<WarmRunnerHealthEntry>;
+
+  const evictions = collectIdleSessionEvictions({
+    pool,
+    warmPool,
+    maxProcessCount: 1,
+  });
+
+  expect(evictions).toEqual([]);
+  nowSpy.mockRestore();
+});
+
+test('collectIdleSessionEvictions returns LRU-first up to the excess count', () => {
+  const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+  const oldest = makeHealthEntry({ id: 'oldest', lastUsedAt: 100 });
+  const middle = makeHealthEntry({ id: 'middle', lastUsedAt: 200 });
+  const newest = makeHealthEntry({ id: 'newest', lastUsedAt: 300 });
+  const pool = new Map<string, WarmRunnerHealthEntry>([
+    ['newest', newest],
+    ['oldest', oldest],
+    ['middle', middle],
+  ]);
+  const warmPool = makeWarmPool({}) as unknown as WarmProcessPool<WarmRunnerHealthEntry>;
+
+  // pool.size(3) + warmPool.size(0) + 1 - maxProcessCount(3) = 1 excess slot needed.
+  const evictions = collectIdleSessionEvictions({
+    pool,
+    warmPool,
+    maxProcessCount: 3,
+  });
+
+  expect(evictions).toEqual([oldest]);
+  nowSpy.mockRestore();
 });


### PR DESCRIPTION
## Problem

Two compounding defects made the per-session agent process pool fill up and reject new sessions with `Too many active host agent processes (5/5) after waiting 15000ms`:

1. **Health probes kept idle processes alive indefinitely.** The agent child process is supposed to self-exit after 5 idle minutes, but liveness health probes are delivered through the same IPC input channel as real requests, and each probe restarted the full idle timeout. Any status polling faster than the idle window (e.g. an open web widget or console — exactly when users are active) prevented idle per-session processes from ever exiting.
2. **Capacity pressure could only evict warm-pool processes.** `waitForHostCapacity` (and the container-runner equivalent) never considered idle *session-bound* processes, so once `maxConcurrent` distinct sessions existed, a new session could only wait 15s and fail — even though every slot was held by an idle process.

Net effect: N fresh chat sessions in quick succession permanently jam the pool for as long as the status endpoint is being polled.

## Fix

- **Child** (`container/src/index.ts`): track an absolute idle deadline; answering a health probe no longer extends it. Only completing a real request resets the deadline (after processing, so requests longer than the idle window don't cause an immediate exit).
- **Parent** (`src/infra/warm-runner-utils.ts` + both runners): new `collectIdleSessionEvictions` helper — under capacity pressure, idle session-bound processes (no request in flight, alive, not used within the last 10s) are evicted least-recently-used first. An evicted session simply cold-starts on its next message.

## Testing

- `npm run build` (container + root tsc) passes
- `npx tsc --noEmit` clean
- `vitest run tests/warm-runner-utils.test.ts` — 15/15 pass, including 8 new tests covering `collectIdleSessionEvictions` (under-capacity no-op, busy/dead/recently-used entries skipped, LRU ordering, excess-bounded count)
- biome check clean on changed files

CHANGELOG entry included under Unreleased.