### PR TITLE
fix: point premium-model guidance at gpt-5.6-luna

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Premium-model errors now point at the current free model**: The guidance
+  shown when a HybridAI request is rejected for premium-model access names
+  `gpt-5.6-luna` — the model available without a paid plan or credits — instead
+  of the retired free-tier default `gpt-4.1-mini`.
+
 ## [0.29.2](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.2) - 2026-08-24
 
 ### Added

--- a/container/src/providers/shared.ts
+++ b/container/src/providers/shared.ts
@@ -103,7 +103,7 @@ function summarizeParsedErrorBody(
     parsed?.type === 'permission_error' &&
     /premium models require a paid plan or token-credit balance/i.test(message)
   ) {
-    return 'Premium model access requires a paid plan or token-credit balance. The non-premium HybridAI model is `gpt-4.1-mini`; use `/model set gpt-4.1-mini`, add credits, or switch to a configured `huggingface/...`, `openrouter/...`, or `openai-codex/...` model.';
+    return 'Premium model access requires a paid plan or token-credit balance. The non-premium HybridAI model is `gpt-5.6-luna`; use `/model set gpt-5.6-luna`, add credits, or switch to a configured `huggingface/...`, `openrouter/...`, or `openai-codex/...` model.';
   }
   return message;
 }

--- a/tests/hybridai-request-error.test.ts
+++ b/tests/hybridai-request-error.test.ts
@@ -20,7 +20,7 @@ describe('ProviderRequestError', () => {
     );
 
     expect(error.message).toBe(
-      'Provider API error 403: Premium model access requires a paid plan or token-credit balance. The non-premium HybridAI model is `gpt-4.1-mini`; use `/model set gpt-4.1-mini`, add credits, or switch to a configured `huggingface/...`, `openrouter/...`, or `openai-codex/...` model.',
+      'Provider API error 403: Premium model access requires a paid plan or token-credit balance. The non-premium HybridAI model is `gpt-5.6-luna`; use `/model set gpt-5.6-luna`, add credits, or switch to a configured `huggingface/...`, `openrouter/...`, or `openai-codex/...` model.',
     );
   });
 


### PR DESCRIPTION
## What

The HybridAI platform's free tier moved from `gpt-4.1-mini` to `gpt-5.6-luna` (matching the gateway's `DEFAULT_HYBRIDAI_MODEL` since v0.29). The hardcoded guidance in the 403 premium-model error still recommended `/model set gpt-4.1-mini`, which is no longer the model available without a paid plan or credits — following that advice would keep the request failing.

## Changes

- `container/src/providers/shared.ts`: the premium-access rejection summary now names `gpt-5.6-luna` and recommends `/model set gpt-5.6-luna`.
- `tests/hybridai-request-error.test.ts`: expectation updated.
- CHANGELOG entry under Unreleased.

## Testing

- `npx vitest run tests/hybridai-request-error.test.ts` — 9 passed.