### PR TITLE
fix(msteams): resolve canonical session keys in message tool sends

### DIFF
--- a/container/shared/msteams-session-ids.d.ts
+++ b/container/shared/msteams-session-ids.d.ts
@@ -1,0 +1,7 @@
+export declare function isMSTeamsSessionId(
+  value: string | null | undefined,
+): boolean;
+
+export declare function isMSTeamsDmSessionId(
+  value: string | null | undefined,
+): boolean;

--- a/container/shared/msteams-session-ids.js
+++ b/container/shared/msteams-session-ids.js
@@ -1,0 +1,20 @@
+import { parseSessionKey } from './session-keys.js';
+
+// Pre-migration Teams rows keep their legacy `teams:...` ids forever
+// (classifySessionKeyShape treats them as opaque), so both spellings
+// stay valid indefinitely.
+const LEGACY_MSTEAMS_SESSION_ID_RE = /^teams:/i;
+const LEGACY_MSTEAMS_DM_SESSION_ID_RE = /^teams:dm:/i;
+
+export function isMSTeamsSessionId(value) {
+  const normalized = String(value || '').trim();
+  if (LEGACY_MSTEAMS_SESSION_ID_RE.test(normalized)) return true;
+  return parseSessionKey(normalized)?.channelKind === 'msteams';
+}
+
+export function isMSTeamsDmSessionId(value) {
+  const normalized = String(value || '').trim();
+  if (LEGACY_MSTEAMS_DM_SESSION_ID_RE.test(normalized)) return true;
+  const parsed = parseSessionKey(normalized);
+  return parsed?.channelKind === 'msteams' && parsed.chatType === 'dm';
+}

--- a/container/shared/session-keys.d.ts
+++ b/container/shared/session-keys.d.ts
@@ -1,0 +1,23 @@
+export interface ParsedSessionKey {
+  agentId: string;
+  channelKind: string;
+  chatType: string;
+  peerId: string;
+  threadId?: string;
+  topicId?: string;
+  subagentId?: string;
+}
+
+export declare function buildSessionKey(
+  agentId: string,
+  channelKind: string,
+  chatType: string,
+  peerId: string,
+  options?: {
+    threadId?: string;
+    topicId?: string;
+    subagentId?: string;
+  },
+): string;
+
+export declare function parseSessionKey(key: string): ParsedSessionKey | null;

