### PR TITLE
chore: drop manifesto tags from PR workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,13 +28,6 @@ Describe the change in 2-5 bullets:
       [DCO](https://developercertificate.org/); the contribution is licensed
       under the repository's MIT license.
 
-## Manifesto Principle
-
-Which manifesto principle does this serve?
-
-- Principle:
-- Changelog tag added or updated: `Manifesto: Principle <Roman numeral> - <principle title>.`
-
 ## Validation
 
 List the checks you ran and the concrete scenarios you verified.

--- a/docs/content/internal/roadmap.md
+++ b/docs/content/internal/roadmap.md
@@ -623,7 +623,6 @@ Use these as issue titles. Keep each issue small enough to ship independently.
 Engineering hygiene that ships alongside P0:
 
 - ⬜ **A1** — End-to-end smoke scenario exercising #1 + #2 + #3 + #4 + #5 + #6 in one run.
-- ✅ **A2** — `CHANGELOG.md` with manifesto-principle tags per entry.
 - ✅ **A3** — Test-fixtures library (agents, clients, threads, secrets).
 - ⬜ **A4** — CI cost-regression gate against the eval suite.
 - ⬜ **A5** — Threat-model document for any feature touching secrets or keys.


### PR DESCRIPTION
## Summary

- Problem: The PR template still required contributors to map changes to a manifesto principle and add a matching changelog tag.
- Why it matters: The requirement adds obsolete process overhead and keeps a convention that is being retired.
- What changed: Removed the manifesto section from the PR template and deleted the corresponding roadmap hygiene item.
- What did not change: Existing manifesto documentation and historical changelog entries remain intact.

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Docs
- [ ] Tests
- [ ] Refactor required for the fix
- [x] Tooling or workflow
- [ ] Security hardening

## Linked Context

- Closes #
- Related #

## Licensing

- [x] All commits are signed off to certify the DCO.

## Validation

- corepack npm run format
- corepack npm run lint
- git diff --check
- Verified repository search finds no remaining contributor-facing manifesto tag requirement.
- Skipped tests because this only changes Markdown contributor guidance.

## Docs And Config Impact

- [x] README, docs, or examples updated
- [ ] Config or environment behavior changed
- [ ] Templates or workspace bootstrap files changed
- [ ] No docs or config impact

## Risk Notes

- Security-sensitive paths touched? No
- Gateway, audit, approval, or container boundaries touched? No

## Evidence

- [x] Focused diff removing the obsolete PR questionnaire and roadmap item
