### PR TITLE
chore: release v0.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,8 @@
 
 ## Unreleased
 
-### Fixed
+## [0.29.1](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.1) - 2026-08-21
 
-- **Thumbs-down corrections reach HybridAI**: `/thumbs down <correction>`
-  forwards the optional text as `better_response`, so HybridAI stores the
-  expected answer instead of silently discarding it.
-  Manifesto: Principle VIII - A coworker doesn't break overnight.
-- Liveness health probes no longer reset an agent process's idle timeout, so
-  idle per-session processes exit after the idle window as intended.
-- When the process pool is at capacity, idle session-bound agent processes
-  are now evicted (least-recently-used first) instead of rejecting new
-  sessions with "Too many active host agent processes".
 ### Added
 
 - **Teams file uploads match console chat metadata**: Files attached in a
@@ -21,6 +12,7 @@
   Office uploads retain their media type. Downloads stream into the managed
   cache with a configurable 100 MB default limit, and oversized partial files
   are removed instead of falling back to a remote URL.
+
 ### Changed
 
 - **Realtime voice picks its backend from the credentials you have**: The
@@ -32,6 +24,24 @@
   they discovered the provider setting. This matches how dictation and
   speech output already resolve their backends; explicit `openai` and
   `hybridai` settings keep pinning a single backend.
