### PR TITLE
fix: forward thumbs-down corrections to HybridAI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Thumbs-down corrections reach HybridAI**: `/thumbs down <correction>`
+  forwards the optional text as `better_response`, so HybridAI stores the
+  expected answer instead of silently discarding it.
+  Manifesto: Principle VIII - A coworker doesn't break overnight.
+
 ## [0.29.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.0) - 2026-08-20
 
 ### Added

--- a/src/gateway/response-ratings.ts
+++ b/src/gateway/response-ratings.ts
@@ -103,7 +103,9 @@ async function forwardHybridAIChatFeedbackForRating(input: {
       ? `[${agentId}] ${input.target.assistant_content}`
       : input.target.assistant_content,
     external_user_id: input.operatorUserId,
-    ...(input.comment ? { comment: input.comment } : {}),
+    ...(input.rating === 'down' && input.comment
+      ? { better_response: input.comment }
+      : {}),
   };
 
   try {

--- a/tests/response-ratings.test.ts
+++ b/tests/response-ratings.test.ts
@@ -284,9 +284,14 @@ describe('response ratings', () => {
       string,
       RequestInit & { body: string },
     ];
-    expect(JSON.parse(request.body)).toMatchObject({
+    expect(JSON.parse(request.body)).toEqual({
+      chatbot_id: 'bot-feedback',
+      browser_id: service.sessionId,
       rating: 'down',
-      comment: 'Correct answer is: 200',
+      user_message: 'Hello',
+      bot_response: '[main] Hi there',
+      external_user_id: 'operator-a',
+      better_response: 'Correct answer is: 200',
     });
   });
 


### PR DESCRIPTION
## Summary

- Problem: `/thumbs down <correction>` persisted the correction locally but sent it to HybridAI as `comment`, a field the `/api/chat_feedback` endpoint ignores.
- Why it matters: the expected answer was missing from HybridAI training data and mirrored bot issues even though HybridClaw reported the feedback as recorded.
- What changed: thumbs-down comments are forwarded as `better_response`, and the regression test now asserts the complete HybridAI request body.
- What did not change: local rating persistence, audit events, adaptive-skill feedback, thumbs-up handling, and rating clearing.

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Docs
- [x] Tests
- [ ] Refactor required for the fix
- [ ] Tooling or workflow
- [ ] Security hardening

## Linked Context

- Closes: N/A — reported directly
- Related: HybridAI `/api/chat_feedback` request schema

## Licensing

- [x] All commits are signed off (`git commit -s`) to certify the
      [DCO](https://developercertificate.org/); the contribution is licensed
      under the repository's MIT license.

## Manifesto Principle

Which manifesto principle does this serve?

- Principle: VIII — A coworker doesn't break overnight.
- Changelog tag added or updated: `Manifesto: Principle VIII - A coworker doesn't break overnight.`

## Validation

```bash
npm run format
npm run typecheck
npm run lint
npx vitest run tests/response-ratings.test.ts
git diff --check
```

- Verified manually: compared the payload fields against HybridAI's `/api/chat_feedback` route and API documentation in `~/src/chat`.
- Edge cases checked: thumbs-up and comment-free ratings remain valid; unauthenticated, inactive-auth, missing-bot, clear-rating, and invalid-message paths remain covered by the 16-test response-ratings suite.
- Skipped checks and why: no live HybridAI feedback POST was made because that would create production training/issue data; the request boundary is covered with an exact-body fetch assertion.

## Docs And Config Impact

- [x] README, docs, or examples updated (Unreleased changelog entry)
- [ ] Config or environment behavior changed
- [ ] Templates or workspace bootstrap files changed
- [ ] No docs or config impact

No templates changed.

## Risk Notes

- Security-sensitive paths touched? `No`
- Gateway, audit, approval, or container boundaries touched? `Yes` — the existing gateway-to-HybridAI feedback request body changed.
- Failure mode and coverage: an incorrect field name silently drops the correction upstream; the test asserts the exact payload, including `better_response` and absence of `comment`.

## Secret Handling Checklist

Threat model: [docs/security/threat-model.md](docs/security/threat-model.md)

- [x] Secret classes are identified: none are introduced or changed; existing HybridAI Bearer-token resolution is untouched.
- [x] Raw secret values stay out of prompts, memory, transcripts, audit logs, telemetry, screenshots, docs examples, and tests.
- [x] Secret resolution remains at the existing HybridAI request boundary and is bound to the configured host and bot.
- [x] Untrusted model, file, web, or tool output cannot redirect secrets to a new sink without validation and approval.
- [x] Failure modes deny access and avoid echoing credential-bearing request or response bodies.
- [x] Tests cover allowed behavior plus missing-key and inactive-auth denial paths.

## Evidence

- [ ] Failing output before and passing output after
- [ ] Screenshot or recording
- [ ] Log snippet
- [x] New or updated test coverage
