### PR TITLE
feat(voice): API-token access to browser realtime voice sessions

### DIFF
--- a/docs/content/channels/admin-console.md
+++ b/docs/content/channels/admin-console.md
@@ -161,7 +161,9 @@ changes before navigation.
   voice-tagged messages, and substantive requests run as ordinary web chat
   turns via `consult_agent`; while a consult runs, the live-call capsule shows
   what the agent is currently doing (for example `Checking — web search…`)
-  and long consults get short spoken progress updates
+  and long consults get short spoken progress updates; external web apps can
+  run the same voice sessions via scoped API tokens — see
+  [Realtime Voice for Web Apps](../guides/voice-web-api.md)
 - destructive admin actions use explicit browser confirmation dialogs before
   HybridClaw applies the requested change
 

--- a/docs/content/guides/README.md
+++ b/docs/content/guides/README.md
@@ -30,5 +30,7 @@ These pages focus on common operator workflows after the base install works.
 - [Vonage Voice Plugin](./vonage-voice.md) for turn-based or realtime phone
   calls through the install-on-demand Vonage integration
 - [Voice and TTS](./voice-tts.md) for voice reply and speech backend setup
+- [Realtime Voice for Web Apps](./voice-web-api.md) for browser voice
+  sessions from your own web app via scoped API tokens
 - [Optional Office Dependencies](./office-dependencies.md) for host-side
   office tooling

