### PR TITLE
fix: always send required voucherStatus on Lexware voucherlist requests

### DIFF
--- a/skills/lexware-office/SKILL.md
+++ b/skills/lexware-office/SKILL.md
@@ -266,6 +266,12 @@ the voucher after explicit operator grant.
 - Never build an Authorization header manually in a prompt. Use
   `bearerSecretName: "LEXWARE_OFFICE_API_KEY"`.
 - Prefer helper-emitted `httpRequest` payloads over handcrafted API calls.
+- Lexware requires the `voucherStatus` query parameter on
+  `GET /v1/voucherlist`; requests without it fail with HTTP 400. The helper
+  always sends it, defaulting `--status` to `any` for `list-invoices`,
+  `list-quotations`, `list-expenses`, `list-bank-transactions`, and the
+  voucherlist-based report plans. Pass an explicit `--status` (single value or
+  comma-separated; run `--help` for accepted values) only to filter.
 - Read before write when IDs, versions, posting categories, contact IDs, or
   invoice recipient details are ambiguous.
 - If multiple contacts or invoices match, stop and ask for the exact ID before

--- a/skills/lexware-office/lexware_office.cjs
+++ b/skills/lexware-office/lexware_office.cjs
@@ -292,10 +292,7 @@ function buildReadRequest(operation, args) {
     return buildHttpRequest({ url: `${API_BASE}/v1/articles/${id}` });
   }
   if (operation === 'list-invoices') {
-    return buildVoucherListRequest(args, {
-      voucherType: 'invoice',
-      voucherStatus: popFlag(args, '--status'),
-    });
+    return buildVoucherListRequest(args, { voucherType: 'invoice' });
   }
   if (operation === 'get-invoice') {
     const id = popFlag(args, '--id');
@@ -311,10 +308,7 @@ function buildReadRequest(operation, args) {
     });
   }
   if (operation === 'list-quotations') {
-    return buildVoucherListRequest(args, {
-      voucherType: 'quotation',
-      voucherStatus: popFlag(args, '--status'),
-    });
+    return buildVoucherListRequest(args, { voucherType: 'quotation' });
   }
   if (operation === 'get-quotation') {
     const id = popFlag(args, '--id');
@@ -340,7 +334,6 @@ function buildReadRequest(operation, args) {
   if (operation === 'list-expenses') {
     return buildVoucherListRequest(args, {
       voucherType: 'purchaseinvoice,purchasecreditnote',
-      voucherStatus: popFlag(args, '--status'),
     });
   }
   if (operation === 'get-voucher') {
@@ -364,79 +357,78 @@ function buildReadRequest(operation, args) {
   die(`Unsupported read operation: ${operation}`);
 }
 
-function buildVoucherListRequest(args, defaults = {}) {
-  const url = appendQuery(`${API_BASE}/v1/voucherlist`, {
+function popVoucherListParams(args, defaults = {}) {
+  return {
     page: popFlag(args, '--page', '0'),
     size: parsePageSize(popFlag(args, '--size', '25')),
     voucherType: popFlag(args, '--voucher-type', defaults.voucherType),
-    voucherStatus: popFlag(args, '--status', defaults.voucherStatus),
+    // Lexware rejects GET /v1/voucherlist without voucherStatus; "any" is the
+    // documented wildcard, so the helper always sends a status.
+    voucherStatus: popFlag(args, '--status', 'any'),
     voucherNumber: popFlag(args, '--voucher-number'),
     contactId: popFlag(args, '--contact-id'),
     voucherDateFrom: popFlag(args, '--start-date'),
     voucherDateTo: popFlag(args, '--end-date'),
-  });
-  return buildHttpRequest({ url });
-}
-
-function statementWindow(args) {
-  return {
-    startDate: popFlag(args, '--start-date'),
-    endDate: popFlag(args, '--end-date'),
   };
 }
 
+function buildVoucherListRequestFromParams(params) {
+  const url = appendQuery(`${API_BASE}/v1/voucherlist`, params);
+  return buildHttpRequest({ url });
+}
+
+function buildVoucherListRequest(args, defaults = {}) {
+  return buildVoucherListRequestFromParams(popVoucherListParams(args, defaults));
+}
+
 function buildStatementPlan(args) {
-  const originalArgs = [...args];
-  const window = statementWindow(args);
+  const params = popVoucherListParams(args);
+  const revenueType =
+    params.voucherType ?? 'invoice,creditnote,salesinvoice,salescreditnote';
+  const expenseType = params.voucherType ?? 'purchaseinvoice,purchasecreditnote';
   return {
     command: 'income-statement-plan',
     note: 'Lexware Office Public API does not expose a native income-statement endpoint. Use voucherlist plus posting categories and aggregate revenue and expenses locally.',
     requestSequence: [
-      buildVoucherListRequest([...originalArgs], {
-        voucherType: 'invoice,creditnote,salesinvoice,salescreditnote',
-      }).httpRequest,
-      buildVoucherListRequest([...originalArgs], {
-        voucherType: 'purchaseinvoice,purchasecreditnote',
-      }).httpRequest,
+      buildVoucherListRequestFromParams({ ...params, voucherType: revenueType })
+        .httpRequest,
+      buildVoucherListRequestFromParams({ ...params, voucherType: expenseType })
+        .httpRequest,
       buildHttpRequest({ url: `${API_BASE}/v1/posting-categories` })
         .httpRequest,
     ],
-    window,
+    window: {
+      startDate: params.voucherDateFrom,
+      endDate: params.voucherDateTo,
+    },
     costMeasurement: COST_MEASUREMENT,
   };
 }
 
 function buildRevenuePlan(args) {
-  const originalArgs = [...args];
-  const window = statementWindow(args);
+  const params = popVoucherListParams(args, {
+    voucherType: 'invoice,creditnote,salesinvoice,salescreditnote',
+  });
   return {
     command: 'revenue-summary-plan',
-    requestSequence: [
-      buildVoucherListRequest([...originalArgs], {
-        voucherType: 'invoice,creditnote,salesinvoice,salescreditnote',
-      }).httpRequest,
-    ],
-    window,
+    requestSequence: [buildVoucherListRequestFromParams(params).httpRequest],
+    window: {
+      startDate: params.voucherDateFrom,
+      endDate: params.voucherDateTo,
+    },
     costMeasurement: COST_MEASUREMENT,
   };
 }
 
 function buildBankTransactionPlan(args) {
-  const status = popFlag(args, '--status');
-  const originalArgs = [...args];
-  if (status && status !== 'any') {
-    originalArgs.push('--status', status);
-  }
+  const params = popVoucherListParams(args, {
+    voucherType:
+      'invoice,creditnote,salesinvoice,salescreditnote,purchaseinvoice,purchasecreditnote',
+  });
   return {
     command: 'bank-transaction-plan',
     note: 'Lexware Office Public API exposes bank-linked payments as paymentItems with paymentItemType partPaymentFinancialTransaction on /v1/payments/{voucherId}. Fetch candidate vouchers first, then fetch payment details per voucher id.',
-    requestSequence: [
-      buildVoucherListRequest([...originalArgs], {
-        voucherType:
-          'invoice,creditnote,salesinvoice,salescreditnote,purchaseinvoice,purchasecreditnote',
-        voucherStatus: status && status !== 'any' ? status : undefined,
-      }).httpRequest,
-    ],
+    requestSequence: [buildVoucherListRequestFromParams(params).httpRequest],
     followUpRequestTemplate: {
       url: `${API_BASE}/v1/payments/{voucherId}`,
       method: 'GET',
@@ -984,16 +976,16 @@ Usage:
   node skills/lexware-office/lexware_office.cjs http-request list-contacts [--name NAME] [--email EMAIL] [--page N] [--size N]
   node skills/lexware-office/lexware_office.cjs http-request get-contact --id UUID
   node skills/lexware-office/lexware_office.cjs http-request list-products [--article-number VALUE] [--type PRODUCT|SERVICE] [--page N] [--size N]
-  node skills/lexware-office/lexware_office.cjs http-request list-invoices [--status open] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]
+  node skills/lexware-office/lexware_office.cjs http-request list-invoices [--status STATUS] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]
   node skills/lexware-office/lexware_office.cjs http-request get-invoice --id UUID
-  node skills/lexware-office/lexware_office.cjs http-request list-quotations [--status open|accepted|rejected|draft] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]
+  node skills/lexware-office/lexware_office.cjs http-request list-quotations [--status STATUS] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]
   node skills/lexware-office/lexware_office.cjs http-request get-quotation --id UUID
   node skills/lexware-office/lexware_office.cjs http-request download-quotation-file --id UUID
   node skills/lexware-office/lexware_office.cjs http-request render-quotation-document --id UUID
-  node skills/lexware-office/lexware_office.cjs http-request list-expenses [--status open] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]
+  node skills/lexware-office/lexware_office.cjs http-request list-expenses [--status STATUS] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]
   node skills/lexware-office/lexware_office.cjs http-request get-voucher --id UUID
   node skills/lexware-office/lexware_office.cjs http-request get-payment --voucher-id UUID
-  node skills/lexware-office/lexware_office.cjs http-request list-bank-transactions [--status any]
+  node skills/lexware-office/lexware_office.cjs http-request list-bank-transactions [--status STATUS]
   node skills/lexware-office/lexware_office.cjs http-request posting-categories
   node skills/lexware-office/lexware_office.cjs http-request income-statement-plan --start-date YYYY-MM-DD --end-date YYYY-MM-DD
   node skills/lexware-office/lexware_office.cjs income-statement --revenue-file PATH --expense-file PATH [--categories-file PATH]
@@ -1007,6 +999,12 @@ Usage:
   node skills/lexware-office/lexware_office.cjs http-request attach-file-to-voucher --voucher-id UUID --file PATH --operator-grant
   node skills/lexware-office/lexware_office.cjs http-request match-transaction --voucher-id UUID --voucher-json JSON --transaction-json JSON --operator-grant
   node skills/lexware-office/lexware_office.cjs eval-scenarios
+
+STATUS values (Lexware GET /v1/voucherlist requires voucherStatus; the helper
+defaults --status to "any"):
+  any | draft | open | paid | paidoff | voided | transferred | sepadebit | overdue | accepted | rejected
+  Comma-separated lists are allowed, e.g. --status open,overdue.
+  Invoices use draft|open|paid|paidoff|voided; quotations use draft|open|accepted|rejected.
 `;
 }
 
@@ -1019,6 +1017,13 @@ function main() {
   }
 
   const command = args.shift();
+  if (
+    command !== 'plan' &&
+    (args.includes('--help') || args.includes('-h'))
+  ) {
+    process.stdout.write(usage());
+    return;
+  }
   let payload;
   if (command === 'plan') {
     const request = args.join(' ').trim();
@@ -1036,6 +1041,11 @@ function main() {
     payload = runEvalScenarios();
   } else {
     die(`Unknown command: ${command}`);
+  }
+  if (command !== 'plan' && args.length > 0) {
+    die(
+      `Unknown arguments for ${command}: ${args.join(' ')}. Run --help for usage.`,
+    );
   }
 
   if (format === 'json') {

--- a/tests/lexware-office-skill.test.ts
+++ b/tests/lexware-office-skill.test.ts
@@ -78,15 +78,42 @@ test('Lexware Office helper --help exits cleanly', () => {
     'list-products [--article-number VALUE] [--type PRODUCT|SERVICE] [--page N] [--size N]',
   );
   expect(result.stdout).toContain(
-    'list-invoices [--status open] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]',
+    'list-invoices [--status STATUS] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]',
   );
   expect(result.stdout).toContain(
-    'list-quotations [--status open|accepted|rejected|draft] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]',
+    'list-quotations [--status STATUS] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]',
   );
   expect(result.stdout).toContain(
-    'list-expenses [--status open] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]',
+    'list-expenses [--status STATUS] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--page N] [--size N]',
   );
+  expect(result.stdout).toContain(
+    'GET /v1/voucherlist requires voucherStatus',
+  );
+  expect(result.stdout).toContain('defaults --status to "any"');
   expect(result.stdout).toContain('eval-scenarios');
+});
+
+test('Lexware Office helper prints usage for --help after an operation', () => {
+  const result = runHelper(['http-request', 'list-invoices', '--help']);
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain('Lexware Office skill helper');
+  expect(result.stdout).not.toContain('httpRequest');
+});
+
+test('Lexware Office helper rejects unknown flags instead of ignoring them', () => {
+  const result = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'list-invoices',
+    '--stauts',
+    'open',
+  ]);
+
+  expect(result.status).not.toBe(0);
+  expect(result.stderr).toContain('Unknown arguments for http-request');
+  expect(result.stderr).toContain('--stauts');
 });
 
 test('Lexware Office helper plans reads, writes, reports, and transaction matching', () => {
@@ -298,8 +325,26 @@ test('Lexware Office helper builds bank transaction read workflow', () => {
   expect(payload.filterPaymentItemType).toBe('partPaymentFinancialTransaction');
 });
 
-test('Lexware Office helper omits any status filter for bank transaction scans', () => {
-  const result = runHelper([
+test('Lexware Office helper always sends the required voucherStatus parameter', () => {
+  const invoices = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'list-invoices',
+  ]);
+  const quotations = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'list-quotations',
+  ]);
+  const expenses = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'list-expenses',
+  ]);
+  const bank = runHelper([
     '--format',
     'json',
     'http-request',
@@ -307,11 +352,34 @@ test('Lexware Office helper omits any status filter for bank transaction scans',
     '--status',
     'any',
   ]);
+  const statement = runHelper([
+    '--format',
+    'json',
+    'http-request',
+    'income-statement-plan',
+    '--start-date',
+    '2026-10-01',
+    '--end-date',
+    '2026-12-31',
+  ]);
 
-  expect(result.status).toBe(0);
-  const payload = JSON.parse(result.stdout);
-  expect(payload.requestSequence[0].url).not.toContain('voucherStatus=any');
-  expect(payload.requestSequence[0].url).not.toContain('voucherStatus=');
+  for (const result of [invoices, quotations, expenses]) {
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).httpRequest.url).toContain(
+      'voucherStatus=any',
+    );
+  }
+  expect(bank.status).toBe(0);
+  expect(JSON.parse(bank.stdout).requestSequence[0].url).toContain(
+    'voucherStatus=any',
+  );
+  expect(statement.status).toBe(0);
+  for (const request of JSON.parse(statement.stdout).requestSequence.slice(
+    0,
+    2,
+  )) {
+    expect(request.url).toContain('voucherStatus=any');
+  }
 });
 
 test('Lexware Office helper aggregates income statements from fetched voucher pages', () => {


### PR DESCRIPTION
## Problem

Lexware's Public API requires the `voucherStatus` query parameter on `GET /v1/voucherlist`, but the skill helper only sent it when `--status` was passed explicitly. Omitting it made `list-invoices`, `list-quotations`, and `list-expenses` emit requests Lexware rejects with HTTP 400 `Missing required request parameters: [voucherStatus]`. The voucherlist requests built by `income-statement-plan`, `revenue-summary-plan`, and `list-bank-transactions --status any` had the same latent bug.

Evidence: session `sess_20260826_140842_164d8f80`, where the agent burned 5 extra tool calls (~50s) rediscovering this. `voucherStatus=any` was verified live in that session and matches the documented wildcard.

## Changes

- **`--status` defaults to `any` everywhere**: voucherlist parsing is refactored into `popVoucherListParams` + `buildVoucherListRequestFromParams`, so every `/v1/voucherlist` request always carries `voucherStatus`. Explicit values (including comma-separated lists) pass through unchanged.
- **`list-bank-transactions` is consistent**: `--status any` (or omitted) now emits `voucherStatus=any` instead of stripping the parameter — the old omission was itself a request the API rejects.
- **Unknown flags now error**: unconsumed arguments after any command (except free-text `plan`) exit 2 with a pointer to `--help`. Previously `http-request list-invoices --help` silently built a default request, which misled the agent; `--help`/`-h` after a command now prints usage.
- **Docs**: usage text shows `[--status STATUS]` plus the requirement, default, and full accepted enum (`any|draft|open|paid|paidoff|voided|transferred|sepadebit|overdue|accepted|rejected`, confirmed against the Lexware API docs); `SKILL.md` gains a Working Rules bullet covering the same.

## Testing

- `npx vitest run tests/lexware-office-skill.test.ts` — 21/21 pass (new tests: `voucherStatus=any` default across all five builders, `--help` passthrough, unknown-flag rejection)
- `node skills/lexware-office/lexware_office.cjs eval-scenarios` — 31/31 pass
- `python3 skills/skill-creator/scripts/quick_validate.py skills/lexware-office` — pass

The deployed copy at `~/.hybridclaw/data/agents/header-smoke/workspace/skills/lexware-office/` was synced separately (byte-identical to this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)