### PR TITLE
feat(speech): move realtime config to speech.realtime with full command and console surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### Added
+
+- **Realtime speech settings are now visible and editable everywhere**: The
+  new `/speech` command reports the realtime provider — including which
+  backend `auto` resolved to — model, voice, and credential status, and
+  `/speech provider|model|voice <value>` changes a setting from a local
+  session. The admin console gains a Speech settings section, and the voice
+  channel editor gains the missing call-mode selector plus a Realtime speech
+  section (provider, model, voice, greeting, extra instructions). In web
+  chat, hovering the voice button or the live-call capsule shows the active
+  provider, model, and voice.
+
+### Changed
+
+- **Realtime speech config moved out of the phone channel**: The settings
+  formerly at `voice.realtime.*` now live at the top-level
+  `speech.realtime.*`, reflecting that they drive realtime phone calls, web
+  console voice mode, and plugin realtime sessions alike — web voice works
+  with the Twilio channel disabled. Existing configs are migrated
+  automatically on startup; `voice.*` remains purely the Twilio phone
+  channel.
+
 ## [0.29.3](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.3) - 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
   channel editor gains the missing call-mode selector plus a Realtime speech
   section (provider, model, voice, greeting, extra instructions). In web
   chat, hovering the voice button or the live-call capsule shows the active
-  provider, model, and voice.
+  provider, model, and voice, and the channels catalog marks the Voice card
+  "realtime speech ready" when a realtime credential is available even
+  without Twilio.
 
 ### Changed
 
@@ -21,8 +23,9 @@
   `speech.realtime.*`, reflecting that they drive realtime phone calls, web
   console voice mode, and plugin realtime sessions alike — web voice works
   with the Twilio channel disabled. Existing configs are migrated
-  automatically on startup; `voice.*` remains purely the Twilio phone
-  channel.
+  automatically on startup, and `config get`/`config set` on the old keys
+  point at the new location instead of silently doing nothing; `voice.*`
+  remains purely the Twilio phone channel.
 
 ## [0.29.3](https://github.com/HybridAIOne/hybridclaw/tree/v0.29.3) - 2026-08-25
 

--- a/config.example.json
+++ b/config.example.json
@@ -307,14 +307,17 @@
       "interruptible": true,
       "welcomeGreeting": "Hello! How can I help you today?"
     },
