### PR TITLE
chore: release v0.29.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+## [0.29.2](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.2) - 2026-08-24
+
+### Added
+
+- **External web apps can start realtime voice sessions securely**: API tokens
+  with the scoped `voice.session` permission can mint single-use stream tokens
+  that expire after 60 seconds, allowing browser clients to connect without
+  putting a long-lived credential in the WebSocket URL. The existing voice
+  concurrency, frame-size, session-key, and start-deadline limits still apply.
+
+### Changed
+
+- **Signal setup is easier to find in the documentation**: The channel guide
+  appears in the docs navigation, and the maintainer landing page is trimmed
+  to its focused contributor guidance.
+
 ### Fixed
 
 - **Signal QR linking completes and survives gateway replacement**: The amd64
@@ -9,6 +25,10 @@
   persistent gateway data volume, and removes expired QR material after a
   successful or failed provisioning attempt instead of leaving a stale code in
   the admin console.
+- **Teams message-tool sends recognize current conversations**: Canonical Teams
+  session keys resolve through the same shared codec in the gateway and
+  container, so agent-initiated messages and attachments target the active chat
+  instead of failing after the reply pipeline has already delivered them.
 
 ## [0.29.1](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.1) - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 
 ### Changed
 
+- **Age-eligible dependency patches harden desktop and web surfaces**: Electron
+  41.10.5 includes upstream sandbox, use-after-free, crash, and installer fixes;
+  sanitize-html 2.17.7 closes an SVG URL sanitization gap; and TanStack Router
+  1.170.29 improves SSR hydration and code-split route reuse. Each release has
+  cleared the repository's seven-day minimum age gate.
 - **Signal setup is easier to find in the documentation**: The channel guide
   appears in the docs navigation, and the maintainer landing page is trimmed
   to its focused contributor guidance.

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Core pieces:
 | Build desktop releases | [Desktop Release Builds](https://hybridaione.github.io/hybridclaw/docs/developer-guide/desktop-release) |
 | Contribute | [CONTRIBUTING.md](./CONTRIBUTING.md), [docs/content/README.md](./docs/content/README.md) |
 
-Latest release: [v0.29.1](https://github.com/HybridAIOne/hybridclaw/releases/tag/v0.29.1).
+Latest release: [v0.29.2](https://github.com/HybridAIOne/hybridclaw/releases/tag/v0.29.2).
 Release notes: [CHANGELOG.md](./CHANGELOG.md)
 
 ## Development

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -190,9 +190,9 @@ texts ship inside the respective packages.
 | @tanstack/history | 1.162.1 | MIT |
 | @tanstack/query-core | 5.101.4 | MIT |
 | @tanstack/react-query | 5.101.4 | MIT |
-| @tanstack/react-router | 1.170.27 | MIT |
+| @tanstack/react-router | 1.170.29 | MIT |
 | @tanstack/react-store | 0.9.3 | MIT |
-| @tanstack/router-core | 1.171.22 | MIT |
+| @tanstack/router-core | 1.171.24 | MIT |
 | @tanstack/store | 0.9.3 | MIT |
 | @types/body-parser | 1.19.6 | MIT |
 | @types/connect | 3.4.38 | MIT |
@@ -671,7 +671,7 @@ texts ship inside the respective packages.
 | safe-buffer | 5.2.1 | MIT |
 | safe-stable-stringify | 2.5.0 | MIT |
 | safer-buffer | 2.1.2 | MIT |
-| sanitize-html | 2.17.6 | MIT |
+| sanitize-html | 2.17.7 | MIT |
 | sax | 1.6.1 | BlueOak-1.0.0 |
 | scheduler | 0.27.0 | MIT |
 | secure-json-parse | 4.1.0 | BSD-3-Clause |
@@ -4031,7 +4031,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ### Text 40 of 364
 
-Applies to: @tanstack/history@1.162.1, @tanstack/query-core@5.101.4, @tanstack/react-query@5.101.4, @tanstack/react-router@1.170.27, @tanstack/router-core@1.171.22
+Applies to: @tanstack/history@1.162.1, @tanstack/query-core@5.101.4, @tanstack/react-query@5.101.4, @tanstack/react-router@1.170.29, @tanstack/router-core@1.171.24
 
 ````text
 MIT License
@@ -15431,7 +15431,7 @@ SOFTWARE.
 
 ### Text 310 of 364
 
-Applies to: sanitize-html@2.17.6
+Applies to: sanitize-html@2.17.7
 
 ````text
 Copyright (c) 2013, 2014, 2015 P'unk Avenue LLC

--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hybridaione/hybridclaw-console",
   "private": true,
-  "version": "0.29.1",
+  "version": "0.29.2",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/console/package.json
+++ b/console/package.json
@@ -18,14 +18,14 @@
   },
   "dependencies": {
     "@tanstack/react-query": "5.101.4",
-    "@tanstack/react-router": "1.170.27",
+    "@tanstack/react-router": "1.170.29",
     "@xterm/addon-fit": "0.11.0",
     "@xterm/xterm": "5.5.0",
     "highlight.js": "11.12.0",
     "marked": "17.0.6",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "sanitize-html": "2.17.6"
+    "sanitize-html": "2.17.7"
   },
   "devDependencies": {
     "@testing-library/react": "16.3.2",

--- a/console/src/release-notes.ts
+++ b/console/src/release-notes.ts
@@ -4,7 +4,7 @@ export const LATEST_RELEASE_NOTES = {
     'Web apps can start secure realtime voice.',
     'Signal linking persists and clears stale QRs.',
     'Teams sends find canonical conversations.',
-    'Signal setup is easier to find in docs.',
+    'Desktop and HTML dependencies are hardened.',
   ],
 } as const;
 

--- a/console/src/release-notes.ts
+++ b/console/src/release-notes.ts
@@ -1,10 +1,10 @@
 export const LATEST_RELEASE_NOTES = {
-  version: '0.29.1',
+  version: '0.29.2',
   highlights: [
-    'Teams uploads preserve type and stream safely.',
-    'Realtime voice selects available credentials.',
-    'Idle agents release capacity reliably.',
-    'Feedback, pairing QRs, and cloud reads work.',
+    'Web apps can start secure realtime voice.',
+    'Signal linking persists and clears stale QRs.',
+    'Teams sends find canonical conversations.',
+    'Signal setup is easier to find in docs.',
   ],
 } as const;
 

--- a/container/npm-shrinkwrap.json
+++ b/container/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/container/package-lock.json
+++ b/container/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/container/package.json
+++ b/container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@hybridaione/hybridclaw-desktop",
   "productName": "HybridClaw",
   "private": true,
-  "version": "0.29.1",
+  "version": "0.29.2",
   "license": "MIT",
   "type": "module",
   "description": "macOS wrapper for the HybridClaw chat and admin web surfaces",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -25,7 +25,7 @@
     "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"
   },
   "devDependencies": {
-    "electron": "41.10.3",
+    "electron": "41.10.5",
     "electron-builder": "26.15.7"
   },
   "build": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -81,7 +81,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "5.101.4",
@@ -107,7 +107,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",
@@ -174,7 +174,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "MIT",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -49,7 +49,7 @@
         "pino-pretty": "13.1.3",
         "playwright": "1.62.1",
         "qrcode-terminal": "0.12.0",
-        "sanitize-html": "2.17.6",
+        "sanitize-html": "2.17.7",
         "stemmer": "2.0.1",
         "ws": "8.21.3",
         "xlsx-populate": "1.21.0",
@@ -85,14 +85,14 @@
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "5.101.4",
-        "@tanstack/react-router": "1.170.27",
+        "@tanstack/react-router": "1.170.29",
         "@xterm/addon-fit": "0.11.0",
         "@xterm/xterm": "5.5.0",
         "highlight.js": "11.12.0",
         "marked": "17.0.6",
         "react": "19.2.8",
         "react-dom": "19.2.8",
-        "sanitize-html": "2.17.6"
+        "sanitize-html": "2.17.7"
       },
       "devDependencies": {
         "@testing-library/react": "16.3.2",
@@ -180,7 +180,7 @@
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"
       },
       "devDependencies": {
-        "electron": "41.10.3",
+        "electron": "41.10.5",
         "electron-builder": "26.15.7"
       }
     },