+
+### Fixed
+
+- **Thumbs-down corrections reach HybridAI**: `/thumbs down <correction>`
+  forwards the optional text as `better_response`, so HybridAI stores the
+  expected answer instead of silently discarding it.
+  Manifesto: Principle VIII - A coworker doesn't break overnight.
+- **Idle agent processes release capacity reliably**: Liveness health probes
+  no longer reset an agent process's idle timeout, and a full process pool
+  evicts idle session-bound processes least-recently-used first instead of
+  rejecting new sessions.
+- **Signal and LINE pairing codes scan from the console**: Pairing flows expose
+  crisp SVG QR codes to the admin console instead of relying on distorted
+  terminal-rendered text; the terminal flow keeps its existing text output.
+- **Cloud-workspace attachments resolve to their real paths**: The container
+  read tool recognizes allowed absolute media paths before applying workspace
+  display aliases, while current-turn media checks and existing write and
+  search boundaries remain unchanged.
 
 ## [0.29.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.0) - 2026-08-20
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Core pieces:
 | Build desktop releases | [Desktop Release Builds](https://hybridaione.github.io/hybridclaw/docs/developer-guide/desktop-release) |
 | Contribute | [CONTRIBUTING.md](./CONTRIBUTING.md), [docs/content/README.md](./docs/content/README.md) |
 
-Latest release: [v0.29.0](https://github.com/HybridAIOne/hybridclaw/releases/tag/v0.29.0).
+Latest release: [v0.29.1](https://github.com/HybridAIOne/hybridclaw/releases/tag/v0.29.1).
 Release notes: [CHANGELOG.md](./CHANGELOG.md)
 
 ## Development

--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hybridaione/hybridclaw-console",
   "private": true,
-  "version": "0.29.0",
+  "version": "0.29.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/console/src/release-notes.ts
+++ b/console/src/release-notes.ts
@@ -1,10 +1,10 @@
 export const LATEST_RELEASE_NOTES = {
-  version: '0.29.0',
+  version: '0.29.1',
   highlights: [
-    'Realtime voice works on calls and web chat.',
-    '/thumbs and Teams reactions capture feedback.',
-    'HybridAI defaults to GPT-5.6 Luna.',
-    'Safer SQLite shutdown and stale WAL recovery.',
+    'Teams uploads preserve type and stream safely.',
+    'Realtime voice selects available credentials.',
+    'Idle agents release capacity reliably.',
+    'Feedback, pairing QRs, and cloud reads are fixed.',
   ],
 } as const;
 

--- a/console/src/release-notes.ts
+++ b/console/src/release-notes.ts
@@ -4,7 +4,7 @@ export const LATEST_RELEASE_NOTES = {
     'Teams uploads preserve type and stream safely.',
     'Realtime voice selects available credentials.',
     'Idle agents release capacity reliably.',
-    'Feedback, pairing QRs, and cloud reads are fixed.',
+    'Feedback, pairing QRs, and cloud reads work.',
   ],
 } as const;
 

--- a/container/npm-shrinkwrap.json
+++ b/container/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/container/package-lock.json
+++ b/container/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/container/package.json
+++ b/container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@hybridaione/hybridclaw-desktop",
   "productName": "HybridClaw",
   "private": true,
-  "version": "0.29.0",
+  "version": "0.29.1",
   "license": "MIT",
   "type": "module",
   "description": "macOS wrapper for the HybridClaw chat and admin web surfaces",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -81,7 +81,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "5.101.4",
@@ -107,7 +107,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",
@@ -174,7 +174,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -81,7 +81,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "5.101.4",
@@ -107,7 +107,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",
@@ -174,7 +174,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "type": "module",
   "description": "Enterprise-ready self-hosted AI assistant runtime with sandboxed execution, secure credentials, approvals, and memory",
   "license": "MIT",

--- a/scripts/dependency-policy-baseline.json
+++ b/scripts/dependency-policy-baseline.json
@@ -1,9 +1,9 @@
 {
   "lockfiles": {
-    "package-lock.json": "3436ca0e59786335e90c6683b7744dd4e3e82b4264cceedd0d93d3d125619e28",
-    "npm-shrinkwrap.json": "3436ca0e59786335e90c6683b7744dd4e3e82b4264cceedd0d93d3d125619e28",
-    "container/package-lock.json": "a6d8ac8d30d9c3cb99bdc40e0727c74a0264304527db93c14bf6f40ade80b6ae",
-    "container/npm-shrinkwrap.json": "a6d8ac8d30d9c3cb99bdc40e0727c74a0264304527db93c14bf6f40ade80b6ae",
+    "package-lock.json": "d0e607678a6192fba9f7e7cc46b75f8861cbc2176f045d9a5b967fd0296b064e",
+    "npm-shrinkwrap.json": "d0e607678a6192fba9f7e7cc46b75f8861cbc2176f045d9a5b967fd0296b064e",
+    "container/package-lock.json": "22386b0337d36fd6a86815c5bd9b938ca02f1120af7c969ff0d0a0b843ac6379",
+    "container/npm-shrinkwrap.json": "22386b0337d36fd6a86815c5bd9b938ca02f1120af7c969ff0d0a0b843ac6379",
     "plugins/brevo-email/package-lock.json": "3377225eb3bdbb252eaa28ad420b9a725ea1da533417388557aa1984730229b5",
     "plugins/line/package-lock.json": "1edbba8cefe83f595528d56ecd9086093c05acdca646594cd3bc043bae9924e8"
   },


### PR DESCRIPTION
## Summary

- Problem: release metadata still identifies `v0.29.0` while six merged fixes and improvements are ready for a patch release.
- Why it matters: package manifests, user-facing release notes, lockfile approvals, and the eventual tag must agree before publishing.
- What changed: bumps all product packages to `0.29.1`, curates the changelog and What's New notes, updates the README release link, and refreshes the approved hashes for version-only lockfile bytes.
- What did not change: no dependency version, lifecycle script, runtime code, release tag, package publication, or GitHub Release is included.

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Docs
- [ ] Tests
- [ ] Refactor required for the fix
- [x] Tooling or workflow
- [ ] Security hardening

## Linked Context

- Packages the merged changes from #1411 and #1413 through #1417.

## Licensing

- [x] All commits are signed off (`git commit -s`) to certify the
      [DCO](https://developercertificate.org/); the contribution is licensed
      under the repository's MIT license.

## Manifesto Principle

- Principle: N/A — release packaging only.
- Changelog tag added or updated: the existing Principle VIII note from #1416 is preserved.

## Validation

```bash
npm run format
npm run lint
npm run test:console
npm run deps:policy
npm run build
npm run release:check
npm --prefix container run release:check
git diff --check
```

- Verified manually: all product/workspace versions resolve to `0.29.1`; root and container lock/shrinkwrap pairs are byte-identical; approved SHA-256 baselines match; the lockfile diff changes product versions only.
- Edge cases checked: the changelog covers all six merge PRs since `v0.29.0`, including the Signal/LINE QR and cloud-workspace read-path fixes that had no prior `Unreleased` entry; all four What's New highlights satisfy the 48-character UI limit, and all 926 console tests pass.
- Skipped checks and why: the full root unit, integration, e2e, and live suites were not rerun because this PR only packages the already-merged release set; the source changes were tested in their originating PRs, and the console, build, and package gates pass here.

## Docs And Config Impact

- [x] README, docs, or examples updated
- [ ] Config or environment behavior changed
- [ ] Templates or workspace bootstrap files changed
- [ ] No docs or config impact

No template files changed.

## Risk Notes

- Security-sensitive paths touched? `No`.
- Gateway, audit, approval, or container boundaries touched? `No`; container package metadata and generated dependency artifacts changed, but container runtime code did not.
- The lockfile risk is bounded to reviewed version-field changes and matching policy hashes; no dependency versions or lifecycle-script flags changed.

## Secret Handling Checklist

Not applicable: this release-packaging PR does not read, store, inject, display, log, trace, audit, delete, or document credential material.

## Evidence

- [x] Failing output before and passing output after — the 49-character highlight failed locally and in CI before passing at 44 characters.
- [ ] Screenshot or recording
- [x] Log snippet — concrete command results are recorded in the Validation section.
- [x] Existing test coverage — the release packages already-merged changes whose originating PRs include targeted coverage.

## After merge

- create and push annotated tag `v0.29.1`
- publish the curated `HybridClaw v0.29.1` GitHub release
