### PR TITLE
fix: make Signal device linking reliable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Signal QR linking completes and survives gateway replacement**: The amd64
+  gateway bundles signal-cli 0.14.7, stores its linked-device identity in the
+  persistent gateway data volume, and removes expired QR material after a
+  successful or failed provisioning attempt instead of leaving a stale code in
+  the admin console.
+
 ## [0.29.1](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.1) - 2026-08-21
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,9 @@ RUN npm prune --omit=dev \
 FROM node:22-slim@sha256:80fdb3f57c815e1b638d221f30a826823467c4a56c8f6a8d7aa091cd9b1675ea AS runtime
 
 ARG TARGETARCH
-ARG SIGNAL_CLI_VERSION=0.14.2
+# 0.14.7 (maintainer diagnosis, 2026-08-23): Signal rejects 0.14.2's final
+# linked-device provisioning request with HTTP 409 after accepting the QR.
+ARG SIGNAL_CLI_VERSION=0.14.7
 
 # The agent runtime needs root to install packages, manage files, etc.
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -74,6 +76,13 @@ RUN if [ "${TARGETARCH}" = "amd64" ]; then \
     else \
       echo "signal-cli native release is not available for TARGETARCH=${TARGETARCH}; use an external signal-cli daemon or sidecar."; \
     fi
+
+# Keep the bundled signal-cli linked identity in the gateway's persistent data
+# mount. The system config also makes later bare daemon commands use the same
+# account store as the admin QR-link flow.
+RUN mkdir -p /etc/signal-cli \
+    && printf '%s\n' '{"dataDir":"/workspace/.data/signal-cli"}' \
+      > /etc/signal-cli/config.json
 
 WORKDIR /app
 

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -1516,6 +1516,34 @@ describe('ChannelsPage', () => {
     ).toBe('▄▄\n██');
   });
 