+    "webhookPath": "/voice",
+    "maxConcurrentCalls": 8
+  },
+  "speech": {
     "realtime": {
+      "provider": "auto",
       "model": "gpt-realtime",
       "voice": "marin",
       "greeting": "Hello! How can I help you today?",
       "instructions": ""
-    },
-    "webhookPath": "/voice",
-    "maxConcurrentCalls": 8
+    }
   },
   "imessage": {
     "enabled": false,

--- a/console/src/api/chat-types.ts
+++ b/console/src/api/chat-types.ts
@@ -12,6 +12,7 @@ export interface ChatRecentResponse {
 
 export interface ChatVoiceCapabilityResponse {
   available: boolean;
+  provider: 'hybridai' | 'openai' | null;
   model: string;
   voice: string;
 }

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -168,6 +168,7 @@ export interface GatewayStatus {
     fromNumberConfigured: boolean;
     authTokenConfigured: boolean;
     authTokenSource: 'config' | 'env' | 'runtime-secrets' | null;
+    realtimeConfigured?: boolean;
     webhookPath: string;
     maxConcurrentCalls: number;
   };

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -753,6 +753,7 @@ export interface AdminConfig {
   voice: {
     enabled: boolean;
     provider: 'twilio';
+    mode: 'relay' | 'realtime';
     twilio: {
       accountSid: string;
       authToken: string;
@@ -768,6 +769,15 @@ export interface AdminConfig {
     };
     webhookPath: string;
     maxConcurrentCalls: number;
+  };
+  speech: {
+    realtime: {
+      provider: 'auto' | 'hybridai' | 'openai';
+      model: string;
+      voice: string;
+      greeting: string;
+      instructions: string;
+    };
   };
   whatsapp: {
     dmPolicy: 'open' | 'pairing' | 'allowlist' | 'disabled';

--- a/console/src/generated/settings-registry.ts
+++ b/console/src/generated/settings-registry.ts
@@ -2536,6 +2536,36 @@ export const GENERATED_SETTINGS_REGISTRY: ReadonlyArray<GeneratedSettingEntry> =
       defaultValue: {},
     },
     {
+      path: 'speech.realtime.greeting',
+      section: 'speech',
+      kind: 'string',
+      defaultValue: 'Hello! How can I help you today?',
+    },
+    {
+      path: 'speech.realtime.instructions',
+      section: 'speech',
+      kind: 'string',
+      defaultValue: '',
+    },
+    {
+      path: 'speech.realtime.model',
+      section: 'speech',
+      kind: 'string',
+      defaultValue: 'gpt-realtime',
+    },
+    {
+      path: 'speech.realtime.provider',
+      section: 'speech',
+      kind: 'string',
+      defaultValue: 'auto',
+    },
+    {
+      path: 'speech.realtime.voice',
+      section: 'speech',
+      kind: 'string',
+      defaultValue: 'marin',
+    },
+    {
       path: 'telegram.allowFrom',
       section: 'telegram',
       kind: 'list',
@@ -2691,7 +2721,7 @@ export const GENERATED_SETTINGS_REGISTRY: ReadonlyArray<GeneratedSettingEntry> =
       path: 'version',
       section: 'version',
       kind: 'number',
-      defaultValue: 37,
+      defaultValue: 38,
     },
     {
       path: 'voice.enabled',
@@ -2716,36 +2746,6 @@ export const GENERATED_SETTINGS_REGISTRY: ReadonlyArray<GeneratedSettingEntry> =
       section: 'voice',
       kind: 'string',
       defaultValue: 'twilio',
-    },
-    {
-      path: 'voice.realtime.greeting',
-      section: 'voice',
-      kind: 'string',
-      defaultValue: 'Hello! How can I help you today?',
-    },
-    {
-      path: 'voice.realtime.instructions',
-      section: 'voice',
-      kind: 'string',
-      defaultValue: '',
-    },
-    {
-      path: 'voice.realtime.model',
-      section: 'voice',
-      kind: 'string',
-      defaultValue: 'gpt-realtime',
-    },
-    {
-      path: 'voice.realtime.provider',
-      section: 'voice',
-      kind: 'string',
-      defaultValue: 'auto',
-    },
-    {
-      path: 'voice.realtime.voice',
-      section: 'voice',
-      kind: 'string',
-      defaultValue: 'marin',
     },
     {
       path: 'voice.relay.interruptible',

--- a/console/src/lib/settings-registry.ts
+++ b/console/src/lib/settings-registry.ts
@@ -104,6 +104,7 @@ const SECTION_ORDER = [
   'whatsapp',
   'line',
   'voice',
+  'speech',
   'imessage',
   'email',
   'hybridai',

--- a/console/src/routes/channels-catalog.ts
+++ b/console/src/routes/channels-catalog.ts
@@ -37,6 +37,7 @@ interface ChannelCatalogOptions {
   telegramTokenConfigured?: boolean;
   threemaSecretConfigured?: boolean;
   voiceAuthTokenConfigured?: boolean;
+  voiceRealtimeConfigured?: boolean;
   whatsappLinked?: boolean;
   lineLinked?: boolean;
   emailPasswordConfigured?: boolean;
@@ -378,6 +379,7 @@ function describeVoice(
   options: ChannelCatalogOptions,
 ): ChannelCatalogItem {
   const authTokenConfigured = options.voiceAuthTokenConfigured === true;
+  const realtimeConfigured = options.voiceRealtimeConfigured === true;
   const accountSid = config.voice.twilio.accountSid.trim();
   const fromNumber = config.voice.twilio.fromNumber.trim();
   const active =
@@ -397,7 +399,9 @@ function describeVoice(
   return {
     kind: 'voice',
     label: 'Voice',
-    summary: `Twilio · webhook ${config.voice.webhookPath}`,
+    summary: `Twilio · webhook ${config.voice.webhookPath}${
+      realtimeConfigured ? ' · realtime speech ready (web chat works)' : ''
+    }`,
     statusTone,
     statusLabel:
       statusTone === 'active'

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -415,6 +415,7 @@ describe('ChannelsPage', () => {
         fromNumberConfigured: false,
         authTokenConfigured: false,
         authTokenSource: null,
+        realtimeConfigured: false,
         webhookPath: '/voice',
         maxConcurrentCalls: 8,
       },
@@ -1634,6 +1635,45 @@ describe('ChannelsPage', () => {
     expect(screen.getByLabelText('Twilio account SID')).toBeTruthy();
     expect(screen.getByLabelText('Webhook path')).toBeTruthy();
     expect(screen.getByLabelText('Channel instructions')).toBeTruthy();
+  });
+
+  it('flags realtime speech readiness on the voice catalog card', async () => {
+    fetchConfigMock.mockResolvedValue({
+      path: '/tmp/config.json',
+      config: makeConfig(),
+    });
+    const voiceStatus = {
+      enabled: false,
+      accountSidConfigured: false,
+      fromNumberConfigured: false,
+      authTokenConfigured: false,
+      authTokenSource: null,
+      realtimeConfigured: true,
+      webhookPath: '/voice',
+      maxConcurrentCalls: 8,
+    };
+    useAuthMock.mockReturnValue({
+      token: 'test-token',
+      gatewayStatus: { voice: voiceStatus },
+    });
+    validateTokenMock.mockResolvedValue({
+      status: 'ok',
+      webAuthConfigured: true,
+      version: 'test',
+      imageTag: null,
+      uptime: 1,
+      sessions: 0,
+      activeContainers: 0,
+      defaultModel: 'gpt-5',
+      ragDefault: true,
+      timestamp: new Date().toISOString(),
+      voice: voiceStatus,
+    });
+
+    renderChannelsPage();
+
+    const voiceButton = await screen.findByRole('button', { name: /Voice/i });
+    expect(voiceButton.textContent || '').toContain('realtime speech ready');
   });
 
   it('saves channel-specific instructions through the config endpoint', async () => {

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -210,6 +210,7 @@ function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
     voice: {
       enabled: false,
       provider: 'twilio',
+      mode: 'relay',
       twilio: {
         accountSid: '',
         authToken: '',
@@ -225,6 +226,15 @@ function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
       },
       webhookPath: '/voice',
       maxConcurrentCalls: 8,
+    },
+    speech: {
+      realtime: {
+        provider: 'auto',
+        model: 'gpt-realtime',
+        voice: 'marin',
+        greeting: 'Hello! How can I help you today?',
+        instructions: '',
+      },
     },
     whatsapp: {
       dmPolicy: 'pairing',

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -3898,6 +3898,7 @@ export function ChannelsPage() {
         signalAccountConfigured: statusQuery.data?.signal?.accountConfigured,
         signalCliAvailable: statusQuery.data?.signal?.cliAvailable,
         voiceAuthTokenConfigured: statusQuery.data?.voice?.authTokenConfigured,
+        voiceRealtimeConfigured: statusQuery.data?.voice?.realtimeConfigured,
         whatsappLinked: statusQuery.data?.whatsapp?.linked,
         lineLinked: statusQuery.data?.line?.linked,
         emailPasswordConfigured: statusQuery.data?.email?.passwordConfigured,

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -2383,6 +2383,30 @@ function VoiceChannelEditor(props: {
         )}
       />
 
+      <FormField
+        name="voice.mode"
+        render={({ field }) => (
+          <Field>
+            <FieldLabel>Phone call mode</FieldLabel>
+            <NativeSelect
+              value={field.value as string}
+              onChange={field.onChange}
+            >
+              <NativeSelectOption value="relay">
+                relay (turn-based ConversationRelay)
+              </NativeSelectOption>
+              <NativeSelectOption value="realtime">
+                realtime (speech-to-speech)
+              </NativeSelectOption>
+            </NativeSelect>
+            <FieldDescription>
+              How incoming and outgoing phone calls are handled. The web console
+              voice mode always uses the realtime settings below.
+            </FieldDescription>
+          </Field>
+        )}
+      />
+
       <div className="field-grid">
         <FormField
           name="voice.twilio.accountSid"
@@ -2440,6 +2464,11 @@ function VoiceChannelEditor(props: {
           )}
         />
       </div>
+
+      <h4>Relay voice</h4>
+      <p className="muted-copy">
+        Turn-based settings used by phone calls in relay mode.
+      </p>
 
       <div className="field-grid">
         <FormField
@@ -2523,12 +2552,87 @@ function VoiceChannelEditor(props: {
           </Field>
         )}
       />
+
+      <h4>Realtime speech</h4>
+      <p className="muted-copy">
+        Speech-to-speech settings (<code>speech.realtime</code>) shared by
+        realtime phone calls and the voice button in the web chat — the web chat
+        uses them even when this channel is disabled.
+      </p>
+
+      <div className="field-grid">
+        <FormField
+          name="speech.realtime.provider"
+          render={({ field }) => (
+            <Field>
+              <FieldLabel>Provider</FieldLabel>
+              <NativeSelect
+                value={field.value as string}
+                onChange={field.onChange}
+              >
+                <NativeSelectOption value="auto">
+                  auto (HybridAI when signed in, else OpenAI)
+                </NativeSelectOption>
+                <NativeSelectOption value="hybridai">
+                  hybridai
+                </NativeSelectOption>
+                <NativeSelectOption value="openai">openai</NativeSelectOption>
+              </NativeSelect>
+            </Field>
+          )}
+        />
+        <FormField
+          name="speech.realtime.model"
+          render={({ field }) => (
+            <Field>
+              <FieldLabel>Model</FieldLabel>
+              <Input {...field} placeholder="gpt-realtime" />
+            </Field>
+          )}
+        />
+      </div>
+
+      <FormField
+        name="speech.realtime.voice"
+        render={({ field }) => (
+          <Field>
+            <FieldLabel>Voice</FieldLabel>
+            <Input {...field} placeholder="marin" />
+            <FieldDescription>
+              Speaking voice for realtime sessions, e.g. marin, cedar, or alloy.
+            </FieldDescription>
+          </Field>
+        )}
+      />
+
+      <FormField
+        name="speech.realtime.greeting"
+        render={({ field }) => (
+          <Field>
+            <FieldLabel>Greeting</FieldLabel>
+            <Textarea rows={3} {...field} />
+          </Field>
+        )}
+      />
+
+      <FormField
+        name="speech.realtime.instructions"
+        render={({ field }) => (
+          <Field>
+            <FieldLabel>Extra instructions</FieldLabel>
+            <Textarea rows={3} {...field} />
+            <FieldDescription>
+              Appended to the built-in realtime voice instructions.
+            </FieldDescription>
+          </Field>
+        )}
+      />
+
       <ChannelInstructionsField kind="voice" />
 
       <p className="muted-copy">
-        Voice uses Twilio ConversationRelay. Expose the configured webhook path
-        over public HTTPS and WSS so Twilio can reach both the webhook and the
-        relay socket.
+        Phone calls use Twilio. Expose the configured webhook path over public
+        HTTPS and WSS so Twilio can reach both the webhook and the audio socket.
       </p>
     </>
   );

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -1494,7 +1494,10 @@ export function ChatPage() {
             voiceAvailable={voiceCapability?.available === true}
             voiceDetail={voiceDetail}
             voiceActive={voiceOpen}
-            onVoiceToggle={() => setVoiceOpen((open) => !open)}
+            onVoiceToggle={() => {
+              if (!voiceOpen) void voiceCapabilityQuery.refetch();
+              setVoiceOpen((open) => !open);
+            }}
           />
         </div>
         <Dialog

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -359,6 +359,12 @@ export function ChatPage() {
     staleTime: Infinity,
     enabled: chatApiReady,
   });
+  const voiceCapability = voiceCapabilityQuery.data;
+  const voiceDetail = voiceCapability?.available
+    ? [voiceCapability.provider, voiceCapability.model, voiceCapability.voice]
+        .filter(Boolean)
+        .join(' · ')
+    : null;
   const [voiceOpen, setVoiceOpen] = useState(false);
   const handleVoiceTranscript = useCallback(() => {
     // The gateway persists every spoken turn (and consulted turns) as
@@ -1467,6 +1473,7 @@ export function ChatPage() {
               status={voiceSession.status}
               error={voiceSession.error}
               consultActivity={voiceSession.consultActivity}
+              detail={voiceDetail}
               onClose={() => setVoiceOpen(false)}
             />
           ) : null}
@@ -1484,7 +1491,8 @@ export function ChatPage() {
             modelRouting={contextQuery.data?.routing}
             onModelSwitch={(modelId) => void handleModelSwitch(modelId)}
             initialValue={initialComposerPrompt}
-            voiceAvailable={voiceCapabilityQuery.data?.available === true}
+            voiceAvailable={voiceCapability?.available === true}
+            voiceDetail={voiceDetail}
             voiceActive={voiceOpen}
             onVoiceToggle={() => setVoiceOpen((open) => !open)}
           />

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -96,6 +96,7 @@ export function Composer(props: {
   onModelSwitch?: (modelId: string) => void;
   initialValue?: string;
   voiceAvailable?: boolean;
+  voiceDetail?: string | null;
   voiceActive?: boolean;
   onVoiceToggle?: () => void;
 }) {
@@ -677,7 +678,10 @@ export function Composer(props: {
                     props.voiceActive ? 'End voice mode' : 'Start voice mode'
                   }
                   title={
-                    props.voiceActive ? 'End voice mode' : 'Start voice mode'
+                    (props.voiceActive
+                      ? 'End voice mode'
+                      : 'Start voice mode') +
+                    (props.voiceDetail ? ` (${props.voiceDetail})` : '')
                   }
                   aria-pressed={props.voiceActive === true}
                 >

--- a/console/src/routes/chat/voice-panel.tsx
+++ b/console/src/routes/chat/voice-panel.tsx
@@ -40,6 +40,7 @@ export function VoicePanel(props: {
   status: VoiceSessionStatus;
   error: string | null;
   consultActivity?: string | null;
+  detail?: string | null;
   onClose: () => void;
 }) {
   const label =
@@ -51,6 +52,7 @@ export function VoicePanel(props: {
       className={cx(css.voiceCapsule, STATUS_CLASSES[props.status])}
       role="status"
       aria-live="polite"
+      title={props.detail || undefined}
     >
       <span className={css.voiceWave} aria-hidden="true">
         {WAVE_BARS.map((bar) => (

--- a/console/src/routes/config.tsx
+++ b/console/src/routes/config.tsx
@@ -61,6 +61,7 @@ const ENUM_OPTIONS: Readonly<Record<string, ReadonlyArray<string>>> = {
     'per-channel-peer',
     'per-account-channel-peer',
   ],
+  'speech.realtime.provider': ['auto', 'hybridai', 'openai'],
   'web.search.provider': ['auto', 'brave', 'perplexity', 'searxng', 'tavily'],
 };
 

--- a/console/src/routes/scheduler.test.tsx
+++ b/console/src/routes/scheduler.test.tsx
@@ -222,6 +222,7 @@ function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
     voice: {
       enabled: false,
       provider: 'twilio',
+      mode: 'relay',
       twilio: {
         accountSid: '',
         authToken: '',
@@ -237,6 +238,15 @@ function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
       },
       webhookPath: '/voice',
       maxConcurrentCalls: 8,
+    },
+    speech: {
+      realtime: {
+        provider: 'auto',
+        model: 'gpt-realtime',
+        voice: 'marin',
+        greeting: 'Hello! How can I help you today?',
+        instructions: '',
+      },
     },
     whatsapp: {
       dmPolicy: 'disabled',

--- a/docs/content/channels/admin-console.md
+++ b/docs/content/channels/admin-console.md
@@ -153,7 +153,7 @@ changes before navigation.
 - the web chat route syntax-highlights completed code blocks, shows language
   labels, and keeps copy controls reachable on hover and touch devices
 - the web chat route offers a realtime voice mode (microphone button in the
-  composer) when the configured `voice.realtime.provider` has a credential —
+  composer) when the configured `speech.realtime.provider` has a credential —
   by default the signed-in HybridAI credential (routing through the
   platform's `/v1/realtime` proxy), or an OpenAI API key: mic
   audio streams to the realtime API for natural speech-to-speech conversation
@@ -163,7 +163,10 @@ changes before navigation.
   what the agent is currently doing (for example `Checking — web search…`)
   and long consults get short spoken progress updates; external web apps can
   run the same voice sessions via scoped API tokens — see
-  [Realtime Voice for Web Apps](../guides/voice-web-api.md)
+  [Realtime Voice for Web Apps](../guides/voice-web-api.md); hovering the
+  voice button or the live-call capsule shows the active provider, model, and
+  voice, all editable in the Speech settings section or under Channels →
+  Voice (`speech.realtime.*`)
 - destructive admin actions use explicit browser confirmation dialogs before
   HybridClaw applies the requested change
 

--- a/docs/content/extensibility/plugins.md
+++ b/docs/content/extensibility/plugins.md
@@ -381,7 +381,7 @@ authentication on these upgrades — the handler must validate the peer itself
 
 Channel plugins that transport live phone audio can open a realtime
 speech-to-speech session with `api.createRealtimeVoiceSession(...)`. The core
-realtime engine (configured by `voice.realtime.*`) fronts the conversation,
+realtime engine (configured by `speech.realtime.*`) fronts the conversation,
 consults the full agent through the plugin dispatch pipeline (so approvals,
 audit, and session history behave like any other turn), and persists spoken
 turns as voice transcripts. Transport audio is 16-bit LE mono PCM at 8 kHz;

--- a/docs/content/guides/twilio-voice.md
+++ b/docs/content/guides/twilio-voice.md
@@ -110,16 +110,21 @@ Notes:
 
 ## Realtime Voice Mode
 
-Set `voice.mode` to `"realtime"` to run calls through the OpenAI Realtime API
-instead of Twilio's turn-based ConversationRelay:
+Set `voice.mode` to `"realtime"` to run calls through the realtime speech
+engine instead of Twilio's turn-based ConversationRelay. The engine itself is
+configured by the top-level `speech.realtime.*` settings, which are shared
+with web console voice mode:
 
 ```json
 {
   "voice": {
     "enabled": true,
     "provider": "twilio",
-    "mode": "realtime",
+    "mode": "realtime"
+  },
+  "speech": {
     "realtime": {
+      "provider": "auto",
       "model": "gpt-realtime",
       "voice": "marin",
       "greeting": "Hello! How can I help you today?",
@@ -156,7 +161,7 @@ alongside the consulted turns.
 Requirements and notes:
 
 - Realtime mode needs a realtime credential. The default
-  `voice.realtime.provider` of `auto` uses the HybridAI platform's
+  `speech.realtime.provider` of `auto` uses the HybridAI platform's
   `/v1/realtime` proxy when a HybridAI credential is present (signed in, or
   `HYBRIDAI_API_KEY`), and OpenAI otherwise. Set the provider to `openai` or
   `hybridai` to pin one backend: `openai` needs the `OPENAI_API_KEY`
@@ -165,10 +170,10 @@ Requirements and notes:
   the HybridAI credential — no OpenAI key required. The gateway refuses to
   start the voice channel in realtime mode without a credential for the
   selected provider.
-- `voice.realtime.voice` accepts any OpenAI realtime voice name (for example
+- `speech.realtime.voice` accepts any OpenAI realtime voice name (for example
   `marin`, `cedar`, `alloy`).
-- `voice.realtime.instructions` is appended to the built-in call instructions;
-  use it for tone, language, or caller-handling guidance.
+- `speech.realtime.instructions` is appended to the built-in call
+  instructions; use it for tone, language, or caller-handling guidance.
 - `voice.relay.*` settings are ignored in realtime mode, and
   `channelInstructions.voice` still applies to the consulted agent turns.
 - Realtime API audio is billed by OpenAI per minute of input and output audio
@@ -176,9 +181,17 @@ Requirements and notes:
 - The same realtime engine also powers voice mode in the web console chat
   (microphone button in the composer). Browser voice needs only the realtime
   credential — it works even when the Twilio voice channel is disabled, and it
-  uses the same `voice.realtime.*` provider, model, voice, greeting, and
+  uses the same `speech.realtime.*` provider, model, voice, greeting, and
   instructions settings. It is the quickest way to try realtime voice before
   wiring up a phone number.
+- All `speech.realtime.*` settings are editable in the admin console (the
+  Speech section of `/admin/config`, or the Realtime speech section under
+  Channels → Voice), and from a local session: `/speech` shows which provider
+  `auto` resolved to and whether a credential is available, and
+  `/speech provider|model|voice <value>` changes a setting — new voice
+  sessions pick changes up immediately.
+- Configs written by v0.29.x used `voice.realtime.*` for these settings; the
+  gateway migrates them to `speech.realtime.*` on startup.
 
 ## Store The Twilio Secret
 

--- a/docs/content/guides/voice-web-api.md
+++ b/docs/content/guides/voice-web-api.md
@@ -14,9 +14,11 @@ with tools, approvals, and session history.
 
 ## Prerequisites
 
-- Realtime voice credentials configured (`voice.realtime.provider`, see
+- Realtime voice credentials configured (`speech.realtime.provider`, see
   [Configuration](../reference/configuration.md)). `GET /api/chat/voice`
-  reports `available: true` when the gateway can start sessions.
+  reports `available: true` when the gateway can start sessions, plus the
+  resolved `provider` (`hybridai`, `openai`, or `null` without a credential)
+  and the configured `model` and `voice`.
 - The gateway reachable over HTTPS from the browser (a tunnel or public
   deployment).
 

--- a/docs/content/guides/vonage-voice.md
+++ b/docs/content/guides/vonage-voice.md
@@ -53,7 +53,7 @@ that speaks the finished reply.
 
 Realtime mode runs calls as natural speech-to-speech conversations with
 instant barge-in, using the gateway's realtime voice engine — the same
-`voice.realtime.*` settings (provider, model, voice, instructions) and
+`speech.realtime.*` settings (provider, model, voice, instructions) and
 credential (`OPENAI_API_KEY` or the HybridAI provider) that power the Twilio
 realtime mode and the web console voice mode. The Twilio channel itself can
 stay disabled. Answered calls where no realtime credential is configured are

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -261,19 +261,28 @@ saved revision history directly.
 - `voice.*` for the Twilio phone channel, including webhook path, concurrency,
   and Twilio number/account settings; `voice.mode` selects `relay`
   (ConversationRelay, `voice.relay.*` voice/STT options) or `realtime`
-  (OpenAI Realtime speech-to-speech over Twilio Media Streams, configured via
-  `voice.realtime.model`, `voice.realtime.voice`, `voice.realtime.greeting`,
-  and `voice.realtime.instructions`). `voice.realtime.provider` selects the
-  realtime backend: `auto` (the default: HybridAI when a HybridAI credential
-  is present, otherwise OpenAI), `openai` (requires an `OPENAI_API_KEY`), or
-  `hybridai` (the HybridAI platform's `/v1/realtime` proxy at
-  `HYBRIDAI_BASE_URL`, authenticated with your signed-in HybridAI credential
-  or `HYBRIDAI_API_KEY` — no OpenAI key needed). The `voice.realtime.*`
-  settings also drive web console voice mode, which needs only the realtime
-  credential and works with the Twilio channel disabled. The auth
+  (speech-to-speech over Twilio Media Streams, driven by the shared
+  `speech.realtime.*` settings below). The auth
   token can stay empty in config when you store `TWILIO_AUTH_TOKEN` in the
   encrypted runtime secret store or use a SecretRef-backed
   `voice.twilio.authToken`
+- `speech.realtime.*` for the realtime speech engine shared by realtime phone
+  calls, web console voice mode, and plugin realtime sessions:
+  `speech.realtime.model`, `speech.realtime.voice`,
+  `speech.realtime.greeting`, and `speech.realtime.instructions`.
+  `speech.realtime.provider` selects the backend: `auto` (the default:
+  HybridAI when a HybridAI credential is present, otherwise OpenAI), `openai`
+  (requires an `OPENAI_API_KEY`), or `hybridai` (the HybridAI platform's
+  `/v1/realtime` proxy at `HYBRIDAI_BASE_URL`, authenticated with your
+  signed-in HybridAI credential or `HYBRIDAI_API_KEY` — no OpenAI key
+  needed). Web console voice mode needs only the realtime credential and
+  works with the Twilio channel disabled. Manage these settings in the admin
+  console (`/admin/config?section=speech`, or the Realtime speech section of
+  the voice channel editor) or from a local session via
+  `/speech provider|model|voice <value>`; `/speech` reports the resolved
+  provider and credential status. Configs from v0.29.x that still set the
+  legacy `voice.realtime.*` keys are migrated to `speech.realtime.*` on
+  startup
 - `deployment.mode`, `deployment.public_url`, `deployment.a2a_local_mode`,
   `deployment.a2a_e2ee_required`, `deployment.tunnel.provider`, and
   `deployment.tunnel.health_check_interval_ms` declare whether the gateway runs

--- a/src/channels/voice/realtime-bridge.ts
+++ b/src/channels/voice/realtime-bridge.ts
@@ -16,7 +16,7 @@
  * framing lives in `media-stream.ts`, browser framing in the gateway) and the
  * upstream socket in `openai-realtime.ts`; this module never touches raw JSON.
  */
-import type { RuntimeVoiceRealtimeConfig } from '../../config/runtime-config.js';
+import type { RuntimeSpeechRealtimeConfig } from '../../config/runtime-config.js';
 import { isRecord } from '../../utils/type-guards.js';
 import {
   OpenAIRealtimeClient,
@@ -66,7 +66,7 @@ export function humanizeConsultToolName(toolName: string): string {
 
 export interface RealtimeBridgeOptions {
   connection: RealtimeConnection;
-  config: RuntimeVoiceRealtimeConfig;
+  config: RuntimeSpeechRealtimeConfig;
   caller: RealtimeCallerInfo;
   surface: RealtimeSurface;
   audioFormat: RealtimeAudioFormat;
@@ -89,7 +89,7 @@ export interface RealtimeBridgeOptions {
 }
 
 export function buildRealtimeInstructions(
-  config: RuntimeVoiceRealtimeConfig,
+  config: RuntimeSpeechRealtimeConfig,
   caller: RealtimeCallerInfo,
   surface: RealtimeSurface = 'phone',
 ): string {

--- a/src/channels/voice/realtime-credentials.ts
+++ b/src/channels/voice/realtime-credentials.ts
@@ -1,7 +1,7 @@
 /**
  * Resolves which upstream serves realtime voice sessions.
  *
- * `voice.realtime.provider` selects between OpenAI directly (`openai`, using
+ * `speech.realtime.provider` selects between OpenAI directly (`openai`, using
  * OPENAI_API_KEY) and the HybridAI platform's `/v1/realtime` proxy
  * (`hybridai`, using the signed-in HybridAI credential and
  * HYBRIDAI_BASE_URL). Both speak the same realtime protocol, so everything
@@ -17,11 +17,14 @@
  */
 import { readHybridAIApiKey } from '../../auth/hybridai-auth.js';
 import { HYBRIDAI_BASE_URL, OPENAI_API_KEY } from '../../config/config.js';
-import type { RuntimeVoiceRealtimeProvider } from '../../config/runtime-config.js';
+import type { RuntimeSpeechRealtimeProvider } from '../../config/runtime-config.js';
 
 export const OPENAI_REALTIME_URL = 'wss://api.openai.com/v1/realtime';
 
+export type ResolvedRealtimeProvider = 'hybridai' | 'openai';
+
 export interface RealtimeConnection {
+  provider: ResolvedRealtimeProvider;
   url: string;
   apiKey: string;
 }
@@ -42,7 +45,7 @@ export function hybridaiRealtimeUrl(baseUrl: string): string {
  * live socket rather than to a caller that could recover.
  */
 export function resolveRealtimeConnection(
-  provider: RuntimeVoiceRealtimeProvider,
+  provider: RuntimeSpeechRealtimeProvider,
 ):
   | { connection: RealtimeConnection; error: null }
   | {
@@ -61,6 +64,7 @@ export function resolveRealtimeConnection(
     }
     return {
       connection: {
+        provider: 'hybridai',
         url: hybridaiRealtimeUrl(HYBRIDAI_BASE_URL),
         apiKey: hybridaiApiKey,
       },
@@ -77,11 +81,14 @@ export function resolveRealtimeConnection(
           : 'Realtime voice requires an OpenAI API key (OPENAI_API_KEY).',
     };
   }
-  return { connection: { url: OPENAI_REALTIME_URL, apiKey }, error: null };
+  return {
+    connection: { provider: 'openai', url: OPENAI_REALTIME_URL, apiKey },
+    error: null,
+  };
 }
 
 export function isRealtimeCredentialConfigured(
-  provider: RuntimeVoiceRealtimeProvider,
+  provider: RuntimeSpeechRealtimeProvider,
 ): boolean {
   return resolveRealtimeConnection(provider).connection !== null;
 }

--- a/src/channels/voice/runtime.ts
+++ b/src/channels/voice/runtime.ts
@@ -723,16 +723,14 @@ function handleMediaStreamConnection(ws: WebSocket, remoteIp: string): void {
             );
           }
           callSid = session.callSid;
-          const voiceConfig = getConfigSnapshot().voice;
-          const resolved = resolveRealtimeConnection(
-            voiceConfig.realtime.provider,
-          );
+          const realtimeConfig = getConfigSnapshot().speech.realtime;
+          const resolved = resolveRealtimeConnection(realtimeConfig.provider);
           if (!resolved.connection) {
             throw new Error(resolved.error);
           }
           const bridge = new RealtimeCallBridge({
             connection: resolved.connection,
-            config: voiceConfig.realtime,
+            config: realtimeConfig,
             caller: {
               from: session.from,
               to: session.to,

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -103,6 +103,7 @@ const REGISTERED_TEXT_COMMAND_NAMES = new Set([
   'mcp',
   'plugin',
   'voice',
+  'speech',
   'clear',
   'reset',
   'compact',
@@ -645,6 +646,9 @@ export function mapCanonicalCommandToGatewayArgs(
       }
       return null;
     }
+
+    case 'speech':
+      return parts.length > 1 ? ['speech', ...parts.slice(1)] : ['speech'];
 
     case 'fullauto':
       return parts.length > 1 ? ['fullauto', ...parts.slice(1)] : ['fullauto'];
@@ -1870,6 +1874,74 @@ function buildSlashCommandCatalogDefinitions(
               kind: 'string',
               name: 'number',
               description: 'Destination phone number in E.164 format',
+              required: true,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'speech',
+      description:
+        'Show or change realtime speech settings (provider, model, voice)',
+      tuiOnly: true,
+      tuiMenuEntries: [
+        {
+          id: 'speech.info',
+          label: '/speech',
+          insertText: '/speech',
+          description:
+            'Show the realtime speech provider, model, voice, and credential status',
+        },
+        {
+          id: 'speech.provider',
+          label: '/speech provider <auto|hybridai|openai>',
+          insertText: '/speech provider ',
+          description: 'Choose the realtime speech backend',
+          depth: 1,
+        },
+        {
+          id: 'speech.model',
+          label: '/speech model <model-id>',
+          insertText: '/speech model ',
+          description: 'Set the realtime speech model',
+          depth: 1,
+        },
+        {
+          id: 'speech.voice',
+          label: '/speech voice <voice-name>',
+          insertText: '/speech voice ',
+          description: 'Set the realtime speaking voice',
+          depth: 1,
+        },
+      ],
+      options: [
+        {
+          kind: 'subcommand',
+          name: 'info',
+          description:
+            'Show the realtime speech provider, model, voice, and credential status',
+        },
+        {
+          kind: 'subcommand',
+          name: 'set',
+          description: 'Change a realtime speech setting',
+          options: [
+            {
+              kind: 'string',
+              name: 'setting',
+              description: 'Which realtime speech setting to change',
+              required: true,
+              choices: [
+                { name: 'provider', value: 'provider' },
+                { name: 'model', value: 'model' },
+                { name: 'voice', value: 'voice' },
+              ],
+            },
+            {
+              kind: 'string',
+              name: 'value',
+              description: 'New value for the chosen setting',
               required: true,
             },
           ],
@@ -3320,6 +3392,17 @@ export function parseCanonicalSlashCommandArgs(
       if (subcommand === 'call') {
         const number = normalizeStringOption(interaction, 'number', true);
         return number ? ['voice', 'call', number] : null;
+      }
+      return null;
+    }
+
+    case 'speech': {
+      const subcommand = normalizeSubcommand(interaction);
+      if (!subcommand || subcommand === 'info') return ['speech'];
+      if (subcommand === 'set') {
+        const setting = normalizeStringOption(interaction, 'setting', true);
+        const value = normalizeStringOption(interaction, 'value', true);
+        return setting && value ? ['speech', setting, value] : null;
       }
       return null;
     }

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -150,7 +150,7 @@ import {
 import { DEFAULT_RUNTIME_HOME_DIR } from './runtime-paths.js';
 
 export const CONFIG_FILE_NAME = 'config.json';
-export const CONFIG_VERSION = 37;
+export const CONFIG_VERSION = 38;
 export const SECURITY_POLICY_VERSION = '2026-02-28';
 export const DEFAULT_HYBRIDAI_MODEL = 'gpt-5.6-luna';
 export const DEFAULT_HYBRIDAI_ONBOARDING_MODEL = '';
@@ -636,7 +636,7 @@ export interface RuntimeLineConfig {
 
 export type RuntimeVoiceProvider = 'twilio';
 export type RuntimeVoiceMode = 'realtime' | 'relay';
-export type RuntimeVoiceRealtimeProvider = 'auto' | 'hybridai' | 'openai';
+export type RuntimeSpeechRealtimeProvider = 'auto' | 'hybridai' | 'openai';
 export type RuntimeVoiceRelayTtsProvider = 'amazon' | 'default' | 'google';
 export type RuntimeVoiceRelayTranscriptionProvider =
   | 'deepgram'
@@ -658,23 +658,32 @@ export interface RuntimeVoiceRelayConfig {
   welcomeGreeting: string;
 }
 
-export interface RuntimeVoiceRealtimeConfig {
-  provider: RuntimeVoiceRealtimeProvider;
-  model: string;
-  voice: string;
-  greeting: string;
-  instructions: string;
-}
-
 export interface RuntimeVoiceConfig {
   enabled: boolean;
   provider: RuntimeVoiceProvider;
   mode: RuntimeVoiceMode;
   twilio: RuntimeVoiceTwilioConfig;
   relay: RuntimeVoiceRelayConfig;
-  realtime: RuntimeVoiceRealtimeConfig;
   webhookPath: string;
   maxConcurrentCalls: number;
+}
+
+/**
+ * Speech settings shared across surfaces, not tied to the `voice` phone
+ * channel: `speech.realtime` drives realtime phone calls, web console voice
+ * mode, and plugin realtime sessions alike. Future speech-output settings
+ * (TTS, dictation) belong here too.
+ */
+export interface RuntimeSpeechRealtimeConfig {
+  provider: RuntimeSpeechRealtimeProvider;
+  model: string;
+  voice: string;
+  greeting: string;
+  instructions: string;
+}
+
+export interface RuntimeSpeechConfig {
+  realtime: RuntimeSpeechRealtimeConfig;
 }
 
 export interface RuntimeSlackConfig {
@@ -1113,6 +1122,7 @@ export interface RuntimeConfig {
   whatsapp: RuntimeWhatsAppConfig;
   line: RuntimeLineConfig;
   voice: RuntimeVoiceConfig;
+  speech: RuntimeSpeechConfig;
   imessage: RuntimeIMessageConfig;
   email: RuntimeEmailConfig;
   hybridai: {
@@ -1779,6 +1789,10 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
       interruptible: true,
       welcomeGreeting: 'Hello! How can I help you today?',
     },
+    webhookPath: '/voice',
+    maxConcurrentCalls: 8,
+  },
+  speech: {
     realtime: {
       provider: 'auto',
       model: 'gpt-realtime',
@@ -1786,8 +1800,6 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
       greeting: 'Hello! How can I help you today?',
       instructions: '',
     },
-    webhookPath: '/voice',
-    maxConcurrentCalls: 8,
   },
   imessage: {
     enabled: false,
@@ -3622,10 +3634,10 @@ function normalizeVoiceMode(
   return fallback;
 }
 
-function normalizeVoiceRealtimeProvider(
+function normalizeSpeechRealtimeProvider(
   value: unknown,
-  fallback: RuntimeVoiceRealtimeProvider,
-): RuntimeVoiceRealtimeProvider {
+  fallback: RuntimeSpeechRealtimeProvider,
+): RuntimeSpeechRealtimeProvider {
   if (typeof value !== 'string') return fallback;
   const normalized = value.trim().toLowerCase();
   if (
@@ -4036,7 +4048,6 @@ function normalizeVoiceConfig(
   const raw = isRecord(value) ? value : {};
   const rawTwilio = isRecord(raw.twilio) ? raw.twilio : {};
   const rawRelay = isRecord(raw.relay) ? raw.relay : {};
-  const rawRealtime = isRecord(raw.realtime) ? raw.realtime : {};
   return {
     enabled: normalizeBoolean(raw.enabled, fallback.enabled),
     provider: normalizeVoiceProvider(raw.provider, fallback.provider),
@@ -4083,8 +4094,27 @@ function normalizeVoiceConfig(
         { allowEmpty: false },
       ),
     },
+    webhookPath: normalizeApiPath(raw.webhookPath, fallback.webhookPath),
+    maxConcurrentCalls: normalizeInteger(
+      raw.maxConcurrentCalls,
+      fallback.maxConcurrentCalls,
+      {
+        min: 1,
+        max: 128,
+      },
+    ),
+  };
+}
+
+function normalizeSpeechConfig(
+  value: unknown,
+  fallback: RuntimeSpeechConfig,
+): RuntimeSpeechConfig {
+  const raw = isRecord(value) ? value : {};
+  const rawRealtime = isRecord(raw.realtime) ? raw.realtime : {};
+  return {
     realtime: {
-      provider: normalizeVoiceRealtimeProvider(
+      provider: normalizeSpeechRealtimeProvider(
         rawRealtime.provider,
         fallback.realtime.provider,
       ),
@@ -4105,15 +4135,6 @@ function normalizeVoiceConfig(
         { allowEmpty: true },
       ),
     },
-    webhookPath: normalizeApiPath(raw.webhookPath, fallback.webhookPath),
-    maxConcurrentCalls: normalizeInteger(
-      raw.maxConcurrentCalls,
-      fallback.maxConcurrentCalls,
-      {
-        min: 1,
-        max: 128,
-      },
-    ),
   };
 }
 
@@ -7053,6 +7074,15 @@ function normalizeRuntimeConfig(
   const rawWhatsApp = isRecord(raw.whatsapp) ? raw.whatsapp : {};
   const rawLine = isRecord(raw.line) ? raw.line : {};
   const rawVoice = isRecord(raw.voice) ? raw.voice : {};
+  // Legacy key (pre-v38): speech.realtime lived at voice.realtime. Honor the
+  // old location when the new one is absent so existing configs keep working;
+  // migrateConfigSchemaOnStartup rewrites the file to the new shape.
+  const rawSpeechRecord = isRecord(raw.speech) ? raw.speech : {};
+  const legacyVoiceRealtime = (rawVoice as Record<string, unknown>).realtime;
+  const rawSpeech =
+    !isRecord(rawSpeechRecord.realtime) && isRecord(legacyVoiceRealtime)
+      ? { ...rawSpeechRecord, realtime: legacyVoiceRealtime }
+      : rawSpeechRecord;
   const rawIMessage = isRecord(raw.imessage) ? raw.imessage : {};
   const rawEmail = isRecord(raw.email) ? raw.email : {};
   const rawHybridAi = isRecord(raw.hybridai) ? raw.hybridai : {};
@@ -7847,6 +7877,7 @@ function normalizeRuntimeConfig(
     voice: normalizeVoiceConfig(rawVoice, DEFAULT_RUNTIME_CONFIG.voice, {
       authToken: resolvedVoiceAuthToken,
     }),
+    speech: normalizeSpeechConfig(rawSpeech, DEFAULT_RUNTIME_CONFIG.speech),
     imessage: normalizeIMessageConfig(
       rawIMessage,
       DEFAULT_RUNTIME_CONFIG.imessage,
@@ -9196,6 +9227,15 @@ function migrateConfigSchemaOnStartup(): void {
     if (legacyAdditionalMountBinds.binds.length > 0) {
       console.warn(
         '[runtime-config] migrated legacy container.additionalMounts into container.binds; update config.json to use container.binds before additionalMounts is removed',
+      );
+    }
+    if (
+      isRecord(parsedRecord.voice) &&
+      isRecord(parsedRecord.voice.realtime) &&
+      !(isRecord(parsedRecord.speech) && isRecord(parsedRecord.speech.realtime))
+    ) {
+      console.warn(
+        '[runtime-config] migrated legacy voice.realtime into speech.realtime; realtime speech settings now live at speech.realtime',
       );
     }
     for (const warning of legacyAdditionalMountBinds.warnings) {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -88,6 +88,7 @@ import {
   getSignalLinkState,
   startSignalLink,
 } from '../channels/signal/pairing.js';
+import { resolveRealtimeConnection } from '../channels/voice/realtime-credentials.js';
 import {
   handleVoiceUpgrade,
   handleVoiceWebhook,
@@ -11174,9 +11175,12 @@ export function startGatewayHttpServer(): GatewayHttpServer {
             return;
           }
           if (pathname === '/api/chat/voice' && method === 'GET') {
-            const voiceConfig = getRuntimeConfig().voice.realtime;
+            const voiceConfig = getRuntimeConfig().speech.realtime;
             sendJson(res, 200, {
               available: isWebchatVoiceAvailable(),
+              provider:
+                resolveRealtimeConnection(voiceConfig.provider).connection
+                  ?.provider ?? null,
               model: voiceConfig.model,
               voice: voiceConfig.voice,
             });

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -132,7 +132,10 @@ import {
   SLACK_WEBHOOK_DEFAULT_TARGET,
   slackWebhookSecretNameForTarget,
 } from '../channels/slack-webhook/target.js';
-import { resolveRealtimeConnection } from '../channels/voice/realtime-credentials.js';
+import {
+  isRealtimeCredentialConfigured,
+  resolveRealtimeConnection,
+} from '../channels/voice/realtime-credentials.js';
 import {
   createTwilioOutboundCall,
   normalizeTwilioPhoneNumber,
@@ -1169,6 +1172,20 @@ const DISCORD_CHANNEL_MODE_VALUES = new Set(['off', 'mention', 'free']);
 const DISCORD_GROUP_POLICY_VALUES = new Set(['open', 'allowlist', 'disabled']);
 
 const SPEECH_REALTIME_PROVIDER_VALUES = new Set(['auto', 'hybridai', 'openai']);
+
+/**
+ * voice.realtime.* moved to speech.realtime.* in config v38. A `config set`
+ * on the old path would vanish silently: normalization drops the unknown
+ * voice.realtime block, and the legacy fallback never applies to a full
+ * config draft (speech.realtime is always present there). Redirect instead
+ * of no-opping — the old key circulated in v0.29.x docs and chats.
+ */
+function legacyVoiceRealtimeKeyHint(key: string): string | null {
+  if (key !== 'voice.realtime' && !key.startsWith('voice.realtime.')) {
+    return null;
+  }
+  return key.replace(/^voice\.realtime/, 'speech.realtime');
+}
 
 /**
  * Status lines for the realtime speech engine (`speech.realtime.*`), shared
@@ -4987,6 +5004,9 @@ export async function getGatewayStatus(
       ),
       authTokenConfigured: voiceAuth.authTokenConfigured,
       authTokenSource: voiceAuth.authTokenSource,
+      realtimeConfigured: isRealtimeCredentialConfigured(
+        runtimeConfig.speech.realtime.provider,
+      ),
       webhookPath: runtimeConfig.voice.webhookPath,
       maxConcurrentCalls: runtimeConfig.voice.maxConcurrentCalls,
     },
@@ -13088,6 +13108,13 @@ export async function handleGatewayCommand(
           if (!key || req.args.length > 3) {
             return badCommand('Usage', 'Usage: `config get <key>`');
           }
+          const movedKey = legacyVoiceRealtimeKeyHint(key);
+          if (movedKey) {
+            return badCommand(
+              'Config Key Moved',
+              `\`${key}\` moved to \`${movedKey}\` (config v38). Use \`config get ${movedKey}\` or the \`speech\` command.`,
+            );
+          }
           try {
             const value = getRuntimeConfigValueAtPath(getRuntimeConfig(), key);
             return infoCommand(
@@ -13114,6 +13141,13 @@ export async function handleGatewayCommand(
             return badCommand(
               'Usage',
               'Usage: `config`, `config check`, `config reload`, `config get <key>`, or `config set <key> <value>`',
+            );
+          }
+          const movedKey = legacyVoiceRealtimeKeyHint(key);
+          if (movedKey) {
+            return badCommand(
+              'Config Key Moved',
+              `\`${key}\` moved to \`${movedKey}\` (config v38); writing the old key would have no effect. Use \`config set ${movedKey} ${rawValue}\` or the \`speech\` command.`,
             );
           }
           try {

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -132,6 +132,7 @@ import {
   SLACK_WEBHOOK_DEFAULT_TARGET,
   slackWebhookSecretNameForTarget,
 } from '../channels/slack-webhook/target.js';
+import { resolveRealtimeConnection } from '../channels/voice/realtime-credentials.js';
 import {
   createTwilioOutboundCall,
   normalizeTwilioPhoneNumber,
@@ -208,6 +209,7 @@ import {
   type RuntimeConfig,
   type RuntimeHttpRequestAuthRule,
   type RuntimeHttpRequestAuthRuleSecret,
+  type RuntimeSpeechRealtimeProvider,
   reloadRuntimeConfig,
   resolveDefaultAgentId,
   runtimeConfigPath,
@@ -1165,6 +1167,32 @@ const MAX_RALPH_ITERATIONS = 64;
 const RESET_CONFIRMATION_TTL_MS = 120_000;
 const DISCORD_CHANNEL_MODE_VALUES = new Set(['off', 'mention', 'free']);
 const DISCORD_GROUP_POLICY_VALUES = new Set(['open', 'allowlist', 'disabled']);
+
+const SPEECH_REALTIME_PROVIDER_VALUES = new Set(['auto', 'hybridai', 'openai']);
+
+/**
+ * Status lines for the realtime speech engine (`speech.realtime.*`), shared
+ * by `/speech` and the realtime section of `/voice info`. The prefix keeps
+ * both surfaces' labels aligned ("Realtime provider: …").
+ */
+function buildSpeechRealtimeStatusLines(prefix: string): string[] {
+  const realtimeConfig = getRuntimeConfig().speech.realtime;
+  const resolved = resolveRealtimeConnection(realtimeConfig.provider);
+  return [
+    realtimeConfig.provider === 'auto'
+      ? `${prefix}provider: auto (${
+          resolved.connection
+            ? `using ${resolved.connection.provider}`
+            : 'no credential found'
+        })`
+      : `${prefix}provider: ${realtimeConfig.provider}`,
+    `${prefix}model: ${realtimeConfig.model}`,
+    `${prefix}voice: ${realtimeConfig.voice}`,
+    resolved.connection
+      ? `${prefix}credential: configured`
+      : `${prefix}credential: missing — ${resolved.error}`,
+  ];
+}
 const IMAGE_QUESTION_RE =
   /(what(?:'s| is)? on (?:the )?(?:image|picture|photo|screenshot)|describe (?:this|the) (?:image|picture|photo)|image|picture|photo|screenshot|ocr|diagram|chart|grafik|bild|foto|was steht|was ist auf dem bild)/i;
 const BROWSER_TAB_RE =
@@ -12839,7 +12867,8 @@ export async function handleGatewayCommand(
               publicWebhook.url
                 ? `Webhook: ${publicWebhook.url}`
                 : `Webhook: unavailable (${publicWebhook.error})`,
-              'Usage: `voice call <e164-number>`',
+              ...buildSpeechRealtimeStatusLines('Realtime '),
+              'Usage: `voice call <e164-number>`; realtime speech settings live under `speech`',
             ].join('\n'),
           );
         }
@@ -12918,6 +12947,77 @@ export async function handleGatewayCommand(
         }
 
         return badCommand('Usage', 'Usage: `voice [info|call <e164-number>]`');
+      }
+
+      case 'speech': {
+        if (!isLocalSession(req)) {
+          return badCommand(
+            'Speech Command Restricted',
+            '`speech` edits local runtime config and is only available from local TUI/web sessions.',
+          );
+        }
+
+        const sub = parseLowerArg(req.args, 1);
+
+        if (!sub || sub === 'info' || sub === 'status') {
+          return infoCommand(
+            'Speech',
+            [
+              ...buildSpeechRealtimeStatusLines('Realtime '),
+              'Usage: `speech provider auto|hybridai|openai`, `speech model <model>`, or `speech voice <voice>`',
+            ].join('\n'),
+          );
+        }
+
+        if (sub === 'provider') {
+          const requested = parseLowerArg(req.args, 2);
+          if (!requested) {
+            return infoCommand(
+              'Speech Provider',
+              [
+                buildSpeechRealtimeStatusLines('Realtime ')[0],
+                'Usage: `speech provider auto|hybridai|openai`',
+              ].join('\n'),
+            );
+          }
+          if (!SPEECH_REALTIME_PROVIDER_VALUES.has(requested)) {
+            return badCommand(
+              'Usage',
+              'Usage: `speech provider auto|hybridai|openai`',
+            );
+          }
+          const provider = requested as RuntimeSpeechRealtimeProvider;
+          updateRuntimeConfig((draft) => {
+            draft.speech.realtime.provider = provider;
+          });
+          const resolved = resolveRealtimeConnection(provider);
+          return plainCommand(
+            resolved.connection
+              ? `Realtime speech provider set to \`${provider}\` (sessions will use ${resolved.connection.provider}).`
+              : `Realtime speech provider set to \`${provider}\`, but no usable credential: ${resolved.error}`,
+          );
+        }
+
+        if (sub === 'model' || sub === 'voice') {
+          const value = req.args.slice(2).join(' ').trim();
+          if (!value) {
+            return badCommand(
+              'Usage',
+              `Usage: \`speech ${sub} <${sub === 'model' ? 'model-id' : 'voice-name'}>\``,
+            );
+          }
+          updateRuntimeConfig((draft) => {
+            draft.speech.realtime[sub] = value;
+          });
+          return plainCommand(
+            `Realtime speech ${sub} set to \`${value}\`. New voice sessions pick it up immediately.`,
+          );
+        }
+
+        return badCommand(
+          'Usage',
+          'Usage: `speech [info|provider|model|voice] <value>`',
+        );
       }
 
       case 'config': {

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -544,6 +544,7 @@ export interface GatewayStatus {
     fromNumberConfigured: boolean;
     authTokenConfigured: boolean;
     authTokenSource: 'config' | 'env' | 'runtime-secrets' | null;
+    realtimeConfigured: boolean;
     webhookPath: string;
     maxConcurrentCalls: number;
   };

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -3340,10 +3340,11 @@ async function startVoiceIntegration(): Promise<boolean> {
     return false;
   }
   if (voiceConfig.mode === 'realtime') {
-    const resolved = resolveRealtimeConnection(voiceConfig.realtime.provider);
+    const realtimeProvider = getConfigSnapshot().speech.realtime.provider;
+    const resolved = resolveRealtimeConnection(realtimeProvider);
     if (!resolved.connection) {
       logger.warn(
-        { provider: voiceConfig.realtime.provider },
+        { provider: realtimeProvider },
         `Voice integration disabled: ${resolved.error}`,
       );
       return false;

--- a/src/gateway/webchat-voice.ts
+++ b/src/gateway/webchat-voice.ts
@@ -105,7 +105,7 @@ export function consumeWebchatVoiceStreamToken(
 
 export function isWebchatVoiceAvailable(): boolean {
   return isRealtimeCredentialConfigured(
-    getConfigSnapshot().voice.realtime.provider,
+    getConfigSnapshot().speech.realtime.provider,
   );
 }
 
@@ -217,7 +217,7 @@ export class WebchatVoiceConnection {
       this.fail('Voice session already started.', 1008);
       return;
     }
-    const voiceConfig = getConfigSnapshot().voice.realtime;
+    const voiceConfig = getConfigSnapshot().speech.realtime;
     const resolved = resolveRealtimeConnection(voiceConfig.provider);
     if (!resolved.connection) {
       this.fail(resolved.error, 1011);

--- a/src/plugins/plugin-realtime-voice.ts
+++ b/src/plugins/plugin-realtime-voice.ts
@@ -55,7 +55,7 @@ export interface PluginRealtimeVoiceDeps {
 
 export function isPluginRealtimeVoiceAvailable(): boolean {
   return isRealtimeCredentialConfigured(
-    getConfigSnapshot().voice.realtime.provider,
+    getConfigSnapshot().speech.realtime.provider,
   );
 }
 
@@ -63,7 +63,7 @@ export function createPluginRealtimeVoiceSession(
   options: PluginRealtimeVoiceSessionOptions,
   deps: PluginRealtimeVoiceDeps,
 ): PluginRealtimeVoiceSession {
-  const voiceConfig = getConfigSnapshot().voice.realtime;
+  const voiceConfig = getConfigSnapshot().speech.realtime;
   const resolved = resolveRealtimeConnection(voiceConfig.provider);
   if (!resolved.connection) {
     throw new Error(resolved.error);

--- a/src/plugins/plugin-types.ts
+++ b/src/plugins/plugin-types.ts
@@ -555,7 +555,7 @@ export interface PluginRealtimeVoiceSessionIdentity {
 
 /**
  * A realtime speech-to-speech voice session backed by the core realtime
- * engine (`voice.realtime.*` config and credentials). Transport audio is
+ * engine (`speech.realtime.*` config and credentials). Transport audio is
  * 16-bit LE mono PCM at 8 kHz; model audio is delivered as paced 20 ms
  * frames so barge-in can cut playback promptly.
  */

--- a/tests/command-registry.test.ts
+++ b/tests/command-registry.test.ts
@@ -682,6 +682,48 @@ test('registers voice as a local slash/text command', async () => {
   ).toEqual(['voice', 'call', '+14155551212']);
 });
 
+test('registers speech as a local slash/text command', async () => {
+  const {
+    buildTuiSlashCommandDefinitions,
+    isRegisteredTextCommandName,
+    parseCanonicalSlashCommandArgs,
+    mapCanonicalCommandToGatewayArgs,
+  } = await importCommandRegistry();
+  expect(isRegisteredTextCommandName('speech')).toBe(true);
+  expect(buildTuiSlashCommandDefinitions([])).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: 'speech',
+        options: expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'subcommand',
+            name: 'set',
+          }),
+        ]),
+      }),
+    ]),
+  );
+  expect(
+    parseCanonicalSlashCommandArgs({
+      commandName: 'speech',
+      getString: () => null,
+      getSubcommand: () => null,
+    }),
+  ).toEqual(['speech']);
+  expect(
+    parseCanonicalSlashCommandArgs({
+      commandName: 'speech',
+      getString: (name) =>
+        name === 'setting' ? 'provider' : name === 'value' ? 'openai' : null,
+      getSubcommand: () => 'set',
+    }),
+  ).toEqual(['speech', 'provider', 'openai']);
+  expect(mapCanonicalCommandToGatewayArgs(['speech'])).toEqual(['speech']);
+  expect(
+    mapCanonicalCommandToGatewayArgs(['speech', 'voice', 'cedar']),
+  ).toEqual(['speech', 'voice', 'cedar']);
+});
+
 test('parses /concierge profile into gateway args', async () => {
   const { parseCanonicalSlashCommandArgs, mapCanonicalCommandToGatewayArgs } =
     await importCommandRegistry();

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -625,6 +625,7 @@ async function importFreshHealth(options?: {
     { id: string; label: string; claims: Record<string, unknown> }
   >;
   webchatVoiceAvailable?: boolean;
+  realtimeResolvedProvider?: 'hybridai' | 'openai' | null;
   mediaUploadQuotaDecision?: {
     allowed: boolean;
     remainingBytes: number;
@@ -2839,6 +2840,24 @@ async function importFreshHealth(options?: {
       webchatVoiceManager: { handleUpgrade: webchatVoiceUpgrade },
     };
   });
+  const realtimeResolvedProvider = options?.realtimeResolvedProvider ?? null;
+  vi.doMock('../src/channels/voice/realtime-credentials.js', () => ({
+    resolveRealtimeConnection: vi.fn(() =>
+      realtimeResolvedProvider
+        ? {
+            connection: {
+              provider: realtimeResolvedProvider,
+              url: 'wss://example.test/v1/realtime',
+              apiKey: 'test-key',
+            },
+            error: null,
+          }
+        : { connection: null, error: 'no credential' },
+    ),
+    isRealtimeCredentialConfigured: vi.fn(
+      () => realtimeResolvedProvider !== null,
+    ),
+  }));
   vi.doMock('../src/plugins/plugin-manager.js', () => ({
     findLoadedPluginCommand: vi.fn(() => undefined),
     listLoadedPluginCommands,
@@ -17124,6 +17143,45 @@ describe('gateway HTTP server', () => {
     expect(state.broadcastShutdownTerminal).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'shutdown' }),
     );
+  });
+
+  test('chat voice capability reports the resolved realtime provider', async () => {
+    const state = await importFreshHealth({
+      realtimeResolvedProvider: 'hybridai',
+    });
+    const req = makeRequest({ url: '/api/chat/voice' });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      available: true,
+      provider: 'hybridai',
+      model: 'gpt-realtime',
+      voice: 'marin',
+    });
+  });
+
+  test('chat voice capability reports a null provider without a credential', async () => {
+    const state = await importFreshHealth({
+      realtimeResolvedProvider: null,
+      webchatVoiceAvailable: false,
+    });
+    const req = makeRequest({ url: '/api/chat/voice' });
+    const res = makeResponse();
+
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      available: false,
+      provider: null,
+      model: 'gpt-realtime',
+      voice: 'marin',
+    });
   });
 
   test('mints a voice stream token for an API token scoped to voice.session', async () => {

--- a/tests/gateway-service.voice-command.test.ts
+++ b/tests/gateway-service.voice-command.test.ts
@@ -298,6 +298,41 @@ test('speech model and voice setters persist trimmed values', async () => {
   expect(missingValue.kind).toBe('error');
 });
 
+test('config get/set on the legacy voice.realtime keys redirects to speech.realtime', async () => {
+  setupHome();
+
+  const { getRuntimeConfig } = await import('../src/config/runtime-config.ts');
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  const setResult = await handleGatewayCommand({
+    sessionId: 'session-legacy-realtime-set',
+    guildId: null,
+    channelId: 'web',
+    args: ['config', 'set', 'voice.realtime.voice', 'cedar'],
+  });
+
+  expect(setResult.kind).toBe('error');
+  expect(setResult.title).toBe('Config Key Moved');
+  expect(setResult.text).toContain('speech.realtime.voice');
+  expect(getRuntimeConfig().speech.realtime.voice).toBe('marin');
+
+  const getResult = await handleGatewayCommand({
+    sessionId: 'session-legacy-realtime-get',
+    guildId: null,
+    channelId: 'web',
+    args: ['config', 'get', 'voice.realtime.provider'],
+  });
+
+  expect(getResult.kind).toBe('error');
+  expect(getResult.title).toBe('Config Key Moved');
+  expect(getResult.text).toContain('speech.realtime.provider');
+});
+
 test('speech command stays restricted to local sessions', async () => {
   setupHome();
 

--- a/tests/gateway-service.voice-command.test.ts
+++ b/tests/gateway-service.voice-command.test.ts
@@ -168,6 +168,157 @@ test('voice call rejects localhost webhook base URLs before dialing', async () =
   expect(result.text).toContain('ops.gatewayBaseUrl');
 });
 
+test('voice info reports realtime provider, model, voice, and credential state', async () => {
+  setupHome();
+
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  updateRuntimeConfig((draft) => {
+    draft.ops.gatewayBaseUrl = 'https://voice.example.com';
+  });
+
+  const result = await handleGatewayCommand({
+    sessionId: 'session-voice-realtime-info',
+    guildId: null,
+    channelId: 'web',
+    args: ['voice', 'info'],
+  });
+
+  expect(result.kind).toBe('info');
+  expect(result.text).toContain('Realtime provider: auto (');
+  expect(result.text).toContain('Realtime model: gpt-realtime');
+  expect(result.text).toContain('Realtime voice: marin');
+  expect(result.text).toContain('Realtime credential:');
+});
+
+test('speech shows a realtime status block', async () => {
+  setupHome();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  const result = await handleGatewayCommand({
+    sessionId: 'session-speech-status',
+    guildId: null,
+    channelId: 'web',
+    args: ['speech'],
+  });
+
+  expect(result.kind).toBe('info');
+  expect(result.title).toBe('Speech');
+  expect(result.text).toContain('Realtime model: gpt-realtime');
+  expect(result.text).toContain('speech provider auto|hybridai|openai');
+});
+
+test('speech provider persists a valid provider and rejects others', async () => {
+  setupHome();
+
+  const { getRuntimeConfig, updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  updateRuntimeConfig((draft) => {
+    draft.speech.realtime.provider = 'auto';
+  });
+
+  const set = await handleGatewayCommand({
+    sessionId: 'session-speech-provider',
+    guildId: null,
+    channelId: 'web',
+    args: ['speech', 'provider', 'openai'],
+  });
+
+  expect(set.kind).toBe('plain');
+  expect(set.text).toContain('Realtime speech provider set to `openai`');
+  expect(getRuntimeConfig().speech.realtime.provider).toBe('openai');
+
+  const rejected = await handleGatewayCommand({
+    sessionId: 'session-speech-provider',
+    guildId: null,
+    channelId: 'web',
+    args: ['speech', 'provider', 'bogus'],
+  });
+
+  expect(rejected.kind).toBe('error');
+  expect(getRuntimeConfig().speech.realtime.provider).toBe('openai');
+});
+
+test('speech model and voice setters persist trimmed values', async () => {
+  setupHome();
+
+  const { getRuntimeConfig } = await import('../src/config/runtime-config.ts');
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  const modelResult = await handleGatewayCommand({
+    sessionId: 'session-speech-model',
+    guildId: null,
+    channelId: 'web',
+    args: ['speech', 'model', ' gpt-realtime-mini '],
+  });
+  expect(modelResult.kind).toBe('plain');
+  expect(getRuntimeConfig().speech.realtime.model).toBe('gpt-realtime-mini');
+
+  const voiceResult = await handleGatewayCommand({
+    sessionId: 'session-speech-voice',
+    guildId: null,
+    channelId: 'web',
+    args: ['speech', 'voice', 'cedar'],
+  });
+  expect(voiceResult.kind).toBe('plain');
+  expect(voiceResult.text).toContain('set to `cedar`');
+  expect(getRuntimeConfig().speech.realtime.voice).toBe('cedar');
+
+  const missingValue = await handleGatewayCommand({
+    sessionId: 'session-speech-voice',
+    guildId: null,
+    channelId: 'web',
+    args: ['speech', 'voice'],
+  });
+  expect(missingValue.kind).toBe('error');
+});
+
+test('speech command stays restricted to local sessions', async () => {
+  setupHome();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { handleGatewayCommand } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  const result = await handleGatewayCommand({
+    sessionId: 'session-speech-remote',
+    guildId: 'guild-1',
+    channelId: 'discord:channel-1',
+    args: ['speech', 'provider', 'openai'],
+  });
+
+  expect(result.kind).toBe('error');
+  expect(result.title).toBe('Speech Command Restricted');
+});
+
 test('voice command stays restricted to local sessions', async () => {
   setupHome();
 

--- a/tests/gateway-status.test.ts
+++ b/tests/gateway-status.test.ts
@@ -1015,6 +1015,7 @@ test('getGatewayStatus includes voice Twilio credential status', async () => {
     fromNumberConfigured: true,
     authTokenConfigured: true,
     authTokenSource: 'runtime-secrets',
+    realtimeConfigured: expect.any(Boolean),
     webhookPath: '/voice',
     maxConcurrentCalls: 8,
   });

--- a/tests/plugin-realtime-voice.test.ts
+++ b/tests/plugin-realtime-voice.test.ts
@@ -72,7 +72,7 @@ async function createSession(params?: {
   vi.doMock('../src/config/config.js', () => ({
     OPENAI_API_KEY: params?.apiKey ?? 'test-key',
     HYBRIDAI_BASE_URL: 'https://hybridai.example',
-    getConfigSnapshot: () => ({ voice: { realtime: REALTIME_CONFIG } }),
+    getConfigSnapshot: () => ({ speech: { realtime: REALTIME_CONFIG } }),
   }));
   vi.doMock('../src/gateway/voice-transcript-store.js', () => ({
     persistVoiceTranscript,

--- a/tests/runtime-config.migration-logging.test.ts
+++ b/tests/runtime-config.migration-logging.test.ts
@@ -300,6 +300,44 @@ describe('runtime config migration logging', () => {
     );
   });
 
+  it('migrates legacy voice.realtime into speech.realtime on startup', async () => {
+    const homeDir = makeTempHome();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writeRuntimeConfig(homeDir, (config) => {
+      config.version = 37;
+      delete (config as unknown as { speech?: unknown }).speech;
+      (config.voice as unknown as Record<string, unknown>).realtime = {
+        provider: 'openai',
+        model: 'custom-realtime-model',
+        voice: 'cedar',
+        greeting: 'Hi there!',
+        instructions: 'Be brief.',
+      };
+    });
+
+    const runtimeConfig = await importFreshRuntimeConfig(homeDir);
+    const stored = JSON.parse(
+      fs.readFileSync(
+        path.join(homeDir, '.hybridclaw', 'config.json'),
+        'utf-8',
+      ),
+    ) as RuntimeConfig & { voice: { realtime?: unknown } };
+
+    expect(runtimeConfig.getRuntimeConfig().speech.realtime).toEqual({
+      provider: 'openai',
+      model: 'custom-realtime-model',
+      voice: 'cedar',
+      greeting: 'Hi there!',
+      instructions: 'Be brief.',
+    });
+    expect(stored.speech.realtime.provider).toBe('openai');
+    expect(stored.voice.realtime).toBeUndefined();
+    expect(stored.version).toBe(runtimeConfig.CONFIG_VERSION);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[runtime-config] migrated legacy voice.realtime into speech.realtime; realtime speech settings now live at speech.realtime',
+    );
+  });
+
   it('normalizes MCP server transport aliases on startup', async () => {
     const homeDir = makeTempHome();
     writeRuntimeConfig(homeDir, (config) => {

--- a/tests/voice.realtime-credentials.test.ts
+++ b/tests/voice.realtime-credentials.test.ts
@@ -34,6 +34,7 @@ test('openai provider connects to api.openai.com with OPENAI_API_KEY', async () 
   const resolved = credentials.resolveRealtimeConnection('openai');
 
   expect(resolved.connection).toEqual({
+    provider: 'openai',
     url: 'wss://api.openai.com/v1/realtime',
     apiKey: 'sk-test',
   });
@@ -59,6 +60,7 @@ test('hybridai provider derives a wss URL from HYBRIDAI_BASE_URL', async () => {
   const resolved = credentials.resolveRealtimeConnection('hybridai');
 
   expect(resolved.connection).toEqual({
+    provider: 'hybridai',
     url: 'wss://hybridai.one/v1/realtime',
     apiKey: 'hai-key',
   });
@@ -97,6 +99,7 @@ test('auto prefers hybridai when a HybridAI credential is present', async () => 
   const resolved = credentials.resolveRealtimeConnection('auto');
 
   expect(resolved.connection).toEqual({
+    provider: 'hybridai',
     url: 'wss://hybridai.one/v1/realtime',
     apiKey: 'hai-key',
   });
@@ -112,6 +115,7 @@ test('auto falls back to openai when only OPENAI_API_KEY is set', async () => {
   const resolved = credentials.resolveRealtimeConnection('auto');
 
   expect(resolved.connection).toEqual({
+    provider: 'openai',
     url: 'wss://api.openai.com/v1/realtime',
     apiKey: 'sk-test',
   });

--- a/tests/voice.runtime.test.ts
+++ b/tests/voice.runtime.test.ts
@@ -251,14 +251,16 @@ test('handleVoiceWebhook returns media stream TwiML in realtime mode', async () 
         interruptible: true,
         welcomeGreeting: 'Hello! How can I help you today?',
       },
+      webhookPath: '/voice',
+      maxConcurrentCalls: 8,
+    },
+    speech: {
       realtime: {
         model: 'gpt-realtime',
         voice: 'marin',
         greeting: 'Hello! How can I help you today?',
         instructions: '',
       },
-      webhookPath: '/voice',
-      maxConcurrentCalls: 8,
     },
   }));
 

--- a/tests/webchat-voice.test.ts
+++ b/tests/webchat-voice.test.ts
@@ -92,7 +92,7 @@ async function createConnection(params?: { apiKey?: string }) {
   vi.doMock('../src/config/config.js', () => ({
     OPENAI_API_KEY: params?.apiKey ?? 'test-key',
     HYBRIDAI_BASE_URL: 'https://hybridai.example',
-    getConfigSnapshot: () => ({ voice: { realtime: REALTIME_CONFIG } }),
+    getConfigSnapshot: () => ({ speech: { realtime: REALTIME_CONFIG } }),
   }));
   vi.doMock('../src/config/runtime-config.js', () => ({
     getRuntimeConfig: () => ({}),
@@ -136,7 +136,7 @@ async function loadWebchatVoiceModule() {
   vi.doMock('../src/config/config.js', () => ({
     OPENAI_API_KEY: 'test-key',
     HYBRIDAI_BASE_URL: 'https://hybridai.example',
-    getConfigSnapshot: () => ({ voice: { realtime: REALTIME_CONFIG } }),
+    getConfigSnapshot: () => ({ speech: { realtime: REALTIME_CONFIG } }),
   }));
   vi.doMock('../src/config/runtime-config.js', () => ({
     getRuntimeConfig: () => ({}),


### PR DESCRIPTION
## Why

Realtime speech settings lived at `voice.realtime.*` inside the Twilio phone channel section, even though they drive three surfaces: realtime phone calls, web console voice mode (which works with the phone channel disabled), and plugin realtime sessions. That made them hard to discover — the Discord question "where are the settings, and which provider is doing this?" had no good answer: no console UI showed them, no command reported them, and `config.example.json` was even missing the `provider` key.

## What

**Config schema move + migration**
- New top-level `speech` section: `speech.realtime.{provider,model,voice,greeting,instructions}` (`CONFIG_VERSION` 37 → 38). `voice.*` is purely the Twilio phone channel again.
- Legacy `voice.realtime.*` configs from v0.29.x are honored during normalization and rewritten to the new shape by the startup schema migration (same pattern as the `container.additionalMounts` → `container.binds` migration), with a warn log.
- `speech` is the anticipated home for future speech settings — the TTS/dictation deferral comments ("until HybridClaw has a general speech settings surface") now have a landing spot.

**New `/speech` command (local sessions)**
- `/speech` — provider (including which backend `auto` resolved to), model, voice, and credential status.
- `/speech provider auto|hybridai|openai`, `/speech model <id>`, `/speech voice <name>` — validated setters; new voice sessions pick changes up immediately.
- `/voice info` keeps a realtime status block and points at `/speech`.

**Admin console**
- `speech` renders as a real settings section in `/admin/config`, with an enum dropdown for the provider.
- The voice channel editor gains the missing `voice.mode` selector and a "Realtime speech" fieldset (bound to `speech.realtime.*`), plus relay/realtime section headings.

**Web chat visibility**
- `resolveRealtimeConnection` now names the provider it resolved; `GET /api/chat/voice` returns it (`provider: 'hybridai' | 'openai' | null`) alongside model and voice, and the voice button / live-call capsule tooltips show e.g. `hybridai · gpt-realtime · marin`.

**Docs**: configuration reference, Twilio voice guide (updated JSON example), web voice API guide, Vonage guide, plugins guide, admin console page, `config.example.json`, changelog.

## Testing

- New tests: legacy-config migration (`runtime-config.migration-logging`), `/speech` command matrix (status, provider validation, model/voice setters, remote-session restriction), command-registry registration/parsers, `/api/chat/voice` payload with a mockable resolved provider.
- Full `npm run lint` (strict tsc + console + desktop typechecks + settings-registry drift check) passes; biome clean.
- Suites run green: migration/command/realtime (118), gateway-http-server + config integration (455), CLI (161), console routes (60).