### PR TITLE
chore: release v0.29.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## [0.29.3](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.3) - 2026-08-25
+
+### Added
+
+- **Sentry events can carry a pseudonymous deployment user**: Operators can
+  pass a process-only `SENTRY_USER_ID` to correlate gateway errors and
+  background work without allowing stored runtime settings to replace that
+  identity.
+
 ### Fixed
 
 - **Premium-model errors now point at the current free model**: The guidance

--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hybridaione/hybridclaw-console",
   "private": true,
-  "version": "0.29.2",
+  "version": "0.29.3",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/console/src/release-notes.ts
+++ b/console/src/release-notes.ts
@@ -1,8 +1,8 @@
 export const LATEST_RELEASE_NOTES = {
   version: '0.29.3',
   highlights: [
-    'Sentry events support pseudonymous deployment IDs.',
-    'Premium-model errors name the current free model.',
+    'Sentry supports pseudonymous deployment IDs.',
+    'Premium errors name the current free model.',
   ],
 } as const;
 

--- a/console/src/release-notes.ts
+++ b/console/src/release-notes.ts
@@ -1,10 +1,8 @@
 export const LATEST_RELEASE_NOTES = {
-  version: '0.29.2',
+  version: '0.29.3',
   highlights: [
-    'Web apps can start secure realtime voice.',
-    'Signal linking persists and clears stale QRs.',
-    'Teams sends find canonical conversations.',
-    'Desktop and HTML dependencies are hardened.',
+    'Sentry events support pseudonymous deployment IDs.',
+    'Premium-model errors name the current free model.',
   ],
 } as const;
 

--- a/container/npm-shrinkwrap.json
+++ b/container/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.29.2",
+      "version": "0.29.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/container/package-lock.json
+++ b/container/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hybridclaw-agent",
-      "version": "0.29.2",
+      "version": "0.29.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/container/package.json
+++ b/container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hybridclaw-agent",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@hybridaione/hybridclaw-desktop",
   "productName": "HybridClaw",
   "private": true,
-  "version": "0.29.2",
+  "version": "0.29.3",
   "license": "MIT",
   "type": "module",
   "description": "macOS wrapper for the HybridClaw chat and admin web surfaces",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.29.2",
+      "version": "0.29.3",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -81,7 +81,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.29.2",
+      "version": "0.29.3",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "5.101.4",
@@ -107,7 +107,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.29.2",
+      "version": "0.29.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",
@@ -174,7 +174,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.29.2",
+      "version": "0.29.3",
       "license": "MIT",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridaione/hybridclaw",
-      "version": "0.29.2",
+      "version": "0.29.3",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -81,7 +81,7 @@
     },
     "console": {
       "name": "@hybridaione/hybridclaw-console",
-      "version": "0.29.2",
+      "version": "0.29.3",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "5.101.4",
@@ -107,7 +107,7 @@
     },
     "container": {
       "name": "hybridclaw-agent",
-      "version": "0.29.2",
+      "version": "0.29.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",
@@ -174,7 +174,7 @@
     },
     "desktop": {
       "name": "@hybridaione/hybridclaw-desktop",
-      "version": "0.29.2",
+      "version": "0.29.3",
       "license": "MIT",
       "dependencies": {
         "@hybridaione/hybridclaw-desktop-packaging-anchor": "file:./support/packaging-anchor"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hybridaione/hybridclaw",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "type": "module",
   "description": "Enterprise-ready self-hosted AI assistant runtime with sandboxed execution, secure credentials, approvals, and memory",
   "license": "MIT",

--- a/scripts/dependency-policy-baseline.json
+++ b/scripts/dependency-policy-baseline.json
@@ -1,9 +1,9 @@
 {
   "lockfiles": {
-    "package-lock.json": "76d1d8bc4542240857cd44d04a16da9457287cd1686d5bfddbfc92ca151acbe8",
-    "npm-shrinkwrap.json": "76d1d8bc4542240857cd44d04a16da9457287cd1686d5bfddbfc92ca151acbe8",
-    "container/package-lock.json": "ab736fb153fb85c6a1b0f46781b430be560f1d7c8637d1e2263668fb7012796c",
-    "container/npm-shrinkwrap.json": "ab736fb153fb85c6a1b0f46781b430be560f1d7c8637d1e2263668fb7012796c",
+    "package-lock.json": "3de0a24119a334f976d05f004df7755425b488118baaac30132ca132af7c5b6e",
+    "npm-shrinkwrap.json": "3de0a24119a334f976d05f004df7755425b488118baaac30132ca132af7c5b6e",
+    "container/package-lock.json": "1414c2bdde1dacbeff3a94b13594b2d952a6dc39d4d8743480e3d81b382f7be7",
+    "container/npm-shrinkwrap.json": "1414c2bdde1dacbeff3a94b13594b2d952a6dc39d4d8743480e3d81b382f7be7",
     "plugins/brevo-email/package-lock.json": "3377225eb3bdbb252eaa28ad420b9a725ea1da533417388557aa1984730229b5",
     "plugins/line/package-lock.json": "1edbba8cefe83f595528d56ecd9086093c05acdca646594cd3bc043bae9924e8"
   },


### PR DESCRIPTION
## Summary

- bump product and workspace metadata to 0.29.3
- publish release highlights for Sentry deployment-user correlation and corrected free-model guidance
- refresh approved lockfile hashes after reviewed version-only changes

## Validation

- `npm run format`
- `npm run lint`
- `npm run release:check`
- `npm --prefix container run release:check`
- `npx vitest run --configLoader runner --project unit tests/hybridai-request-error.test.ts tests/sentry.test.ts`
- `git diff --check`