### PR TITLE
feat: Teams-native multi-session support with /new and /sessions switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+### Added
+
+- **Multiple sessions per chat with `/new` and `/sessions switch`**: `/new`
+  starts a fresh session for the current chat while preserving the previous
+  conversation, `/sessions list` shows the sessions recorded for the chat, and
+  `/sessions switch <number|session-id>` re-activates an earlier one. In
+  Microsoft Teams the session list arrives with an Adaptive Card whose buttons
+  switch sessions or start a new one.
+
+### Changed
+
+- **Microsoft Teams conversations map to sessions the Teams-native way**: every
+  team-channel post is its own session (replying in the post's thread continues
+  it), each group chat is one shared session governed by the group policy
+  instead of blending into members' personal DM sessions, and one-on-one chats
+  keep one ongoing session per user. Existing channel-thread sessions are
+  re-keyed automatically; group chats start fresh sessions under the new
+  per-conversation keys.
+
 ## [0.29.3](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.3) - 2026-08-25
 
 ### Added

--- a/docs/content/channels/msteams.md
+++ b/docs/content/channels/msteams.md
@@ -131,6 +131,29 @@ incremental response. Teams supports this streaming experience only in
 one-on-one chats. Group chats and team channels use the standard typing and
 message-update fallback.
 