@@ -4798,14 +4798,14 @@
       }
     },
     "node_modules/@tanstack/react-router": {
-      "version": "1.170.27",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.27.tgz",
-      "integrity": "sha512-Hxl49xzd8ffWd2ZMigqfXZmpySpixWGvjq5zfh2nK2DbzzDH6IGVh+iUuwarK9MJNcnhWPZ85tOoy6o/OmNlww==",
+      "version": "1.170.29",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.29.tgz",
+      "integrity": "sha512-xQwakR0ReaUGu3xeXEl2CqzlIXk4i9vxaf/zqdzoELMY0mDZgMOr+xobiA5cQdn8cnovqZgqqUxcwXhsruC+NA==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/history": "1.162.1",
         "@tanstack/react-store": "^0.9.3",
-        "@tanstack/router-core": "1.171.22",
+        "@tanstack/router-core": "1.171.24",
         "isbot": "^5.1.22"
       },
       "engines": {
@@ -4839,9 +4839,9 @@
       }
     },
     "node_modules/@tanstack/router-core": {
-      "version": "1.171.22",
-      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.22.tgz",
-      "integrity": "sha512-sitsuRkz4qpTjIAV97S5zFCoeGv0OFd6+VWg3ZcIlQbi5R4NIXfz6ogg51n5w6rvTwSODz/lKWb5dl5tvh2bQw==",
+      "version": "1.171.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.24.tgz",
+      "integrity": "sha512-+j+8NmV4QOS+ILNLdXFlLTdKPPbBQIy6mXDZ0QWEKYZ0xQOdlnOCXVHPflyGanD2SWSxjqGkw8CsW0CXXP7fLg==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/history": "1.162.1",
@@ -8561,9 +8561,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.10.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.10.3.tgz",
-      "integrity": "sha512-MJuSODPw8siv/I8JjhctW/cS/XNldwI4gLRyyWZx6QkoZJUDgbEvitp7IVOnGrHENTQb6Udo+zMpKhFnhlIhdg==",
+      "version": "41.10.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.10.5.tgz",
+      "integrity": "sha512-grSJOhLddanWX1UfE8B4xA2kOOduUCfpYoOQ2D4zEYte8lSQtrd1HYbV4xErsZmm+V+1Q3yzCQLBsCxEIiw/QQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -13318,9 +13318,9 @@
       }
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.6",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.6.tgz",
-      "integrity": "sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA==",
+      "version": "2.17.7",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.7.tgz",
+      "integrity": "sha512-PGtEkc9cbnedU3s9TmzDbpsZ8w086g/0Q8k8/oIO1NLNU3i5k9yn835CrjJSajp1KMmkisbO1qPXxNKO3welAg==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -81,7 +81,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "5.101.4",
@@ -107,7 +107,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",
@@ -174,7 +174,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "MIT",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "pino-pretty": "13.1.3",
         "playwright": "1.62.1",
         "qrcode-terminal": "0.12.0",
