### PR TITLE
fix: use Browser Use Cloud V4 defaults

### DIFF
--- a/src/browser/browser-use-cloud-provider.ts
+++ b/src/browser/browser-use-cloud-provider.ts
@@ -155,14 +155,14 @@ interface ActiveCloudSession {
   accruedCostUsd: number;
 }
 
-const DEFAULT_BASE_URL = 'https://api.browser-use.com/api/v3';
+const DEFAULT_BASE_URL = 'https://api.browser-use.com/api/v4';
 const DEFAULT_API_KEY_REF: SecretRef = {
   source: 'store',
   id: 'BROWSER_USE_API_KEY',
 };
 const DEFAULT_BROWSER_USE_CLOUD_PRICING: BrowserUseCloudPricing = {
-  // Browser Use Cloud documents Pay As You Go browser sessions at $0.06/hour.
-  browserUsdPerMinute: 0.001,
+  // Browser Use Cloud documents browser sessions at $0.02/hour.
+  browserUsdPerMinute: 0.02 / 60,
   actionUsd: 0,
 };
 const MINIMUM_BILLED_MINUTES = 1;

--- a/tests/browser-use-cloud-provider.test.ts
+++ b/tests/browser-use-cloud-provider.test.ts
@@ -196,7 +196,7 @@ test('browser-use cloud provider launches via stored SecretRef and emits audit p
   );
   const provider = new BrowserUseCloudProvider({
     apiKeyRef: { source: 'store', id: 'BROWSER_USE_API_KEY' },
-    baseUrl: 'https://api.browser-use.test/api/v3',
+    baseUrl: 'https://api.browser-use.test/api/v4',
     browser: {
       timeoutMinutes: 5,
       proxyCountryCode: null,
@@ -215,7 +215,7 @@ test('browser-use cloud provider launches via stored SecretRef and emits audit p
   });
 
   expect(fetchMock).toHaveBeenCalledWith(
-    'https://api.browser-use.test/api/v3/browsers',
+    'https://api.browser-use.test/api/v4/browsers',
     expect.objectContaining({
       method: 'POST',
       headers: expect.objectContaining({
@@ -234,7 +234,7 @@ test('browser-use cloud provider launches via stored SecretRef and emits audit p
 
   const { getSessionUsageTotals } = await import('../src/memory/db.js');
   const totals = getSessionUsageTotals('session-cloud');
-  expect(totals.total_cost_usd).toBeCloseTo(0.001, 6);
+  expect(totals.total_cost_usd).toBeCloseTo(0.02 / 60, 6);
   expect(totals.call_count).toBe(1);
 
   const auditEvents = getRecentStructuredAuditForSession('session-cloud', 10);
@@ -337,7 +337,7 @@ test('browser-use cloud provider records action usage, resolves fill secrets, an
   expect(locator.pressSequentially).toHaveBeenCalledWith('secret-password');
   expect(secretAudit).toHaveBeenCalled();
   expect(fetchMock).toHaveBeenLastCalledWith(
-    'https://api.browser-use.com/api/v3/browsers/cloud-session-2',
+    'https://api.browser-use.com/api/v4/browsers/cloud-session-2',
     expect.objectContaining({
       method: 'PATCH',
       body: JSON.stringify({ action: 'stop' }),
@@ -538,7 +538,7 @@ test('browser-use cloud provider rejects non-websocket CDP URLs and stops the cl
   ).rejects.toThrow(/expected a ws:\/\/ or wss:\/\//u);
   expect(mock.connectOverCDP).not.toHaveBeenCalled();
   expect(fetchMock).toHaveBeenLastCalledWith(
-    'https://api.browser-use.com/api/v3/browsers/cloud-session-bad-cdp',
+    'https://api.browser-use.com/api/v4/browsers/cloud-session-bad-cdp',
     expect.objectContaining({
       method: 'PATCH',
       body: JSON.stringify({ action: 'stop' }),
@@ -590,7 +590,7 @@ test('browser-use cloud provider stops cloud session when CDP connection fails',
     }),
   ).rejects.toThrow(/cdp unavailable/u);
   expect(fetchMock).toHaveBeenLastCalledWith(
-    'https://api.browser-use.com/api/v3/browsers/cloud-session-connect-fail',
+    'https://api.browser-use.com/api/v4/browsers/cloud-session-connect-fail',
     expect.objectContaining({
       method: 'PATCH',
       body: JSON.stringify({ action: 'stop' }),
@@ -707,7 +707,7 @@ test('browser-use cloud provider closes CDP handle and stops cloud session when 
   ).rejects.toThrow(/did not expose a browser context/u);
   expect(mock.browser.close).toHaveBeenCalledTimes(1);
   expect(fetchMock).toHaveBeenLastCalledWith(
-    'https://api.browser-use.com/api/v3/browsers/cloud-session-no-context',
+    'https://api.browser-use.com/api/v4/browsers/cloud-session-no-context',
     expect.objectContaining({
       method: 'PATCH',
       body: JSON.stringify({ action: 'stop' }),


### PR DESCRIPTION
## What

- switch the Browser Use Cloud provider's default base URL from `/api/v3` to `/api/v4`
- align the default Browser Use session estimate with the current documented price of $0.02/hour
- update focused provider assertions

## Why

HybridClaw already sends a create/stop contract supported by V4. Keeping the old route and $0.06/hour estimate made the shipped integration one API version behind and overstated the default browser cost by 3×.

## Validation

- 11 focused provider tests
- full type-check
- full lint
- targeted Biome check
- V4 create/stop schema checked against the current OpenAPI

No credentials or live Browser Use sessions were used.