--- a/container/shared/session-keys.js
+++ b/container/shared/session-keys.js
@@ -1,0 +1,117 @@
+const SESSION_KEY_MARKERS = new Set([
+  'agent',
+  'channel',
+  'chat',
+  'peer',
+  'thread',
+  'topic',
+  'subagent',
+]);
+
+function normalizeSessionKeySegment(value, label) {
+  const normalized = String(value || '')
+    .trim()
+    .toLowerCase();
+  if (!normalized) {
+    throw new Error(`Session key ${label} cannot be empty`);
+  }
+  return normalized;
+}
+
+function encodeSessionKeySegment(value, label) {
+  return encodeURIComponent(normalizeSessionKeySegment(value, label));
+}
+
+function decodeSessionKeySegment(value) {
+  const normalized = String(value || '').trim();
+  if (!normalized) return '';
+  try {
+    return decodeURIComponent(normalized);
+  } catch {
+    return '';
+  }
+}
+
+export function buildSessionKey(
+  agentId,
+  channelKind,
+  chatType,
+  peerId,
+  options,
+) {
+  const parts = [
+    'agent',
+    encodeSessionKeySegment(agentId, 'agentId'),
+    'channel',
+    encodeSessionKeySegment(channelKind, 'channelKind'),
+    'chat',
+    encodeSessionKeySegment(chatType, 'chatType'),
+    'peer',
+    encodeSessionKeySegment(peerId, 'peerId'),
+  ];
+
+  if (options?.threadId) {
+    parts.push('thread', encodeSessionKeySegment(options.threadId, 'threadId'));
+  }
+  if (options?.topicId) {
+    parts.push('topic', encodeSessionKeySegment(options.topicId, 'topicId'));
+  }
+  if (options?.subagentId) {
+    parts.push(
+      'subagent',
+      encodeSessionKeySegment(options.subagentId, 'subagentId'),
+    );
+  }
+
+  return parts.join(':');
+}
+
+function parseTypedSessionKey(parts) {
+  if (parts.length < 8 || parts[0] !== 'agent') return null;
+
+  const values = new Map();
+  for (let index = 0; index < parts.length; index += 2) {
+    const marker = parts[index];
+    const rawValue = parts[index + 1];
+    if (!SESSION_KEY_MARKERS.has(marker) || rawValue === undefined) {
+      return null;
+    }
+    if (values.has(marker)) return null;
+    const decoded = decodeSessionKeySegment(rawValue);
+    if (!decoded) return null;
+    values.set(marker, decoded);
+  }
+
+  const agentId = values.get('agent');
+  const channelKind = values.get('channel');
+  const chatType = values.get('chat');
+  const peerId = values.get('peer');
+  if (!agentId || !channelKind || !chatType || !peerId) return null;
+
+  return {
+    agentId,
+    channelKind,
+    chatType,
+    peerId,
+    ...(values.get('thread') ? { threadId: values.get('thread') } : {}),
+    ...(values.get('topic') ? { topicId: values.get('topic') } : {}),
+    ...(values.get('subagent') ? { subagentId: values.get('subagent') } : {}),
+  };
+}
+
+export function parseSessionKey(key) {
+  const parts = String(key || '')
+    .trim()
+    .split(':');
+  if (parts.length < 5) return null;
+  if (parts[0] !== 'agent') return null;
+  if (parts[2] === 'channel') {
+    return parseTypedSessionKey(parts);
+  }
+
+  // Keep positional canonical keys readable for pre-typed rows and exports.
+  const [_, agentId, channelKind, chatType, ...peerParts] = parts;
+  const peerId = peerParts.join(':').trim();
+  if (!agentId || !channelKind || !chatType || !peerId) return null;
+  return { agentId, channelKind, chatType, peerId };
+}

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -7,6 +7,7 @@ import {
   formatMessageToolChannelList,
   normalizeMessageToolChannelKinds,
 } from '../shared/message-tool-channels.js';