-        "sanitize-html": "2.17.6",
+        "sanitize-html": "2.17.7",
         "stemmer": "2.0.1",
         "ws": "8.21.3",
         "xlsx-populate": "1.21.0",
@@ -85,14 +85,14 @@
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "5.101.4",
-        "@tanstack/react-router": "1.170.27",
+        "@tanstack/react-router": "1.170.29",
         "@xterm/addon-fit": "0.11.0",
         "@xterm/xterm": "5.5.0",
         "highlight.js": "11.12.0",
         "marked": "17.0.6",
         "react": "19.2.8",
         "react-dom": "19.2.8",
-        "sanitize-html": "2.17.6"
+        "sanitize-html": "2.17.7"
       },
       "devDependencies": {
         "@testing-library/react": "16.3.2",
@@ -180,7 +180,7 @@
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"
       },
       "devDependencies": {
-        "electron": "41.10.3",
+        "electron": "41.10.5",
         "electron-builder": "26.15.7"
       }
     },
@@ -4798,14 +4798,14 @@
       }
     },
     "node_modules/@tanstack/react-router": {
-      "version": "1.170.27",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.27.tgz",
-      "integrity": "sha512-Hxl49xzd8ffWd2ZMigqfXZmpySpixWGvjq5zfh2nK2DbzzDH6IGVh+iUuwarK9MJNcnhWPZ85tOoy6o/OmNlww==",
+      "version": "1.170.29",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.29.tgz",
+      "integrity": "sha512-xQwakR0ReaUGu3xeXEl2CqzlIXk4i9vxaf/zqdzoELMY0mDZgMOr+xobiA5cQdn8cnovqZgqqUxcwXhsruC+NA==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/history": "1.162.1",
         "@tanstack/react-store": "^0.9.3",
-        "@tanstack/router-core": "1.171.22",
+        "@tanstack/router-core": "1.171.24",
         "isbot": "^5.1.22"
       },
       "engines": {
@@ -4839,9 +4839,9 @@
       }
     },
     "node_modules/@tanstack/router-core": {
-      "version": "1.171.22",
-      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.22.tgz",
-      "integrity": "sha512-sitsuRkz4qpTjIAV97S5zFCoeGv0OFd6+VWg3ZcIlQbi5R4NIXfz6ogg51n5w6rvTwSODz/lKWb5dl5tvh2bQw==",
+      "version": "1.171.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.24.tgz",
+      "integrity": "sha512-+j+8NmV4QOS+ILNLdXFlLTdKPPbBQIy6mXDZ0QWEKYZ0xQOdlnOCXVHPflyGanD2SWSxjqGkw8CsW0CXXP7fLg==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/history": "1.162.1",
@@ -8561,9 +8561,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.10.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.10.3.tgz",
-      "integrity": "sha512-MJuSODPw8siv/I8JjhctW/cS/XNldwI4gLRyyWZx6QkoZJUDgbEvitp7IVOnGrHENTQb6Udo+zMpKhFnhlIhdg==",
+      "version": "41.10.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.10.5.tgz",
+      "integrity": "sha512-grSJOhLddanWX1UfE8B4xA2kOOduUCfpYoOQ2D4zEYte8lSQtrd1HYbV4xErsZmm+V+1Q3yzCQLBsCxEIiw/QQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -13318,9 +13318,9 @@
       }
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.6",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.6.tgz",
-      "integrity": "sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA==",
+      "version": "2.17.7",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.7.tgz",
+      "integrity": "sha512-PGtEkc9cbnedU3s9TmzDbpsZ8w086g/0Q8k8/oIO1NLNU3i5k9yn835CrjJSajp1KMmkisbO1qPXxNKO3welAg==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "type": "module",
   "description": "Enterprise-ready self-hosted AI assistant runtime with sandboxed execution, secure credentials, approvals, and memory",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "pino-pretty": "13.1.3",
     "playwright": "1.62.1",
     "qrcode-terminal": "0.12.0",
