### PR TITLE
fix: simplify internal release notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,7 +430,8 @@ When the user says "bump release":
    - any user-facing version text (for example `src/tui.ts` banner)
 3. **Always** update `console/src/release-notes.ts` for the new version with up
    to four ultra-short highlights for the What's New dialog. Do not carry the
-   previous release's version or highlights forward.
+   previous release's version or highlights forward. For a patch release whose
+   changes are only technical or internal, use the single highlight `Bug fixes`.
 4. Review the generated lockfile diff. Even a version-only release changes the
    lockfile bytes, so update the matching SHA-256 entries in
    `scripts/dependency-policy-baseline.json` after confirming that no dependency

--- a/console/src/release-notes.ts
+++ b/console/src/release-notes.ts
@@ -1,9 +1,6 @@
 export const LATEST_RELEASE_NOTES = {
   version: '0.29.3',
-  highlights: [
-    'Sentry supports pseudonymous deployment IDs.',
-    'Premium errors name the current free model.',
-  ],
+  highlights: ['Bug fixes'],
 } as const;
 
 export function getReleaseHighlights(version: string): readonly string[] {


### PR DESCRIPTION
## Summary

- show a single `Bug fixes` highlight for the internal-only v0.29.3 patch
- document the same rule for future internal-only patch releases

## Validation

- `npm --workspace console run test -- src/release-notes.test.ts`
- `npm run lint`
- `npx biome check --write console/src/release-notes.ts`
- `git diff --check`