+import { isMSTeamsSessionId } from '../shared/msteams-session-ids.js';
 import { buildSanitizedEnv } from '../shared/sensitive-env.js';
 import {
   currentDateStampInTimezone,
@@ -253,8 +254,6 @@ const MESSAGE_TOOL_DESCRIPTION_BASE =
   'Send or read messages on active communication channels.';
 let gatewayConfiguredChannels: string[] = [];
 const DISCORD_SNOWFLAKE_RE = /^\d{16,22}$/;
-// Matches legacy `teams:...` ids and canonical `agent:...:channel:msteams:...` keys.
-const TEAMS_SESSION_ID_RE = /^teams:|:channel:msteams:/i;
 let persistentBashStateEnabled = true;
 type PersistentBashSession = {
   sessionDir: string;
@@ -681,7 +680,7 @@ function resolveGatewayDiscordChannelFallback(): string {
 }
 
 function resolveGatewayMSTeamsChannelFallback(): string {
-  if (!TEAMS_SESSION_ID_RE.test(currentSessionId)) return '';
+  if (!isMSTeamsSessionId(currentSessionId)) return '';
   return readStringValue(gatewayChannelId) || '';
 }
 

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -253,7 +253,8 @@ const MESSAGE_TOOL_DESCRIPTION_BASE =
   'Send or read messages on active communication channels.';
 let gatewayConfiguredChannels: string[] = [];
 const DISCORD_SNOWFLAKE_RE = /^\d{16,22}$/;
-const TEAMS_SESSION_ID_RE = /^teams:/i;
+// Matches legacy `teams:...` ids and canonical `agent:...:channel:msteams:...` keys.
+const TEAMS_SESSION_ID_RE = /^teams:|:channel:msteams:/i;
 let persistentBashStateEnabled = true;
 type PersistentBashSession = {
   sessionDir: string;

--- a/src/channels/message/tool-actions.ts
+++ b/src/channels/message/tool-actions.ts
@@ -33,7 +33,10 @@ import {
 import { getLineAuthStatus } from '../line/auth.js';
 import { sendToLineSelfChat } from '../line/runtime.js';
 import { normalizeLineChannelId } from '../line/target.js';
-import { isMSTeamsSessionId } from '../msteams/utils.js';
+import {
+  isMSTeamsSessionId,
+  looksLikeMSTeamsConversationId,
+} from '../msteams/utils.js';
 import { sendToSignalChat } from '../signal/runtime.js';
 import { normalizeSignalChannelId } from '../signal/target.js';
 import { maybeRunSlackToolAction } from '../slack/tool-actions.js';
@@ -201,10 +204,6 @@ function normalizeEmailMessageTarget(rawTarget: string): string | null {
 
 function normalizeMessageToolValue(rawValue: string | undefined): string {
   return String(rawValue || '').trim();
-}
-
-function looksLikeMSTeamsConversationId(value: string): boolean {
-  return /^(?:a:|19:)/.test(normalizeMessageToolValue(value));
 }
 
 function isLikelyMSTeamsToolRequest(

--- a/src/channels/message/tool-actions.ts
+++ b/src/channels/message/tool-actions.ts
@@ -33,6 +33,7 @@ import {
 import { getLineAuthStatus } from '../line/auth.js';
 import { sendToLineSelfChat } from '../line/runtime.js';
 import { normalizeLineChannelId } from '../line/target.js';
+import { isMSTeamsSessionId } from '../msteams/utils.js';
 import { sendToSignalChat } from '../signal/runtime.js';
 import { normalizeSignalChannelId } from '../signal/target.js';
 import { maybeRunSlackToolAction } from '../slack/tool-actions.js';
@@ -72,7 +73,6 @@ const MESSAGE_TOOL_LINE_PREFIX_RE = /^line:/i;
 const MESSAGE_TOOL_SIGNAL_PREFIX_RE = /^signal:/i;
 const MESSAGE_TOOL_SLACK_WEBHOOK_PREFIX_RE = /^slack[_-]?webhook(?::|$)/i;
 const MESSAGE_TOOL_TEAMS_CURRENT_PREFIX_RE = /^(?:msteams|teams):current$/i;
-const MESSAGE_TOOL_TEAMS_SESSION_PREFIX_RE = /^teams:/i;
 const MESSAGE_TOOL_TELEGRAM_PREFIX_RE = /^(telegram|tg):/i;
 const MESSAGE_TOOL_THREEMA_PREFIX_RE = /^threema:/i;
 const MESSAGE_TOOL_WHATSAPP_PREFIX_RE = /^whatsapp:/i;
@@ -211,7 +211,7 @@ function isLikelyMSTeamsToolRequest(
   request: DiscordToolActionRequest,
 ): boolean {
   const sessionId = normalizeMessageToolValue(request.sessionId);
-  if (MESSAGE_TOOL_TEAMS_SESSION_PREFIX_RE.test(sessionId)) {
+  if (isMSTeamsSessionId(sessionId)) {
     return true;
   }
 
@@ -219,7 +219,7 @@ function isLikelyMSTeamsToolRequest(
   if (!channelId) return false;
   return (
     MESSAGE_TOOL_TEAMS_CURRENT_PREFIX_RE.test(channelId) ||
-    MESSAGE_TOOL_TEAMS_SESSION_PREFIX_RE.test(channelId) ||
+    isMSTeamsSessionId(channelId) ||
     looksLikeMSTeamsConversationId(channelId)
   );
 }

--- a/src/channels/msteams/tool-actions.ts
+++ b/src/channels/msteams/tool-actions.ts
@@ -11,6 +11,8 @@ import {
   sendToActiveMSTeamsSession,
 } from './runtime.js';
 import {
+  isMSTeamsDmSessionId,
+  isMSTeamsSessionId,
   isRecord,
   MSTEAMS_CONVERSATION_REFERENCE_KEY,
   normalizeValue,
@@ -19,7 +21,6 @@ import {
 const MESSAGE_TOOL_READ_DEFAULT_LIMIT = 20;
 const MESSAGE_TOOL_READ_MAX_LIMIT = 100;
 const MESSAGE_TOOL_TEAMS_CURRENT_PREFIX_RE = /^(?:msteams|teams):current$/i;
-const MESSAGE_TOOL_TEAMS_SESSION_PREFIX_RE = /^teams:/i;
 
 interface StoredMSTeamsReferenceUser {
   id: string;
@@ -36,10 +37,6 @@ interface MSTeamsMemberLookupCandidate {
   id: string;
   name: string;
   lastSeenAt: string | null;
-}
-
-function isMSTeamsSessionId(value: string): boolean {
-  return MESSAGE_TOOL_TEAMS_SESSION_PREFIX_RE.test(normalizeValue(value));
 }
 
 function looksLikeMSTeamsConversationId(value: string): boolean {
@@ -393,7 +390,7 @@ function runMSTeamsChannelInfoAction(
       id: targetSession.channel_id,
       sessionId: targetSession.id,
       teamId: targetSession.guild_id,
-      isDm: targetSession.id.startsWith('teams:dm:'),
+      isDm: isMSTeamsDmSessionId(targetSession.id),
       active: hasActiveMSTeamsSession(targetSession.id),
       proactiveAvailable: Boolean(
         getMemoryValue(targetSession.id, MSTEAMS_CONVERSATION_REFERENCE_KEY),

--- a/src/channels/msteams/tool-actions.ts
+++ b/src/channels/msteams/tool-actions.ts
@@ -14,6 +14,7 @@ import {
   isMSTeamsDmSessionId,
   isMSTeamsSessionId,
   isRecord,
+  looksLikeMSTeamsConversationId,
   MSTEAMS_CONVERSATION_REFERENCE_KEY,
   normalizeValue,
 } from './utils.js';
@@ -37,11 +38,6 @@ interface MSTeamsMemberLookupCandidate {
   id: string;
   name: string;
   lastSeenAt: string | null;
-}
-
-function looksLikeMSTeamsConversationId(value: string): boolean {
-  const normalized = normalizeValue(value);
-  return /^(?:a:|19:)/.test(normalized);
 }
 
 function normalizeMSTeamsMemberLookupQuery(

--- a/src/channels/msteams/utils.ts
+++ b/src/channels/msteams/utils.ts
@@ -1,4 +1,3 @@
-import { parseSessionKey } from '../../session/session-key.js';
 import {
   normalizeNullableTrimmedString,
   normalizeTrimmedString as normalizeValue,
@@ -7,25 +6,15 @@ import {
 export const MSTEAMS_CONVERSATION_REFERENCE_KEY =
   'msteams:conversation-reference';
 export const MSTEAMS_RATING_TARGETS_KEY = 'msteams:rating-targets';
+export {
+  isMSTeamsDmSessionId,
+  isMSTeamsSessionId,
+} from '../../../container/shared/msteams-session-ids.js';
 export { isRecord } from '../../utils/type-guards.js';
 export { normalizeValue };
 
-const LEGACY_MSTEAMS_SESSION_ID_RE = /^teams:/i;
-const LEGACY_MSTEAMS_DM_SESSION_ID_RE = /^teams:dm:/i;
-
-export function isMSTeamsSessionId(value: string | null | undefined): boolean {
-  const normalized = normalizeValue(String(value || ''));
-  if (LEGACY_MSTEAMS_SESSION_ID_RE.test(normalized)) return true;
-  return parseSessionKey(normalized)?.channelKind === 'msteams';
-}
-
-export function isMSTeamsDmSessionId(
-  value: string | null | undefined,
-): boolean {
-  const normalized = normalizeValue(String(value || ''));
-  if (LEGACY_MSTEAMS_DM_SESSION_ID_RE.test(normalized)) return true;
-  const parsed = parseSessionKey(normalized);
-  return parsed?.channelKind === 'msteams' && parsed.chatType === 'dm';
+export function looksLikeMSTeamsConversationId(value: string): boolean {
+  return /^(?:a:|19:)/.test(normalizeValue(value));
 }
 
 export function normalizeOptionalValue(value: unknown): string | null {

--- a/src/channels/msteams/utils.ts
+++ b/src/channels/msteams/utils.ts
@@ -1,3 +1,4 @@
+import { parseSessionKey } from '../../session/session-key.js';
 import {
   normalizeNullableTrimmedString,
   normalizeTrimmedString as normalizeValue,
@@ -8,6 +9,24 @@ export const MSTEAMS_CONVERSATION_REFERENCE_KEY =
 export const MSTEAMS_RATING_TARGETS_KEY = 'msteams:rating-targets';
 export { isRecord } from '../../utils/type-guards.js';
 export { normalizeValue };
+
+const LEGACY_MSTEAMS_SESSION_ID_RE = /^teams:/i;
+const LEGACY_MSTEAMS_DM_SESSION_ID_RE = /^teams:dm:/i;
+
+export function isMSTeamsSessionId(value: string | null | undefined): boolean {
+  const normalized = normalizeValue(String(value || ''));
+  if (LEGACY_MSTEAMS_SESSION_ID_RE.test(normalized)) return true;
+  return parseSessionKey(normalized)?.channelKind === 'msteams';
+}
+
+export function isMSTeamsDmSessionId(
+  value: string | null | undefined,
+): boolean {
+  const normalized = normalizeValue(String(value || ''));
+  if (LEGACY_MSTEAMS_DM_SESSION_ID_RE.test(normalized)) return true;
+  const parsed = parseSessionKey(normalized);
+  return parsed?.channelKind === 'msteams' && parsed.chatType === 'dm';
+}
 
 export function normalizeOptionalValue(value: unknown): string | null {
   const normalized =

--- a/src/session/session-key.ts
+++ b/src/session/session-key.ts
@@ -1,14 +1,11 @@
+import {
+  buildSessionKey,
+  parseSessionKey,
+} from '../../container/shared/session-keys.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 
-export interface ParsedSessionKey {
-  agentId: string;
-  channelKind: string;
-  chatType: string;
-  peerId: string;
-  threadId?: string;
-  topicId?: string;
-  subagentId?: string;
-}
+export type { ParsedSessionKey } from '../../container/shared/session-keys.js';
+export { buildSessionKey, parseSessionKey };
 
 export interface SessionKeyMigrationResult {
   key: string;
@@ -29,127 +26,6 @@ interface SessionKeyMigrationContext {
 }
 
 const DISCORD_SESSION_KEY_RE = /^\d{16,22}:\d{16,22}$/;
-const SESSION_KEY_MARKERS = new Set([
-  'agent',
-  'channel',
-  'chat',
-  'peer',
-  'thread',
-  'topic',
-  'subagent',
-]);
-
-function normalizeSessionKeySegment(value: string, label: string): string {
-  const normalized = String(value || '')
-    .trim()
-    .toLowerCase();
-  if (!normalized) {
-    throw new Error(`Session key ${label} cannot be empty`);
-  }
-  return normalized;
-}
-
-function encodeSessionKeySegment(value: string, label: string): string {
-  return encodeURIComponent(normalizeSessionKeySegment(value, label));
-}
-
-function decodeSessionKeySegment(value: string): string {
-  const normalized = String(value || '').trim();
-  if (!normalized) return '';
-  try {
-    return decodeURIComponent(normalized);
-  } catch {
-    return '';
-  }
-}
-
-export function buildSessionKey(
-  agentId: string,
-  channelKind: string,
-  chatType: string,
-  peerId: string,
-  options?: {
-    threadId?: string;
-    topicId?: string;
-    subagentId?: string;
-  },
-): string {
-  const parts = [
-    'agent',
-    encodeSessionKeySegment(agentId, 'agentId'),
-    'channel',
-    encodeSessionKeySegment(channelKind, 'channelKind'),
-    'chat',
-    encodeSessionKeySegment(chatType, 'chatType'),
-    'peer',
-    encodeSessionKeySegment(peerId, 'peerId'),
-  ];
-
-  if (options?.threadId) {
-    parts.push('thread', encodeSessionKeySegment(options.threadId, 'threadId'));
-  }
-  if (options?.topicId) {
-    parts.push('topic', encodeSessionKeySegment(options.topicId, 'topicId'));
-  }
-  if (options?.subagentId) {
-    parts.push(
-      'subagent',
-      encodeSessionKeySegment(options.subagentId, 'subagentId'),
-    );
-  }
-
-  return parts.join(':');
-}
-
-function parseTypedSessionKey(parts: string[]): ParsedSessionKey | null {
-  if (parts.length < 8 || parts[0] !== 'agent') return null;
-
-  const values = new Map<string, string>();
-  for (let index = 0; index < parts.length; index += 2) {
-    const marker = parts[index];
-    const rawValue = parts[index + 1];
-    if (!SESSION_KEY_MARKERS.has(marker) || rawValue === undefined) {
-      return null;
-    }
-    if (values.has(marker)) return null;
-    const decoded = decodeSessionKeySegment(rawValue);
-    if (!decoded) return null;
-    values.set(marker, decoded);
-  }
-
-  const agentId = values.get('agent');
-  const channelKind = values.get('channel');
-  const chatType = values.get('chat');
-  const peerId = values.get('peer');
-  if (!agentId || !channelKind || !chatType || !peerId) return null;
-
-  return {
-    agentId,
-    channelKind,
-    chatType,
-    peerId,
-    ...(values.get('thread') ? { threadId: values.get('thread') } : {}),
-    ...(values.get('topic') ? { topicId: values.get('topic') } : {}),
-    ...(values.get('subagent') ? { subagentId: values.get('subagent') } : {}),
-  };
-}
-
-export function parseSessionKey(key: string): ParsedSessionKey | null {
-  const parts = String(key || '')
-    .trim()
-    .split(':');
-  if (parts.length < 5) return null;
-  if (parts[0] !== 'agent') return null;
-  if (parts[2] === 'channel') {
-    return parseTypedSessionKey(parts);
-  }
-
-  // Keep positional canonical keys readable for pre-typed rows and exports.
-  const [_, agentId, channelKind, chatType, ...peerParts] = parts;
-  const peerId = peerParts.join(':').trim();
-  if (!agentId || !channelKind || !chatType || !peerId) return null;
-  return { agentId, channelKind, chatType, peerId };
-}
 
 export function classifySessionKeyShape(key: string): SessionKeyShape {
   const normalized = String(key || '').trim();

--- a/tests/container.message-tool-normalization.test.ts
+++ b/tests/container.message-tool-normalization.test.ts
@@ -394,6 +394,44 @@ describe.sequential('container message tool normalization', () => {
     expect(payload.filePath).toBe('package.json');
   });
 
+  test('send targets the current Teams conversation for canonical session keys', async () => {
+    const canonicalSessionId =
+      'agent:main:channel:msteams:chat:dm:peer:user-aad-id';
+    const fetchMock = mockGatewayFetch({
+      ok: true,
+      action: 'send',
+      channelId: 'a:teams-current-conversation',
+    });
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs, 'statSync').mockReturnValue({
+      isFile: () => true,
+    } as fs.Stats);
+    setGatewayContext(
+      'http://gateway.local',
+      'token',
+      'a:teams-current-conversation',
+    );
+    setSessionContext(canonicalSessionId);
+
+    const result = await executeTool(
+      'message',
+      JSON.stringify({
+        action: 'send',
+        filePath: 'package.json',
+      }),
+    );
+
+    expect(result).toContain('"ok": true');
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(init.body || '{}')) as Record<
+      string,
+      unknown
+    >;
+    expect(payload.channelId).toBe('a:teams-current-conversation');
+    expect(payload.sessionId).toBe(canonicalSessionId);
+    expect(payload.filePath).toBe('package.json');
+  });
+
   test('message tool description does not advertise inactive WhatsApp', () => {
     setGatewayContext(
       'http://gateway.local',

--- a/tests/message.tool-actions-send.test.ts
+++ b/tests/message.tool-actions-send.test.ts
@@ -188,7 +188,13 @@ async function importFreshMessageToolActions(a2aLocalMode = false) {
   }));
   const enqueueProactiveMessage = vi.fn(() => ({ queued: 1, dropped: 0 }));
   let currentTeamsChannelId = 'a:teams-current-conversation';
-  let knownTeamsSessions = [
+  let knownTeamsSessions: Array<{
+    id: string;
+    guild_id: string | null;
+    channel_id: string;
+    last_active: string;
+    created_at: string;
+  }> = [
     {
       id: 'teams:dm:user-aad-id',
       guild_id: null,
@@ -987,6 +993,109 @@ test('send action prefers the active Teams conversation over accidental WhatsApp
     channelId: teamsConversationId,
     transport: 'msteams',
     attachmentCount: 1,
+  });
+});
+
+test('send action resolves canonical msteams session keys for current Teams uploads', async () => {
+  const state = await importFreshMessageToolActions();
+  const canonicalSessionId =
+    'agent:main:channel:msteams:chat:dm:peer:user-aad-id';
+  state.setKnownTeamsSessions([
+    {
+      id: canonicalSessionId,
+      guild_id: null,
+      channel_id: 'a:teams-current-conversation',
+      last_active: '2026-03-13T19:00:00.000Z',
+      created_at: '2026-03-13T18:00:00.000Z',
+    },
+  ]);
+
+  const result = await state.runMessageToolAction({
+    action: 'send',
+    sessionId: canonicalSessionId,
+    channelId: 'a:teams-current-conversation',
+    content: 'attached pdf',
+    filePath: '.browser-artifacts/hybridclaw-homepage.png',
+  });
+
+  expect(state.sendToActiveMSTeamsSession).toHaveBeenCalledWith({
+    sessionId: canonicalSessionId,
+    text: 'attached pdf',
+    filePath:
+      '/tmp/hybridclaw-agent-workspace/.browser-artifacts/hybridclaw-homepage.png',
+  });
+  expect(state.runDiscordToolAction).not.toHaveBeenCalled();
+  expect(result).toMatchObject({
+    ok: true,
+    action: 'send',
+    channelId: 'a:teams-current-conversation',
+    transport: 'msteams',
+    attachmentCount: 1,
+  });
+});
+
+test('send action targets the current Teams chat via msteams:current with a canonical session key', async () => {
+  const state = await importFreshMessageToolActions();
+  const canonicalSessionId =
+    'agent:main:channel:msteams:chat:dm:peer:user-aad-id';
+  state.setKnownTeamsSessions([
+    {
+      id: canonicalSessionId,
+      guild_id: null,
+      channel_id: 'a:teams-current-conversation',
+      last_active: '2026-03-13T19:00:00.000Z',
+      created_at: '2026-03-13T18:00:00.000Z',
+    },
+  ]);
+
+  const result = await state.runMessageToolAction({
+    action: 'send',
+    sessionId: canonicalSessionId,
+    channelId: 'msteams:current',
+    content: 'hello current teams chat',
+  });
+
+  expect(state.sendToActiveMSTeamsSession).toHaveBeenCalledWith({
+    sessionId: canonicalSessionId,
+    text: 'hello current teams chat',
+    filePath: null,
+  });
+  expect(result).toMatchObject({
+    ok: true,
+    action: 'send',
+    transport: 'msteams',
+  });
+});
+
+test('channel-info reports DM state for canonical msteams session keys', async () => {
+  const state = await importFreshMessageToolActions();
+  const canonicalSessionId =
+    'agent:main:channel:msteams:chat:dm:peer:user-aad-id';
+  state.setKnownTeamsSessions([
+    {
+      id: canonicalSessionId,
+      guild_id: null,
+      channel_id: 'a:teams-current-conversation',
+      last_active: '2026-03-13T19:00:00.000Z',
+      created_at: '2026-03-13T18:00:00.000Z',
+    },
+  ]);
+
+  const result = await state.runMessageToolAction({
+    action: 'channel-info',
+    sessionId: canonicalSessionId,
+    channelId: 'msteams:current',
+  });
+
+  expect(result).toMatchObject({
+    ok: true,
+    action: 'channel-info',
+    transport: 'msteams',
+    channel: {
+      id: 'a:teams-current-conversation',
+      sessionId: canonicalSessionId,
+      isDm: true,
+    },
   });
 });
 


### PR DESCRIPTION
## Problem

Agent-initiated sends into the current Teams chat via the `message` tool always failed, while the reply-pipeline consent-card delivery worked — so the agent told the user "I couldn't attach the file to this Teams chat" right before the file arrived. Observed live on 2026-08-24 in the HybridAI-tenant HybridClaw DM (and on 2026-08-21 during the #1415 file-upload verification, reported as "channel lookup failed").

## Root cause

Teams sessions have used canonical session keys (`agent:<id>:channel:msteams:chat:<type>:peer:<id>`) since the extensible session routing migration (8920fc7f), but the message-tool Teams routing still matched only the legacy `teams:` prefix:

- `container/src/tools.ts` — `TEAMS_SESSION_ID_RE = /^teams:/i` meant the sandbox tool neither advertised the current Teams conversation nor used it as the default send target.
- `src/channels/message/tool-actions.ts` — `isLikelyMSTeamsToolRequest` didn't recognize canonical session ids.
- `src/channels/msteams/tool-actions.ts` — `isMSTeamsSessionId` / `pickMostRecentMatchingSession` never matched any stored session, so resolution failed with "No known Teams conversation matched this request", and `ensureAuthorizedMSTeamsSendTarget` would have rejected the requester anyway. `channel-info` also mis-reported `isDm` for canonical keys.

Discord got the equivalent fix (`:channel:discord:` awareness) but Teams was left behind; the existing tests only used legacy `teams:dm:...` fixtures, which is why this never surfaced in CI.

## Fix

- Add shared `isMSTeamsSessionId` / `isMSTeamsDmSessionId` helpers in `src/channels/msteams/utils.ts` that accept canonical keys via `parseSessionKey` (mirroring Slack's `isSlackSessionId`) plus the legacy `teams:` prefix for pre-migration rows.
- Use them in the message-tool gate and the msteams tool actions.
- Widen the container-side regex to `/^teams:|:channel:msteams:/i` (same approach as the container's Discord check).

## Testing

- New gateway-side tests: canonical-key send with attachment, `msteams:current` targeting, and `channel-info` DM reporting.
- New container-side test: send defaults to the current Teams conversation with a canonical session key.
- `npx vitest run tests/message.tool-actions-send.test.ts tests/container.message-tool-normalization.test.ts` (68 passed) plus msteams runtime/inbound/attachments, channel-message-tool-hints, container schema, and gateway-http-server suites (452 passed); `tsc --noEmit` clean in root and container; biome clean on touched files.

The live behavior (upload direction, consent-card delivery) was verified end-to-end in Teams web today; after this lands the agent's direct send path should stop erroring and the misleading "couldn't attach" replies should disappear.