### PR TITLE
feat(console): install plugins from catalog or source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- **Plugins can be installed from the web console**: The Plugins & Tools page
+  accepts a plugin ID, npm package, local path, or archive URL, reports install
+  failures inline, and refreshes the live registry after the gateway reloads
+  the plugin runtime.
+
 ## [0.29.2](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.2) - 2026-08-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Added
 
-- **Plugins can be installed from the web console**: The Plugins & Tools page
-  accepts a plugin ID, npm package, local path, or archive URL, reports install
-  failures inline, and refreshes the live registry after the gateway reloads
-  the plugin runtime.
+- **Official plugins can be installed from the web console**: The Plugins &
+  Tools page lists curated bundled and channel plugins, reports install failures
+  inline, and refreshes the live registry after the gateway reloads the plugin
+  runtime. Third-party and local sources are not exposed in the console.
 
 ## [0.29.2](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.2) - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### Added
 
-- **Official plugins can be installed from the web console**: The Plugins &
-  Tools page lists curated bundled and channel plugins, reports install failures
-  inline, and refreshes the live registry after the gateway reloads the plugin
-  runtime. Third-party and local sources are not exposed in the console.
+- **Plugins can be installed from the web console**: The Plugins & Tools page
+  combines one-click installs from the official catalog with direct installs
+  from plugin IDs, npm packages, local paths, and archive URLs. It reports
+  failures inline and refreshes the live registry after the gateway reloads the
+  plugin runtime.
 
 ## [0.29.3](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.3) - 2026-08-25
 

--- a/console/src/api/client.test.ts
+++ b/console/src/api/client.test.ts
@@ -9,6 +9,7 @@ import {
   fetchAdminHybridAIBots,
   fetchAgentList,
   installOfficialPlugin,
+  installPlugin,
   readStoredToken,
   registerDistillAgent,
   setAuthReloadHandlerForTest,
@@ -317,6 +318,27 @@ describe('client command helpers', () => {
       guildId: null,
       channelId: 'web',
       args: ['plugin', 'install-official', 'whatsapp', '--yes'],
+    });
+  });
+
+  it('installs a plugin source through a local web admin command', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ kind: 'info', text: 'installed' }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    await installPlugin('test-token', '@example/demo-plugin');
+
+    const request = vi.mocked(fetch).mock.calls[0]?.[1];
+    expect(JSON.parse(String(request?.body))).toEqual({
+      sessionId: 'web-admin-plugins',
+      guildId: null,
+      channelId: 'web',
+      args: ['plugin', 'install', '@example/demo-plugin', '--yes'],
     });
   });
 

--- a/console/src/api/client.test.ts
+++ b/console/src/api/client.test.ts
@@ -8,7 +8,7 @@ import {
   dispatchAuthRequired,
   fetchAdminHybridAIBots,
   fetchAgentList,
-  installPlugin,
+  installOfficialPlugin,
   readStoredToken,
   registerDistillAgent,
   setAuthReloadHandlerForTest,
@@ -299,7 +299,7 @@ describe('client command helpers', () => {
     });
   });
 