+  it('does not render stale Signal pairing material after an error', async () => {
+    fetchConfigMock.mockResolvedValue({
+      path: '/tmp/config.json',
+      config: makeConfig(),
+    });
+    fetchSignalLinkMock.mockResolvedValue({
+      status: 'error',
+      pairingQrText: 'stale QR text',
+      pairingQrSvg: '<svg>stale QR</svg>',
+      pairingUri: 'sgnl://linkdevice?uuid=stale&pub_key=stale',
+      updatedAt: new Date().toISOString(),
+      error: 'Link request error: StatusCode: 409',
+    });
+
+    renderChannelsPage();
+
+    await screen.findByRole('button', { name: /Signal/i });
+    fireEvent.click(screen.getByRole('button', { name: /Signal/i }));
+
+    expect(
+      await screen.findByText('Link request error: StatusCode: 409'),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole('img', { name: 'Signal linked-device QR' }),
+    ).toBeNull();
+    expect(screen.queryByText('stale QR text')).toBeNull();
+  });
+
   it('disables Signal linked-device setup when signal-cli is unavailable', async () => {
     fetchConfigMock.mockResolvedValue({
       path: '/tmp/config.json',

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -1463,13 +1463,24 @@ function SignalChannelEditor(props: {
             external daemon/sidecar.
             {props.cliError ? ` ${props.cliError}` : ''}
           </p>
-        ) : signalLink?.pairingQrSvg ? (
+        ) : signalLink?.status === 'error' ? (
+          <p className="muted-copy">
+            {signalLink.error || 'Signal linked-device setup failed.'}
+          </p>
+        ) : signalLink?.status === 'complete' ? (
+          <p className="muted-copy">
+            Linked-device flow completed. Start the daemon and save the account
+            below.
+          </p>
+        ) : signalLink?.status === 'starting' ? (
+          <p className="muted-copy">Waiting for signal-cli to print a QR.</p>
+        ) : signalLink?.status === 'qr' && signalLink.pairingQrSvg ? (
           <img
             className="channel-pairing-qr"
             src={`data:image/svg+xml;charset=utf-8,${encodeURIComponent(signalLink.pairingQrSvg)}`}
             alt="Signal linked-device QR"
           />
-        ) : signalLink?.pairingQrText ? (
+        ) : signalLink?.status === 'qr' && signalLink.pairingQrText ? (
           <pre
             className="whatsapp-pairing-qr"
             role="img"
@@ -1477,17 +1488,6 @@ function SignalChannelEditor(props: {
           >
             {signalLink.pairingQrText}
           </pre>
-        ) : signalLink?.status === 'starting' ? (
-          <p className="muted-copy">Waiting for signal-cli to print a QR.</p>
-        ) : signalLink?.status === 'complete' ? (
-          <p className="muted-copy">
-            Linked-device flow completed. Start the daemon and save the account
-            below.
-          </p>
-        ) : signalLink?.status === 'error' ? (
-          <p className="muted-copy">
-            {signalLink.error || 'Signal linked-device setup failed.'}
-          </p>
         ) : (
           <p className="muted-copy">
             Starts `signal-cli link -n HybridClaw` on the gateway host

--- a/docs/content/channels/signal.md
+++ b/docs/content/channels/signal.md
@@ -53,6 +53,11 @@ The admin UI enables **Start QR link** only when the gateway can run
 `signal-cli --version`. If the probe fails, install `signal-cli` in the gateway
 runtime or use a sidecar daemon and complete the link flow there.
 
+The bundled amd64 gateway stores this linked-device identity under
+`/workspace/.data/signal-cli`. Keep `/workspace/.data` on the gateway's
+persistent volume so replacing or restarting the container does not require a
+new QR link.
+
 This is the same model as WhatsApp linked-device setup: your phone remains the
 primary Signal device, and the server gets its own linked session. Do not use
 the SMS registration flow for your personal phone number unless you understand

--- a/src/channels/signal/pairing-state.ts
+++ b/src/channels/signal/pairing-state.ts
@@ -1,3 +1,9 @@
+/**
+ * Signal pairing state shared by the gateway API and admin console.
+ *
+ * Terminal states discard provisioning URIs and rendered QR material so an
+ * expired link token cannot remain actionable. Process lifecycle lives elsewhere.
+ */
 export type SignalPairingStatus =
   | 'idle'
   | 'starting'
@@ -55,8 +61,10 @@ export function setSignalPairingQr(params: {
 
 export function setSignalPairingComplete(): void {
   currentPairingState = {
-    ...currentPairingState,
     status: 'complete',
+    pairingQrText: null,
+    pairingQrSvg: null,
+    pairingUri: null,
     updatedAt: now(),
     error: null,
   };
@@ -64,8 +72,10 @@ export function setSignalPairingComplete(): void {
 
 export function setSignalPairingError(error: string): void {
   currentPairingState = {
-    ...currentPairingState,
     status: 'error',
+    pairingQrText: null,
+    pairingQrSvg: null,
+    pairingUri: null,
     updatedAt: now(),
     error,
   };

--- a/src/channels/signal/pairing.ts
+++ b/src/channels/signal/pairing.ts
@@ -14,6 +14,7 @@ const DEFAULT_SIGNAL_CLI_PATH = 'signal-cli';
 const DEFAULT_SIGNAL_LINK_DEVICE_NAME = 'HybridClaw';
 const SIGNAL_LINK_TIMEOUT_MS = 180_000;
 const SIGNAL_LINK_URI_RE = /sgnl:\/\/linkdevice\?[^\s"'<>]+/i;
+const SIGNAL_LINK_URI_GLOBAL_RE = /sgnl:\/\/linkdevice\?[^\s"'<>]+/gi;
 const OUTPUT_LIMIT = 8_000;
 
 let activeLinkProcess: ChildProcess | null = null;
@@ -57,6 +58,13 @@ function appendOutput(chunk: Buffer | string): void {
     pairingQrText: renderPairingQrText(pairingUri),
     pairingQrSvg: renderQrSvg(pairingUri, 'Signal linked-device QR'),
   });
+}
+
+function redactPairingUris(value: string): string {
+  return value.replace(
+    SIGNAL_LINK_URI_GLOBAL_RE,
+    '[Signal linked-device URI redacted]',
+  );
 }
 
 function clearActiveTimeout(): void {
@@ -152,7 +160,7 @@ export function startSignalLink(params?: {
     }
     if (getSignalPairingState().status === 'error') return;
     setSignalPairingError(
-      capturedOutput.trim() ||
+      redactPairingUris(capturedOutput).trim() ||
         `signal-cli link exited with code ${code ?? 'unknown'}.`,
     );
   });

--- a/tests/dockerfile-runtime-tools.test.ts
+++ b/tests/dockerfile-runtime-tools.test.ts
@@ -51,6 +51,10 @@ describe('Docker runtime tool parity', () => {
     expect(runtime).toContain(
       'ln -s /app/node_modules/@e965/xlsx /app/node_modules/xlsx',
     );
+    expect(runtime).toContain('ARG SIGNAL_CLI_VERSION=0.14.7');
+    expect(runtime).toContain(
+      '{"dataDir":"/workspace/.data/signal-cli"}',
+    );
   });
 
   test('standalone agent runtime includes spreadsheet inspection tools', () => {

--- a/tests/gateway-docker.e2e.test.ts
+++ b/tests/gateway-docker.e2e.test.ts
@@ -124,7 +124,21 @@ describe.skipIf(!DOCKER_E2E)('gateway Docker image', () => {
       `docker exec ${CONTAINER_NAME} signal-cli --version`,
       { encoding: 'utf-8', timeout: 10_000 },
     ).trim();
-    expect(result).toContain('signal-cli');
+    expect(result).toContain('signal-cli 0.14.7');
+
+    const signalConfig = execSync(
+      `docker exec ${CONTAINER_NAME} cat /etc/signal-cli/config.json`,
+      { encoding: 'utf-8', timeout: 10_000 },
+    ).trim();
+    expect(JSON.parse(signalConfig)).toEqual({
+      dataDir: '/workspace/.data/signal-cli',
+    });
+
+    const dataDirResult = execSync(
+      `docker exec ${CONTAINER_NAME} sh -lc 'signal-cli listAccounts >/dev/null 2>&1 && test -d /workspace/.data/signal-cli && test ! -e /root/.local/share/signal-cli && echo ok'`,
+      { encoding: 'utf-8', timeout: 10_000 },
+    ).trim();
+    expect(dataDirResult).toBe('ok');
   });
 
   // ── HTTP endpoint checks ─────────────────────────────────────────────

--- a/tests/signal-pairing.test.ts
+++ b/tests/signal-pairing.test.ts
@@ -7,7 +7,7 @@ vi.mock('node:child_process', () => ({
   spawn: spawnMock,
   spawnSync: vi.fn(() => ({
     status: 0,
-    stdout: 'signal-cli 0.14.2\n',
+    stdout: 'signal-cli 0.14.7\n',
     stderr: '',
     error: undefined,
   })),
@@ -83,6 +83,43 @@ describe('Signal pairing', () => {
     expect(getSignalLinkState().pairingQrSvg).toContain(
       'aria-label="Signal linked-device QR"',
     );
+
+    child.emit('close', 0);
+    expect(getSignalLinkState()).toMatchObject({
+      status: 'complete',
+      pairingUri: null,
+      pairingQrText: null,
+      pairingQrSvg: null,
+      error: null,
+    });
+  });
+
+  test('clears and redacts pairing material when signal-cli fails', async () => {
+    const child = createFakeSignalCliProcess();
+    spawnMock.mockReturnValue(child);
+    const { getSignalLinkState, startSignalLink } = await import(
+      '../src/channels/signal/pairing.ts'
+    );
+
+    startSignalLink();
+    child.stdout.emit(
+      'data',
+      'Open this link: sgnl://linkdevice?uuid=abc&pub_key=def',
+    );
+    child.stderr.emit('data', '\nLink request error: StatusCode: 409');
+    child.emit('close', 3);
+
+    expect(getSignalLinkState()).toMatchObject({
+      status: 'error',
+      pairingUri: null,
+      pairingQrText: null,
+      pairingQrSvg: null,
+      error: expect.stringContaining('StatusCode: 409'),
+    });
+    expect(getSignalLinkState().error).toContain(
+      '[Signal linked-device URI redacted]',
+    );
+    expect(getSignalLinkState().error).not.toContain('sgnl://');
   });
 
   test('records spawn errors for the admin UI', async () => {
@@ -97,6 +134,9 @@ describe('Signal pairing', () => {
 
     expect(getSignalLinkState()).toMatchObject({
       status: 'error',
+      pairingUri: null,
+      pairingQrText: null,
+      pairingQrSvg: null,
       error: 'signal-cli not found',
     });
   });


### PR DESCRIPTION
## Summary

- upgrade the bundled amd64 signal-cli from 0.14.2 to 0.14.7
- store the bundled linked-device identity under `/workspace/.data/signal-cli`
- clear QR text, SVG, and provisioning URIs when pairing succeeds or fails
- redact provisioning URIs from signal-cli failure output and make terminal status win over stale QR fields in the console
- document the persistent data path and add regression coverage

## Root cause

The QR scan and provisioning callback completed, but Signal rejected the final link request from signal-cli 0.14.2 with HTTP 409. After the process failed, the gateway retained the QR fields and the console rendered them before the error state, which made the expired QR look reusable. The default signal-cli account store also lived under `/root/.local/share`, outside the gateway persistent data volume.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run format`
- focused Signal and Dockerfile unit tests: 5 passed
- console channel tests: 44 passed
- built `hybridclaw-signal-pr:local` from the amended Dockerfile
- freshly built image reports `signal-cli 0.14.7` and resolves account data only under `/workspace/.data/signal-cli`
- gateway Docker E2E: 29 passed, 2 credential-dependent tests skipped
- live diagnosis confirmed 0.14.2 failed with HTTP 409, while 0.14.7 linked and delivered a Note to Self message through the production Signal delivery module

## Risk and boundaries

- Linked-device credentials are sensitive and now survive container replacement with the existing gateway data volume. Deployments must protect `/workspace/.data` with the same permissions and backup controls as other gateway secrets.
- Provisioning URIs are removed from terminal pairing state and redacted from errors, reducing accidental replay or disclosure.
- Signal sender allowlists, group policy, daemon network binding, and transport authorization are unchanged.
- The bundled native binary remains amd64-only; arm64 and external-daemon deployments keep their existing sidecar flow.
- No migration shim is added for the prior ephemeral `/root/.local/share/signal-cli` location.