--- a/docs/content/guides/voice-web-api.md
+++ b/docs/content/guides/voice-web-api.md
@@ -1,0 +1,107 @@
+---
+title: Realtime Voice for Web Apps
+description: Start browser realtime voice sessions from your own web app using a scoped API token and the gateway voice stream.
+sidebar_position: 9
+---
+
+# Realtime Voice for Web Apps
+
+Any web app can run a realtime speech-to-speech session against the gateway —
+the same engine that powers the admin console voice mode and realtime phone
+calls. The browser streams microphone audio over a websocket, the agent
+answers with spoken audio, and substantive requests run as ordinary chat turns
+with tools, approvals, and session history.
+
+## Prerequisites
+
+- Realtime voice credentials configured (`voice.realtime.provider`, see
+  [Configuration](../reference/configuration.md)). `GET /api/chat/voice`
+  reports `available: true` when the gateway can start sessions.
+- The gateway reachable over HTTPS from the browser (a tunnel or public
+  deployment).
+
+## 1. Create a scoped API token
+
+Create a token that can only mint voice sessions:
+
+```bash
+hybridclaw token create --label "voice webapp" --actions voice.session
+```
+
+Keep the `hck_` token on your server. Do not embed it in a public page — every
+holder can start voice sessions (and spend realtime-model minutes) on your
+gateway.
+
+## 2. Mint a stream token
+
+Browsers cannot send an `Authorization` header on websocket upgrades, so a
+session starts with a short-lived credential minted over HTTPS:
+
+```bash
+curl -X POST https://gateway.example/api/chat/voice/token \
+  -H "Authorization: Bearer hck_..." \
+  -H "Content-Type: application/json" \
+  -d '{"userId": "visitor-123", "username": "Visitor"}'
+```
+
+```json
+{
+  "token": "wq0…",
+  "expiresIn": 60,
+  "path": "/api/chat/voice/stream?token=wq0…"
+}
+```
+
+- The stream token is **single-use** and expires after 60 seconds; mint one
+  per session, right before connecting.
+- `userId` / `username` are optional and attribute the session's chat history;
+  they default to the minting token's identity.
+- The route answers CORS preflights and allows any origin for bearer-token
+  clients; cookie-authenticated requests are still same-origin only. The
+  recommended shape is still to mint from your backend and hand only the
+  stream token to the page.
+
+## 3. Connect and stream audio
+
+Open a websocket to the returned `path` on the gateway host and speak the
+webchat voice frame protocol — JSON text frames both ways:
+
+| Direction | Frame | Meaning |
+| --- | --- | --- |
+| client → server | `{"type":"start","sessionId?":"…","agentId?":"…"}` | Start the session (within 10 s of connecting) |
+| client → server | `{"type":"audio","payload":"<base64 PCM16>"}` | Microphone audio |
+| client → server | `{"type":"stop"}` | End the session |
+| server → client | `{"type":"ready","sessionId":"…"}` | Session is live |
+| server → client | `{"type":"audio","payload":"<base64 PCM16>"}` | Agent speech |
+| server → client | `{"type":"clear"}` | Barge-in: drop queued playback |
+| server → client | `{"type":"state","state":"listening\|speaking\|thinking"}` | Turn state |
+| server → client | `{"type":"consult","label":"…"}` | Tool/agent activity label |
+| server → client | `{"type":"transcript","role":"user\|assistant","text":"…"}` | Spoken-turn transcript |
+| server → client | `{"type":"error"}` / `{"type":"ended"}` | Failure / session end |
+
+Audio is 16-bit little-endian mono PCM at **24 kHz**, base64-encoded, in both
+directions.
+
+Minimal client sketch:
+
+```js
+const { token } = await fetch('/my-backend/voice-token', { method: 'POST' })
+  .then((res) => res.json());
+const ws = new WebSocket(`wss://gateway.example/api/chat/voice/stream?token=${token}`);
+ws.onopen = () => ws.send(JSON.stringify({ type: 'start' }));
+ws.onmessage = (event) => {
+  const frame = JSON.parse(event.data);
+  if (frame.type === 'audio') playPcm16Base64(frame.payload); // 24 kHz mono
+  if (frame.type === 'clear') stopPlayback();
+};
+// Capture: AudioWorklet/ScriptProcessor at 24 kHz → Int16 PCM → base64:
+// ws.send(JSON.stringify({ type: 'audio', payload: base64Chunk }));
+```
+
+## Limits
+
+- Stream tokens: single-use, 60 s TTL, at most 32 unclaimed mints pending.
+- Sessions: at most 4 concurrent voice sessions per gateway, 256 KB max
+  frame size, and a 10 s deadline to send `start` after connecting.
+- Spoken turns persist into session history as regular messages tagged
+  `source: 'voice'`.

--- a/docs/content/reference/commands.md
+++ b/docs/content/reference/commands.md
@@ -98,7 +98,7 @@ hybridclaw token revoke <token-id>
 - `--role` accepts admin RBAC role bundles such as `admin.viewer`,
   `admin.security_manager`, or `admin.full`
 - `--actions` accepts explicit action names such as `openai.api`,
-  `chat.send`, `status.read`, `admin.tokens.read`,
+  `chat.send`, `voice.session`, `status.read`, `admin.tokens.read`,
   `admin.tokens.create`, and `admin.tokens.revoke`
 - `/admin/credentials?tab=api-tokens` provides the same create/list/revoke workflow in the browser
   with role presets, action filters, and expiry presets

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -457,8 +457,11 @@ import {
   synthesizeWebchatSpeech,
 } from './webchat-speech.js';
 import {
+  consumeWebchatVoiceStreamToken,
   isWebchatVoiceAvailable,
+  mintWebchatVoiceStreamToken,
   WEBCHAT_VOICE_STREAM_PATH,
+  WEBCHAT_VOICE_TOKEN_PATH,
   webchatVoiceManager,
 } from './webchat-voice.js';
 
@@ -2705,6 +2708,58 @@ function resolveGatewayRequestUserId(params: {
     normalizeOptionalString(params.requestedUserId) ||
     normalizeOptionalString(params.fallbackUserId)
   );
+}
+
+// Bearer-token browser clients only: cookie auth is never accepted
+// cross-origin on this route, and `*` without Allow-Credentials keeps
+// credentialed cross-site requests rejected by the browser.
+const VOICE_TOKEN_CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+  'Access-Control-Max-Age': '600',
+};
+
+function setVoiceTokenCorsHeaders(res: ServerResponse): void {
+  for (const [name, value] of Object.entries(VOICE_TOKEN_CORS_HEADERS)) {
+    res.setHeader(name, value);
+  }
+}
+
+function normalizeVoiceIdentityField(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, 128) : null;
+}
+
+async function handleApiChatVoiceToken(
+  req: IncomingMessage,
+  res: ServerResponse,
+  authContext: ResolvedAuthContext,
+): Promise<void> {
+  if (!isWebchatVoiceAvailable()) {
+    sendJson(res, 503, { error: 'Realtime voice is not configured.' });
+    return;
+  }
+  const body = (await readJsonBody(req)) as Record<string, unknown>;
+  const actor =
+    resolveApiTokenActor(authContext) ||
+    resolveAdminSessionActor(authContext.payload) ||
+    resolveGatewayRequestUserId({ req, channelId: 'web' }) ||
+    null;
+  const minted = mintWebchatVoiceStreamToken({
+    userId: normalizeVoiceIdentityField(body.userId) || actor,
+    username: normalizeVoiceIdentityField(body.username),
+  });
+  if (!minted) {
+    sendJson(res, 429, { error: 'Too many pending voice stream tokens.' });
+    return;
+  }
+  sendJson(res, 200, {
+    token: minted.token,
+    expiresIn: minted.expiresInSeconds,
+    path: `${WEBCHAT_VOICE_STREAM_PATH}?token=${minted.token}`,
+  });
 }
 
 function isWithinRoot(candidate: string, root: string): boolean {
@@ -10537,6 +10592,18 @@ export function startGatewayHttpServer(): GatewayHttpServer {
         return;
       }
 
+      if (pathname === WEBCHAT_VOICE_TOKEN_PATH) {
+        // Browser clients mint from third-party origins with a bearer token;
+        // reflect CORS on every outcome so failures stay visible cross-origin.
+        setVoiceTokenCorsHeaders(res);
+        if (method === 'OPTIONS') {
+          // Preflight carries no credentials; auth happens on the POST.
+          res.writeHead(204);
+          res.end();
+          return;
+        }
+      }
+
       const authContext = resolveAuthContext(req, url, {
         allowQueryToken: false,
         allowLocalWebSession: true,
@@ -11115,6 +11182,10 @@ export function startGatewayHttpServer(): GatewayHttpServer {
             });
             return;
           }
+          if (pathname === WEBCHAT_VOICE_TOKEN_PATH && method === 'POST') {
+            await handleApiChatVoiceToken(req, res, authContext);
+            return;
+          }
           if (pathname === '/api/agents' && method === 'GET') {
             await handleApiAgents(res);
             return;
@@ -11359,9 +11430,26 @@ export function startGatewayHttpServer(): GatewayHttpServer {
     }
 
     if (url.pathname === WEBCHAT_VOICE_STREAM_PATH) {
-      // Same browser-auth gate as the admin terminal stream: a signed session
-      // cookie or an authenticated same-origin request (including the
-      // loopback local web session). No query tokens, no API tokens.
+      // Two credentials: a single-use stream token minted over the
+      // authenticated `/api/chat/voice/token` route (external web apps;
+      // browsers cannot set websocket headers), or the same browser-auth
+      // gate as the admin terminal stream — a signed session cookie or an
+      // authenticated same-origin request (including the loopback local web
+      // session). No long-lived query tokens, no direct API tokens.
+      const streamToken = (url.searchParams.get('token') || '').trim();
+      if (streamToken) {
+        const streamIdentity = consumeWebchatVoiceStreamToken(streamToken);
+        if (!streamIdentity) {
+          writeUpgradeError(socket, 401, 'Unauthorized');
+          return;
+        }
+        if (!isWebchatVoiceAvailable()) {
+          writeUpgradeError(socket, 503, 'Voice Unavailable');
+          return;
+        }
+        webchatVoiceManager.handleUpgrade(req, socket, head, streamIdentity);
+        return;
+      }
       const voiceSessionPayload = getSessionAuthPayload(req);
       const voiceRequestAuth = resolveAuthContext(req, url, {
         allowApiTokens: false,

--- a/src/gateway/webchat-voice.ts
+++ b/src/gateway/webchat-voice.ts
@@ -9,9 +9,12 @@
  * ordinary web chat turn through `handleGatewayMessage`, so tools, approvals,
  * and session history behave exactly like typed chat.
  *
- * Threat model: the HTTP server authenticates the upgrade (session cookie or
- * loopback web session) BEFORE handing sockets to this module — nothing here
- * may run for anonymous peers. This module still enforces its own limits:
+ * Threat model: the HTTP server authenticates the upgrade BEFORE handing
+ * sockets to this module — nothing here may run for anonymous peers. Two
+ * upgrade credentials exist: a session cookie / loopback web session (the
+ * console), or a single-use short-lived stream token minted here over the
+ * authenticated `/api/chat/voice/token` route (external API clients; browsers
+ * cannot set websocket headers). This module still enforces its own limits:
  * bounded frame size, a concurrent-session cap, a start deadline for idle
  * sockets, and canonical-session-id validation so a client cannot consult
  * into an arbitrary key shape. Audio payloads are opaque and never logged;
@@ -20,7 +23,7 @@
  * NOT the Twilio path: phone calls live in `src/channels/voice/runtime.ts`.
  */
 
-import { randomUUID } from 'node:crypto';
+import { randomBytes, randomUUID } from 'node:crypto';
 import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
 import WebSocket, * as wsModule from 'ws';
@@ -48,14 +51,56 @@ import { handleGatewayMessage } from './gateway-chat-service.js';
 import { persistVoiceTranscript } from './voice-transcript-store.js';
 
 export const WEBCHAT_VOICE_STREAM_PATH = '/api/chat/voice/stream';
+export const WEBCHAT_VOICE_TOKEN_PATH = '/api/chat/voice/token';
 
 const MAX_CONCURRENT_SESSIONS = 4;
 const MAX_FRAME_BYTES = 256 * 1024;
 const START_DEADLINE_MS = 10_000;
+// 60s single-use TTL, small pending cap (call, 2026-08-24): clients mint and
+// connect immediately, so the cap only bounds unclaimed mints.
+const STREAM_TOKEN_TTL_MS = 60_000;
+const MAX_PENDING_STREAM_TOKENS = 32;
 
 export interface WebchatVoiceIdentity {
   userId: string | null;
   username: string | null;
+}
+
+interface PendingVoiceStreamToken {
+  identity: WebchatVoiceIdentity;
+  expiresAtMs: number;
+}
+
+const pendingStreamTokens = new Map<string, PendingVoiceStreamToken>();
+
+function prunePendingStreamTokens(): void {
+  const now = Date.now();
+  for (const [token, entry] of pendingStreamTokens) {
+    if (entry.expiresAtMs <= now) pendingStreamTokens.delete(token);
+  }
+}
+
+export function mintWebchatVoiceStreamToken(
+  identity: WebchatVoiceIdentity,
+): { token: string; expiresInSeconds: number } | null {
+  prunePendingStreamTokens();
+  if (pendingStreamTokens.size >= MAX_PENDING_STREAM_TOKENS) return null;
+  const token = randomBytes(24).toString('base64url');
+  pendingStreamTokens.set(token, {
+    identity,
+    expiresAtMs: Date.now() + STREAM_TOKEN_TTL_MS,
+  });
+  return { token, expiresInSeconds: STREAM_TOKEN_TTL_MS / 1000 };
+}
+
+export function consumeWebchatVoiceStreamToken(
+  token: string,
+): WebchatVoiceIdentity | null {
+  prunePendingStreamTokens();
+  const entry = pendingStreamTokens.get(token);
+  if (!entry) return null;
+  pendingStreamTokens.delete(token);
+  return entry.identity;
 }
 
 export function isWebchatVoiceAvailable(): boolean {

--- a/src/security/admin-rbac.ts
+++ b/src/security/admin-rbac.ts
@@ -15,6 +15,7 @@ export const ADMIN_RBAC_ACTIONS = [
   ...ADMIN_TOKEN_RBAC_ACTIONS,
   'openai.api',
   'chat.send',
+  'voice.session',
   'status.read',
   'agents.read',
   'apps.read',
@@ -392,6 +393,9 @@ export function resolveAdminRbacAction(
   }
   if (pathname === '/api/chat' && method === 'POST') {
     return 'chat.send';
+  }
+  if (pathname === '/api/chat/voice/token' && method === 'POST') {
+    return 'voice.session';
   }
   if (pathname === '/api/command' && method === 'POST') {
     return 'chat.send';

--- a/tests/admin-rbac.test.ts
+++ b/tests/admin-rbac.test.ts
@@ -177,6 +177,10 @@ describe('admin RBAC role bundles', () => {
     );
     expect(resolveAdminRbacAction('/v1/models', 'GET')).toBe('openai.api');
     expect(resolveAdminRbacAction('/api/chat', 'POST')).toBe('chat.send');
+    expect(resolveAdminRbacAction('/api/chat/voice/token', 'POST')).toBe(
+      'voice.session',
+    );
+    expect(resolveAdminRbacAction('/api/chat/voice/token', 'GET')).toBeNull();
     expect(resolveAdminRbacAction('/api/command', 'POST')).toBe('chat.send');
     expect(resolveAdminRbacAction('/api/status', 'GET')).toBe('status.read');
     expect(resolveAdminRbacAction('/api/agents', 'GET')).toBe('agents.read');

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -624,6 +624,7 @@ async function importFreshHealth(options?: {
     string,
     { id: string; label: string; claims: Record<string, unknown> }
   >;
+  webchatVoiceAvailable?: boolean;
   mediaUploadQuotaDecision?: {
     allowed: boolean;
     remainingBytes: number;
@@ -688,6 +689,10 @@ async function importFreshHealth(options?: {
   const synthesizeWebchatSpeech = vi.fn(async () =>
     Buffer.from('generated-mp3'),
   );
+  const isWebchatVoiceAvailableMock = vi.fn(
+    () => options?.webchatVoiceAvailable ?? true,
+  );
+  const webchatVoiceUpgrade = vi.fn();
   const getGatewayHistory = vi.fn((sessionId: string) => ({
     sessionId,
     agentId: 'research',
@@ -2824,6 +2829,16 @@ async function importFreshHealth(options?: {
     MAX_WEBCHAT_SPEECH_CHARS: 4_096,
     synthesizeWebchatSpeech,
   }));
+  vi.doMock('../src/gateway/webchat-voice.js', async () => {
+    const actual = await vi.importActual<
+      typeof import('../src/gateway/webchat-voice.js')
+    >('../src/gateway/webchat-voice.js');
+    return {
+      ...actual,
+      isWebchatVoiceAvailable: isWebchatVoiceAvailableMock,
+      webchatVoiceManager: { handleUpgrade: webchatVoiceUpgrade },
+    };
+  });
   vi.doMock('../src/plugins/plugin-manager.js', () => ({
     findLoadedPluginCommand: vi.fn(() => undefined),
     listLoadedPluginCommands,
@@ -2941,6 +2956,8 @@ async function importFreshHealth(options?: {
     handleTerminalUpgrade,
     broadcastShutdownTerminal,
     upgradeHandler,
+    isWebchatVoiceAvailableMock,
+    webchatVoiceUpgrade,
     moveGatewayAdminSchedulerJob,
     requestGatewayRestart,
     ResponseRatingNotFoundError,
@@ -17106,6 +17123,231 @@ describe('gateway HTTP server', () => {
     expect(sseRes.writableEnded).toBe(true);
     expect(state.broadcastShutdownTerminal).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'shutdown' }),
+    );
+  });
+
+  test('mints a voice stream token for an API token scoped to voice.session', async () => {
+    const state = await importFreshHealth({
+      apiTokens: {
+        hck_voice_token: {
+          id: 'voicetok00001',
+          label: 'webapp',
+          claims: { actions: ['voice.session'] },
+        },
+      },
+    });
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/chat/voice/token',
+      noAuth: true,
+      headers: {
+        authorization: 'Bearer hck_voice_token',
+        origin: 'https://webapp.example',
+      },
+      body: { userId: 'visitor-1', username: 'Visitor' },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.getHeader('Access-Control-Allow-Origin')).toBe('*');
+    const payload = JSON.parse(res.body) as {
+      token: string;
+      expiresIn: number;
+      path: string;
+    };
+    expect(payload.token.length).toBeGreaterThan(20);
+    expect(payload.expiresIn).toBe(60);
+    expect(payload.path).toBe(`/api/chat/voice/stream?token=${payload.token}`);
+
+    const socket = { write: vi.fn(), destroy: vi.fn() };
+    state.upgradeHandler?.(
+      makeRequest({
+        method: 'GET',
+        url: `/api/chat/voice/stream?token=${payload.token}`,
+        remoteAddress: '203.0.113.10',
+        noAuth: true,
+      }) as never,
+      socket as never,
+      Buffer.alloc(0) as never,
+    );
+
+    expect(socket.write).not.toHaveBeenCalled();
+    expect(state.webchatVoiceUpgrade).toHaveBeenCalledWith(
+      expect.anything(),
+      socket,
+      expect.any(Buffer),
+      { userId: 'visitor-1', username: 'Visitor' },
+    );
+
+    // Stream tokens are single-use: a replay is rejected.
+    const replaySocket = { write: vi.fn(), destroy: vi.fn() };
+    state.upgradeHandler?.(
+      makeRequest({
+        method: 'GET',
+        url: `/api/chat/voice/stream?token=${payload.token}`,
+        remoteAddress: '203.0.113.10',
+        noAuth: true,
+      }) as never,
+      replaySocket as never,
+      Buffer.alloc(0) as never,
+    );
+    expect(String(replaySocket.write.mock.calls[0]?.[0] || '')).toContain(
+      '401 Unauthorized',
+    );
+    expect(state.webchatVoiceUpgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test('voice token identity defaults to the minting API token actor', async () => {
+    const state = await importFreshHealth({
+      apiTokens: {
+        hck_voice_token: {
+          id: 'voicetok00001',
+          label: 'webapp',
+          claims: { actions: ['voice.session'] },
+        },
+      },
+    });
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/chat/voice/token',
+      noAuth: true,
+      headers: { authorization: 'Bearer hck_voice_token' },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(200);
+    const payload = JSON.parse(res.body) as { token: string };
+
+    const socket = { write: vi.fn(), destroy: vi.fn() };
+    state.upgradeHandler?.(
+      makeRequest({
+        method: 'GET',
+        url: `/api/chat/voice/stream?token=${payload.token}`,
+        remoteAddress: '203.0.113.10',
+        noAuth: true,
+      }) as never,
+      socket as never,
+      Buffer.alloc(0) as never,
+    );
+
+    expect(state.webchatVoiceUpgrade).toHaveBeenCalledWith(
+      expect.anything(),
+      socket,
+      expect.any(Buffer),
+      { userId: 'apiToken:voicetok00001:webapp', username: null },
+    );
+  });
+
+  test('rejects voice token mints for API tokens without voice.session', async () => {
+    const state = await importFreshHealth({
+      apiTokens: {
+        hck_chat_only: {
+          id: 'chattok000001',
+          label: 'chat',
+          claims: { actions: ['chat.send'] },
+        },
+      },
+    });
+    const req = makeRequest({
+      method: 'POST',
+      url: '/api/chat/voice/token',
+      noAuth: true,
+      headers: { authorization: 'Bearer hck_chat_only' },
+    });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.getHeader('Access-Control-Allow-Origin')).toBe('*');
+  });
+
+  test('rejects unauthenticated voice token mints but answers preflight', async () => {
+    const state = await importFreshHealth();
+
+    const postRes = makeResponse();
+    state.handler(
+      makeRequest({
+        method: 'POST',
+        url: '/api/chat/voice/token',
+        noAuth: true,
+      }) as never,
+      postRes as never,
+    );
+    await waitForResponse(postRes, (next) => next.writableEnded);
+    expect(postRes.statusCode).toBe(401);
+    expect(postRes.getHeader('Access-Control-Allow-Origin')).toBe('*');
+
+    const preflightRes = makeResponse();
+    state.handler(
+      makeRequest({
+        method: 'OPTIONS',
+        url: '/api/chat/voice/token',
+        noAuth: true,
+        headers: { origin: 'https://webapp.example' },
+      }) as never,
+      preflightRes as never,
+    );
+    await waitForResponse(preflightRes, (next) => next.writableEnded);
+    expect(preflightRes.statusCode).toBe(204);
+    expect(preflightRes.getHeader('Access-Control-Allow-Origin')).toBe('*');
+    expect(preflightRes.getHeader('Access-Control-Allow-Headers')).toBe(
+      'Authorization, Content-Type',
+    );
+  });
+
+  test('returns 503 for voice token mints when realtime voice is unavailable', async () => {
+    const state = await importFreshHealth({
+      webchatVoiceAvailable: false,
+      apiTokens: {
+        hck_voice_token: {
+          id: 'voicetok00001',
+          label: 'webapp',
+          claims: { actions: ['voice.session'] },
+        },
+      },
+    });
+    const res = makeResponse();
+
+    state.handler(
+      makeRequest({
+        method: 'POST',
+        url: '/api/chat/voice/token',
+        noAuth: true,
+        headers: { authorization: 'Bearer hck_voice_token' },
+      }) as never,
+      res as never,
+    );
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(503);
+  });
+
+  test('rejects voice stream upgrades with a garbage query token', async () => {
+    const state = await importFreshHealth();
+    const socket = { write: vi.fn(), destroy: vi.fn() };
+
+    state.upgradeHandler?.(
+      makeRequest({
+        method: 'GET',
+        url: '/api/chat/voice/stream?token=bogus',
+        remoteAddress: '203.0.113.10',
+        noAuth: true,
+      }) as never,
+      socket as never,
+      Buffer.alloc(0) as never,
+    );
+
+    expect(state.webchatVoiceUpgrade).not.toHaveBeenCalled();
+    expect(String(socket.write.mock.calls[0]?.[0] || '')).toContain(
+      '401 Unauthorized',
     );
   });
 });

--- a/tests/webchat-voice.test.ts
+++ b/tests/webchat-voice.test.ts
@@ -132,6 +132,34 @@ async function createConnection(params?: { apiKey?: string }) {
   return { browser, realtime, finished };
 }
 
+async function loadWebchatVoiceModule() {
+  vi.doMock('../src/config/config.js', () => ({
+    OPENAI_API_KEY: 'test-key',
+    HYBRIDAI_BASE_URL: 'https://hybridai.example',
+    getConfigSnapshot: () => ({ voice: { realtime: REALTIME_CONFIG } }),
+  }));
+  vi.doMock('../src/config/runtime-config.js', () => ({
+    getRuntimeConfig: () => ({}),
+    resolveDefaultAgentId: () => 'main',
+  }));
+  vi.doMock('../src/gateway/gateway-chat-service.js', () => ({
+    handleGatewayMessage,
+  }));
+  vi.doMock('../src/gateway/voice-transcript-store.js', () => ({
+    persistVoiceTranscript,
+    VOICE_MESSAGE_SOURCE: 'voice',
+  }));
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+  }));
+  return import('../src/gateway/webchat-voice.js');
+}
+
 async function flushAsync(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve));
 }
@@ -350,4 +378,71 @@ test('starting without an OpenAI key fails closed', async () => {
   expect(String(error.message)).toContain('OpenAI API key');
   expect(browser.closeCode).toBe(1011);
   expect(finished).toHaveBeenCalled();
+});
+
+test('stream tokens are single-use and carry the minted identity', async () => {
+  const { mintWebchatVoiceStreamToken, consumeWebchatVoiceStreamToken } =
+    await loadWebchatVoiceModule();
+
+  const minted = mintWebchatVoiceStreamToken({
+    userId: 'apiToken:abc123',
+    username: 'kiosk',
+  });
+  expect(minted).not.toBeNull();
+  expect(minted?.expiresInSeconds).toBe(60);
+
+  expect(consumeWebchatVoiceStreamToken(minted?.token ?? '')).toEqual({
+    userId: 'apiToken:abc123',
+    username: 'kiosk',
+  });
+  expect(consumeWebchatVoiceStreamToken(minted?.token ?? '')).toBeNull();
+});
+
+test('unknown stream tokens are rejected', async () => {
+  const { consumeWebchatVoiceStreamToken } = await loadWebchatVoiceModule();
+
+  expect(consumeWebchatVoiceStreamToken('not-a-token')).toBeNull();
+});
+
+test('stream tokens expire after their TTL', async () => {
+  vi.useFakeTimers();
+  try {
+    const { mintWebchatVoiceStreamToken, consumeWebchatVoiceStreamToken } =
+      await loadWebchatVoiceModule();
+
+    const minted = mintWebchatVoiceStreamToken({
+      userId: 'user_a',
+      username: null,
+    });
+    vi.advanceTimersByTime(61_000);
+    expect(consumeWebchatVoiceStreamToken(minted?.token ?? '')).toBeNull();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('pending stream tokens are capped until stale mints expire', async () => {
+  vi.useFakeTimers();
+  try {
+    const { mintWebchatVoiceStreamToken } = await loadWebchatVoiceModule();
+
+    for (let index = 0; index < 32; index += 1) {
+      expect(
+        mintWebchatVoiceStreamToken({
+          userId: `user_${index}`,
+          username: null,
+        }),
+      ).not.toBeNull();
+    }
+    expect(
+      mintWebchatVoiceStreamToken({ userId: 'user_overflow', username: null }),
+    ).toBeNull();
+
+    vi.advanceTimersByTime(61_000);
+    expect(
+      mintWebchatVoiceStreamToken({ userId: 'user_fresh', username: null }),
+    ).not.toBeNull();
+  } finally {
+    vi.useRealTimers();
+  }
 });


### PR DESCRIPTION
## What

Lets an external web app (the "web app with just a play button" use case) start a realtime speech-to-speech voice session against the gateway via API access, reusing the existing webchat voice engine unchanged.

- New `voice.session` RBAC action for scoped `hck_` API tokens.
- `POST /api/chat/voice/token` (gated on `voice.session`) mints a **single-use, 60s** stream token, optionally carrying a per-visitor `userId`/`username` (defaults to the minting token's actor).
- The `/api/chat/voice/stream` websocket upgrade accepts that stream token as a second credential next to the existing console cookie/same-origin gate — browsers can't set `Authorization` headers on websockets, and this keeps long-lived credentials out of websocket URLs (same pattern the vonage plugin already uses).
- The mint route answers CORS preflights with `Access-Control-Allow-Origin: *` for bearer-token clients; recommended integration is still a server-side mint.
- New guide: `docs/content/guides/voice-web-api.md` (token setup, frame protocol, audio format, limits).

## Threat / risk notes (high-risk paths: src/gateway, src/security)

- API tokens without `voice.session` get 403 from the RBAC route map; unauthenticated mints get 401.
- Stream tokens are single-use (replay → 401 before any upgrade), expire after 60s, and at most 32 unclaimed mints are pending (429 beyond that).
- CORS `*` is safe here: cookie auth on this POST route is same-origin only, and `*` without `Allow-Credentials` makes browsers reject credentialed cross-site use — only bearer-token clients benefit.
- The existing webchat voice limits still bound token-authed peers: 4 concurrent sessions, 256KB frames, 10s start deadline, canonical session-key validation.
- Console cookie flow is unchanged.

## Tests

- Unit: mint/consume single-use, TTL expiry, pending cap (tests/webchat-voice.test.ts).
- RBAC mapping for the new route (tests/admin-rbac.test.ts).
- Integration: mint→upgrade happy path incl. identity passthrough and replay rejection, 401/403/503/preflight, garbage upgrade token (tests/gateway-http-server.test.ts).
- `npm run lint`, `npm run check`, and the touched vitest suites (422 tests) pass.