-  it('installs a channel plugin through a local web admin command', async () => {
+  it('installs an official plugin through a local web admin command', async () => {
     vi.mocked(fetch).mockResolvedValue(
       new Response(JSON.stringify({ kind: 'info', text: 'installed' }), {
         status: 200,
@@ -309,14 +309,14 @@ describe('client command helpers', () => {
       }),
     );
 
-    await installPlugin('test-token', '@example/plugin-package');
+    await installOfficialPlugin('test-token', 'whatsapp');
 
     const request = vi.mocked(fetch).mock.calls[0]?.[1];
     expect(JSON.parse(String(request?.body))).toEqual({
-      sessionId: 'web-admin-channels',
+      sessionId: 'web-admin-plugins',
       guildId: null,
       channelId: 'web',
-      args: ['plugin', 'install', '@example/plugin-package', '--yes'],
+      args: ['plugin', 'install-official', 'whatsapp', '--yes'],
     });
   });
 

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -1224,6 +1224,18 @@ export function installOfficialPlugin(
   ]);
 }
 
+export function installPlugin(
+  token: string,
+  source: string,
+): Promise<AdminCommandResult> {
+  return runAdminCommand(token, 'web-admin-plugins', [
+    'plugin',
+    'install',
+    source,
+    '--yes',
+  ]);
+}
+
 export function fetchAdminSecrets(
   token: string,
 ): Promise<AdminSecretsResponse> {

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -1212,14 +1212,14 @@ export function setRuntimeSecret(
   ]);
 }
 
-export function installPlugin(
+export function installOfficialPlugin(
   token: string,
-  source: string,
+  pluginId: string,
 ): Promise<AdminCommandResult> {
-  return runAdminCommand(token, 'web-admin-channels', [
+  return runAdminCommand(token, 'web-admin-plugins', [
     'plugin',
-    'install',
-    source,
+    'install-official',
+    pluginId,
     '--yes',
   ]);
 }

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -2060,6 +2060,14 @@ export interface AdminPlugin {
   hooks: string[];
 }
 
+export interface AdminOfficialPlugin {
+  id: string;
+  name: string | null;
+  version: string | null;
+  description: string | null;
+  source: 'bundled' | 'channel';
+}
+
 export interface AdminPluginsResponse {
   totals: {
     totalPlugins: number;
@@ -2070,6 +2078,7 @@ export interface AdminPluginsResponse {
     hooks: number;
   };
   plugins: AdminPlugin[];
+  availableOfficialPlugins: AdminOfficialPlugin[];
 }
 
 export interface AdminOutputGuardProfile {

--- a/console/src/routes/channel-plugin-notice.tsx
+++ b/console/src/routes/channel-plugin-notice.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { installPlugin } from '../api/client';
+import { installOfficialPlugin } from '../api/client';
 import type { GatewayChannelPluginStatus } from '../api/types';
 import { Button } from '../components/button';
 import { useToast } from '../components/toast';
@@ -14,9 +14,9 @@ export function ChannelPluginNotice(props: {
   const toast = useToast();
   const installMutation = useMutation({
     mutationFn: async () => {
-      const result = await installPlugin(
+      const result = await installOfficialPlugin(
         props.token,
-        props.plugin.installSource,
+        props.plugin.pluginId,
       );
       if (result.kind === 'error') throw new Error(result.text);
       return result;

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -13,8 +13,8 @@ const fetchAdminAgentsMock = vi.fn<() => Promise<AdminAgent[]>>();
 const fetchConfigMock = vi.fn<() => Promise<AdminConfigResponse>>();
 const fetchEmailConfigMock = vi.fn();
 const fetchSignalLinkMock = vi.fn();
-const installPluginMock =
-  vi.fn<(token: string, source: string) => Promise<AdminCommandResult>>();
+const installOfficialPluginMock =
+  vi.fn<(token: string, pluginId: string) => Promise<AdminCommandResult>>();
 const saveConfigMock = vi.fn();
 const saveDiscordWebhookTargetMock = vi.fn();
 const saveSlackWebhookTargetMock = vi.fn();
@@ -28,8 +28,8 @@ vi.mock('../api/client', () => ({
   fetchConfig: () => fetchConfigMock(),
   fetchEmailConfig: (...args: unknown[]) => fetchEmailConfigMock(...args),
   fetchSignalLink: (...args: unknown[]) => fetchSignalLinkMock(...args),
-  installPlugin: (token: string, source: string) =>
-    installPluginMock(token, source),
+  installOfficialPlugin: (token: string, pluginId: string) =>
+    installOfficialPluginMock(token, pluginId),
   saveConfig: (...args: unknown[]) => saveConfigMock(...args),
   saveDiscordWebhookTarget: (...args: unknown[]) =>
     saveDiscordWebhookTargetMock(...args),
@@ -342,7 +342,7 @@ describe('ChannelsPage', () => {
     fetchConfigMock.mockReset();
     fetchEmailConfigMock.mockReset();
     fetchSignalLinkMock.mockReset();
-    installPluginMock.mockReset();
+    installOfficialPluginMock.mockReset();
     saveConfigMock.mockReset();
     saveDiscordWebhookTargetMock.mockReset();
     saveSlackWebhookTargetMock.mockReset();
@@ -351,7 +351,7 @@ describe('ChannelsPage', () => {
     validateTokenMock.mockReset();
     useAuthMock.mockReset();
     fetchAdminAgentsMock.mockResolvedValue([]);
-    installPluginMock.mockResolvedValue({
+    installOfficialPluginMock.mockResolvedValue({
       kind: 'info',
       title: 'Plugin Installed',
       text: 'Installed plugin `whatsapp`.',
@@ -930,9 +930,9 @@ describe('ChannelsPage', () => {
     );
 
     await waitFor(() => {
-      expect(installPluginMock).toHaveBeenCalledWith(
+      expect(installOfficialPluginMock).toHaveBeenCalledWith(
         'test-token',
-        'https://github.com/HybridAIOne/hybridclaw-whatsapp/releases/download/v0.1.0/hybridaione-hybridclaw-whatsapp-0.1.0.tgz',
+        'whatsapp',
       );
     });
   });
@@ -975,9 +975,9 @@ describe('ChannelsPage', () => {
     );
 
     await waitFor(() => {
-      expect(installPluginMock).toHaveBeenCalledWith(
+      expect(installOfficialPluginMock).toHaveBeenCalledWith(
         'test-token',
-        '@hybridaione/hybridclaw-line',
+        'line',
       );
     });
   });

--- a/console/src/routes/plugins.test.tsx
+++ b/console/src/routes/plugins.test.tsx
@@ -11,11 +11,15 @@ import { PluginsPage } from './plugins';
 const fetchPluginsMock = vi.fn<() => Promise<AdminPluginsResponse>>();
 const installOfficialPluginMock =
   vi.fn<(token: string, pluginId: string) => Promise<AdminCommandResult>>();
+const installPluginMock =
+  vi.fn<(token: string, source: string) => Promise<AdminCommandResult>>();
 
 vi.mock('../api/client', () => ({
   fetchPlugins: () => fetchPluginsMock(),
   installOfficialPlugin: (token: string, pluginId: string) =>
     installOfficialPluginMock(token, pluginId),
+  installPlugin: (token: string, source: string) =>
+    installPluginMock(token, source),
 }));
 
 vi.mock('../auth', () => ({
@@ -63,6 +67,7 @@ describe('PluginsPage', () => {
   beforeEach(() => {
     fetchPluginsMock.mockReset();
     installOfficialPluginMock.mockReset();
+    installPluginMock.mockReset();
     fetchPluginsMock.mockResolvedValue(makeResponse());
   });
 
@@ -108,12 +113,71 @@ describe('PluginsPage', () => {
     expect(fetchPluginsMock).toHaveBeenCalledTimes(1);
   });
 
-  it('does not expose an arbitrary plugin source input', async () => {
+  it('installs a trimmed plugin source and refreshes the registry', async () => {
+    installPluginMock.mockResolvedValue({
+      kind: 'info',
+      title: 'Plugin Installed',
+      text: 'Installed plugin `demo-plugin`.',
+    });
+
     renderWithProviders(<PluginsPage />);
     await screen.findByText('Memory Store');
 
-    expect(screen.queryByLabelText('Plugin source')).toBeNull();
+    fireEvent.change(screen.getByLabelText('Plugin source'), {
+      target: { value: '  @example/demo-plugin  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Install plugin' }));
+
+    await waitFor(() => {
+      expect(installPluginMock).toHaveBeenCalledWith(
+        'test-token',
+        '@example/demo-plugin',
+      );
+      expect(fetchPluginsMock).toHaveBeenCalledTimes(2);
+    });
+    expect(
+      (screen.getByLabelText('Plugin source') as HTMLInputElement).value,
+    ).toBe('');
+    expect(await screen.findByText('Plugin Installed')).toBeTruthy();
     expect(screen.getByText('Official · channel')).toBeTruthy();
-    expect(installOfficialPluginMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces source install errors and keeps the source for correction', async () => {
+    installPluginMock.mockResolvedValue({
+      kind: 'error',
+      title: 'Plugin Install Failed',
+      text: 'Plugin manifest was not found.',
+    });
+
+    renderWithProviders(<PluginsPage />);
+    await screen.findByText('Memory Store');
+
+    fireEvent.change(screen.getByLabelText('Plugin source'), {
+      target: { value: './missing-plugin' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Install plugin' }));
+
+    expect(await screen.findByText('Plugin installation failed')).toBeTruthy();
+    expect(screen.getByText('Plugin manifest was not found.')).toBeTruthy();
+    expect(
+      (screen.getByLabelText('Plugin source') as HTMLInputElement).value,
+    ).toBe('./missing-plugin');
+    expect(fetchPluginsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not allow an empty plugin source', async () => {
+    renderWithProviders(<PluginsPage />);
+    await screen.findByText('Memory Store');
+
+    const installButton = screen.getByRole('button', {
+      name: 'Install plugin',
+    });
+    expect((installButton as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText('Plugin source'), {
+      target: { value: '   ' },
+    });
+    expect((installButton as HTMLButtonElement).disabled).toBe(true);
+    expect(installPluginMock).not.toHaveBeenCalled();
   });
 });

--- a/console/src/routes/plugins.test.tsx
+++ b/console/src/routes/plugins.test.tsx
@@ -9,13 +9,13 @@ import { renderWithProviders } from '../test-utils';
 import { PluginsPage } from './plugins';
 
 const fetchPluginsMock = vi.fn<() => Promise<AdminPluginsResponse>>();
-const installPluginMock =
-  vi.fn<(token: string, source: string) => Promise<AdminCommandResult>>();
+const installOfficialPluginMock =
+  vi.fn<(token: string, pluginId: string) => Promise<AdminCommandResult>>();
 
 vi.mock('../api/client', () => ({
   fetchPlugins: () => fetchPluginsMock(),
-  installPlugin: (token: string, source: string) =>
-    installPluginMock(token, source),
+  installOfficialPlugin: (token: string, pluginId: string) =>
+    installOfficialPluginMock(token, pluginId),
 }));
 
 vi.mock('../auth', () => ({
@@ -47,18 +47,27 @@ function makeResponse(): AdminPluginsResponse {
         hooks: ['before_prompt'],
       },
     ],
+    availableOfficialPlugins: [
+      {
+        id: 'whatsapp',
+        name: 'WhatsApp',
+        version: null,
+        description: 'Official WhatsApp transport maintained by HybridAIOne.',
+        source: 'channel',
+      },
+    ],
   };
 }
 
 describe('PluginsPage', () => {
   beforeEach(() => {
     fetchPluginsMock.mockReset();
-    installPluginMock.mockReset();
+    installOfficialPluginMock.mockReset();
     fetchPluginsMock.mockResolvedValue(makeResponse());
   });
 
-  it('installs a trimmed plugin source and refreshes the registry', async () => {
-    installPluginMock.mockResolvedValue({
+  it('installs a selected official plugin and refreshes the registry', async () => {
+    installOfficialPluginMock.mockResolvedValue({
       kind: 'info',
       title: 'Plugin Installed',
       text: 'Installed plugin `demo-plugin`.',
@@ -67,26 +76,20 @@ describe('PluginsPage', () => {
     renderWithProviders(<PluginsPage />);
     await screen.findByText('Memory Store');
 
-    fireEvent.change(screen.getByLabelText('Plugin source'), {
-      target: { value: '  @example/demo-plugin  ' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Install plugin' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Install WhatsApp' }));
 
     await waitFor(() => {
-      expect(installPluginMock).toHaveBeenCalledWith(
+      expect(installOfficialPluginMock).toHaveBeenCalledWith(
         'test-token',
-        '@example/demo-plugin',
+        'whatsapp',
       );
       expect(fetchPluginsMock).toHaveBeenCalledTimes(2);
     });
-    expect(
-      (screen.getByLabelText('Plugin source') as HTMLInputElement).value,
-    ).toBe('');
     expect(await screen.findByText('Plugin Installed')).toBeTruthy();
   });
 
-  it('surfaces command errors and keeps the source for correction', async () => {
-    installPluginMock.mockResolvedValue({
+  it('surfaces command errors and keeps the official plugin available', async () => {
+    installOfficialPluginMock.mockResolvedValue({
       kind: 'error',
       title: 'Plugin Install Failed',
       text: 'Plugin manifest was not found.',
@@ -95,32 +98,22 @@ describe('PluginsPage', () => {
     renderWithProviders(<PluginsPage />);
     await screen.findByText('Memory Store');
 
-    fireEvent.change(screen.getByLabelText('Plugin source'), {
-      target: { value: './missing-plugin' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Install plugin' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Install WhatsApp' }));
 
     expect(await screen.findByText('Plugin installation failed')).toBeTruthy();
     expect(screen.getByText('Plugin manifest was not found.')).toBeTruthy();
     expect(
-      (screen.getByLabelText('Plugin source') as HTMLInputElement).value,
-    ).toBe('./missing-plugin');
+      screen.getByRole('button', { name: 'Install WhatsApp' }),
+    ).toBeTruthy();
     expect(fetchPluginsMock).toHaveBeenCalledTimes(1);
   });
 
-  it('does not allow an empty plugin source', async () => {
+  it('does not expose an arbitrary plugin source input', async () => {
     renderWithProviders(<PluginsPage />);
     await screen.findByText('Memory Store');
 
-    const installButton = screen.getByRole('button', {
-      name: 'Install plugin',
-    });
-    expect((installButton as HTMLButtonElement).disabled).toBe(true);
-
-    fireEvent.change(screen.getByLabelText('Plugin source'), {
-      target: { value: '   ' },
-    });
-    expect((installButton as HTMLButtonElement).disabled).toBe(true);
-    expect(installPluginMock).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText('Plugin source')).toBeNull();
+    expect(screen.getByText('Official · channel')).toBeTruthy();
+    expect(installOfficialPluginMock).not.toHaveBeenCalled();
   });
 });

--- a/console/src/routes/plugins.test.tsx
+++ b/console/src/routes/plugins.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Plugin page interaction tests — operator installs must reach the local web
+ * command boundary and refresh the gateway-backed registry on success.
+ */
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AdminCommandResult, AdminPluginsResponse } from '../api/types';
+import { renderWithProviders } from '../test-utils';
+import { PluginsPage } from './plugins';
+
+const fetchPluginsMock = vi.fn<() => Promise<AdminPluginsResponse>>();
+const installPluginMock =
+  vi.fn<(token: string, source: string) => Promise<AdminCommandResult>>();
+
+vi.mock('../api/client', () => ({
+  fetchPlugins: () => fetchPluginsMock(),
+  installPlugin: (token: string, source: string) =>
+    installPluginMock(token, source),
+}));
+
+vi.mock('../auth', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+function makeResponse(): AdminPluginsResponse {
+  return {
+    totals: {
+      totalPlugins: 1,
+      enabledPlugins: 1,
+      failedPlugins: 0,
+      commands: 1,
+      tools: 2,
+      hooks: 1,
+    },
+    plugins: [
+      {
+        id: 'memory-store',
+        name: 'Memory Store',
+        version: '1.2.3',
+        description: 'Durable agent memory.',
+        source: 'home',
+        enabled: true,
+        status: 'loaded',
+        error: null,
+        commands: ['memory'],
+        tools: ['memory_search', 'memory_write'],
+        hooks: ['before_prompt'],
+      },
+    ],
+  };
+}
+
+describe('PluginsPage', () => {
+  beforeEach(() => {
+    fetchPluginsMock.mockReset();
+    installPluginMock.mockReset();
+    fetchPluginsMock.mockResolvedValue(makeResponse());
+  });
+
+  it('installs a trimmed plugin source and refreshes the registry', async () => {
+    installPluginMock.mockResolvedValue({
+      kind: 'info',
+      title: 'Plugin Installed',
+      text: 'Installed plugin `demo-plugin`.',
+    });
+
+    renderWithProviders(<PluginsPage />);
+    await screen.findByText('Memory Store');
+
+    fireEvent.change(screen.getByLabelText('Plugin source'), {
+      target: { value: '  @example/demo-plugin  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Install plugin' }));
+
+    await waitFor(() => {
+      expect(installPluginMock).toHaveBeenCalledWith(
+        'test-token',
+        '@example/demo-plugin',
+      );
+      expect(fetchPluginsMock).toHaveBeenCalledTimes(2);
+    });
+    expect(
+      (screen.getByLabelText('Plugin source') as HTMLInputElement).value,
+    ).toBe('');
+    expect(await screen.findByText('Plugin Installed')).toBeTruthy();
+  });
+
+  it('surfaces command errors and keeps the source for correction', async () => {
+    installPluginMock.mockResolvedValue({
+      kind: 'error',
+      title: 'Plugin Install Failed',
+      text: 'Plugin manifest was not found.',
+    });
+
+    renderWithProviders(<PluginsPage />);
+    await screen.findByText('Memory Store');
+
+    fireEvent.change(screen.getByLabelText('Plugin source'), {
+      target: { value: './missing-plugin' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Install plugin' }));
+
+    expect(await screen.findByText('Plugin installation failed')).toBeTruthy();
+    expect(screen.getByText('Plugin manifest was not found.')).toBeTruthy();
+    expect(
+      (screen.getByLabelText('Plugin source') as HTMLInputElement).value,
+    ).toBe('./missing-plugin');
+    expect(fetchPluginsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not allow an empty plugin source', async () => {
+    renderWithProviders(<PluginsPage />);
+    await screen.findByText('Memory Store');
+
+    const installButton = screen.getByRole('button', {
+      name: 'Install plugin',
+    });
+    expect((installButton as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText('Plugin source'), {
+      target: { value: '   ' },
+    });
+    expect((installButton as HTMLButtonElement).disabled).toBe(true);
+    expect(installPluginMock).not.toHaveBeenCalled();
+  });
+});

--- a/console/src/routes/plugins.tsx
+++ b/console/src/routes/plugins.tsx
@@ -1,8 +1,15 @@
-import { useQuery } from '@tanstack/react-query';
-import { useDeferredValue, useState } from 'react';
-import { fetchPlugins } from '../api/client';
+/**
+ * Plugin operations surface — the console view of the gateway's live registry.
+ *
+ * Installs are explicit operator actions and refresh this registry after the
+ * gateway reloads; discovery and dependency policy remain gateway concerns.
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { type FormEvent, useDeferredValue, useState } from 'react';
+import { fetchPlugins, installPlugin } from '../api/client';
 import type { AdminPlugin } from '../api/types';
 import { useAuth } from '../auth';
+import { Button } from '../components/button';
 import {
   Card,
   CardContent,
@@ -12,6 +19,7 @@ import {
 } from '../components/card';
 import { Input } from '../components/input';
 import { TabbedPageActions } from '../components/tabbed-page';
+import { useToast } from '../components/toast';
 import {
   BooleanPill,
   MetricCard,
@@ -19,6 +27,7 @@ import {
   SortableHeader,
   useSortableRows,
 } from '../components/ui';
+import { getErrorMessage } from '../lib/error-message';
 import { compareBoolean, compareNumber, compareText } from '../lib/sort';
 
 type PluginSortKey =
@@ -89,7 +98,10 @@ function matchesPluginFilter(plugin: AdminPlugin, needle: string): boolean {
 
 export function PluginsPage(props: { embedded?: boolean } = {}) {
   const auth = useAuth();
+  const queryClient = useQueryClient();
+  const toast = useToast();
   const [filter, setFilter] = useState('');
+  const [installSource, setInstallSource] = useState('');
   const deferredFilter = useDeferredValue(filter);
   const filterNeedle = deferredFilter.trim().toLowerCase();
 
@@ -97,6 +109,33 @@ export function PluginsPage(props: { embedded?: boolean } = {}) {
     queryKey: ['plugins', auth.token],
     queryFn: () => fetchPlugins(auth.token),
   });
+
+  const installMutation = useMutation({
+    mutationFn: async (source: string) => {
+      const result = await installPlugin(auth.token, source);
+      if (result.kind === 'error') throw new Error(result.text);
+      return result;
+    },
+    onSuccess: async (result) => {
+      setInstallSource('');
+      await queryClient.invalidateQueries({
+        queryKey: ['plugins', auth.token],
+      });
+      toast.success(
+        result.title || 'Plugin installed',
+        'The gateway reloaded the plugin runtime and refreshed the registry.',
+      );
+    },
+    onError: (error) => {
+      toast.error('Plugin installation failed', getErrorMessage(error));
+    },
+  });
+
+  function handleInstall(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+    const source = installSource.trim();
+    if (source) installMutation.mutate(source);
+  }
 
   const filteredPlugins = (pluginsQuery.data?.plugins || []).filter((plugin) =>
     matchesPluginFilter(plugin, filterNeedle),
@@ -133,6 +172,37 @@ export function PluginsPage(props: { embedded?: boolean } = {}) {
         <TabbedPageActions>{filterInput}</TabbedPageActions>
       ) : null}
       <PageHeader actions={props.embedded ? undefined : filterInput} />
+
+      <Card variant="muted" className="plugin-install-card">
+        <CardHeader>
+          <CardTitle>Install a plugin</CardTitle>
+          <CardDescription>
+            Add a reviewed plugin from a plugin ID, npm package, local path, or
+            archive URL. Installation approves its declared dependencies and
+            reloads the plugin runtime.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="plugin-install-form" onSubmit={handleInstall}>
+            <Input
+              value={installSource}
+              onChange={(event) => setInstallSource(event.target.value)}
+              placeholder="Plugin ID, package, path, or archive URL"
+              aria-label="Plugin source"
+              autoComplete="off"
+              spellCheck={false}
+              disabled={installMutation.isPending}
+            />
+            <Button
+              type="submit"
+              loading={installMutation.isPending}
+              disabled={!installSource.trim()}
+            >
+              {installMutation.isPending ? 'Installing...' : 'Install plugin'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
 
       <div className="metric-grid">
         <MetricCard

--- a/console/src/routes/plugins.tsx
+++ b/console/src/routes/plugins.tsx
@@ -5,8 +5,12 @@
  * gateway reloads; discovery and dependency policy remain gateway concerns.
  */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useDeferredValue, useState } from 'react';
-import { fetchPlugins, installOfficialPlugin } from '../api/client';
+import { type FormEvent, useDeferredValue, useState } from 'react';
+import {
+  fetchPlugins,
+  installOfficialPlugin,
+  installPlugin,
+} from '../api/client';
 import type { AdminPlugin } from '../api/types';
 import { useAuth } from '../auth';
 import { Button } from '../components/button';
@@ -101,6 +105,7 @@ export function PluginsPage(props: { embedded?: boolean } = {}) {
   const queryClient = useQueryClient();
   const toast = useToast();
   const [filter, setFilter] = useState('');
+  const [installSource, setInstallSource] = useState('');
   const deferredFilter = useDeferredValue(filter);
   const filterNeedle = deferredFilter.trim().toLowerCase();
 
@@ -109,7 +114,7 @@ export function PluginsPage(props: { embedded?: boolean } = {}) {
     queryFn: () => fetchPlugins(auth.token),
   });
 
-  const installMutation = useMutation({
+  const officialInstallMutation = useMutation({
     mutationFn: async (pluginId: string) => {
       const result = await installOfficialPlugin(auth.token, pluginId);
       if (result.kind === 'error') throw new Error(result.text);
@@ -128,6 +133,36 @@ export function PluginsPage(props: { embedded?: boolean } = {}) {
       toast.error('Plugin installation failed', getErrorMessage(error));
     },
   });
+
+  const sourceInstallMutation = useMutation({
+    mutationFn: async (source: string) => {
+      const result = await installPlugin(auth.token, source);
+      if (result.kind === 'error') throw new Error(result.text);
+      return result;
+    },
+    onSuccess: async (result) => {
+      setInstallSource('');
+      await queryClient.invalidateQueries({
+        queryKey: ['plugins', auth.token],
+      });
+      toast.success(
+        result.title || 'Plugin installed',
+        'The gateway reloaded the plugin runtime and refreshed the registry.',
+      );
+    },
+    onError: (error) => {
+      toast.error('Plugin installation failed', getErrorMessage(error));
+    },
+  });
+
+  function handleSourceInstall(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+    const source = installSource.trim();
+    if (source) sourceInstallMutation.mutate(source);
+  }
+
+  const isInstalling =
+    officialInstallMutation.isPending || sourceInstallMutation.isPending;
 
   const filteredPlugins = (pluginsQuery.data?.plugins || []).filter((plugin) =>
     matchesPluginFilter(plugin, filterNeedle),
@@ -169,8 +204,7 @@ export function PluginsPage(props: { embedded?: boolean } = {}) {
         <CardHeader>
           <CardTitle>Official plugins</CardTitle>
           <CardDescription>
-            Install capabilities curated and maintained by HybridClaw. Advanced
-            third-party and local sources remain available from the CLI.
+            One-click installs from the HybridClaw curated catalog.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -180,9 +214,9 @@ export function PluginsPage(props: { embedded?: boolean } = {}) {
             <div className="list-stack selectable-list">
               {pluginsQuery.data.availableOfficialPlugins.map((plugin) => {
                 const label = plugin.name || plugin.id;
-                const isInstalling =
-                  installMutation.isPending &&
-                  installMutation.variables === plugin.id;
+                const isInstallingOfficialPlugin =
+                  officialInstallMutation.isPending &&
+                  officialInstallMutation.variables === plugin.id;
                 return (
                   <div className="list-row" key={plugin.id}>
                     <div>
@@ -202,11 +236,15 @@ export function PluginsPage(props: { embedded?: boolean } = {}) {
                       <Button
                         type="button"
                         size="sm"
-                        loading={isInstalling}
-                        disabled={installMutation.isPending}
-                        onClick={() => installMutation.mutate(plugin.id)}
+                        loading={isInstallingOfficialPlugin}
+                        disabled={isInstalling}
+                        onClick={() =>
+                          officialInstallMutation.mutate(plugin.id)
+                        }
                       >
-                        {isInstalling ? 'Installing...' : `Install ${label}`}
+                        {isInstallingOfficialPlugin
+                          ? 'Installing...'
+                          : `Install ${label}`}
                       </Button>
                     </div>
                   </div>
@@ -218,6 +256,39 @@ export function PluginsPage(props: { embedded?: boolean } = {}) {
               Every available official plugin is already installed.
             </div>
           )}
+        </CardContent>
+      </Card>
+
+      <Card variant="muted" className="plugin-install-card">
+        <CardHeader>
+          <CardTitle>Install from a source</CardTitle>
+          <CardDescription>
+            Install any compatible plugin by ID, npm package, local path, or
+            archive URL. The gateway installs declared dependencies and reloads
+            the runtime.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="plugin-install-form" onSubmit={handleSourceInstall}>
+            <Input
+              value={installSource}
+              onChange={(event) => setInstallSource(event.target.value)}
+              placeholder="Plugin ID, package, path, or archive URL"
+              aria-label="Plugin source"
+              autoComplete="off"
+              spellCheck={false}
+              disabled={isInstalling}
+            />
+            <Button
+              type="submit"
+              loading={sourceInstallMutation.isPending}
+              disabled={isInstalling || !installSource.trim()}
+            >
+              {sourceInstallMutation.isPending
+                ? 'Installing...'
+                : 'Install plugin'}
+            </Button>
+          </form>
         </CardContent>
       </Card>
 

--- a/console/src/routes/plugins.tsx
+++ b/console/src/routes/plugins.tsx
@@ -5,8 +5,8 @@
  * gateway reloads; discovery and dependency policy remain gateway concerns.
  */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { type FormEvent, useDeferredValue, useState } from 'react';
-import { fetchPlugins, installPlugin } from '../api/client';
+import { useDeferredValue, useState } from 'react';
+import { fetchPlugins, installOfficialPlugin } from '../api/client';
 import type { AdminPlugin } from '../api/types';
 import { useAuth } from '../auth';
 import { Button } from '../components/button';
@@ -101,7 +101,6 @@ export function PluginsPage(props: { embedded?: boolean } = {}) {
   const queryClient = useQueryClient();
   const toast = useToast();
   const [filter, setFilter] = useState('');
-  const [installSource, setInstallSource] = useState('');
   const deferredFilter = useDeferredValue(filter);
   const filterNeedle = deferredFilter.trim().toLowerCase();
 
@@ -111,13 +110,12 @@ export function PluginsPage(props: { embedded?: boolean } = {}) {
   });
 
   const installMutation = useMutation({
-    mutationFn: async (source: string) => {
-      const result = await installPlugin(auth.token, source);
+    mutationFn: async (pluginId: string) => {
+      const result = await installOfficialPlugin(auth.token, pluginId);
       if (result.kind === 'error') throw new Error(result.text);
       return result;
     },
     onSuccess: async (result) => {
-      setInstallSource('');
       await queryClient.invalidateQueries({
         queryKey: ['plugins', auth.token],
       });
@@ -130,12 +128,6 @@ export function PluginsPage(props: { embedded?: boolean } = {}) {
       toast.error('Plugin installation failed', getErrorMessage(error));
     },
   });
-
-  function handleInstall(event: FormEvent<HTMLFormElement>): void {
-    event.preventDefault();
-    const source = installSource.trim();
-    if (source) installMutation.mutate(source);
-  }
 
   const filteredPlugins = (pluginsQuery.data?.plugins || []).filter((plugin) =>
     matchesPluginFilter(plugin, filterNeedle),
@@ -175,32 +167,57 @@ export function PluginsPage(props: { embedded?: boolean } = {}) {
 
       <Card variant="muted" className="plugin-install-card">
         <CardHeader>
-          <CardTitle>Install a plugin</CardTitle>
+          <CardTitle>Official plugins</CardTitle>
           <CardDescription>
-            Add a reviewed plugin from a plugin ID, npm package, local path, or
-            archive URL. Installation approves its declared dependencies and
-            reloads the plugin runtime.
+            Install capabilities curated and maintained by HybridClaw. Advanced
+            third-party and local sources remain available from the CLI.
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <form className="plugin-install-form" onSubmit={handleInstall}>
-            <Input
-              value={installSource}
-              onChange={(event) => setInstallSource(event.target.value)}
-              placeholder="Plugin ID, package, path, or archive URL"
-              aria-label="Plugin source"
-              autoComplete="off"
-              spellCheck={false}
-              disabled={installMutation.isPending}
-            />
-            <Button
-              type="submit"
-              loading={installMutation.isPending}
-              disabled={!installSource.trim()}
-            >
-              {installMutation.isPending ? 'Installing...' : 'Install plugin'}
-            </Button>
-          </form>
+          {pluginsQuery.isLoading ? (
+            <div className="empty-state">Loading official plugins...</div>
+          ) : pluginsQuery.data?.availableOfficialPlugins.length ? (
+            <div className="list-stack selectable-list">
+              {pluginsQuery.data.availableOfficialPlugins.map((plugin) => {
+                const label = plugin.name || plugin.id;
+                const isInstalling =
+                  installMutation.isPending &&
+                  installMutation.variables === plugin.id;
+                return (
+                  <div className="list-row" key={plugin.id}>
+                    <div>
+                      <strong>{label}</strong>
+                      <small>
+                        {plugin.id}
+                        {plugin.version ? ` · v${plugin.version}` : ''}
+                      </small>
+                      {plugin.description ? (
+                        <small>{plugin.description}</small>
+                      ) : null}
+                    </div>
+                    <div className="plugin-catalog-action">
+                      <span className="list-status">
+                        Official · {plugin.source}
+                      </span>
+                      <Button
+                        type="button"
+                        size="sm"
+                        loading={isInstalling}
+                        disabled={installMutation.isPending}
+                        onClick={() => installMutation.mutate(plugin.id)}
+                      >
+                        {isInstalling ? 'Installing...' : `Install ${label}`}
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="empty-state">
+              Every available official plugin is already installed.
+            </div>
+          )}
         </CardContent>
       </Card>
 

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -605,11 +605,12 @@ code {
   border-color: var(--line-strong);
 }
 
-.plugin-install-form {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+.plugin-catalog-action {
+  display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   align-items: center;
+  justify-content: flex-end;
 }
 
 .skills-review-grid {
@@ -4389,8 +4390,8 @@ th {
     grid-template-columns: 1fr;
   }
 
-  .plugin-install-form {
-    grid-template-columns: 1fr;
+  .plugin-catalog-action {
+    justify-content: flex-start;
   }
 
   .jobs-columns {

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -613,6 +613,13 @@ code {
   justify-content: flex-end;
 }
 
+.plugin-install-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+}
+
 .skills-review-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
@@ -4392,6 +4399,10 @@ th {
 
   .plugin-catalog-action {
     justify-content: flex-start;
+  }
+
+  .plugin-install-form {
+    grid-template-columns: 1fr;
   }
 
   .jobs-columns {

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -601,6 +601,17 @@ code {
   grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
 }
 
+.plugin-install-card {
+  border-color: var(--line-strong);
+}
+
+.plugin-install-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+}
+
 .skills-review-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
@@ -4375,6 +4386,10 @@ th {
   }
 
   .jobs-board-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .plugin-install-form {
     grid-template-columns: 1fr;
   }
 

--- a/src/channels/channel-plugin-catalog.ts
+++ b/src/channels/channel-plugin-catalog.ts
@@ -1,3 +1,7 @@
+/**
+ * Official channel-plugin catalog — the source of truth for install-on-demand
+ * transports. Entries are curated code provenance, not runtime availability.
+ */
 import type { ChannelKind } from './channel.js';
 import { hasChannelTransport } from './channel-transport.js';
 
@@ -7,30 +11,51 @@ export interface ChannelPluginCatalogEntry {
   installSource: string;
 }
 
-export interface ChannelPluginStatus extends ChannelPluginCatalogEntry {
+export interface OfficialChannelPluginCatalogEntry
+  extends ChannelPluginCatalogEntry {
+  name: string;
+  description: string;
+}
+
+export interface ChannelPluginStatus {
+  channel: ChannelKind;
+  pluginId: string;
+  installSource: string;
   transportAvailable: boolean;
 }
 
+// Official web-install allowlist (owner call, 2026-08-25): third-party catalog
+// discovery and publisher verification are deliberately deferred.
 const CHANNEL_PLUGIN_CATALOG = {
   line: {
     pluginId: 'line',
+    name: 'LINE',
+    description: 'Official LINE personal-account transport.',
     installSource: 'line',
   },
   whatsapp: {
     pluginId: 'whatsapp',
+    name: 'WhatsApp',
+    description: 'Official WhatsApp transport maintained by HybridAIOne.',
     installSource:
       'https://github.com/HybridAIOne/hybridclaw-whatsapp/releases/download/v0.1.0/hybridaione-hybridclaw-whatsapp-0.1.0.tgz',
   },
 } as const satisfies Partial<
-  Record<ChannelKind, Omit<ChannelPluginCatalogEntry, 'channel'>>
+  Record<ChannelKind, Omit<OfficialChannelPluginCatalogEntry, 'channel'>>
 >;
 
 export function getChannelPluginCatalogEntry(
   channel: ChannelKind,
 ): ChannelPluginCatalogEntry | undefined {
-  const entry: Omit<ChannelPluginCatalogEntry, 'channel'> | undefined =
+  const entry =
     CHANNEL_PLUGIN_CATALOG[channel as keyof typeof CHANNEL_PLUGIN_CATALOG];
-  return entry ? { channel, ...entry } : undefined;
+  return entry
+    ? {
+        channel,
+        pluginId: entry.pluginId,
+        installSource: entry.installSource,
+      }
+    : undefined;
 }
 
 export function getChannelPluginCatalogEntryByPluginId(
@@ -44,6 +69,17 @@ export function getChannelPluginCatalogEntryByPluginId(
   return undefined;
 }
 
+export function getOfficialChannelPluginCatalogEntries(): OfficialChannelPluginCatalogEntry[] {
+  return Object.keys(CHANNEL_PLUGIN_CATALOG).map((channel) => {
+    const entry =
+      CHANNEL_PLUGIN_CATALOG[channel as keyof typeof CHANNEL_PLUGIN_CATALOG];
+    if (!entry) {
+      throw new Error(`Invalid channel plugin catalog entry: ${channel}`);
+    }
+    return { channel: channel as ChannelKind, ...entry };
+  });
+}
+
 export function getChannelPluginInstallCommand(channel: ChannelKind): string {
   const entry = getChannelPluginCatalogEntry(channel);
   if (!entry) {
@@ -55,15 +91,12 @@ export function getChannelPluginInstallCommand(channel: ChannelKind): string {
 }
 
 export function getChannelPluginStatuses(): ChannelPluginStatus[] {
-  return Object.keys(CHANNEL_PLUGIN_CATALOG).map((channel) => {
-    const entry = getChannelPluginCatalogEntry(channel as ChannelKind);
-    if (!entry)
-      throw new Error(`Invalid channel plugin catalog entry: ${channel}`);
-    return {
-      ...entry,
-      transportAvailable: hasChannelTransport(entry.channel),
-    };
-  });
+  return getOfficialChannelPluginCatalogEntries().map((entry) => ({
+    channel: entry.channel,
+    pluginId: entry.pluginId,
+    installSource: entry.installSource,
+    transportAvailable: hasChannelTransport(entry.channel),
+  }));
 }
 
 export interface ChannelPluginAvailabilityChange {

--- a/src/gateway/gateway-plugin-service.ts
+++ b/src/gateway/gateway-plugin-service.ts
@@ -1,3 +1,8 @@
+/**
+ * Plugin gateway service — the authenticated command and admin boundary.
+ * Official web installs resolve server-side against curated catalog entries;
+ * plugin discovery and execution remain responsibilities of the manager.
+ */
 import { randomUUID } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import {
@@ -5,6 +10,7 @@ import {
   type ChannelPluginAvailabilitySnapshot,
   diffChannelPluginTransportAvailability,
   getChannelPluginCatalogEntryByPluginId,
+  getOfficialChannelPluginCatalogEntries,
   snapshotChannelPluginTransportAvailability,
 } from '../channels/channel-plugin-catalog.js';
 import { sendWebhookJson, WebhookHttpError } from '../channels/webhook-http.js';
@@ -33,6 +39,7 @@ import {
   checkPlugin,
   formatDependencyPlanDetails,
   installPlugin,
+  listBundledInstallablePlugins,
   listInstallablePlugins,
   reinstallPlugin,
   uninstallPlugin,
@@ -50,6 +57,7 @@ import { consumeCommandApproval } from './command-approval-trust.js';
 import { handleGatewayMessage } from './gateway-chat-service.js';
 import { tryEnsurePluginManagerInitializedForGateway } from './gateway-plugin-runtime.js';
 import type {
+  GatewayAdminOfficialPlugin,
   GatewayAdminPluginsResponse,
   GatewayCommandRequest,
   GatewayCommandResult,
@@ -86,6 +94,18 @@ function formatPluginConfigValue(value: unknown): string {
   } catch {
     return String(value);
   }
+}
+
+function resolveOfficialPluginInstallSource(pluginId: string): string | null {
+  const normalizedPluginId = String(pluginId || '').trim();
+  const bundled = listBundledInstallablePlugins().find(
+    (plugin) => plugin.id === normalizedPluginId,
+  );
+  if (bundled) return bundled.installSource;
+  return (
+    getChannelPluginCatalogEntryByPluginId(normalizedPluginId)?.installSource ??
+    null
+  );
 }
 
 function formatMissingBinaryRequirement(params: {
@@ -807,25 +827,32 @@ export async function handlePluginGatewayCommand(params: {
     }
   }
 
-  if (sub === 'install') {
-    const source = parseIdArg(req.args, 2);
+  if (sub === 'install' || sub === 'install-official') {
+    const requestedSource = parseIdArg(req.args, 2);
     const yes = parseIdArg(req.args, 3);
-    if (!source) {
-      return badCommand(
-        'Usage',
-        'Usage: `plugin install <path|plugin-id|npm-spec> [--yes]`',
-      );
+    const officialOnly = sub === 'install-official';
+    const usage = officialOnly
+      ? 'Usage: `plugin install-official <plugin-id> [--yes]`'
+      : 'Usage: `plugin install <path|plugin-id|npm-spec> [--yes]`';
+    if (!requestedSource) {
+      return badCommand('Usage', usage);
     }
     if (yes && yes !== '--yes') {
-      return badCommand(
-        'Usage',
-        'Usage: `plugin install <path|plugin-id|npm-spec> [--yes]`',
-      );
+      return badCommand('Usage', usage);
     }
     if (!isLocalSession(req)) {
       return badCommand(
         'Plugin Install Restricted',
         '`plugin install` is only available from local TUI/web sessions.',
+      );
+    }
+    const source = officialOnly
+      ? resolveOfficialPluginInstallSource(requestedSource)
+      : requestedSource;
+    if (!source) {
+      return badCommand(
+        'Official Plugin Not Found',
+        `Plugin \`${requestedSource}\` is not in the official HybridClaw catalog.`,
       );
     }
     const depsSatisfiedLines: string[] = [];
@@ -1209,6 +1236,29 @@ export async function getGatewayAdminPlugins(): Promise<GatewayAdminPluginsRespo
       hooks: [...plugin.hooks].sort((left, right) => left.localeCompare(right)),
     }))
     .sort((left, right) => left.id.localeCompare(right.id));
+  const installedIds = new Set(plugins.map((plugin) => plugin.id));
+  const availableOfficialPlugins = new Map<string, GatewayAdminOfficialPlugin>(
+    listBundledInstallablePlugins().map((plugin) => [
+      plugin.id,
+      {
+        id: plugin.id,
+        name: plugin.name || null,
+        version: plugin.version || null,
+        description: plugin.description || null,
+        source: 'bundled' as const,
+      },
+    ]),
+  );
+  for (const plugin of getOfficialChannelPluginCatalogEntries()) {
+    if (availableOfficialPlugins.has(plugin.pluginId)) continue;
+    availableOfficialPlugins.set(plugin.pluginId, {
+      id: plugin.pluginId,
+      name: plugin.name,
+      version: null,
+      description: plugin.description,
+      source: 'channel',
+    });
+  }
 
   return {
     totals: {
@@ -1224,6 +1274,9 @@ export async function getGatewayAdminPlugins(): Promise<GatewayAdminPluginsRespo
       hooks: plugins.reduce((sum, plugin) => sum + plugin.hooks.length, 0),
     },
     plugins,
+    availableOfficialPlugins: [...availableOfficialPlugins.values()]
+      .filter((plugin) => !installedIds.has(plugin.id))
+      .sort((left, right) => left.id.localeCompare(right.id)),
   };
 }
 

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -1749,6 +1749,14 @@ export interface GatewayAdminPlugin {
   hooks: string[];
 }
 
+export interface GatewayAdminOfficialPlugin {
+  id: string;
+  name: string | null;
+  version: string | null;
+  description: string | null;
+  source: 'bundled' | 'channel';
+}
+
 export interface GatewayAdminPluginsResponse {
   totals: {
     totalPlugins: number;
@@ -1759,6 +1767,7 @@ export interface GatewayAdminPluginsResponse {
     hooks: number;
   };
   plugins: GatewayAdminPlugin[];
+  availableOfficialPlugins: GatewayAdminOfficialPlugin[];
 }
 
 export interface GatewayAdminOutputGuardProfile {

--- a/src/plugins/plugin-install.ts
+++ b/src/plugins/plugin-install.ts
@@ -1,3 +1,7 @@
+/**
+ * Plugin installation boundary — resolves sources, stages plugin trees, and
+ * installs declared dependencies. Trust decisions stay with its callers.
+ */
 import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
@@ -297,8 +301,26 @@ export function listInstallablePlugins(options?: {
   cwd?: string;
 }): PluginAvailableSummary[] {
   const cwd = options?.cwd || process.cwd();
+  return listInstallablePluginsFromRoots(listPluginCatalogRoots(cwd));
+}
+
+export function listBundledInstallablePlugins(): PluginAvailableSummary[] {
+  return listInstallablePluginsFromRoots([
+    {
+      dir: path.join(PACKAGE_ROOT, 'plugins'),
+      source: 'bundled',
+    },
+  ]);
+}
+
+function listInstallablePluginsFromRoots(
+  roots: Array<{
+    dir: string;
+    source: PluginAvailableSummary['source'];
+  }>,
+): PluginAvailableSummary[] {
   const discovered = new Map<string, PluginAvailableSummary>();
-  for (const root of listPluginCatalogRoots(cwd)) {
+  for (const root of roots) {
     if (!fs.existsSync(root.dir)) continue;
     const entries = fs
       .readdirSync(root.dir, { withFileTypes: true })

--- a/tests/gateway-service.plugins.test.ts
+++ b/tests/gateway-service.plugins.test.ts
@@ -12,6 +12,7 @@ const {
   checkPluginMock,
   formatDependencyPlanDetailsMock,
   installPluginMock,
+  listBundledInstallablePluginsMock,
   listInstallablePluginsMock,
   pluginDependencyApprovalRequiredError,
   readPluginConfigEntryMock,
@@ -107,6 +108,7 @@ const {
       requiresEnv: ['DEMO_PLUGIN_TOKEN'],
       requiredConfigKeys: ['workspaceId'],
     })),
+    listBundledInstallablePluginsMock: vi.fn(() => []),
     listInstallablePluginsMock: vi.fn(() => []),
     readPluginConfigEntryMock: vi.fn((pluginId: string) => ({
       pluginId,
@@ -231,6 +233,7 @@ vi.mock('../src/plugins/plugin-install.js', () => ({
   checkPlugin: checkPluginMock,
   formatDependencyPlanDetails: formatDependencyPlanDetailsMock,
   installPlugin: installPluginMock,
+  listBundledInstallablePlugins: listBundledInstallablePluginsMock,
   listInstallablePlugins: listInstallablePluginsMock,
   PluginDependencyApprovalRequiredError: pluginDependencyApprovalRequiredError,
   reinstallPlugin: reinstallPluginMock,
@@ -273,6 +276,8 @@ const { setupHome } = setupGatewayTest({
     checkPluginMock.mockClear();
     formatDependencyPlanDetailsMock.mockClear();
     installPluginMock.mockClear();
+    listBundledInstallablePluginsMock.mockReset();
+    listBundledInstallablePluginsMock.mockReturnValue([]);
     listInstallablePluginsMock.mockClear();
     readPluginConfigEntryMock.mockClear();
     readPluginConfigValueMock.mockClear();
@@ -1482,6 +1487,53 @@ test('handleGatewayCommand reports missing binary guidance after plugin install'
   );
 });
 
+test('handleGatewayCommand resolves official web installs from the curated channel catalog', async () => {
+  setupHome();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const result = await handleGatewayCommand({
+    sessionId: 'session-plugin-install-official',
+    guildId: null,
+    channelId: 'web',
+    args: ['plugin', 'install-official', 'whatsapp', '--yes'],
+  });
+
+  expect(installPluginMock).toHaveBeenCalledWith(
+    'https://github.com/HybridAIOne/hybridclaw-whatsapp/releases/download/v0.1.0/hybridaione-hybridclaw-whatsapp-0.1.0.tgz',
+    expect.objectContaining({ approveDependencyInstall: true }),
+  );
+  expect(result.kind).toBe('info');
+});
+
+test('handleGatewayCommand rejects plugin ids outside the official web catalog', async () => {
+  setupHome();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const result = await handleGatewayCommand({
+    sessionId: 'session-plugin-install-unofficial',
+    guildId: null,
+    channelId: 'web',
+    args: ['plugin', 'install-official', '@unknown/plugin', '--yes'],
+  });
+
+  expect(installPluginMock).not.toHaveBeenCalled();
+  expect(result).toMatchObject({
+    kind: 'error',
+    title: 'Official Plugin Not Found',
+    text: 'Plugin `@unknown/plugin` is not in the official HybridClaw catalog.',
+  });
+});
+
 test('handleGatewayCommand rejects plugin install outside local TUI/web sessions', async () => {
   setupHome();
 
@@ -2125,6 +2177,26 @@ test('getGatewayAdminPlugins summarizes plugin status for the admin console', as
       hooks: [],
     },
   ]);
+  listBundledInstallablePluginsMock.mockReturnValue([
+    {
+      id: 'demo-plugin',
+      name: 'Demo Plugin',
+      version: '1.0.0',
+      description: 'Already installed',
+      source: 'bundled',
+      dir: '/tmp/package/plugins/demo-plugin',
+      installSource: 'demo-plugin',
+    },
+    {
+      id: 'official-memory',
+      name: 'Official Memory',
+      version: '0.2.0',
+      description: 'Curated memory plugin',
+      source: 'bundled',
+      dir: '/tmp/package/plugins/official-memory',
+      installSource: 'official-memory',
+    },
+  ]);
 
   const result = await getGatewayAdminPlugins();
 
@@ -2165,6 +2237,29 @@ test('getGatewayAdminPlugins summarizes plugin status for the admin console', as
         commands: ['demo_status'],
         tools: ['demo_tool'],
         hooks: ['gateway_start'],
+      },
+    ],
+    availableOfficialPlugins: [
+      {
+        id: 'line',
+        name: 'LINE',
+        version: null,
+        description: 'Official LINE personal-account transport.',
+        source: 'channel',
+      },
+      {
+        id: 'official-memory',
+        name: 'Official Memory',
+        version: '0.2.0',
+        description: 'Curated memory plugin',
+        source: 'bundled',
+      },
+      {
+        id: 'whatsapp',
+        name: 'WhatsApp',
+        version: null,
+        description: 'Official WhatsApp transport maintained by HybridAIOne.',
+        source: 'channel',
       },
     ],
   });

--- a/tests/plugin-install.test.ts
+++ b/tests/plugin-install.test.ts
@@ -489,6 +489,25 @@ describe('plugin install', () => {
     );
   });
 
+  test('lists the bundled catalog independently from project plugins', async () => {
+    const { listBundledInstallablePlugins } = await import(
+      '../src/plugins/plugin-install.js'
+    );
+
+    const result = listBundledInstallablePlugins();
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.every((plugin) => plugin.source === 'bundled')).toBe(true);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'line',
+          installSource: 'line',
+        }),
+      ]),
+    );
+  });
+
   test('installs manifest-declared npm packages with scripts disabled when no package.json is present', async () => {
     const homeDir = makeTempDir('hybridclaw-plugin-home-');
     const cwd = makeTempDir('hybridclaw-plugin-cwd-');


### PR DESCRIPTION
## Summary

- list official plugins as one-click installs on the console's Plugins & Tools page
- keep a visible direct installer for plugin IDs, npm packages, local paths, and archive URLs
- resolve official catalog IDs inside the gateway while routing direct sources through the existing local install command
- refresh the plugin registry after a successful runtime reload, preserve failed source input, and report failures inline

## Validation

- `npm run lint`
- `npx vitest run tests/gateway-service.plugins.test.ts tests/plugin-install.test.ts tests/channel-transport.test.ts` (3 files, 65 tests)
- `npm --prefix console test` (104 files, 933 tests)
- `npm --prefix console run build`

## Risk notes

- Plugins execute as trusted gateway-host code; direct sources intentionally receive the same trust as plugins installed through the CLI.
- Official one-click installs still resolve against the server-side catalog, and boundary tests verify that unknown official IDs never reach the installer.
- Direct installs accept operator-provided IDs, npm specs, gateway-local paths, and archive URLs through the authenticated local web command boundary.
- Clicking Install approves dependencies declared by the selected source, matching the existing local install behavior.
