### PR TITLE
fix: preserve absolute read paths in cloud workspaces

### DIFF
--- a/container/src/read-path.ts
+++ b/container/src/read-path.ts
@@ -1,0 +1,98 @@
+/**
+ * Read-tool media paths — resolves only files attached to the current turn.
+ *
+ * Unlike the general media resolver, this does not expose the whole cache;
+ * unlike workspace resolution, it authorizes no writes or directory searches.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  DISCORD_MEDIA_CACHE_ROOT,
+  DISCORD_MEDIA_CACHE_ROOT_DISPLAY,
+  resolveMediaPath,
+  UPLOADED_MEDIA_CACHE_ROOT,
+  UPLOADED_MEDIA_CACHE_ROOT_DISPLAY,
+} from './runtime-paths.js';
+import type { MediaContextItem } from './types.js';
+
+function canonicalPath(filePath: string): string {
+  try {
+    return fs.realpathSync.native(filePath);
+  } catch {
+    try {
+      return fs.realpathSync(filePath);
+    } catch {
+      return path.resolve(filePath);
+    }
+  }
+}
+
+function resolveCurrentTurnMediaPath(
+  rawPath: string,
+  media: readonly MediaContextItem[],
+): string | null {
+  const requestedPath = resolveMediaPath(rawPath);
+  if (!requestedPath) return null;
+  const requestedCanonical = canonicalPath(requestedPath);
+
+  for (const item of media) {
+    const itemPath = typeof item.path === 'string' ? item.path.trim() : '';
+    if (!itemPath) continue;
+    const resolvedItemPath = resolveMediaPath(itemPath);
+    if (!resolvedItemPath) continue;
+    if (canonicalPath(resolvedItemPath) === requestedCanonical) {
+      return requestedCanonical;
+    }
+  }
+
+  return null;
+}
+
+function mapHostRootToDisplay(
+  filePath: string,
+  actualRoot: string,
+  displayRoot: string,
+): string | null {
+  const relative = path.relative(
+    path.resolve(actualRoot),
+    path.resolve(filePath),
+  );
+  if (
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    return null;
+  }
+  return relative
+    ? path.posix.join(displayRoot, relative.replace(/\\/g, '/'))
+    : displayRoot;
+}
+
+export function resolveCurrentTurnMediaReadPath(
+  rawPath: string,
+  media: readonly MediaContextItem[],
+): string | null {
+  return resolveCurrentTurnMediaPath(rawPath, media);
+}
+
+export function resolveCurrentTurnMediaSandboxPath(
+  rawPath: string,
+  media: readonly MediaContextItem[],
+): string | null {
+  const mediaPath = resolveCurrentTurnMediaPath(rawPath, media);
+  if (!mediaPath) return null;
+  return (
+    mapHostRootToDisplay(
+      mediaPath,
+      DISCORD_MEDIA_CACHE_ROOT,
+      DISCORD_MEDIA_CACHE_ROOT_DISPLAY,
+    ) ||
+    mapHostRootToDisplay(
+      mediaPath,
+      UPLOADED_MEDIA_CACHE_ROOT,
+      UPLOADED_MEDIA_CACHE_ROOT_DISPLAY,
+    )
+  );
+}

--- a/container/src/runtime-paths.ts
+++ b/container/src/runtime-paths.ts
@@ -185,6 +185,10 @@ function resolveRootBoundPath(
       return resolvedActual;
     }
 
+    if (ALLOWED_HOST_ROOTS.some((root) => isWithinRoot(resolvedActual, root))) {
+      return resolvedActual;
+    }
+
     const fromDisplay = resolveDisplayAbsoluteToActual(
       path.posix.normalize(normalizedInput),
       displayRoot,
@@ -194,9 +198,6 @@ function resolveRootBoundPath(
       return isWithinRoot(fromDisplay, actualRoot) ? fromDisplay : null;
     }
 
-    if (ALLOWED_HOST_ROOTS.some((root) => isWithinRoot(resolvedActual, root))) {
-      return resolvedActual;
-    }
     return null;
   }
 

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -36,6 +36,10 @@ import {
   resolveRuntimeProviderContext,
 } from './providers/provider-ids.js';
 import {
+  resolveCurrentTurnMediaReadPath,
+  resolveCurrentTurnMediaSandboxPath,
+} from './read-path.js';
+import {
   DISCORD_MEDIA_CACHE_ROOT,
   DISCORD_MEDIA_CACHE_ROOT_DISPLAY,
   replaceWorkspaceRootInOutput,
@@ -2706,7 +2710,11 @@ async function executeToolInternal(
       try {
         let content = '';
         if (TASK_SANDBOX_FS_ENABLED) {
-          const sandboxPath = resolveTaskSandboxPath(args.path);
+          const sandboxPath =
+            resolveCurrentTurnMediaSandboxPath(
+              args.path,
+              currentMediaContext,
+            ) || resolveTaskSandboxPath(args.path);
           if (!sandboxPath) {
             return failTool(`Error: Path escapes workspace: ${args.path}`);
           }
@@ -2714,7 +2722,9 @@ async function executeToolInternal(
           tempDirToCleanup = copied.tempDir;
           content = fs.readFileSync(copied.localPath, 'utf-8');
         } else {
-          const filePath = safeJoin(args.path);
+          const filePath =
+            resolveCurrentTurnMediaReadPath(args.path, currentMediaContext) ||
+            safeJoin(args.path);
           if (!fs.existsSync(filePath))
             return failTool(`Error: File not found: ${args.path}`);
           content = fs.readFileSync(filePath, 'utf-8');

--- a/tests/container.read-tool.test.ts
+++ b/tests/container.read-tool.test.ts
@@ -1,0 +1,125 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+describe.sequential('container read tool paths', () => {
+  let cloudRoot = '';
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    if (cloudRoot) {
+      fs.rmSync(cloudRoot, { recursive: true, force: true });
+      cloudRoot = '';
+    }
+  });
+
+  async function loadCloudReadRuntime(options?: {
+    allowUploadedRoot?: boolean;
+  }) {
+    cloudRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'hybridclaw-cloud-workspace-'),
+    );
+    const workspaceRoot = path.join(
+      cloudRoot,
+      '.data',
+      'data',
+      'agents',
+      'anika',
+      'workspace',
+    );
+    const uploadedRoot = path.join(
+      cloudRoot,
+      '.data',
+      'data',
+      'uploaded-media-cache',
+    );
+    fs.mkdirSync(workspaceRoot, { recursive: true });
+    fs.mkdirSync(uploadedRoot, { recursive: true });
+
+    vi.stubEnv('HYBRIDCLAW_AGENT_WORKSPACE_ROOT', workspaceRoot);
+    vi.stubEnv('HYBRIDCLAW_AGENT_WORKSPACE_DISPLAY_ROOT', cloudRoot);
+    vi.stubEnv('HYBRIDCLAW_AGENT_UPLOADED_MEDIA_ROOT', uploadedRoot);
+    if (options?.allowUploadedRoot) {
+      vi.stubEnv(
+        'HYBRIDCLAW_AGENT_ALLOWED_ROOTS',
+        JSON.stringify([uploadedRoot]),
+      );
+    }
+    vi.resetModules();
+
+    const tools = await import('../container/src/tools.js');
+    return { ...tools, uploadedRoot };
+  }
+
+  test('preserves an existing absolute path under an allowed root', async () => {
+    const { executeTool, uploadedRoot } = await loadCloudReadRuntime({
+      allowUploadedRoot: true,
+    });
+    const uploadedFile = path.join(uploadedRoot, '2026-08-21', 'note.txt');
+    fs.mkdirSync(path.dirname(uploadedFile), { recursive: true });
+    fs.writeFileSync(uploadedFile, 'allowed absolute path', 'utf8');
+
+    const result = await executeTool(
+      'read',
+      JSON.stringify({ path: uploadedFile }),
+    );
+
+    expect(result).toBe('allowed absolute path');
+  });
+
+  test('preserves a current-turn upload path that shares the workspace display prefix', async () => {
+    const { executeTool, setMediaContext, uploadedRoot } =
+      await loadCloudReadRuntime();
+    const uploadedFile = path.join(uploadedRoot, '2026-08-21', 'note.txt');
+    fs.mkdirSync(path.dirname(uploadedFile), { recursive: true });
+    fs.writeFileSync(uploadedFile, 'cloud attachment text', 'utf8');
+    setMediaContext([
+      {
+        path: uploadedFile,
+        url: '',
+        originalUrl: '',
+        mimeType: 'text/plain',
+        sizeBytes: fs.statSync(uploadedFile).size,
+        filename: 'note.txt',
+      },
+    ]);
+
+    const result = await executeTool(
+      'read',
+      JSON.stringify({ path: uploadedFile }),
+    );
+
+    expect(result).toBe('cloud attachment text');
+  });
+
+  test('does not expose a different file from the uploaded-media cache', async () => {
+    const { executeTool, setMediaContext, uploadedRoot } =
+      await loadCloudReadRuntime();
+    const currentFile = path.join(uploadedRoot, '2026-08-21', 'current.txt');
+    const otherFile = path.join(uploadedRoot, '2026-08-21', 'other.txt');
+    fs.mkdirSync(path.dirname(currentFile), { recursive: true });
+    fs.writeFileSync(currentFile, 'current attachment', 'utf8');
+    fs.writeFileSync(otherFile, 'other session data', 'utf8');
+    setMediaContext([
+      {
+        path: currentFile,
+        url: '',
+        originalUrl: '',
+        mimeType: 'text/plain',
+        sizeBytes: fs.statSync(currentFile).size,
+        filename: 'current.txt',
+      },
+    ]);
+
+    const result = await executeTool(
+      'read',
+      JSON.stringify({ path: otherFile }),
+    );
+
+    expect(result).not.toContain('other session data');
+    expect(result).toContain('File not found');
+  });
+});

--- a/tests/container.runtime-paths.test.ts
+++ b/tests/container.runtime-paths.test.ts
@@ -157,6 +157,25 @@ describe.sequential('container runtime path aliases', () => {
     ).toBe('/workspace/.data/data/agents/main/workspace/output.pdf');
   });
 
+  test('prefers real paths under allowed roots over the workspace display alias', async () => {
+    const workspaceRoot = '/workspace/.data/data/agents/main/workspace';
+    const uploadedRoot = '/workspace/.data/data/uploaded-media-cache';
+    const uploadedFile = `${uploadedRoot}/2026-08-21/note.txt`;
+    vi.stubEnv('HYBRIDCLAW_AGENT_WORKSPACE_ROOT', workspaceRoot);
+    vi.stubEnv('HYBRIDCLAW_AGENT_WORKSPACE_DISPLAY_ROOT', '/workspace');
+    vi.stubEnv(
+      'HYBRIDCLAW_AGENT_ALLOWED_ROOTS',
+      JSON.stringify([uploadedRoot]),
+    );
+    vi.resetModules();
+
+    const { resolveWorkspacePath } = await import(
+      '../container/src/runtime-paths.ts'
+    );
+
+    expect(resolveWorkspacePath(uploadedFile)).toBe(uploadedFile);
+  });
+
   test('resolves uploaded-media cache display paths', async () => {
     const { resolveMediaPath } = await import(
       '../container/src/runtime-paths.ts'


### PR DESCRIPTION
## Summary

- prefer real absolute paths under allowed host roots before applying workspace display aliases
- let `read` resolve current-turn attachment paths before workspace remapping
- keep write, edit, glob, and cache-wide access boundaries unchanged

## Root cause

Cloud deployments store runtime media under `/workspace/.data/data/...` while `/workspace` is also the logical agent-workspace display alias. The resolver treated the real absolute media path as a display path and incorrectly re-rooted it below the agent workspace.

## Security notes

- attachment reads are limited to paths present in the current turn media context
- canonical path matching prevents a different cached upload from being selected
- no write or directory-search permissions are broadened

## Validation

- `./node_modules/.bin/vitest run tests/container.read-tool.test.ts tests/container.runtime-paths.test.ts tests/security.media-paths.test.ts` (19 tests passed)
- `npm --prefix container run lint`
- `npm run typecheck`
- `npm run lint`
- `npm run build`