### PR TITLE
feat(observability): attach deployment user to Sentry

### DIFF
--- a/docs/content/developer-guide/runtime.md
+++ b/docs/content/developer-guide/runtime.md
@@ -185,9 +185,10 @@ Supported environment variables:
 - `SENTRY_ENVIRONMENT` optionally overrides the Sentry environment; the default is `production`
 - `SENTRY_RELEASE` optionally overrides the Sentry release name; the default is `hybridclaw@<package-version>`
 - `SENTRY_TRACES_SAMPLE_RATE` optionally enables Sentry transaction sampling with a value from `0` to `1`; set it with `hybridclaw env set SENTRY_TRACES_SAMPLE_RATE <rate>`
+- `SENTRY_USER_ID` optionally attaches a stable pseudonymous deployment user ID to every event; it is read only from the process environment so stored runtime settings cannot replace an operator-provided identity
 
 Process environment variables with the same names are fallback values when no
-runtime env value is stored.
+runtime env value is stored, except `SENTRY_USER_ID`, which is process-only.
 
 HybridClaw already owns OpenTelemetry setup, so the Sentry SDK is initialized
 with its OpenTelemetry auto-setup disabled. Sentry events are passed through the

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -119,7 +119,7 @@ saved revision history directly.
   `OTEL_EXPORTER_OTLP_PROTOCOL`, and `OTEL_SERVICE_NAME` for optional built-in
   distributed tracing export to OTLP collectors; see
   [Runtime Internals](../developer-guide/runtime.md)
-- `SENTRY_DSN` runtime env value for optional Sentry gateway error reporting; `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`, and `SENTRY_TRACES_SAMPLE_RATE` are optional overrides. Set values with `hybridclaw env set` and see [Runtime Internals](../developer-guide/runtime.md)
+- `SENTRY_DSN` runtime env value for optional Sentry gateway error reporting; `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`, and `SENTRY_TRACES_SAMPLE_RATE` are optional overrides. Deployments can pass the process-only `SENTRY_USER_ID` to attach a stable pseudonymous user identity. Set runtime values with `hybridclaw env set` and see [Runtime Internals](../developer-guide/runtime.md)
 - `hybridai.baseUrl` for the HybridAI API origin; `HYBRIDAI_BASE_URL` can
   override it for the current process without rewriting `config.json`
 - `hybridai.maxTokens` for the default completion output budget; the shipped

--- a/src/observability/sentry.ts
+++ b/src/observability/sentry.ts
@@ -120,6 +120,9 @@ export async function initSentry(): Promise<void> {
         },
       });
       if (!client) return;
+      const userId = String(process.env.SENTRY_USER_ID || '').trim();
+      // A gateway process belongs to one deployment user, including background work.
+      if (userId) sdk.getGlobalScope().setUser({ id: userId });
       sdk.setTag('service', 'hybridclaw-gateway');
       sentry = sdk;
       initialized = true;

--- a/tests/sentry.test.ts
+++ b/tests/sentry.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 
 const sentryInit = vi.fn(() => ({}));
 const sentrySetTag = vi.fn();
+const sentryGlobalScopeSetUser = vi.fn();
 const sentryCaptureException = vi.fn();
 const sentryFlush = vi.fn(async () => true);
 const originalNpmPackageVersion = process.env.npm_package_version;
@@ -15,6 +16,7 @@ async function importFreshSentry() {
   vi.doMock('@sentry/node', () => ({
     captureException: sentryCaptureException,
     flush: sentryFlush,
+    getGlobalScope: () => ({ setUser: sentryGlobalScopeSetUser }),
     init: sentryInit,
     setTag: sentrySetTag,
   }));
@@ -32,6 +34,7 @@ describe('Sentry observability', () => {
     delete process.env.SENTRY_ENVIRONMENT;
     delete process.env.SENTRY_RELEASE;
     delete process.env.SENTRY_TRACES_SAMPLE_RATE;
+    delete process.env.SENTRY_USER_ID;
     if (originalNpmPackageVersion === undefined) {
       delete process.env.npm_package_version;
     } else {
@@ -39,6 +42,7 @@ describe('Sentry observability', () => {
     }
     sentryInit.mockClear();
     sentrySetTag.mockClear();
+    sentryGlobalScopeSetUser.mockClear();
     sentryCaptureException.mockClear();
     sentryFlush.mockClear();
   });
@@ -80,6 +84,35 @@ describe('Sentry observability', () => {
       'service',
       'hybridclaw-gateway',
     );
+    expect(sentryGlobalScopeSetUser).not.toHaveBeenCalled();
+  });
+
+  test('sets a process-provided pseudonymous user id', async () => {
+    process.env.SENTRY_DSN = 'https://public@example.com/1';
+    process.env.SENTRY_USER_ID = 'platform-user-123';
+    const { initSentry } = await importFreshSentry();
+
+    await initSentry();
+
+    expect(sentryGlobalScopeSetUser).toHaveBeenCalledOnce();
+    expect(sentryGlobalScopeSetUser).toHaveBeenCalledWith({
+      id: 'platform-user-123',
+    });
+  });
+
+  test('does not let stored runtime env override deployment user identity', async () => {
+    runtimeEnvValues = {
+      SENTRY_DSN: 'https://public@example.com/1',
+      SENTRY_USER_ID: 'stored-user',
+    };
+    process.env.SENTRY_USER_ID = 'deployment-user';
+    const { initSentry } = await importFreshSentry();
+
+    await initSentry();
+
+    expect(sentryGlobalScopeSetUser).toHaveBeenCalledWith({
+      id: 'deployment-user',
+    });
   });
 
   test('defaults environment and release from app version', async () => {


### PR DESCRIPTION
## Summary

- read the process-only `SENTRY_USER_ID` after Sentry initializes
- attach it as global Sentry `user.id`, covering request and background errors in a single-user gateway process
- prevent stored runtime settings from overriding the operator-provided identity
- document the deployment setting and its pseudonymous-only contract

## Privacy

Only a stable opaque deployment-specific identifier is attached. No email address or profile data is sent.

## Validation

- `npm exec vitest -- run tests/sentry.test.ts` (12 passed)
- `npm run lint`
- `npm run typecheck`
- `npm run format`

## Deployment

Set `SENTRY_USER_ID` in the gateway process environment when pseudonymous event attribution is desired. Existing deployments receive the context after restarting with the updated environment and image.