+## Sessions
+
+HybridClaw maps Teams conversations to sessions using the containers Teams
+provides natively:
+
+- **Team channels:** every channel post starts its own session. Mention the
+  bot in a new post for a fresh session; reply inside the post's thread to
+  continue that session.
+- **Group chats:** each group chat is one session, shared by all
+  participants. Create another group chat that includes the bot to run a
+  parallel session, and rename the chat to name the session.
+- **Direct messages:** the one-on-one chat is one ongoing session. Send
+  `/new` to start a fresh session; the previous conversation is preserved.
+  Send `/sessions list` to see the sessions for the chat — the reply includes
+  an Adaptive Card with buttons to switch back — or switch directly with
+  `/sessions switch <number|session-id>`.
+
+`/new` and `/sessions` work in every Teams conversation, not only direct
+messages. To surface them as native compose-box suggestions, add both to the
+bot **command list** in the Teams Developer Portal (app -> **Features** ->
+**Bot** -> commands), then publish the new package as described in
+[Update an installed Teams app](#update-an-installed-teams-app).
+
 Generated files are delivered in direct messages through a Teams file-consent
 card. Select **Accept** on that card to upload the file to OneDrive and receive
 an openable file card. The Teams bot file API supports this flow only in
@@ -177,6 +200,7 @@ need a new package.
 | Enable or disable bot file upload and download (`supportsFiles`) | Yes |
 | Add or remove bot scopes (personal, team, group chat) | Yes |
 | Change the app name, description, or icons | Yes |
+| Add compose-box command suggestions (bot command list) | Yes |
 | Change the messaging endpoint | No, it is an Azure Bot resource setting |
 | Rotate `MSTEAMS_APP_PASSWORD` | No |
 | Change DM policy, allowlists, or media limits | No, they are HybridClaw channel settings |
@@ -238,7 +262,8 @@ message until the sender is allowed.
 4. Save the channel settings and send another direct message to the bot.
 
 Using `open` allows any user who can reach the bot to send it direct messages.
-Prefer adding stable AAD object IDs before wider use. Do not use display names
+The DM policy applies only to one-on-one chats; group chats and team channels
+follow **Group policy**. Prefer adding stable AAD object IDs before wider use. Do not use display names
 unless there is no alternative: display names are mutable and not guaranteed
 to be unique.
 

--- a/docs/content/reference/commands.md
+++ b/docs/content/reference/commands.md
@@ -718,6 +718,7 @@ plugins and explicit skill invocations can add dynamic slash commands; use
 | `/memory inspect [sessionId]` | local TUI/web | Inspect built-in memory layers |
 | `/memory query <query>` | local TUI/web | Preview prompt-time memory attachment |
 | `/model [info|list|set|clear|default|select]` | local and chat channels | Inspect or set session/default models |
+| `/new` | local and chat channels | Start a fresh session for the current chat; the previous session stays switchable via `/sessions` |
 | `/paste` | TUI | Attach a copied local file or clipboard image |
 | `/policy [status|list|allow|deny|delete|preset|default|reset]` | local TUI/web | Inspect or update workspace network policy |
 | `/plugin [list|enable|disable|config|install|reinstall|reload|uninstall]` | local TUI/web | Manage runtime plugins |
@@ -727,7 +728,7 @@ plugins and explicit skill invocations can add dynamic slash commands; use
 | `/schedule add|list|remove|toggle ...` | local and chat channels | Manage scheduled tasks for the session |
 | `/secret [list|set|status|unset|route]` | local TUI/web | Manage encrypted secrets and HTTP auth routes |
 | `/second-opinion [compare|validate|fact-check]` | local and chat channels | Ask a stronger configured model to compare, validate, or fact-check |
-| `/sessions [active|clear-active|prune --older-than <duration> [--dry-run|--confirm]]` | local and chat channels | Inspect active session tracking or prune old persisted sessions |
+| `/sessions [list|switch <number|session-id>|active|clear-active|prune --older-than <duration> [--dry-run|--confirm]]` | local and chat channels | List or switch sessions for the current chat, inspect active session tracking, or prune old persisted sessions |
 | `/show [all|thinking|tools|none]` | local and chat channels | Control thinking/tool activity visibility |
 | `/skill ...` or `/<skill>` | local TUI/web | Manage skills or explicitly invoke one skill |
 | `/status` | local and chat channels | Show runtime, session, and agent status |

--- a/src/channels/msteams/delivery.ts
+++ b/src/channels/msteams/delivery.ts
@@ -59,6 +59,73 @@ export function buildAdaptiveCardAttachment(
   return CardFactory.adaptiveCard(card);
 }
 
+export interface MSTeamsSessionSwitcherEntry {
+  sessionId: string;
+  label: string;
+  isCurrent: boolean;
+}
+
+const SESSION_SWITCHER_MAX_ACTIONS = 5;
+const SESSION_SWITCHER_TITLE_LIMIT = 60;
+
+function truncateCardTitle(title: string): string {
+  const normalized = title.trim();
+  if (normalized.length <= SESSION_SWITCHER_TITLE_LIMIT) return normalized;
+  return `${normalized.slice(0, SESSION_SWITCHER_TITLE_LIMIT - 1)}…`;
+}
+
+function buildMessageBackAction(params: {
+  title: string;
+  commandText: string;
+}): Record<string, unknown> {
+  return {
+    type: 'Action.Submit',
+    title: truncateCardTitle(params.title),
+    data: {
+      msteams: {
+        type: 'messageBack',
+        text: params.commandText,
+        displayText: params.commandText,
+      },
+    },
+  };
+}
+
+export function buildMSTeamsSessionSwitcherCard(
+  entries: MSTeamsSessionSwitcherEntry[],
+): Attachment {
+  const actions = entries
+    .filter((entry) => !entry.isCurrent)
+    .slice(0, SESSION_SWITCHER_MAX_ACTIONS)
+    .map((entry) =>
+      buildMessageBackAction({
+        title: entry.label,
+        commandText: `/sessions switch ${entry.sessionId}`,
+      }),
+    );
+  actions.push(
+    buildMessageBackAction({
+      title: 'Start a new session',
+      commandText: '/new',
+    }),
+  );
+
+  return buildAdaptiveCardAttachment({
+    $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
+    type: 'AdaptiveCard',
+    version: '1.4',
+    body: [
+      {
+        type: 'TextBlock',
+        text: 'Switch session',
+        weight: 'Bolder',
+        wrap: true,
+      },
+    ],
+    actions,
+  });
+}
+
 export function formatMSTeamsMarkdown(text: string): string {
   const lines = text.replace(/\r\n?/g, '\n').split('\n');
   let inCodeFence = false;

--- a/src/channels/msteams/inbound.ts
+++ b/src/channels/msteams/inbound.ts
@@ -238,12 +238,37 @@ export function extractTeamsTeamId(activity: Partial<Activity>): string | null {
   return teamId || null;
 }
 
-export function isTeamsDm(activity: Partial<Activity>): boolean {
+export type MSTeamsConversationKind = 'personal' | 'group' | 'channel';
+
+export function resolveTeamsConversationKind(
+  activity: Partial<Activity>,
+): MSTeamsConversationKind {
   const conversationType = normalizeValue(
     activity.conversation?.conversationType,
   ).toLowerCase();
-  if (conversationType === 'personal') return true;
-  return !extractTeamsTeamId(activity);
+  if (conversationType === 'personal') return 'personal';
+  if (conversationType === 'groupchat') return 'group';
+  if (conversationType === 'channel') return 'channel';
+  return extractTeamsTeamId(activity) ? 'channel' : 'personal';
+}
+
+export interface ParsedTeamsConversationId {
+  baseId: string;
+  messageId: string | null;
+}
+
+// Teams channel activities carry the root post id inside conversation.id
+// ("19:...@thread.tacv2;messageid=123"), so every post thread arrives as its
+// own conversation.
+export function parseTeamsConversationId(
+  conversationId: string,
+): ParsedTeamsConversationId {
+  const normalized = normalizeValue(conversationId);
+  const match = normalized.match(/^(.+);messageid=([^;=]+)$/i);
+  if (!match) {
+    return { baseId: normalized, messageId: null };
+  }
+  return { baseId: match[1], messageId: match[2] };
 }
 
 export function hasBotMention(
@@ -297,14 +322,26 @@ export function buildSessionIdFromActivity(
   activity: Partial<Activity>,
   agentId = DEFAULT_AGENT_ID,
 ): string {
-  const actor = extractActorIdentity(activity);
-  const teamId = extractTeamsTeamId(activity);
+  const kind = resolveTeamsConversationKind(activity);
   const conversationId = normalizeValue(activity.conversation?.id);
-  if (!teamId) {
+  if (kind === 'personal') {
+    const actor = extractActorIdentity(activity);
     return buildSessionKey(agentId, 'msteams', 'dm', actor.userId);
   }
-  return buildSessionKey(agentId, 'msteams', 'channel', conversationId, {
-    topicId: teamId,
+  if (kind === 'group') {
+    return buildSessionKey(agentId, 'msteams', 'group', conversationId);
+  }
+
+  const teamId = extractTeamsTeamId(activity);
+  const { baseId, messageId } = parseTeamsConversationId(conversationId);
+  if (messageId) {
+    return buildSessionKey(agentId, 'msteams', 'thread', baseId, {
+      threadId: messageId,
+      ...(teamId ? { topicId: teamId } : {}),
+    });
+  }
+  return buildSessionKey(agentId, 'msteams', 'channel', baseId, {
+    ...(teamId ? { topicId: teamId } : {}),
   });
 }
 

--- a/src/channels/msteams/prompt-adapter.ts
+++ b/src/channels/msteams/prompt-adapter.ts
@@ -21,6 +21,8 @@ export const msteamsAgentPromptAdapter: ChannelAgentPromptAdapter = {
     }
     if (teamId) {
       hints.push(`- Current Teams team: \`${teamId}\`.`);
+    } else if (channelId.startsWith('19:')) {
+      hints.push('- Current Teams context is a group chat.');
     } else {
       hints.push('- Current Teams context is a direct message.');
     }

--- a/src/channels/msteams/runtime.ts
+++ b/src/channels/msteams/runtime.ts
@@ -44,8 +44,8 @@ import {
   extractPrimaryText,
   extractTeamsTeamId,
   hasBotMention,
-  isTeamsDm,
   parseCommand,
+  resolveTeamsConversationKind,
 } from './inbound.js';
 import {
   type ResolveMSTeamsChannelPolicyResult,
@@ -612,7 +612,8 @@ async function handleIncomingMessage(turnContext: TurnContext): Promise<void> {
   const channelId = normalizeValue(activity.conversation?.id);
   if (!channelId) return;
 
-  const isDm = isTeamsDm(activity);
+  const conversationKind = resolveTeamsConversationKind(activity);
+  const isDm = conversationKind === 'personal';
   const policy = resolveMSTeamsChannelPolicy({
     isDm,
     teamId,

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -104,6 +104,7 @@ const REGISTERED_TEXT_COMMAND_NAMES = new Set([
   'plugin',
   'voice',
   'clear',
+  'new',
   'reset',
   'compact',
   'context',
@@ -667,6 +668,9 @@ export function mapCanonicalCommandToGatewayArgs(
     case 'clear':
       return ['clear'];
 
+    case 'new':
+      return ['new'];
+
     case 'reset':
       return parts.length > 1 ? ['reset', ...parts.slice(1)] : ['reset'];
 
@@ -682,7 +686,7 @@ export function mapCanonicalCommandToGatewayArgs(
     }
 
     case 'sessions':
-      return ['sessions'];
+      return ['sessions', ...parts.slice(1)];
 
     case 'audit':
       return ['audit', ...parts.slice(1)];
@@ -2304,6 +2308,11 @@ function buildSlashCommandCatalogDefinitions(
       description: 'Clear session history',
     },
     {
+      name: 'new',
+      description:
+        'Start a fresh session for this chat; the previous session stays switchable via /sessions',
+    },
+    {
       name: 'reset',
       description:
         'Clear session history, reset session settings, and remove the current agent workspace',
@@ -2434,7 +2443,7 @@ function buildSlashCommandCatalogDefinitions(
     {
       name: 'sessions',
       description:
-        'List chat sessions, inspect active sandbox sessions, or prune old persisted sessions',
+        'List or switch sessions for this chat, inspect active sandbox sessions, or prune old persisted sessions',
     },
     {
       name: 'audit',
@@ -3628,6 +3637,9 @@ export function parseCanonicalSlashCommandArgs(
 
     case 'clear':
       return ['clear'];
+
+    case 'new':
+      return ['new'];
 
     case 'reset': {
       const confirm = normalizeStringOption(interaction, 'confirm');

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -292,6 +292,7 @@ import {
   getUsageTotals,
   listMessageTrendByDay,
   listSemanticMemoriesForSession,
+  listSessionInstancesForKey,
   listSessionTrendByDay,
   listStatsByChannel,
   listStructuredAuditEntries,
@@ -304,6 +305,7 @@ import {
   recordRequestLog,
   sessionHasUserMessages,
   setMemoryValue,
+  switchCurrentSessionInstance,
   updateSessionAgent,
   updateSessionChatbot,
   updateSessionModel,
@@ -13308,6 +13310,32 @@ export async function handleGatewayCommand(
         );
       }
 
+      case 'new': {
+        if (!sessionHasUserMessages(session.id)) {
+          return plainCommand('This is already a fresh session.');
+        }
+        const rotated = createFreshSessionInstance(session.id);
+        req.sessionId = rotated.session.id;
+        session = rotated.session;
+        if (pluginManager) {
+          await pluginManager.handleSessionReset({
+            previousSessionId: rotated.previousSession.id,
+            sessionId: rotated.session.id,
+            userId: String(req.userId || ''),
+            agentId: resolveSessionAgentId(rotated.previousSession),
+            channelId: req.channelId,
+            reason: 'new',
+          });
+        }
+        return infoCommand(
+          'New Session',
+          [
+            'Started a fresh session for this chat.',
+            `The previous session (${rotated.deletedMessages} message${rotated.deletedMessages === 1 ? '' : 's'}) is preserved — use \`/sessions list\` and \`/sessions switch\` to continue it later.`,
+          ].join('\n'),
+        );
+      }
+
       case 'reset': {
         const sub = parseLowerArg(req.args, 1);
         if (sub && sub !== 'yes' && sub !== 'no') {
@@ -13791,6 +13819,102 @@ export async function handleGatewayCommand(
 
       case 'sessions': {
         const sub = parseLowerArg(req.args, 1);
+        if (sub === 'list') {
+          const sessionKey = session.session_key || session.id;
+          const instances = listSessionInstancesForKey(sessionKey, {
+            limit: 10,
+          });
+          if (instances.length === 0) {
+            return plainCommand('No sessions recorded for this chat yet.');
+          }
+          const boundariesBySessionId = getSessionBoundaryMessagesBySessionIds(
+            instances.map((instance) => instance.id),
+          );
+          const describeInstance = (
+            instance: (typeof instances)[number],
+          ): string => {
+            const boundary = boundariesBySessionId.get(instance.id) || {
+              firstMessage: null,
+              lastMessage: null,
+            };
+            return `${instance.message_count} msgs, last: ${formatDisplayTimestamp(instance.last_active)}${formatSessionSnippetSummary(boundary)}`;
+          };
+          const lines = instances.map((instance, index) => {
+            const marker = instance.is_current ? ' — current' : '';
+            return `${index + 1}. \`${instance.id}\`${marker} — ${describeInstance(instance)}`;
+          });
+          return infoCommand(
+            'Sessions For This Chat',
+            [
+              ...lines,
+              '',
+              'Use `/sessions switch <number|session-id>` to continue an older session, or `/new` to start a fresh one.',
+            ].join('\n'),
+            undefined,
+            {
+              sessionSwitcher: instances.map((instance, index) => ({
+                sessionId: instance.id,
+                label: `${index + 1}. ${describeInstance(instance)}`,
+                isCurrent: Boolean(instance.is_current),
+              })),
+            },
+          );
+        }
+        if (sub === 'switch') {
+          const targetArg = parseIdArg(req.args, 2);
+          if (!targetArg) {
+            return badCommand(
+              'Usage',
+              'Usage: `sessions switch <number|session-id>` — numbers come from `sessions list`.',
+            );
+          }
+          const sessionKey = session.session_key || session.id;
+          let targetSessionId = targetArg;
+          if (/^\d{1,2}$/.test(targetArg)) {
+            const instances = listSessionInstancesForKey(sessionKey, {
+              limit: 10,
+            });
+            const byIndex = instances[Number(targetArg) - 1];
+            if (!byIndex) {
+              return badCommand(
+                'Not Found',
+                `No session ${targetArg} in \`sessions list\` for this chat.`,
+              );
+            }
+            targetSessionId = byIndex.id;
+          }
+          let switched: ReturnType<typeof switchCurrentSessionInstance>;
+          try {
+            switched = switchCurrentSessionInstance({
+              sessionKey,
+              targetSessionId,
+            });
+          } catch (error) {
+            return badCommand('Switch Failed', (error as Error).message);
+          }
+          if (switched.previousSession?.id === switched.session.id) {
+            return plainCommand(
+              `Session \`${switched.session.id}\` is already active.`,
+            );
+          }
+          req.sessionId = switched.session.id;
+          const previousSession = switched.previousSession;
+          session = switched.session;
+          if (pluginManager && previousSession) {
+            await pluginManager.handleSessionReset({
+              previousSessionId: previousSession.id,
+              sessionId: switched.session.id,
+              userId: String(req.userId || ''),
+              agentId: resolveSessionAgentId(previousSession),
+              channelId: req.channelId,
+              reason: 'switch',
+            });
+          }
+          return infoCommand(
+            'Session Switched',
+            `Now continuing session \`${switched.session.id}\` (${switched.session.message_count} message${switched.session.message_count === 1 ? '' : 's'}).`,
+          );
+        }
         if (sub === 'active') {
           const activeSessionIds = getActiveExecutorSessionIds();
           if (activeSessionIds.length === 0) {
@@ -13915,7 +14039,7 @@ export async function handleGatewayCommand(
         if (sub) {
           return badCommand(
             'Usage',
-            `Usage: \`sessions\`, \`sessions active\`, \`sessions clear-active\`, or ${SESSION_PRUNE_USAGE.replace(
+            `Usage: \`sessions\`, \`sessions list\`, \`sessions switch <number|session-id>\`, \`sessions active\`, \`sessions clear-active\`, or ${SESSION_PRUNE_USAGE.replace(
               'Usage: ',
               '',
             )}`,

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -68,6 +68,12 @@ export interface GatewayModelCatalogEntry {
   recommended?: boolean;
 }
 
+export interface GatewaySessionSwitcherEntry {
+  sessionId: string;
+  label: string;
+  isCurrent: boolean;
+}
+
 export interface GatewayCommandResult {
   kind: 'plain' | 'info' | 'error';
   title?: string;
@@ -77,6 +83,7 @@ export interface GatewayCommandResult {
   mainSessionKey?: string;
   components?: GatewayMessageComponents;
   modelCatalog?: GatewayModelCatalogEntry[];
+  sessionSwitcher?: GatewaySessionSwitcherEntry[];
 }
 
 export interface GatewayAssistantPresentation {

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -76,7 +76,10 @@ import {
   shutdownLine,
 } from '../channels/line/runtime.js';
 import { isLineChannelId } from '../channels/line/target.js';
-import { stripUnusableMSTeamsArtifactLinks } from '../channels/msteams/delivery.js';
+import {
+  buildMSTeamsSessionSwitcherCard,
+  stripUnusableMSTeamsArtifactLinks,
+} from '../channels/msteams/delivery.js';
 import {
   mapMSTeamsReactionToRating,
   recordMSTeamsRatingTargets,
@@ -254,6 +257,7 @@ import type {
   GatewayChatApprovalEvent,
   GatewayChatRequest,
   GatewayChatResult,
+  GatewayCommandResult,
 } from './gateway-types.js';
 import { runManagedMediaCleanup } from './managed-media-cleanup.js';
 import {
@@ -801,6 +805,14 @@ async function handleTextChannelCommand(params: {
   username: string;
   args: string[];
   reply: ReplyFn;
+  /**
+   * Channel-specific presentation hook. Return true after delivering the
+   * result to skip the default text reply.
+   */
+  onCommandResult?: (
+    result: GatewayCommandResult,
+    renderedText: string,
+  ) => Promise<boolean>;
 }): Promise<void> {
   const { sessionId, guildId, channelId, userId, username, args, reply } =
     params;
@@ -842,6 +854,9 @@ async function handleTextChannelCommand(params: {
     },
   });
   const text = renderTextChannelCommandResult(result);
+  if (params.onCommandResult && (await params.onCommandResult(result, text))) {
+    return;
+  }
   if (result.components !== undefined) {
     await reply(text, undefined, result.components);
     return;
@@ -1896,6 +1911,13 @@ async function startMSTeamsIntegration(): Promise<boolean> {
           username,
           args,
           reply: bridgedReply,
+          onCommandResult: async (result, renderedText) => {
+            if (!result.sessionSwitcher?.length) return false;
+            await reply(renderedText, [
+              buildMSTeamsSessionSwitcherCard(result.sessionSwitcher),
+            ]);
+            return true;
+          },
         });
       } catch (error) {
         logger.error(

--- a/src/memory/schema/migrations.ts
+++ b/src/memory/schema/migrations.ts
@@ -16,12 +16,14 @@ import {
 import { parseUserId } from '../../identity/user-id.js';
 import { logger } from '../../logger.js';
 import {
+  buildSessionKey,
   inspectSessionKeyMigration,
   isLegacySessionKey,
+  parseSessionKey,
 } from '../../session/session-key.js';
 import type { CanonicalSessionMessage, Session } from '../../types/session.js';
 
-export const DATABASE_SCHEMA_VERSION = 55;
+export const DATABASE_SCHEMA_VERSION = 56;
 const AGENT_CANONICAL_ID_COLLISION_LIMIT = 20;
 const AUDIT_ACTOR_MIGRATION_BATCH_SIZE = 500;
 const ACTOR_ID_MAX_LENGTH =
@@ -3441,6 +3443,63 @@ function migrateV55(
   recordMigration(database, 55, 'Persist message source (e.g. voice turns)');
 }
 
+function migrateV56(database: Database.Database): void {
+  // Teams channel activities embed the root post id in conversation.id
+  // ("...;messageid=123"). Those sessions are now keyed as chat-type
+  // "thread" with the post id split into the thread segment.
+  if (
+    tableExists(database, 'sessions') &&
+    columnExists(database, 'sessions', 'session_key')
+  ) {
+    const rows = database
+      .prepare(
+        `SELECT DISTINCT session_key
+         FROM sessions
+         WHERE session_key LIKE 'agent:%:channel:msteams:chat:channel:peer:%'`,
+      )
+      .all() as Array<{ session_key: string }>;
+    const updateSessions = database.prepare(
+      `UPDATE sessions
+       SET main_session_key = CASE
+             WHEN main_session_key = ? THEN ?
+             ELSE main_session_key
+           END,
+           session_key = ?
+       WHERE session_key = ?`,
+    );
+    const updateKvStore = tableExists(database, 'kv_store')
+      ? database.prepare(
+          'UPDATE OR IGNORE kv_store SET agent_id = ? WHERE agent_id = ?',
+        )
+      : null;
+    for (const row of rows) {
+      const parsed = parseSessionKey(row.session_key);
+      if (parsed?.channelKind !== 'msteams' || parsed.chatType !== 'channel') {
+        continue;
+      }
+      const match = parsed.peerId.match(/^(.+);messageid=([^;=]+)$/i);
+      if (!match) continue;
+      const nextKey = buildSessionKey(
+        parsed.agentId,
+        'msteams',
+        'thread',
+        match[1],
+        {
+          threadId: match[2],
+          ...(parsed.topicId ? { topicId: parsed.topicId } : {}),
+        },
+      );
+      updateSessions.run(row.session_key, nextKey, nextKey, row.session_key);
+      updateKvStore?.run(nextKey, row.session_key);
+    }
+  }
+  recordMigration(
+    database,
+    56,
+    'Re-key Teams channel-thread sessions as chat-type thread',
+  );
+}
+
 export function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -3577,6 +3636,7 @@ export function runMigrations(
   if (currentVersion < 55 || messageSourceNeedMigration(database)) {
     migrateV55(database, opts);
   }
+  if (currentVersion < 56) migrateV56(database);
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);
   if (!quiet && currentVersion < DATABASE_SCHEMA_VERSION) {

--- a/src/memory/sessions.ts
+++ b/src/memory/sessions.ts
@@ -794,6 +794,61 @@ export function createFreshSessionInstance(
   };
 }
 
+export function listSessionInstancesForKey(
+  sessionKey: string,
+  options?: { limit?: number },
+): Session[] {
+  const normalizedKey = String(sessionKey || '').trim();
+  if (!normalizedKey) return [];
+  const limit = Math.max(1, Math.floor(options?.limit ?? 10));
+  return queryAll<Session, [string, number]>(
+    getSessionDatabase(),
+    `SELECT *
+     FROM sessions
+     WHERE session_key = ?
+     ORDER BY is_current DESC, last_active DESC
+     LIMIT ?`,
+    normalizedKey,
+    limit,
+  );
+}
+
+export function switchCurrentSessionInstance(params: {
+  sessionKey: string;
+  targetSessionId: string;
+}): { previousSession: Session | null; session: Session } {
+  const normalizedKey = String(params.sessionKey || '').trim();
+  const target = getSessionById(String(params.targetSessionId || '').trim());
+  if (!target) {
+    throw new Error(`Session ${params.targetSessionId} was not found.`);
+  }
+  if (!normalizedKey || target.session_key !== normalizedKey) {
+    throw new Error(
+      `Session ${target.id} does not belong to this conversation.`,
+    );
+  }
+  const previousSession =
+    selectCurrentSessionBySessionKey(normalizedKey) || null;
+  if (previousSession?.id === target.id) {
+    return { previousSession, session: target };
+  }
+
+  const nowIso = new Date().toISOString();
+  const switchTx = getSessionDatabase().transaction(() => {
+    getSessionDatabase()
+      .prepare('UPDATE sessions SET is_current = 0 WHERE session_key = ?')
+      .run(normalizedKey);
+    getSessionDatabase()
+      .prepare(
+        'UPDATE sessions SET is_current = 1, last_active = ? WHERE id = ?',
+      )
+      .run(nowIso, target.id);
+  });
+  switchTx();
+
+  return { previousSession, session: requireSessionById(target.id) };
+}
+
 export function getAnyChatbotId(): string | null {
   const row = queryOne<Pick<Session, 'chatbot_id'>>(
     getSessionDatabase(),

--- a/src/plugins/plugin-types.ts
+++ b/src/plugins/plugin-types.ts
@@ -237,7 +237,13 @@ export interface PluginSessionResetContext {
   userId: string;
   agentId: string;
   channelId: string;
-  reason: 'clear' | 'reset' | 'auto-reset' | 'workspace-reset';
+  reason:
+    | 'clear'
+    | 'new'
+    | 'reset'
+    | 'auto-reset'
+    | 'switch'
+    | 'workspace-reset';
 }
 
 export interface PluginCompactionContext {

--- a/tests/discord-slash-commands.test.ts
+++ b/tests/discord-slash-commands.test.ts
@@ -55,6 +55,7 @@ test('buildSlashCommandDefinitions includes the expanded Discord command set', (
       'memory',
       'plugin',
       'clear',
+      'new',
       'reset',
       'usage',
       'export',

--- a/tests/gateway-service.session-switch.test.ts
+++ b/tests/gateway-service.session-switch.test.ts
@@ -1,0 +1,143 @@
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
+
+const ORIGINAL_HOME = process.env.HOME;
+
+const makeTempHome = useTempDir('hybridclaw-gateway-session-switch-');
+
+useCleanMocks({
+  restoreAllMocks: true,
+  cleanup: () => {
+    if (ORIGINAL_HOME === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = ORIGINAL_HOME;
+    }
+  },
+  resetModules: true,
+});
+
+const SESSION_KEY = 'agent:main:channel:msteams:chat:dm:peer:user-1';
+
+async function seedSessionFixture() {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const { initDatabase, getOrCreateSession } = await import(
+    '../src/memory/db.ts'
+  );
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const session = getOrCreateSession(SESSION_KEY, null, 'a:1');
+  memoryService.storeMessage({
+    sessionId: session.id,
+    userId: 'user-1',
+    username: 'user',
+    role: 'user',
+    content: 'first conversation',
+  });
+
+  return { handleGatewayCommand, getOrCreateSession, session };
+}
+
+test('new rotates to a fresh session and keeps the previous instance', async () => {
+  const fixture = await seedSessionFixture();
+
+  const result = await fixture.handleGatewayCommand({
+    sessionId: SESSION_KEY,
+    guildId: null,
+    channelId: 'a:1',
+    userId: 'user-1',
+    username: 'user',
+    args: ['new'],
+  });
+
+  expect(result.kind).toBe('info');
+  expect(result.text).toContain('preserved');
+  const current = fixture.getOrCreateSession(SESSION_KEY, null, 'a:1');
+  expect(current.id).not.toBe(fixture.session.id);
+  expect(current.message_count).toBe(0);
+});
+
+test('new on a fresh session is a no-op', async () => {
+  const fixture = await seedSessionFixture();
+
+  await fixture.handleGatewayCommand({
+    sessionId: SESSION_KEY,
+    guildId: null,
+    channelId: 'a:1',
+    userId: 'user-1',
+    username: 'user',
+    args: ['new'],
+  });
+  const result = await fixture.handleGatewayCommand({
+    sessionId: SESSION_KEY,
+    guildId: null,
+    channelId: 'a:1',
+    userId: 'user-1',
+    username: 'user',
+    args: ['new'],
+  });
+
+  expect(result.text).toContain('already a fresh session');
+});
+
+test('sessions list and switch move between instances of this chat', async () => {
+  const fixture = await seedSessionFixture();
+
+  await fixture.handleGatewayCommand({
+    sessionId: SESSION_KEY,
+    guildId: null,
+    channelId: 'a:1',
+    userId: 'user-1',
+    username: 'user',
+    args: ['new'],
+  });
+
+  const listed = await fixture.handleGatewayCommand({
+    sessionId: SESSION_KEY,
+    guildId: null,
+    channelId: 'a:1',
+    userId: 'user-1',
+    username: 'user',
+    args: ['sessions', 'list'],
+  });
+  expect(listed.title).toBe('Sessions For This Chat');
+  expect(listed.sessionSwitcher).toHaveLength(2);
+  expect(listed.sessionSwitcher?.[0].isCurrent).toBe(true);
+  expect(listed.sessionSwitcher?.[1].sessionId).toBe(fixture.session.id);
+
+  const switched = await fixture.handleGatewayCommand({
+    sessionId: SESSION_KEY,
+    guildId: null,
+    channelId: 'a:1',
+    userId: 'user-1',
+    username: 'user',
+    args: ['sessions', 'switch', '2'],
+  });
+  expect(switched.title).toBe('Session Switched');
+  expect(fixture.getOrCreateSession(SESSION_KEY, null, 'a:1').id).toBe(
+    fixture.session.id,
+  );
+});
+
+test('sessions switch rejects unknown targets', async () => {
+  const fixture = await seedSessionFixture();
+
+  const result = await fixture.handleGatewayCommand({
+    sessionId: SESSION_KEY,
+    guildId: null,
+    channelId: 'a:1',
+    userId: 'user-1',
+    username: 'user',
+    args: ['sessions', 'switch', 'sess_does_not_exist'],
+  });
+
+  expect(result.kind).toBe('error');
+  expect(result.title).toBe('Switch Failed');
+});

--- a/tests/msteams-thread-key-migration.test.ts
+++ b/tests/msteams-thread-key-migration.test.ts
@@ -1,0 +1,97 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, expect, test, vi } from 'vitest';
+
+let tempDir: string | null = null;
+const ORIGINAL_HOME = process.env.HOME;
+
+afterEach(() => {
+  vi.resetModules();
+  if (ORIGINAL_HOME === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = ORIGINAL_HOME;
+  }
+  if (tempDir) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  }
+});
+
+const OLD_KEY =
+  'agent:main:channel:msteams:chat:channel:peer:19%3Achannel%40thread.tacv2%3Bmessageid%3D175:topic:19%3Ateam%40thread.tacv2';
+const NEW_KEY =
+  'agent:main:channel:msteams:chat:thread:peer:19%3Achannel%40thread.tacv2:thread:175:topic:19%3Ateam%40thread.tacv2';
+const PLAIN_CHANNEL_KEY =
+  'agent:main:channel:msteams:chat:channel:peer:19%3Aother%40thread.tacv2:topic:19%3Ateam%40thread.tacv2';
+
+test('migrateV56 re-keys Teams channel-thread sessions', async () => {
+  tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hybridclaw-msteams-thread-key-migration-'),
+  );
+  process.env.HOME = tempDir;
+  const dbPath = path.join(tempDir, 'hybridclaw.db');
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  initDatabase({ quiet: true, dbPath });
+
+  const seeded = new Database(dbPath);
+  const insertSession = seeded.prepare(
+    `INSERT INTO sessions (id, session_key, main_session_key, is_current, guild_id, channel_id, agent_id)
+     VALUES (?, ?, ?, ?, ?, ?, 'main')`,
+  );
+  insertSession.run(
+    'sess_old_thread',
+    OLD_KEY,
+    OLD_KEY,
+    1,
+    '19:team@thread.tacv2',
+    '19:channel@thread.tacv2;messageid=175',
+  );
+  insertSession.run(
+    'sess_plain_channel',
+    PLAIN_CHANNEL_KEY,
+    PLAIN_CHANNEL_KEY,
+    1,
+    '19:team@thread.tacv2',
+    '19:other@thread.tacv2',
+  );
+  seeded
+    .prepare(
+      `INSERT INTO kv_store (agent_id, key, value, version, updated_at)
+       VALUES (?, 'msteams:conversation-reference', '{}', 1, datetime('now'))`,
+    )
+    .run(OLD_KEY);
+  seeded.pragma('user_version = 55');
+  seeded.close();
+
+  initDatabase({ quiet: true, dbPath });
+
+  const migrated = new Database(dbPath, { readonly: true });
+  try {
+    const threadRow = migrated
+      .prepare('SELECT session_key, main_session_key FROM sessions WHERE id = ?')
+      .get('sess_old_thread') as {
+      session_key: string;
+      main_session_key: string;
+    };
+    expect(threadRow.session_key).toBe(NEW_KEY);
+    expect(threadRow.main_session_key).toBe(NEW_KEY);
+
+    const plainRow = migrated
+      .prepare('SELECT session_key FROM sessions WHERE id = ?')
+      .get('sess_plain_channel') as { session_key: string };
+    expect(plainRow.session_key).toBe(PLAIN_CHANNEL_KEY);
+
+    const kvRow = migrated
+      .prepare(
+        "SELECT agent_id FROM kv_store WHERE key = 'msteams:conversation-reference'",
+      )
+      .get() as { agent_id: string };
+    expect(kvRow.agent_id).toBe(NEW_KEY);
+  } finally {
+    migrated.close();
+  }
+});

--- a/tests/msteams.delivery.test.ts
+++ b/tests/msteams.delivery.test.ts
@@ -2,11 +2,36 @@ import { expect, test, vi } from 'vitest';
 
 import {
   buildMSTeamsMessageActivity,
+  buildMSTeamsSessionSwitcherCard,
   formatMSTeamsMarkdown,
   prepareChunkedActivities,
   sendChunkedReply,
   stripUnusableMSTeamsArtifactLinks,
 } from '../src/channels/msteams/delivery.js';
+
+test('buildMSTeamsSessionSwitcherCard offers switch and new-session actions', () => {
+  const attachment = buildMSTeamsSessionSwitcherCard([
+    { sessionId: 'sess_current', label: '1. current', isCurrent: true },
+    { sessionId: 'sess_older', label: '2. older chat', isCurrent: false },
+  ]);
+
+  expect(attachment.contentType).toBe(
+    'application/vnd.microsoft.card.adaptive',
+  );
+  const card = attachment.content as {
+    actions: Array<{
+      title: string;
+      data: { msteams: { type: string; text: string } };
+    }>;
+  };
+  expect(card.actions).toHaveLength(2);
+  expect(card.actions[0].title).toBe('2. older chat');
+  expect(card.actions[0].data.msteams).toMatchObject({
+    type: 'messageBack',
+    text: '/sessions switch sess_older',
+  });
+  expect(card.actions[1].data.msteams.text).toBe('/new');
+});
 
 test('stripUnusableMSTeamsArtifactLinks keeps artifact names but removes local URLs', () => {
   expect(

--- a/tests/msteams.inbound.test.ts
+++ b/tests/msteams.inbound.test.ts
@@ -156,3 +156,99 @@ test('cleanIncomingContent falls back to HTML attachment content', async () => {
     }),
   ).toBe('Hello world One Two');
 });
+
+test('parseTeamsConversationId splits the channel root post id', async () => {
+  const { parseTeamsConversationId } = await importInboundModule();
+
+  expect(
+    parseTeamsConversationId('19:channel@thread.tacv2;messageid=1755000000001'),
+  ).toEqual({
+    baseId: '19:channel@thread.tacv2',
+    messageId: '1755000000001',
+  });
+  expect(parseTeamsConversationId('19:group@thread.v2')).toEqual({
+    baseId: '19:group@thread.v2',
+    messageId: null,
+  });
+});
+
+test('resolveTeamsConversationKind classifies personal, group, and channel chats', async () => {
+  const { resolveTeamsConversationKind } = await importInboundModule();
+
+  expect(
+    resolveTeamsConversationKind({
+      conversation: { conversationType: 'personal', id: 'a:1' },
+    } as never),
+  ).toBe('personal');
+  expect(
+    resolveTeamsConversationKind({
+      conversation: { conversationType: 'groupChat', id: '19:group@thread.v2' },
+    } as never),
+  ).toBe('group');
+  expect(
+    resolveTeamsConversationKind({
+      conversation: { id: '19:channel@thread.tacv2;messageid=5' },
+      channelData: { team: { id: '19:team@thread.tacv2' } },
+    } as never),
+  ).toBe('channel');
+  expect(
+    resolveTeamsConversationKind({
+      conversation: { id: 'a:legacy' },
+    } as never),
+  ).toBe('personal');
+});
+
+test('buildSessionIdFromActivity keys personal chats by user', async () => {
+  const { buildSessionIdFromActivity } = await importInboundModule();
+
+  expect(
+    buildSessionIdFromActivity({
+      conversation: { conversationType: 'personal', id: 'a:1' },
+      from: { id: '29:enc', aadObjectId: 'User-AAD' },
+    } as never),
+  ).toBe('agent:main:channel:msteams:chat:dm:peer:user-aad');
+});
+
+test('buildSessionIdFromActivity keys group chats by conversation', async () => {
+  const { buildSessionIdFromActivity } = await importInboundModule();
+
+  expect(
+    buildSessionIdFromActivity({
+      conversation: {
+        conversationType: 'groupChat',
+        id: '19:Group@thread.v2',
+      },
+      from: { id: '29:enc', aadObjectId: 'user-aad' },
+    } as never),
+  ).toBe('agent:main:channel:msteams:chat:group:peer:19%3Agroup%40thread.v2');
+});
+
+test('buildSessionIdFromActivity keys channel posts as per-thread sessions', async () => {
+  const { buildSessionIdFromActivity } = await importInboundModule();
+
+  expect(
+    buildSessionIdFromActivity({
+      conversation: {
+        conversationType: 'channel',
+        id: '19:channel@thread.tacv2;messageid=1755000000001',
+      },
+      channelData: { team: { id: '19:team@thread.tacv2' } },
+      from: { id: '29:enc', aadObjectId: 'user-aad' },
+    } as never),
+  ).toBe(
+    'agent:main:channel:msteams:chat:thread:peer:19%3Achannel%40thread.tacv2:thread:1755000000001:topic:19%3Ateam%40thread.tacv2',
+  );
+
+  expect(
+    buildSessionIdFromActivity({
+      conversation: {
+        conversationType: 'channel',
+        id: '19:channel@thread.tacv2',
+      },
+      channelData: { team: { id: '19:team@thread.tacv2' } },
+      from: { id: '29:enc', aadObjectId: 'user-aad' },
+    } as never),
+  ).toBe(
+    'agent:main:channel:msteams:chat:channel:peer:19%3Achannel%40thread.tacv2:topic:19%3Ateam%40thread.tacv2',
+  );
+});

--- a/tests/msteams.runtime.test.ts
+++ b/tests/msteams.runtime.test.ts
@@ -192,7 +192,7 @@ async function importRuntime() {
     })),
     extractTeamsTeamId: vi.fn(() => null),
     hasBotMention: vi.fn(() => false),
-    isTeamsDm: vi.fn(() => true),
+    resolveTeamsConversationKind: vi.fn(() => 'personal'),
     parseCommand: parseCommandMock,
   }));
   vi.doMock('../src/channels/msteams/send-permissions.js', () => ({

--- a/tests/session-instances.test.ts
+++ b/tests/session-instances.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from 'vitest';
+
+import { setupGatewayTest } from './helpers/gateway-test-setup.js';
+
+const { setupHome } = setupGatewayTest({
+  tempHomePrefix: 'hybridclaw-session-instances-',
+});
+
+const SESSION_KEY = 'agent:main:channel:msteams:chat:dm:peer:user-1';
+const OTHER_SESSION_KEY = 'agent:main:channel:msteams:chat:dm:peer:user-2';
+
+test('listSessionInstancesForKey returns the current instance first', async () => {
+  setupHome();
+
+  const {
+    createFreshSessionInstance,
+    getOrCreateSession,
+    initDatabase,
+    listSessionInstancesForKey,
+  } = await import('../src/memory/db.ts');
+
+  initDatabase({ quiet: true });
+  const first = getOrCreateSession(SESSION_KEY, null, 'a:1');
+  const rotated = createFreshSessionInstance(first.id);
+
+  const instances = listSessionInstancesForKey(SESSION_KEY);
+  expect(instances.map((instance) => instance.id)).toEqual([
+    rotated.session.id,
+    first.id,
+  ]);
+  expect(instances[0].is_current).toBe(1);
+  expect(instances[1].is_current).toBe(0);
+});
+
+test('switchCurrentSessionInstance re-points the session key', async () => {
+  setupHome();
+
+  const {
+    createFreshSessionInstance,
+    getOrCreateSession,
+    initDatabase,
+    switchCurrentSessionInstance,
+  } = await import('../src/memory/db.ts');
+
+  initDatabase({ quiet: true });
+  const first = getOrCreateSession(SESSION_KEY, null, 'a:1');
+  const rotated = createFreshSessionInstance(first.id);
+  expect(getOrCreateSession(SESSION_KEY, null, 'a:1').id).toBe(
+    rotated.session.id,
+  );
+
+  const switched = switchCurrentSessionInstance({
+    sessionKey: SESSION_KEY,
+    targetSessionId: first.id,
+  });
+  expect(switched.previousSession?.id).toBe(rotated.session.id);
+  expect(switched.session.id).toBe(first.id);
+  expect(switched.session.is_current).toBe(1);
+  expect(getOrCreateSession(SESSION_KEY, null, 'a:1').id).toBe(first.id);
+});
+
+test('switchCurrentSessionInstance is a no-op for the active instance', async () => {
+  setupHome();
+
+  const { getOrCreateSession, initDatabase, switchCurrentSessionInstance } =
+    await import('../src/memory/db.ts');
+
+  initDatabase({ quiet: true });
+  const session = getOrCreateSession(SESSION_KEY, null, 'a:1');
+
+  const switched = switchCurrentSessionInstance({
+    sessionKey: SESSION_KEY,
+    targetSessionId: session.id,
+  });
+  expect(switched.previousSession?.id).toBe(session.id);
+  expect(switched.session.id).toBe(session.id);
+});
+
+test('switchCurrentSessionInstance rejects instances from other conversations', async () => {
+  setupHome();
+
+  const { getOrCreateSession, initDatabase, switchCurrentSessionInstance } =
+    await import('../src/memory/db.ts');
+
+  initDatabase({ quiet: true });
+  getOrCreateSession(SESSION_KEY, null, 'a:1');
+  const other = getOrCreateSession(OTHER_SESSION_KEY, null, 'a:2');
+
+  expect(() =>
+    switchCurrentSessionInstance({
+      sessionKey: SESSION_KEY,
+      targetSessionId: other.id,
+    }),
+  ).toThrow(/does not belong to this conversation/);
+});


### PR DESCRIPTION
## Summary

Makes multiple parallel sessions possible in Microsoft Teams by leaning on the conversation containers Teams provides natively, and adds a channel-agnostic `/new` + `/sessions switch` flow for surfaces without a native container (1:1 chats).

### Tier 1 — Teams-native session mapping

- **Team channels:** every channel post is its own session. The `;messageid=<rootPostId>` suffix Teams embeds in `conversation.id` is now parsed into a `chat:thread` session key with a proper `threadId`; replying in the post's thread continues that session.
- **Group chats:** previously conflated with personal DMs — a group message landed in the *sender's own DM session*, so each participant talked to a different session. Group chats are now keyed per conversation (`chat:group`), shared by all participants, governed by **Group policy** instead of DM policy, and no longer attempt DM-only features (native streaming, file-consent cards).
- **Migration V56** re-keys existing channel-thread sessions (and their stored conversation references) so channel conversations keep their history across the upgrade. Group chats cannot be migrated (their history is blended into personal DM sessions) and start fresh under the new keys.

### Tier 2 — `/new` and `/sessions` switching

- `/new` rotates the current chat to a fresh session instance; the previous conversation is preserved and switchable (unlike `/clear`). No-ops on an already-empty session.
- `/sessions list` shows the sessions recorded for the current chat; `/sessions switch <number|session-id>` re-activates an earlier one. Plugin `session_reset` hooks fire with the new `new`/`switch` reasons.
- In Teams, `/sessions list` replies with an **Adaptive Card** whose `messageBack` buttons run `/sessions switch …` or `/new` — the closest thing Teams has to a native session picker. Other channels keep the plain-text rendering.
- Side-effect fix: `/sessions active|clear-active|prune` arguments were silently dropped when typed in chat channels; args now pass through.

### Docs

- `docs/content/channels/msteams.md`: new **Sessions** section, including the one-time manual step of registering `/new` and `/sessions` in the Teams app manifest command list so they appear as compose-box suggestions.
- `docs/content/reference/commands.md` and `CHANGELOG.md` updated.

## Testing

- New tests: Teams session-key mapping (personal/group/channel-thread), V56 migration, session-instance list/switch, gateway `/new` + `/sessions list|switch` commands, Adaptive Card builder.
- `npm run typecheck`, `npm run lint`, and biome are clean on touched files.
- Full unit suite passes except four pre-existing environment failures unrelated to this change (worktree-local `node_modules`/CLI path expectations: eval-command, admin-terminal, host-runner suites).

## Notes

- Built with meaningful AI assistance (Claude); diff reviewed and tests verified by the author.
