### PR TITLE
feat(msteams): align file uploads with console chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- **Teams file uploads match console chat metadata**: Files attached in a
+  Microsoft Teams direct message are staged for the agent even without message
+  text, and JSON, CSV, Markdown, plain-text, XML, image, audio, video, PDF, and
+  Office uploads retain their media type.
+
 ## [0.29.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.0) - 2026-08-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 - **Teams file uploads match console chat metadata**: Files attached in a
   Microsoft Teams direct message are staged for the agent even without message
   text, and JSON, CSV, Markdown, plain-text, XML, image, audio, video, PDF, and
-  Office uploads retain their media type.
+  Office uploads retain their media type. Downloads stream into the managed
+  cache with a configurable 100 MB default limit, and oversized partial files
+  are removed instead of falling back to a remote URL.
 
 ## [0.29.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.0) - 2026-08-20
 

--- a/console/src/generated/settings-registry.ts
+++ b/console/src/generated/settings-registry.ts
@@ -1803,7 +1803,7 @@ export const GENERATED_SETTINGS_REGISTRY: ReadonlyArray<GeneratedSettingEntry> =
       path: 'msteams.mediaMaxMb',
       section: 'msteams',
       kind: 'number',
-      defaultValue: 20,
+      defaultValue: 100,
     },
     {
       path: 'msteams.replyStyle',

--- a/docs/content/channels/msteams.md
+++ b/docs/content/channels/msteams.md
@@ -116,8 +116,10 @@ The app can take some time to appear in the organization's Teams app catalog.
 
 1. Install the app from your organization's Teams app catalog.
 2. Open a direct message with the bot and send `hello`.
-3. Add the app to a team and send `@BotName hello` in a channel.
-4. Confirm the bot replies in both places.
+3. Attach a file in the direct message and ask the bot to inspect or summarize
+   it.
+4. Add the app to a team and send `@BotName hello` in a channel.
+5. Confirm the bot replies in both places.
 
 Team channel messages require a mention by default. A plain `hello` in a team
 channel does not trigger a reply unless you change the Teams policy in
@@ -134,6 +136,13 @@ card. Select **Accept** on that card to upload the file to OneDrive and receive
 an openable file card. The Teams bot file API supports this flow only in
 one-on-one chats; channel and group-chat file delivery requires a separate
 Microsoft Graph and SharePoint/OneDrive integration.
+
+Files attached by the user in a direct message are downloaded into
+HybridClaw's managed upload cache and exposed to the agent in the same way as
+console chat uploads. Common image and audio formats, PDF and Office documents,
+JSON, CSV, Markdown, plain text, and XML retain their media type. The default
+per-file limit is 20 MB and is controlled by `msteams.mediaMaxMb` under
+**Advanced delivery settings**.
 
 ## Troubleshooting: a generated file is only a link
 

--- a/docs/content/channels/msteams.md
+++ b/docs/content/channels/msteams.md
@@ -140,9 +140,9 @@ Microsoft Graph and SharePoint/OneDrive integration.
 Files attached by the user in a direct message are downloaded into
 HybridClaw's managed upload cache and exposed to the agent in the same way as
 console chat uploads. Common image and audio formats, PDF and Office documents,
-JSON, CSV, Markdown, plain text, and XML retain their media type. The default
-per-file limit is 20 MB and is controlled by `msteams.mediaMaxMb` under
-**Advanced delivery settings**.
+JSON, CSV, Markdown, plain text, and XML retain their media type. Downloads are
+streamed into the managed cache with a default per-file limit of 100 MB,
+controlled by `msteams.mediaMaxMb` under **Advanced delivery settings**.
 
 ## Troubleshooting: a generated file is only a link
 

--- a/src/channels/msteams/attachments.ts
+++ b/src/channels/msteams/attachments.ts
@@ -1,3 +1,8 @@
+/**
+ * Teams attachment boundary — stages trusted-host inbound uploads and builds
+ * outbound Bot Framework attachments. Cached local paths are the agent-facing
+ * source of record; delivery and streaming stay in their neighboring modules.
+ */
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -18,22 +23,33 @@ import type { MediaContextItem } from '../../types/container.js';
 import type { ArtifactMetadata } from '../../types/execution.js';
 import { isRecord, normalizeValue } from './utils.js';
 
-const OUTBOUND_MIME_TYPE_BY_EXTENSION: Record<string, string> = {
+const MIME_TYPE_BY_EXTENSION: Record<string, string> = {
+  '.bmp': 'image/bmp',
+  '.csv': 'text/csv',
+  '.flac': 'audio/flac',
   '.gif': 'image/gif',
+  '.json': 'application/json',
   '.jpg': 'image/jpeg',
   '.jpeg': 'image/jpeg',
   '.m4a': 'audio/mp4',
+  '.md': 'text/markdown',
+  '.mov': 'video/quicktime',
   '.mp3': 'audio/mpeg',
+  '.mp4': 'video/mp4',
   '.ogg': 'audio/ogg',
   '.pdf': 'application/pdf',
   '.png': 'image/png',
   '.pptx':
     'application/vnd.openxmlformats-officedocument.presentationml.presentation',
   '.wav': 'audio/wav',
+  '.webm': 'video/webm',
   '.webp': 'image/webp',
   '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   '.docx':
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.svg': 'image/svg+xml',
+  '.txt': 'text/plain',
+  '.xml': 'text/xml',
 };
 const HTML_IMAGE_SRC_RE = /<img[^>]+src=["']([^"']+)["'][^>]*>/gi;
 const TEAMS_FILE_DOWNLOAD_INFO_CONTENT_TYPE =
@@ -163,9 +179,7 @@ function inferOutboundMimeType(
   const normalizedPreferred = normalizeValue(preferredMimeType);
   if (normalizedPreferred) return normalizedPreferred;
   const extension = path.extname(filePath).toLowerCase();
-  return (
-    OUTBOUND_MIME_TYPE_BY_EXTENSION[extension] || 'application/octet-stream'
-  );
+  return MIME_TYPE_BY_EXTENSION[extension] || 'application/octet-stream';
 }
 
 function inferMimeTypeFromFilename(
@@ -183,13 +197,13 @@ function inferMimeTypeFromFilename(
     return normalizedFallback;
   }
   const extension = path.extname(filename).toLowerCase();
-  return OUTBOUND_MIME_TYPE_BY_EXTENSION[extension] || null;
+  return MIME_TYPE_BY_EXTENSION[extension] || null;
 }
 
 function inferMimeTypeFromTeamsFileType(fileType: string): string | null {
   const normalized = normalizeValue(fileType).toLowerCase();
   if (!normalized) return null;
-  return OUTBOUND_MIME_TYPE_BY_EXTENSION[`.${normalized}`] || null;
+  return MIME_TYPE_BY_EXTENSION[`.${normalized}`] || null;
 }
 
 function sniffMimeTypeFromBuffer(buffer: Buffer): string | null {

--- a/src/channels/msteams/attachments.ts
+++ b/src/channels/msteams/attachments.ts
@@ -18,7 +18,11 @@ import {
   MSTEAMS_TENANT_ID,
 } from '../../config/config.js';
 import { logger } from '../../logger.js';
-import { createUploadedMediaContextItem } from '../../media/uploaded-media-cache.js';
+import {
+  createUploadedMediaContextItem,
+  createUploadedMediaContextItemFromStream,
+  UPLOADED_MEDIA_CACHE_LIMIT_ERROR,
+} from '../../media/uploaded-media-cache.js';
 import type { MediaContextItem } from '../../types/container.js';
 import type { ArtifactMetadata } from '../../types/execution.js';
 import { isRecord, normalizeValue } from './utils.js';
@@ -697,6 +701,61 @@ async function stageInboundTeamsBuffer(params: {
   });
 }
 
+async function readResponseChunks(response: Response): Promise<{
+  cancel: () => Promise<void>;
+  chunks: AsyncIterable<Uint8Array>;
+  prefix: Buffer;
+}> {
+  if (!response.body) {
+    throw new Error('Teams attachment response did not include a body.');
+  }
+  const reader = response.body.getReader();
+  let first: ReadableStreamReadResult<Uint8Array>;
+  try {
+    first = await reader.read();
+  } catch (error) {
+    reader.releaseLock();
+    throw error;
+  }
+  const prefix = Buffer.from(first.value || []);
+  let released = false;
+
+  async function release(cancel: boolean): Promise<void> {
+    if (released) return;
+    released = true;
+    if (cancel) {
+      await reader.cancel().catch(() => {});
+    }
+    reader.releaseLock();
+  }
+
+  async function* chunks(): AsyncGenerator<Uint8Array> {
+    let current = first;
+    try {
+      while (!current.done) {
+        if (current.value?.length) yield current.value;
+        current = await reader.read();
+      }
+    } finally {
+      await release(!current.done);
+    }
+  }
+
+  return {
+    cancel: () => release(true),
+    chunks: chunks(),
+    prefix,
+  };
+}
+
+function isUploadedMediaLimitError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message === UPLOADED_MEDIA_CACHE_LIMIT_ERROR ||
+      error.message === 'Teams attachment exceeds configured media limit.')
+  );
+}
+
 async function buildMediaItem(params: {
   url: string;
   filename: string;
@@ -758,14 +817,15 @@ async function buildMediaItem(params: {
       contentLength > 0 &&
       contentLength > getMaxInboundTeamsMediaBytes()
     ) {
+      await response.body?.cancel().catch(() => {});
       throw new Error('Teams attachment exceeds configured media limit.');
     }
-    const buffer = Buffer.from(await response.arrayBuffer());
     const responseMimeType =
       normalizeValue(response.headers.get('content-type'))
         .split(';')[0]
         .trim()
         .toLowerCase() || null;
+    const responseStream = await readResponseChunks(response);
     const resolvedMimeType =
       (responseMimeType &&
       !GENERIC_MIME_TYPES.has(responseMimeType) &&
@@ -773,24 +833,40 @@ async function buildMediaItem(params: {
         ? responseMimeType
         : null) ||
       inferMimeTypeFromFilename(fallback.filename, fallback.mimeType) ||
-      sniffMimeTypeFromBuffer(buffer) ||
+      sniffMimeTypeFromBuffer(responseStream.prefix) ||
       null;
-    const staged = await stageInboundTeamsBuffer({
-      buffer,
-      filename: fallback.filename,
-      mimeType: resolvedMimeType,
-      sizeBytes: buffer.length,
-      originalUrl: fallback.url,
-    });
+    let staged: MediaContextItem;
+    try {
+      staged = await createUploadedMediaContextItemFromStream({
+        attachmentName: fallback.filename,
+        chunks: responseStream.chunks,
+        maxBytes: getMaxInboundTeamsMediaBytes(),
+        mimeType: resolvedMimeType,
+        originalUrl: fallback.url,
+      });
+    } catch (error) {
+      await responseStream.cancel();
+      throw error;
+    }
     return {
       ...staged,
       url: fallback.url,
       originalUrl: fallback.url,
       mimeType: resolvedMimeType || null,
-      sizeBytes: buffer.length,
+      sizeBytes: staged.sizeBytes,
       filename: fallback.filename,
     };
   } catch (error) {
+    if (isUploadedMediaLimitError(error)) {
+      logger.warn(
+        {
+          filename: fallback.filename,
+          maxBytes: getMaxInboundTeamsMediaBytes(),
+        },
+        'Skipping Teams attachment that exceeds configured media limit',
+      );
+      return null;
+    }
     logger.debug(
       { error, url: fallback.url, name: fallback.filename },
       'Failed to stage Teams attachment locally; using remote URL fallback',

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -350,7 +350,9 @@ export let MSTEAMS_REQUIRE_MENTION = true;
 export let MSTEAMS_TEXT_CHUNK_LIMIT = 4_000;
 export let MSTEAMS_REPLY_STYLE: RuntimeConfig['msteams']['replyStyle'] =
   'thread';
-export let MSTEAMS_MEDIA_MAX_MB = 20;
+// 100 MB (owner call, 2026-08-21): Teams downloads stream to the managed
+// cache; the console upload limit remains 20 MB.
+export let MSTEAMS_MEDIA_MAX_MB = 100;
 export let MSTEAMS_DANGEROUSLY_ALLOW_NAME_MATCHING = false;
 export let MSTEAMS_MEDIA_ALLOW_HOSTS: string[] = [];
 export let MSTEAMS_MEDIA_AUTH_ALLOW_HOSTS: string[] = [];

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -1662,7 +1662,9 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
     requireMention: true,
     textChunkLimit: 4_000,
     replyStyle: 'thread',
-    mediaMaxMb: 20,
+    // 100 MB (owner call, 2026-08-21): Teams downloads stream to the managed
+    // cache; the console upload limit remains 20 MB.
+    mediaMaxMb: 100,
     dangerouslyAllowNameMatching: false,
     mediaAllowHosts: [
       'graph.microsoft.com',

--- a/src/media/uploaded-media-cache.ts
+++ b/src/media/uploaded-media-cache.ts
@@ -1,3 +1,8 @@
+/**
+ * Uploaded-media cache — the bounded local store for untrusted inbound files.
+ * Runtime paths remain stable across host and container modes, and incomplete
+ * streamed writes are never exposed. It does not decide transport allowlists.
+ */
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -8,6 +13,8 @@ import type { MediaContextItem } from '../types/container.js';
 import { normalizeMimeType } from './mime-utils.js';
 
 export const UPLOADED_MEDIA_CACHE_ROOT_DISPLAY = '/uploaded-media-cache';
+export const UPLOADED_MEDIA_CACHE_LIMIT_ERROR =
+  'uploaded_media_cache_limit_exceeded';
 
 const UPLOADED_MEDIA_CACHE_DIR_MODE = 0o700;
 const UPLOADED_MEDIA_CACHE_FILE_MODE = 0o644;
@@ -274,11 +281,16 @@ export function startUploadedMediaCacheCleanup(params?: {
   return cleanupPromise;
 }
 
-export async function writeUploadedMediaCacheFile(params: {
+interface UploadedMediaCacheTarget {
+  hostPath: string;
+  runtimePath: string;
+  filename: string;
+}
+
+async function prepareUploadedMediaCacheTarget(params: {
   attachmentName: string;
-  buffer: Buffer;
   mimeType?: string | null;
-}): Promise<{ hostPath: string; runtimePath: string; filename: string }> {
+}): Promise<UploadedMediaCacheTarget> {
   const cacheDir = resolveUploadedMediaCacheHostDir();
   const datePrefix = new Date().toISOString().slice(0, 10);
   const unique = randomUUID().slice(0, 8);
@@ -292,21 +304,73 @@ export async function writeUploadedMediaCacheFile(params: {
 
   await ensureCacheDirectory(cacheDir);
   await ensureCacheDirectory(dayDir);
-  await fs.promises.writeFile(hostPath, params.buffer, {
-    mode: UPLOADED_MEDIA_CACHE_FILE_MODE,
-  });
 
   const runtimePath = normalizeUploadedMediaPathForRuntime(hostPath);
   if (!runtimePath) {
     throw new Error(`uploaded_media_cache_path_error:${hostPath}`);
   }
 
-  startUploadedMediaCacheCleanup();
   return {
     hostPath,
     runtimePath,
     filename,
   };
+}
+
+export async function writeUploadedMediaCacheFile(params: {
+  attachmentName: string;
+  buffer: Buffer;
+  mimeType?: string | null;
+}): Promise<UploadedMediaCacheTarget> {
+  const target = await prepareUploadedMediaCacheTarget(params);
+  await fs.promises.writeFile(target.hostPath, params.buffer, {
+    mode: UPLOADED_MEDIA_CACHE_FILE_MODE,
+  });
+  startUploadedMediaCacheCleanup();
+  return target;
+}
+
+export async function writeUploadedMediaCacheStream(params: {
+  attachmentName: string;
+  chunks: AsyncIterable<Uint8Array>;
+  maxBytes: number;
+  mimeType?: string | null;
+}): Promise<UploadedMediaCacheTarget & { sizeBytes: number }> {
+  const maxBytes = Math.floor(params.maxBytes);
+  if (!Number.isFinite(maxBytes) || maxBytes < 1) {
+    throw new Error('uploaded_media_cache_invalid_limit');
+  }
+
+  const target = await prepareUploadedMediaCacheTarget(params);
+  const partialPath = `${target.hostPath}.part-${randomUUID().slice(0, 8)}`;
+  let handle: Awaited<ReturnType<typeof fs.promises.open>> | null = null;
+  let sizeBytes = 0;
+  try {
+    handle = await fs.promises.open(
+      partialPath,
+      'wx',
+      UPLOADED_MEDIA_CACHE_FILE_MODE,
+    );
+    for await (const chunk of params.chunks) {
+      const buffer = Buffer.from(chunk);
+      if (buffer.length === 0) continue;
+      sizeBytes += buffer.length;
+      if (sizeBytes > maxBytes) {
+        throw new Error(UPLOADED_MEDIA_CACHE_LIMIT_ERROR);
+      }
+      await handle.writeFile(buffer);
+    }
+    await handle.close();
+    handle = null;
+    await fs.promises.rename(partialPath, target.hostPath);
+  } catch (error) {
+    await handle?.close().catch(() => {});
+    await fs.promises.rm(partialPath, { force: true }).catch(() => {});
+    throw error;
+  }
+
+  startUploadedMediaCacheCleanup();
+  return { ...target, sizeBytes };
 }
 
 export async function createUploadedMediaContextItem(params: {
@@ -333,6 +397,33 @@ export async function createUploadedMediaContextItem(params: {
       typeof params.sizeBytes === 'number' && Number.isFinite(params.sizeBytes)
         ? Math.max(0, Math.floor(params.sizeBytes))
         : params.buffer.length,
+    filename,
+  };
+}
+
+export async function createUploadedMediaContextItemFromStream(params: {
+  attachmentName: string;
+  chunks: AsyncIterable<Uint8Array>;
+  maxBytes: number;
+  mimeType?: string | null;
+  originalUrl?: string | null;
+}): Promise<MediaContextItem> {
+  const normalizedMimeType = normalizeMimeType(params.mimeType);
+  const { runtimePath, filename, sizeBytes } =
+    await writeUploadedMediaCacheStream({
+      attachmentName: params.attachmentName,
+      chunks: params.chunks,
+      maxBytes: params.maxBytes,
+      mimeType: normalizedMimeType,
+    });
+  const originalUrl = String(params.originalUrl || '').trim() || runtimePath;
+
+  return {
+    path: runtimePath,
+    url: originalUrl,
+    originalUrl,
+    mimeType: normalizedMimeType,
+    sizeBytes,
     filename,
   };
 }

--- a/tests/msteams.attachments.test.ts
+++ b/tests/msteams.attachments.test.ts
@@ -605,6 +605,52 @@ test('buildTeamsAttachmentContext extracts Teams file download info attachments'
   );
 });
 
+test('buildTeamsAttachmentContext recognizes console-compatible document uploads', async () => {
+  const { buildTeamsAttachmentContext } = await importAttachmentsModule();
+  const markdown = Buffer.from('# Project notes\n\nShip the Teams upload.');
+  const fetchMock = vi.fn(
+    async () =>
+      new Response(markdown, {
+        status: 200,
+        headers: {
+          'content-length': String(markdown.length),
+          'content-type': 'application/octet-stream',
+        },
+      }),
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  const media = await buildTeamsAttachmentContext({
+    activity: {
+      attachments: [
+        {
+          contentType: 'application/vnd.microsoft.teams.file.download.info',
+          content: {
+            downloadUrl:
+              'https://contoso.blob.core.windows.net/teams/project-notes.md?sig=test',
+            fileName: 'project-notes.md',
+            fileType: 'md',
+          },
+          name: 'project-notes.md',
+        },
+      ],
+    },
+  });
+  trackTempDirFromMediaPath(media[0]?.path);
+
+  expect(media).toHaveLength(1);
+  expect(media[0]).toEqual({
+    path: expect.any(String),
+    url: 'https://contoso.blob.core.windows.net/teams/project-notes.md?sig=test',
+    originalUrl:
+      'https://contoso.blob.core.windows.net/teams/project-notes.md?sig=test',
+    mimeType: 'text/markdown',
+    sizeBytes: markdown.length,
+    filename: 'project-notes.md',
+  });
+  expect(fs.readFileSync(media[0]?.path || '')).toEqual(markdown);
+});
+
 test('buildTeamsAttachmentContext extracts inline html image urls', async () => {
   const { buildTeamsAttachmentContext } = await importAttachmentsModule();
   const fetchMock = vi.fn(

--- a/tests/msteams.attachments.test.ts
+++ b/tests/msteams.attachments.test.ts
@@ -749,6 +749,41 @@ test('buildTeamsAttachmentContext rejects oversized data url images before writi
   expect(writeFileSpy).not.toHaveBeenCalled();
 });
 
+test('buildTeamsAttachmentContext streams remote files and removes oversized partial downloads', async () => {
+  const { buildTeamsAttachmentContext } = await importAttachmentsModule({
+    MSTEAMS_MEDIA_MAX_MB: 1,
+  });
+  const oversizedBuffer = Buffer.alloc(1_048_577, 1);
+  const response = new Response(oversizedBuffer, {
+    status: 200,
+    headers: {
+      'content-type': 'application/pdf',
+    },
+  });
+  const arrayBufferSpy = vi.spyOn(response, 'arrayBuffer');
+  vi.stubGlobal('fetch', vi.fn(async () => response));
+
+  const media = await buildTeamsAttachmentContext({
+    activity: {
+      attachments: [
+        {
+          contentType: 'application/vnd.microsoft.teams.file.download.info',
+          content: {
+            downloadUrl:
+              'https://contoso.blob.core.windows.net/teams/too-large.pdf?sig=test',
+            fileName: 'too-large.pdf',
+            fileType: 'pdf',
+          },
+          name: 'too-large.pdf',
+        },
+      ],
+    },
+  });
+
+  expect(media).toEqual([]);
+  expect(arrayBufferSpy).not.toHaveBeenCalled();
+});
+
 test('buildTeamsAttachmentContext retries Teams media downloads with auth for Teams hosts', async () => {
   const { buildTeamsAttachmentContext } = await importAttachmentsModule({
     MSTEAMS_MEDIA_ALLOW_HOSTS: ['*.teams.microsoft.com'],

--- a/tests/msteams.runtime.test.ts
+++ b/tests/msteams.runtime.test.ts
@@ -16,6 +16,7 @@ const buildTeamsAttachmentContextMock = vi.fn(async () => []);
 const maybeHandleMSTeamsFileConsentInvokeMock = vi.fn(async () => false);
 const getMemoryValueMock = vi.fn();
 const setMemoryValueMock = vi.fn();
+const cleanIncomingContentMock = vi.fn(() => 'Hi!');
 const extractPrimaryTextMock = vi.fn(() => 'Hi!');
 const parseCommandMock = vi.fn(() => ({
   args: [],
@@ -181,7 +182,7 @@ async function importRuntime() {
   }));
   vi.doMock('../src/channels/msteams/inbound.js', () => ({
     buildSessionIdFromActivity: vi.fn(() => 'teams:dm:user'),
-    cleanIncomingContent: vi.fn(() => 'Hi!'),
+    cleanIncomingContent: cleanIncomingContentMock,
     extractPrimaryText: extractPrimaryTextMock,
     extractActorIdentity: vi.fn(() => ({
       aadObjectId: 'user-aad-id',
@@ -237,6 +238,8 @@ afterEach(() => {
   getMemoryValueMock.mockReset();
   getMemoryValueMock.mockReturnValue(null);
   setMemoryValueMock.mockReset();
+  cleanIncomingContentMock.mockReset();
+  cleanIncomingContentMock.mockReturnValue('Hi!');
   parseCommandMock.mockReset();
   parseCommandMock.mockReturnValue({
     args: [],
@@ -701,6 +704,72 @@ describe('Microsoft Teams runtime webhook adapter', () => {
           path: '/tmp/teams-image.png',
           sizeBytes: 3,
           url: 'https://example.com/teams-image.png',
+        },
+      ],
+      expect.any(Function),
+      expect.any(Object),
+    );
+  });
+
+  test('forwards attachment-only Teams uploads to the message handler', async () => {
+    processMock.mockImplementation(
+      async (_req, _res, logic: (context: unknown) => Promise<void>) => {
+        await logic({
+          activity: {
+            type: 'message',
+            text: '',
+            attachments: [
+              {
+                contentType:
+                  'application/vnd.microsoft.teams.file.download.info',
+                name: 'project-notes.md',
+              },
+            ],
+            conversation: { id: 'conversation-123' },
+            recipient: { id: 'bot-id' },
+          },
+          sendActivity: vi.fn(async () => ({ id: 'reply-1' })),
+          turnState: new Map(),
+        });
+      },
+    );
+    cleanIncomingContentMock.mockReturnValueOnce('');
+    buildTeamsAttachmentContextMock.mockResolvedValueOnce([
+      {
+        filename: 'project-notes.md',
+        mimeType: 'text/markdown',
+        originalUrl: 'https://example.com/project-notes.md',
+        path: '/uploaded-media-cache/2026-08-21/project-notes.md',
+        sizeBytes: 42,
+        url: 'https://example.com/project-notes.md',
+      },
+    ]);
+
+    const runtime = await importRuntime();
+    const onMessage = vi.fn(async () => {});
+    const onCommand = vi.fn(async () => {});
+    runtime.initMSTeams(onMessage, onCommand);
+
+    await runtime.handleMSTeamsWebhook(
+      makeRequest({ type: 'message', text: '' }),
+      makeResponse(),
+    );
+
+    expect(onMessage).toHaveBeenCalledWith(
+      'teams:dm:user',
+      null,
+      'conversation-123',
+      'user-id',
+      'User',
+      '',
+      [
+        {
+          filename: 'project-notes.md',
+          mimeType: 'text/markdown',
+          originalUrl: 'https://example.com/project-notes.md',
+          path: '/uploaded-media-cache/2026-08-21/project-notes.md',
+          sizeBytes: 42,
+          url: 'https://example.com/project-notes.md',
         },
       ],
       expect.any(Function),

--- a/tests/uploaded-media-cache.test.ts
+++ b/tests/uploaded-media-cache.test.ts
@@ -132,3 +132,81 @@ test('createUploadedMediaContextItem preserves a provided originalUrl', async ()
   );
   expect(fs.existsSync(hostPath)).toBe(true);
 });
+
+test('createUploadedMediaContextItemFromStream writes chunks without buffering the full upload', async () => {
+  vi.resetModules();
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-uploaded-media-stream-'),
+  );
+  dataDirs.push(dataDir);
+
+  vi.doMock('../src/config/config.ts', () => ({
+    get CONTAINER_SANDBOX_MODE() {
+      return 'host';
+    },
+    get DATA_DIR() {
+      return dataDir;
+    },
+  }));
+
+  const { createUploadedMediaContextItemFromStream } = await import(
+    '../src/media/uploaded-media-cache.js'
+  );
+  async function* chunks(): AsyncGenerator<Uint8Array> {
+    yield Buffer.from('streamed ');
+    yield Buffer.from('content');
+  }
+
+  const item = await createUploadedMediaContextItemFromStream({
+    attachmentName: 'notes.md',
+    chunks: chunks(),
+    maxBytes: 32,
+    mimeType: 'text/markdown',
+  });
+
+  expect(item.sizeBytes).toBe(16);
+  expect(fs.readFileSync(item.path || '', 'utf8')).toBe('streamed content');
+});
+
+test('createUploadedMediaContextItemFromStream removes partial files that exceed the limit', async () => {
+  vi.resetModules();
+  const dataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-uploaded-media-limit-'),
+  );
+  dataDirs.push(dataDir);
+
+  vi.doMock('../src/config/config.ts', () => ({
+    get CONTAINER_SANDBOX_MODE() {
+      return 'host';
+    },
+    get DATA_DIR() {
+      return dataDir;
+    },
+  }));
+
+  const {
+    createUploadedMediaContextItemFromStream,
+    resolveUploadedMediaCacheHostDir,
+    UPLOADED_MEDIA_CACHE_LIMIT_ERROR,
+  } = await import('../src/media/uploaded-media-cache.js');
+  async function* chunks(): AsyncGenerator<Uint8Array> {
+    yield Buffer.from('123');
+    yield Buffer.from('456');
+  }
+
+  await expect(
+    createUploadedMediaContextItemFromStream({
+      attachmentName: 'too-large.txt',
+      chunks: chunks(),
+      maxBytes: 5,
+      mimeType: 'text/plain',
+    }),
+  ).rejects.toThrow(UPLOADED_MEDIA_CACHE_LIMIT_ERROR);
+
+  const cacheDir = resolveUploadedMediaCacheHostDir();
+  const cachedFiles = fs
+    .readdirSync(cacheDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .flatMap((entry) => fs.readdirSync(path.join(cacheDir, entry.name)));
+  expect(cachedFiles).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- align Microsoft Teams upload MIME inference with console chat for JSON, CSV, Markdown, plain text, XML, additional image/audio formats, and video
- verify attachment-only Teams turns reach the gateway with locally staged media
- stream inbound Teams downloads atomically into the managed cache instead of buffering the full file in memory
- raise the configurable Teams default to 100 MB and remove oversized partial files without exposing a remote fallback
- document direct-message uploads, the new default limit, and the required verification flow

## Validation

- `corepack npm exec -- vitest run --configLoader runner --project unit tests/msteams.attachments.test.ts tests/msteams.runtime.test.ts tests/uploaded-media-cache.test.ts` (46 passed)
- `corepack npm run typecheck`
- `corepack npm run lint`
- `corepack npm --workspace console run registry:check`
- `corepack npm run format` (pre-existing optional-chain suggestions only)

## Risk notes

- upload host allowlists, authenticated-fetch allowlists, and container path isolation are unchanged
- files are written under a temporary random name and atomically renamed only after the bounded stream completes
- existing explicit `msteams.mediaMaxMb` values remain operator-controlled; the default for new/missing configuration is 100 MB
- channel and group-chat file delivery limitations are unchanged