-    "sanitize-html": "2.17.6",
+    "sanitize-html": "2.17.7",
     "stemmer": "2.0.1",
     "ws": "8.21.3",
     "xlsx-populate": "1.21.0",

--- a/scripts/dependency-policy-baseline.json
+++ b/scripts/dependency-policy-baseline.json
@@ -1,7 +1,7 @@
 {
   "lockfiles": {
-    "package-lock.json": "a3c338ad2335ade6c684407bdfab7111805d0b765b6cf92c4ccbb205a6925f0f",
-    "npm-shrinkwrap.json": "a3c338ad2335ade6c684407bdfab7111805d0b765b6cf92c4ccbb205a6925f0f",
+    "package-lock.json": "76d1d8bc4542240857cd44d04a16da9457287cd1686d5bfddbfc92ca151acbe8",
+    "npm-shrinkwrap.json": "76d1d8bc4542240857cd44d04a16da9457287cd1686d5bfddbfc92ca151acbe8",
     "container/package-lock.json": "ab736fb153fb85c6a1b0f46781b430be560f1d7c8637d1e2263668fb7012796c",
     "container/npm-shrinkwrap.json": "ab736fb153fb85c6a1b0f46781b430be560f1d7c8637d1e2263668fb7012796c",
     "plugins/brevo-email/package-lock.json": "3377225eb3bdbb252eaa28ad420b9a725ea1da533417388557aa1984730229b5",

--- a/scripts/dependency-policy-baseline.json
+++ b/scripts/dependency-policy-baseline.json
@@ -1,9 +1,9 @@
 {
   "lockfiles": {
-    "package-lock.json": "d0e607678a6192fba9f7e7cc46b75f8861cbc2176f045d9a5b967fd0296b064e",
-    "npm-shrinkwrap.json": "d0e607678a6192fba9f7e7cc46b75f8861cbc2176f045d9a5b967fd0296b064e",
-    "container/package-lock.json": "22386b0337d36fd6a86815c5bd9b938ca02f1120af7c969ff0d0a0b843ac6379",
-    "container/npm-shrinkwrap.json": "22386b0337d36fd6a86815c5bd9b938ca02f1120af7c969ff0d0a0b843ac6379",
+    "package-lock.json": "a3c338ad2335ade6c684407bdfab7111805d0b765b6cf92c4ccbb205a6925f0f",
+    "npm-shrinkwrap.json": "a3c338ad2335ade6c684407bdfab7111805d0b765b6cf92c4ccbb205a6925f0f",
+    "container/package-lock.json": "ab736fb153fb85c6a1b0f46781b430be560f1d7c8637d1e2263668fb7012796c",
+    "container/npm-shrinkwrap.json": "ab736fb153fb85c6a1b0f46781b430be560f1d7c8637d1e2263668fb7012796c",
     "plugins/brevo-email/package-lock.json": "3377225eb3bdbb252eaa28ad420b9a725ea1da533417388557aa1984730229b5",
     "plugins/line/package-lock.json": "1edbba8cefe83f595528d56ecd9086093c05acdca646594cd3bc043bae9924e8"
   },


### PR DESCRIPTION
## Summary

- bump all product packages and generated lockfile metadata to 0.29.2
- move the merged realtime voice, Signal linking, Teams routing, and docs work into the 0.29.2 changelog
- refresh the console What's New highlights, README release link, and reviewed lockfile-policy hashes
- apply three age-eligible dependency patches for Router, HTML sanitization, and Electron

## Validation

- `npm run format`
- `npm run lint`
- `npm --prefix container run lint`
- `npm run build`
- `npm audit signatures`: 1,278 verified registry signatures and 278 verified attestations
- `npm run audit:dependencies`
- `npm run notices:check`
- `npm run deps:policy`
- `npm run release:check`
- `npm --prefix container run release:check`
- console tests: 927 passed
- desktop tests: 25 passed
- full unit run: 5,583 passed; 8 environment-sensitive failures caused by the ignored checkout `.env`
- all 36 tests in the 5 affected files passed when rerun individually from a clean test root with Node 22

## Lockfile review

The dependency refresh changes exactly four package records:

- `@tanstack/react-router` 1.170.27 → 1.170.29
- `@tanstack/router-core` 1.171.22 → 1.171.24 (Router's pinned core)
- `sanitize-html` 2.17.6 → 2.17.7
- `electron` 41.10.3 → 41.10.5

All direct releases cleared the seven-day minimum-age gate. No unrelated package version or lifecycle-script flag changed; the container lockfiles remain dependency-identical.
