### PR TITLE
feat(console): configure agent skills and tools from the console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Added
 
+- **Agents are configurable from the web console**: `/admin/agents` opens on a
+  new Configuration tab that edits an agent's display name, workspace
+  directory, pinned model, and — grouped, searchable, with per-group toggles —
+  which skills it may load and which tools it may call. Agents can also be
+  created and deleted from the browser. Each allowlist starts unrestricted:
+  unchecking an entry converts it into an explicit allowlist, and "Reset to
+  all" clears it so skills and tools installed later stay available.
+- **Per-agent tool allowlists**: the new `agents.list[].tools` key restricts
+  which tools an agent may call, mirroring `agents.list[].skills`. It is
+  intersected with the caller's allowlist, so it can only narrow a turn's
+  toolset, and globally disabled tools stay off regardless. Editable from the
+  console, `hybridclaw agent config`, and `config.json`.
 - **Plugins can be installed from the web console**: The Plugins & Tools page
   combines one-click installs from the official catalog with direct installs
   from plugin IDs, npm packages, local paths, and archive URLs. It reports
@@ -59,6 +71,12 @@
 
 ### Fixed
 
+- **The console view switcher highlights the page you are on**: its Agents
+  entry pointed at `/agents`, a redirect into `/admin/agents`, so following it
+  lit up Admin instead. It now links straight to the agents page, and the
+  switcher no longer lets the router mark Admin as a second current page on
+  every `/admin/*` route. Stored `ui.navigation` entries still pointing at
+  `/agents` are rewritten when the config loads.
 - **Premium-model errors now point at the current free model**: The guidance
   shown when a HybridAI request is rejected for premium-model access names
   `gpt-5.6-luna` — the model available without a paid plan or credits — instead

--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -13,6 +13,7 @@ import type {
   AdminAgentMarkdownRevisionResponse,
   AdminAgentProxyConfig,
   AdminAgentScoreboardResponse,
+  AdminAgentSettingsPayload,
   AdminAgentsResponse,
   AdminApiTokenCreatePayload,
   AdminApiTokenCreateResponse,
@@ -799,7 +800,7 @@ export async function fetchAdminHybridAIBots(
 export async function updateAdminAgent(
   token: string,
   agentId: string,
-  payload: {
+  payload: AdminAgentSettingsPayload & {
     proxy?: AdminAgentProxyConfig | null;
     archived?: boolean;
   },
@@ -813,6 +814,34 @@ export async function updateAdminAgent(
     },
   );
   return response.agent;
+}
+
+export async function createAdminAgent(
+  token: string,
+  payload: AdminAgentSettingsPayload & { id: string },
+): Promise<AdminAgent> {
+  const response = await requestJson<{ agent: AdminAgent }>(
+    '/api/admin/agents',
+    {
+      token,
+      method: 'POST',
+      body: payload,
+    },
+  );
+  return response.agent;
+}
+
+export function deleteAdminAgent(
+  token: string,
+  agentId: string,
+): Promise<{ deleted: boolean; agentId: string }> {
+  return requestJson<{ deleted: boolean; agentId: string }>(
+    `/api/admin/agents/${encodeURIComponent(agentId)}`,
+    {
+      token,
+      method: 'DELETE',
+    },
+  );
 }
 
 export function fetchAdminTeamStructure(

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -1187,6 +1187,7 @@ export interface AdminAgent {
   emptyChatHeader?: string | null;
   model: string | null;
   skills: string[] | null;
+  tools: string[] | null;
   chatbotId: string | null;
   enableRag: boolean | null;
   proxy?: AdminAgentProxyConfig | null;
@@ -1201,6 +1202,17 @@ export interface AdminAgent {
 
 export interface AdminAgentsResponse {
   agents: AdminAgent[];
+}
+
+/** Editable agent fields shared by the create and update admin endpoints. */
+export interface AdminAgentSettingsPayload {
+  name?: string;
+  model?: string;
+  workspace?: string;
+  /** `null` clears the allowlist so every skill stays available. */
+  skills?: string[] | null;
+  /** `null` clears the allowlist so every tool stays available. */
+  tools?: string[] | null;
 }
 
 export interface AdminHybridAIBot {

--- a/console/src/components/tabbed-page.tsx
+++ b/console/src/components/tabbed-page.tsx
@@ -18,6 +18,7 @@ export function TabbedPage<TabId extends string>(props: {
   tabs: ReadonlyArray<PageTab<TabId>>;
   activeTab: TabId;
   onTabChange: (tab: TabId) => void;
+  description?: ReactNode;
   actions?: ReactNode;
   children: ReactNode;
 }) {
@@ -31,7 +32,7 @@ export function TabbedPage<TabId extends string>(props: {
   return (
     <TabBarActionsContext.Provider value={tabBarActionsElement}>
       <div className="page-stack tabbed-page">
-        <PageHeader actions={props.actions} />
+        <PageHeader description={props.description} actions={props.actions} />
         <div className="page-tabs">
           <div
             className="page-tab-list"

--- a/console/src/components/view-switch.test.tsx
+++ b/console/src/components/view-switch.test.tsx
@@ -10,15 +10,32 @@ const mockRouterState = vi.hoisted(() => ({
 type MockLinkProps = {
   to: string;
   className?: string;
+  activeOptions?: { exact?: boolean };
   children: ReactNode;
 };
 
+// Mirrors the router's own active marking, including the fuzzy prefix match it
+// applies by default, so the nav's active resolution stays the only source.
+function isRouterActive(to: string, exact: boolean | undefined): boolean {
+  const { pathname } = mockRouterState;
+  if (exact) return pathname === to;
+  return pathname === to || pathname.startsWith(`${to}/`);
+}
+
 vi.mock('@tanstack/react-router', () => ({
-  Link: ({ to, className, children }: MockLinkProps) => (
-    <a data-router-link="true" href={to} className={className}>
-      {children}
-    </a>
-  ),
+  Link: ({ to, className, activeOptions, children }: MockLinkProps) => {
+    const active = isRouterActive(to, activeOptions?.exact);
+    return (
+      <a
+        data-router-link="true"
+        href={to}
+        className={active ? `${className} active` : className}
+        aria-current={active ? 'page' : undefined}
+      >
+        {children}
+      </a>
+    );
+  },
   useRouterState: (params: {
     select: (state: { location: { pathname: string } }) => string;
   }) =>
@@ -42,7 +59,7 @@ describe('ViewSwitchNav', () => {
     );
 
     const agentsLink = screen.getByRole('link', { name: 'Agents' });
-    expect(agentsLink.getAttribute('href')).toBe('/agents');
+    expect(agentsLink.getAttribute('href')).toBe('/admin/agents');
     expect(agentsLink.dataset.routerLink).toBe('true');
 
     const docsLink = screen.getByRole('link', { name: 'Docs' });
@@ -51,13 +68,17 @@ describe('ViewSwitchNav', () => {
   });
 
   it('marks the agents SPA view active by pathname', () => {
-    mockRouterState.pathname = '/agents';
+    mockRouterState.pathname = '/admin/agents';
 
     render(<ViewSwitchNav />);
 
     const agentsItem = screen.getByText('Agents').closest('.view-switch-link');
     expect(agentsItem?.getAttribute('aria-current')).toBe('page');
     expect(agentsItem?.className).toContain('active');
+
+    const adminItem = screen.getByText('Admin').closest('.view-switch-link');
+    expect(adminItem?.getAttribute('aria-current')).toBeNull();
+    expect(adminItem?.className).not.toContain('active');
   });
 
   it('renders custom local and external navigation items', () => {

--- a/console/src/components/view-switch.tsx
+++ b/console/src/components/view-switch.tsx
@@ -15,7 +15,7 @@ export type ViewSwitchItem = {
 
 export const DEFAULT_VIEW_SWITCH_ITEMS: ReadonlyArray<ViewSwitchItem> = [
   { href: '/chat', icon: 'chat', label: 'Chat' },
-  { href: '/agents', icon: 'agents', label: 'Agents' },
+  { href: '/admin/agents', icon: 'agents', label: 'Agents' },
   { href: '/admin', icon: 'admin', label: 'Admin' },
   {
     href: 'https://github.com/HybridAIOne/hybridclaw',
@@ -145,7 +145,15 @@ export function ViewSwitchNav(props: {
             {inner}
           </span>
         ) : (
-          <Link key={key} className="view-switch-link" to={item.href}>
+          // This nav resolves its own active item, so the router must not add
+          // its fuzzy prefix match on top: `/admin` would otherwise claim
+          // `aria-current` on every `/admin/*` route as well.
+          <Link
+            key={key}
+            className="view-switch-link"
+            to={item.href}
+            activeOptions={{ exact: true }}
+          >
             {inner}
           </Link>
         );

--- a/console/src/generated/settings-registry.ts
+++ b/console/src/generated/settings-registry.ts
@@ -2696,7 +2696,7 @@ export const GENERATED_SETTINGS_REGISTRY: ReadonlyArray<GeneratedSettingEntry> =
           icon: 'chat',
         },
         {
-          href: '/agents',
+          href: '/admin/agents',
           label: 'Agents',
           icon: 'agents',
         },

--- a/console/src/lib/admin-tabs.ts
+++ b/console/src/lib/admin-tabs.ts
@@ -5,6 +5,7 @@ export const ACTIVITY_TABS = [
 ] as const;
 
 export const AGENT_TABS = [
+  { id: 'configure', label: 'Configuration' },
   { id: 'scoreboard', label: 'Scoreboard' },
   { id: 'files', label: 'Workspace files' },
 ] as const;

--- a/console/src/routes/agent-config.module.css
+++ b/console/src/routes/agent-config.module.css
@@ -1,0 +1,196 @@
+.scopeCard,
+.dangerCard {
+  display: grid;
+  gap: 16px;
+  padding: 20px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--panel-bg);
+}
+
+.scopeHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.scopeTitle {
+  margin: 0 0 4px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.agentId {
+  font-size: 0.8125rem;
+  color: var(--muted-foreground);
+}
+
+.modelRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.scopeToolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.scopeToolbar > :first-child {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.scopeCount {
+  font-size: 0.8125rem;
+  color: var(--muted-foreground);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.scopeGroups {
+  display: grid;
+  gap: 8px;
+  max-height: 420px;
+  overflow-y: auto;
+  padding: 4px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel-muted);
+}
+
+.scopeGroup {
+  display: grid;
+  gap: 4px;
+  padding: 8px;
+}
+
+.scopeGroupHead {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--line);
+}
+
+.scopeItems {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 2px;
+}
+
+.scopeItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.scopeItem:hover {
+  background: var(--panel-bg);
+}
+
+.scopeItemText {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.scopeItemName {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.scopeItemText small {
+  color: var(--muted-foreground);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.scopeBadge {
+  font-style: normal;
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted-foreground);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 0 5px;
+}
+
+.overviewGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.overviewCard {
+  display: grid;
+  gap: 4px;
+  justify-items: start;
+  text-align: left;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--panel-bg);
+  cursor: pointer;
+}
+
+.overviewCard:hover {
+  border-color: var(--line-strong);
+}
+
+.overviewCard code {
+  font-size: 0.8125rem;
+  color: var(--muted-foreground);
+}
+
+.overviewCounts {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.overviewCounts em {
+  font-style: normal;
+  font-size: 0.75rem;
+  color: var(--muted-foreground);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 2px 6px;
+}
+
+.dangerCard {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  border-color: var(--danger);
+}
+
+.saveBar {
+  position: sticky;
+  bottom: 16px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 12px 12px 20px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
+  background: var(--panel-bg);
+  box-shadow: 0 10px 30px rgb(0 0 0 / 18%);
+  font-weight: 500;
+}

--- a/console/src/routes/agent-config.test.tsx
+++ b/console/src/routes/agent-config.test.tsx
@@ -1,0 +1,167 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  AdminAgent,
+  AdminModelsResponse,
+  AdminSkillsResponse,
+  AdminToolsResponse,
+} from '../api/types';
+import { renderWithProviders } from '../test-utils';
+import { AgentConfigPage } from './agent-config';
+
+const fetchAdminAgentsMock = vi.fn<() => Promise<AdminAgent[]>>();
+const fetchSkillsMock = vi.fn<() => Promise<AdminSkillsResponse>>();
+const fetchToolsMock = vi.fn<() => Promise<AdminToolsResponse>>();
+const fetchModelsMock = vi.fn<() => Promise<AdminModelsResponse>>();
+const updateAdminAgentMock = vi.fn();
+const deleteAdminAgentMock = vi.fn();
+const useAuthMock = vi.fn();
+
+vi.mock('../api/client', () => ({
+  fetchAdminAgents: () => fetchAdminAgentsMock(),
+  fetchSkills: () => fetchSkillsMock(),
+  fetchTools: () => fetchToolsMock(),
+  fetchModels: () => fetchModelsMock(),
+  updateAdminAgent: (...args: unknown[]) => updateAdminAgentMock(...args),
+  deleteAdminAgent: (...args: unknown[]) => deleteAdminAgentMock(...args),
+}));
+
+vi.mock('../auth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+function makeAgent(overrides: Partial<AdminAgent> = {}): AdminAgent {
+  return {
+    id: 'support',
+    archived: false,
+    name: 'Support Agent',
+    model: null,
+    skills: null,
+    tools: null,
+    chatbotId: null,
+    enableRag: null,
+    role: null,
+    reportsTo: null,
+    delegatesTo: null,
+    peers: null,
+    workspace: null,
+    workspacePath: '/tmp/support/workspace',
+    markdownFiles: [],
+    ...overrides,
+  };
+}
+
+function makeSkill(name: string, category: string) {
+  return {
+    name,
+    description: `${name} description`,
+    category,
+    developer: 'HybridClaw',
+    source: 'bundled',
+    available: true,
+    enabled: true,
+    missing: [],
+    userInvocable: false,
+    disableModelInvocation: false,
+    always: false,
+    capabilities: [],
+    supportedChannels: [],
+    requires: { bins: [], env: [] },
+    tags: [],
+  } as unknown as AdminSkillsResponse['skills'][number];
+}
+
+function makeTool(name: string) {
+  return {
+    name,
+    group: 'Files',
+    kind: 'builtin' as const,
+    recentCalls: 0,
+    recentErrors: 0,
+    lastUsedAt: null,
+    recentErrorSamples: [],
+  };
+}
+
+describe('AgentConfigPage', () => {
+  beforeEach(() => {
+    fetchAdminAgentsMock.mockReset();
+    fetchSkillsMock.mockReset();
+    fetchToolsMock.mockReset();
+    fetchModelsMock.mockReset();
+    updateAdminAgentMock.mockReset();
+    deleteAdminAgentMock.mockReset();
+    useAuthMock.mockReset();
+    useAuthMock.mockReturnValue({ token: 'test-token' });
+    fetchAdminAgentsMock.mockResolvedValue([makeAgent()]);
+    fetchSkillsMock.mockResolvedValue({
+      skills: [makeSkill('pdf', 'documents'), makeSkill('docx', 'documents')],
+    } as AdminSkillsResponse);
+    fetchToolsMock.mockResolvedValue({
+      totals: {
+        totalTools: 2,
+        builtinTools: 2,
+        mcpTools: 0,
+        otherTools: 0,
+        recentExecutions: 0,
+        recentErrors: 0,
+      },
+      groups: [{ label: 'Files', tools: [makeTool('read'), makeTool('bash')] }],
+      recentExecutions: [],
+    });
+    fetchModelsMock.mockResolvedValue({
+      defaultModel: 'gpt-5',
+      providerStatus: {},
+      models: [],
+    } as unknown as AdminModelsResponse);
+  });
+
+  it('lists agents to pick from when none is selected', async () => {
+    renderWithProviders(<AgentConfigPage onAgentChange={() => {}} />);
+
+    expect(await screen.findByText('Support Agent')).toBeTruthy();
+    expect(screen.getByText('all skills')).toBeTruthy();
+    expect(screen.getByText('all tools')).toBeTruthy();
+  });
+
+  it('narrows an unrestricted allowlist when a tool is unchecked', async () => {
+    updateAdminAgentMock.mockResolvedValue(makeAgent({ tools: ['read'] }));
+    renderWithProviders(
+      <AgentConfigPage selectedAgentId="support" onAgentChange={() => {}} />,
+    );
+
+    const bash = await screen.findByRole('checkbox', { name: 'bash' });
+    fireEvent.click(bash);
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(updateAdminAgentMock).toHaveBeenCalledWith(
+        'test-token',
+        'support',
+        expect.objectContaining({ tools: ['read'], skills: null }),
+      );
+    });
+  });
+
+  it('sends null when an allowlist is reset to everything', async () => {
+    fetchAdminAgentsMock.mockResolvedValue([makeAgent({ skills: ['pdf'] })]);
+    updateAdminAgentMock.mockResolvedValue(makeAgent());
+    renderWithProviders(
+      <AgentConfigPage selectedAgentId="support" onAgentChange={() => {}} />,
+    );
+
+    const resetButtons = await screen.findAllByRole('button', {
+      name: 'Reset to all',
+    });
+    fireEvent.click(resetButtons[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(updateAdminAgentMock).toHaveBeenCalledWith(
+        'test-token',
+        'support',
+        expect.objectContaining({ skills: null }),
+      );
+    });
+  });
+});

--- a/console/src/routes/agent-config.tsx
+++ b/console/src/routes/agent-config.tsx
@@ -1,0 +1,453 @@
+/**
+ * Agent configuration tab — the console's editor for one agent's runtime
+ * settings (name, model, workspace, skill allowlist, tool allowlist).
+ *
+ * Edits stay local until Save, and Save sends the whole editable set in one
+ * PUT so a half-applied agent is never persisted. Skill and tool allowlists
+ * are sent as `null` when unrestricted, which is what clears them server-side.
+ *
+ * NOT the workspace-file editor (`agents.tsx` owns AGENTS.md and friends) and
+ * NOT the global skill/tool catalogs (`/admin/skills`, `/admin/extensions`).
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+import {
+  deleteAdminAgent,
+  fetchAdminAgents,
+  fetchModels,
+  fetchSkills,
+  fetchTools,
+  updateAdminAgent,
+} from '../api/client';
+import type { AdminAgent } from '../api/types';
+import { useAuth } from '../auth';
+import { Button } from '../components/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../components/dialog';
+import { Field, FieldDescription, FieldLabel } from '../components/field';
+import { Input } from '../components/input';
+import { useToast } from '../components/toast';
+import { SegmentedToggle } from '../components/ui';
+import { DEFAULT_AGENT_ID } from '../lib/chat-helpers';
+import { getErrorMessage } from '../lib/error-message';
+import styles from './agent-config.module.css';
+import { type AgentScopeGroup, AgentScopePicker } from './agent-scope-picker';
+import { ModelSwitchSelect } from './chat/model-switch-select';
+
+interface AgentDraft {
+  name: string;
+  model: string;
+  workspace: string;
+  skills: string[] | null;
+  tools: string[] | null;
+}
+
+function toDraft(agent: AdminAgent): AgentDraft {
+  return {
+    name: agent.name || '',
+    model: agent.model || '',
+    workspace: agent.workspace || '',
+    skills: agent.skills ? [...agent.skills] : null,
+    tools: agent.tools ? [...agent.tools] : null,
+  };
+}
+
+function sameSelection(a: string[] | null, b: string[] | null): boolean {
+  if (a === null || b === null) return a === b;
+  return a.length === b.length && a.every((entry, index) => entry === b[index]);
+}
+
+function isDirtyDraft(draft: AgentDraft, agent: AdminAgent): boolean {
+  const base = toDraft(agent);
+  return (
+    draft.name !== base.name ||
+    draft.model !== base.model ||
+    draft.workspace !== base.workspace ||
+    !sameSelection(draft.skills, base.skills) ||
+    !sameSelection(draft.tools, base.tools)
+  );
+}
+
+/** Appends configured entries the catalog cannot account for. */
+function withUnknownEntries(
+  groups: AgentScopeGroup[],
+  selected: string[] | null,
+): AgentScopeGroup[] {
+  if (!selected) return groups;
+  const known = new Set(groups.flatMap((g) => g.items.map((item) => item.id)));
+  const unknown = selected.filter((entry) => !known.has(entry));
+  if (unknown.length === 0) return groups;
+  return [
+    ...groups,
+    {
+      label: 'Not in catalog',
+      items: unknown.map((entry) => ({
+        id: entry,
+        label: entry,
+        badges: ['unlisted'],
+      })),
+    },
+  ];
+}
+
+function AgentOverview(props: {
+  agents: AdminAgent[];
+  onSelect: (agentId: string) => void;
+}) {
+  return (
+    <div className={styles.overviewGrid}>
+      {props.agents.map((agent) => (
+        <button
+          className={styles.overviewCard}
+          key={agent.id}
+          type="button"
+          onClick={() => props.onSelect(agent.id)}
+        >
+          <strong>{agent.name || agent.id}</strong>
+          <code>{agent.id}</code>
+          <span className="supporting-text">
+            {agent.model || 'default model'}
+          </span>
+          <span className={styles.overviewCounts}>
+            <em>
+              {agent.skills ? `${agent.skills.length} skills` : 'all skills'}
+            </em>
+            <em>{agent.tools ? `${agent.tools.length} tools` : 'all tools'}</em>
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function AgentConfigPage(props: {
+  selectedAgentId?: string;
+  onAgentChange: (agentId: string) => void;
+}) {
+  const auth = useAuth();
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const [draft, setDraft] = useState<AgentDraft | null>(null);
+  const [draftAgentId, setDraftAgentId] = useState<string | null>(null);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [deleteConfirmation, setDeleteConfirmation] = useState('');
+
+  const agentsQuery = useQuery({
+    queryKey: ['admin-agents', auth.token],
+    queryFn: () => fetchAdminAgents(auth.token),
+  });
+  const skillsQuery = useQuery({
+    queryKey: ['admin-skills', auth.token],
+    queryFn: () => fetchSkills(auth.token),
+  });
+  const toolsQuery = useQuery({
+    queryKey: ['admin-tools', auth.token],
+    queryFn: () => fetchTools(auth.token),
+  });
+  const modelsQuery = useQuery({
+    queryKey: ['admin-models', auth.token],
+    queryFn: () => fetchModels(auth.token),
+  });
+
+  const activeAgents = useMemo(
+    () => (agentsQuery.data || []).filter((agent) => !agent.archived),
+    [agentsQuery.data],
+  );
+  const agent =
+    activeAgents.find((entry) => entry.id === props.selectedAgentId) || null;
+
+  if (agent && draftAgentId !== agent.id) {
+    setDraftAgentId(agent.id);
+    setDraft(toDraft(agent));
+  }
+
+  const skillGroups = useMemo<AgentScopeGroup[]>(() => {
+    const byCategory = new Map<string, AgentScopeGroup>();
+    for (const skill of skillsQuery.data?.skills || []) {
+      const label = skill.category || 'Uncategorized';
+      let group = byCategory.get(label);
+      if (!group) {
+        group = { label, items: [] };
+        byCategory.set(label, group);
+      }
+      const badges: string[] = [];
+      if (!skill.available) badges.push('unavailable');
+      else if (!skill.enabled) badges.push('off globally');
+      if (skill.blocked) badges.push('blocked');
+      group.items.push({
+        id: skill.name,
+        label: skill.name,
+        description: skill.shortDescription || skill.description,
+        ...(badges.length > 0 ? { badges } : {}),
+      });
+    }
+    return [...byCategory.values()].sort((left, right) =>
+      left.label.localeCompare(right.label),
+    );
+  }, [skillsQuery.data]);
+
+  const toolGroups = useMemo<AgentScopeGroup[]>(
+    () =>
+      (toolsQuery.data?.groups || []).map((group) => ({
+        label: group.label,
+        items: group.tools.map((tool) => ({
+          id: tool.name,
+          label: tool.name,
+          ...(tool.kind === 'builtin' ? {} : { badges: [tool.kind] }),
+        })),
+      })),
+    [toolsQuery.data],
+  );
+
+  const saveMutation = useMutation({
+    mutationFn: async (input: { agentId: string; draft: AgentDraft }) =>
+      updateAdminAgent(auth.token, input.agentId, {
+        name: input.draft.name.trim(),
+        model: input.draft.model.trim(),
+        workspace: input.draft.workspace.trim(),
+        skills: input.draft.skills,
+        tools: input.draft.tools,
+      }),
+    onSuccess: (saved) => {
+      void queryClient.invalidateQueries({
+        queryKey: ['admin-agents', auth.token],
+      });
+      void queryClient.invalidateQueries({ queryKey: ['agents'] });
+      setDraftAgentId(saved.id);
+      setDraft(toDraft(saved));
+      toast.success('Agent saved', `${saved.name || saved.id} updated.`);
+    },
+    onError: (error) => {
+      toast.error('Save failed', getErrorMessage(error));
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (agentId: string) =>
+      deleteAdminAgent(auth.token, agentId),
+    onSuccess: (_result, agentId) => {
+      void queryClient.invalidateQueries({
+        queryKey: ['admin-agents', auth.token],
+      });
+      void queryClient.invalidateQueries({ queryKey: ['agents'] });
+      setDeleteDialogOpen(false);
+      setDeleteConfirmation('');
+      props.onAgentChange('');
+      toast.success('Agent deleted', `${agentId} was removed.`);
+    },
+    onError: (error) => {
+      toast.error('Delete failed', getErrorMessage(error));
+    },
+  });
+
+  if (agentsQuery.isLoading) {
+    return <div className="empty-state">Loading agents...</div>;
+  }
+  if (agentsQuery.isError) {
+    return (
+      <div className="empty-state">
+        Failed to load agents: {getErrorMessage(agentsQuery.error)}
+      </div>
+    );
+  }
+  if (!agent || !draft) {
+    return (
+      <div className="detail-stack">
+        <p className="supporting-text">Pick an agent to configure.</p>
+        <AgentOverview agents={activeAgents} onSelect={props.onAgentChange} />
+      </div>
+    );
+  }
+
+  const dirty = isDirtyDraft(draft, agent);
+  const defaultModel = modelsQuery.data?.defaultModel || 'the default model';
+
+  return (
+    <div className="detail-stack">
+      <section className={styles.scopeCard}>
+        <header className={styles.scopeHeader}>
+          <div>
+            <h3 className={styles.scopeTitle}>Identity</h3>
+            <p className="supporting-text">
+              How this agent introduces itself and where its workspace lives.
+            </p>
+          </div>
+          <code className={styles.agentId}>{agent.id}</code>
+        </header>
+
+        <div className="field-grid">
+          <Field>
+            <FieldLabel>Display name</FieldLabel>
+            <Input
+              value={draft.name}
+              placeholder={agent.id}
+              onChange={(event) =>
+                setDraft({ ...draft, name: event.target.value })
+              }
+            />
+            <FieldDescription>
+              Shown in chat, selectors, and the org chart.
+            </FieldDescription>
+          </Field>
+
+          <Field>
+            <FieldLabel>Workspace</FieldLabel>
+            <Input
+              value={draft.workspace}
+              placeholder={agent.id}
+              onChange={(event) =>
+                setDraft({ ...draft, workspace: event.target.value })
+              }
+            />
+            <FieldDescription>
+              Workspace directory name. Empty uses the agent id.
+            </FieldDescription>
+          </Field>
+        </div>
+
+        <Field>
+          <FieldLabel>Model</FieldLabel>
+          <div className={styles.modelRow}>
+            <SegmentedToggle
+              ariaLabel="Model source"
+              size="sm"
+              value={draft.model ? 'pinned' : 'default'}
+              options={[
+                { value: 'default', label: 'Runtime default' },
+                { value: 'pinned', label: 'Pinned model' },
+              ]}
+              onChange={(mode) =>
+                setDraft({
+                  ...draft,
+                  model:
+                    mode === 'default'
+                      ? ''
+                      : draft.model || modelsQuery.data?.defaultModel || '',
+                })
+              }
+            />
+            {draft.model ? (
+              <ModelSwitchSelect
+                models={modelsQuery.data?.models || []}
+                selectedModelId={draft.model}
+                disabled={modelsQuery.isLoading}
+                onSwitch={(model) => setDraft({ ...draft, model })}
+              />
+            ) : (
+              <span className="supporting-text">
+                Follows the runtime default ({defaultModel}).
+              </span>
+            )}
+          </div>
+        </Field>
+      </section>
+
+      <AgentScopePicker
+        title="Skills"
+        description="Skills this agent may load. Everything else stays out of its prompt."
+        allLabel="All skills"
+        restrictedNote="Only the selected skills load. Skills installed later stay off for this agent until you add them here."
+        searchPlaceholder="Search skills"
+        groups={withUnknownEntries(skillGroups, draft.skills)}
+        value={draft.skills}
+        loading={skillsQuery.isLoading}
+        onChange={(skills) => setDraft({ ...draft, skills })}
+      />
+
+      <AgentScopePicker
+        title="Tools"
+        description="Tools this agent may call. Globally disabled tools stay off regardless."
+        allLabel="All tools"
+        restrictedNote="Only the selected tools are offered to the model. Plugin and MCP tools added later stay off for this agent until you add them here."
+        searchPlaceholder="Search tools"
+        groups={withUnknownEntries(toolGroups, draft.tools)}
+        value={draft.tools}
+        loading={toolsQuery.isLoading}
+        allowCustomEntries
+        onChange={(tools) => setDraft({ ...draft, tools })}
+      />
+
+      {agent.id === DEFAULT_AGENT_ID ? null : (
+        <section className={styles.dangerCard}>
+          <div>
+            <strong>Delete this agent</strong>
+            <p className="supporting-text">
+              Removes the agent registration. Its workspace files stay on disk.
+              Archive instead to keep it out of selectors without deleting.
+            </p>
+          </div>
+          <Button variant="outline" onClick={() => setDeleteDialogOpen(true)}>
+            Delete agent
+          </Button>
+        </section>
+      )}
+
+      {dirty ? (
+        <div className={styles.saveBar}>
+          <span>Unsaved changes</span>
+          <div className="button-row">
+            <Button
+              variant="ghost"
+              disabled={saveMutation.isPending}
+              onClick={() => setDraft(toDraft(agent))}
+            >
+              Discard
+            </Button>
+            <Button
+              loading={saveMutation.isPending}
+              onClick={() => saveMutation.mutate({ agentId: agent.id, draft })}
+            >
+              Save changes
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      <Dialog
+        open={deleteDialogOpen}
+        onOpenChange={(open) => {
+          setDeleteDialogOpen(open);
+          if (!open) setDeleteConfirmation('');
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete {agent.name || agent.id}</DialogTitle>
+            <DialogDescription>
+              Sessions keep their history, but the agent disappears from every
+              selector and can no longer be addressed. Type the agent id to
+              confirm.
+            </DialogDescription>
+          </DialogHeader>
+          <Field>
+            <FieldLabel>Agent id</FieldLabel>
+            <Input
+              value={deleteConfirmation}
+              placeholder={agent.id}
+              onChange={(event) => setDeleteConfirmation(event.target.value)}
+            />
+          </Field>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setDeleteDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="danger"
+              disabled={deleteConfirmation.trim() !== agent.id}
+              loading={deleteMutation.isPending}
+              onClick={() => deleteMutation.mutate(agent.id)}
+            >
+              Delete agent
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/console/src/routes/agent-create-dialog.tsx
+++ b/console/src/routes/agent-create-dialog.tsx
@@ -1,0 +1,127 @@
+/**
+ * New-agent dialog — the only console surface that registers an agent id.
+ *
+ * The id it accepts is the permanent runtime key (workspace directory,
+ * addressing, audit rows), so it is validated here and never editable later;
+ * everything else the dialog collects is a starting point the configuration
+ * tab can change.
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { createAdminAgent } from '../api/client';
+import { useAuth } from '../auth';
+import { Button } from '../components/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../components/dialog';
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+} from '../components/field';
+import { Input } from '../components/input';
+import { useToast } from '../components/toast';
+import { getErrorMessage } from '../lib/error-message';
+
+const AGENT_ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+export function AgentCreateDialog(props: {
+  open: boolean;
+  existingAgentIds: string[];
+  onOpenChange: (open: boolean) => void;
+  onCreated: (agentId: string) => void;
+}) {
+  const auth = useAuth();
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const [agentId, setAgentId] = useState('');
+  const [name, setName] = useState('');
+
+  const normalizedId = agentId.trim().toLowerCase();
+  const idTaken = props.existingAgentIds.includes(normalizedId);
+  const idError = !normalizedId
+    ? null
+    : idTaken
+      ? 'An agent with this id already exists.'
+      : AGENT_ID_PATTERN.test(normalizedId)
+        ? null
+        : 'Use lowercase letters, digits, and dashes.';
+
+  const createMutation = useMutation({
+    mutationFn: async () =>
+      createAdminAgent(auth.token, {
+        id: normalizedId,
+        name: name.trim(),
+      }),
+    onSuccess: (agent) => {
+      void queryClient.invalidateQueries({
+        queryKey: ['admin-agents', auth.token],
+      });
+      void queryClient.invalidateQueries({ queryKey: ['agents'] });
+      setAgentId('');
+      setName('');
+      props.onOpenChange(false);
+      props.onCreated(agent.id);
+      toast.success('Agent created', `${agent.name || agent.id} is ready.`);
+    },
+    onError: (error) => {
+      toast.error('Create failed', getErrorMessage(error));
+    },
+  });
+
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New agent</DialogTitle>
+          <DialogDescription>
+            The agent starts with every skill and tool available. Narrow that
+            down on the configuration tab.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Field error={idError}>
+          <FieldLabel>Agent id</FieldLabel>
+          <Input
+            value={agentId}
+            placeholder="research"
+            onChange={(event) => setAgentId(event.target.value)}
+          />
+          <FieldDescription>
+            Permanent. Used for addressing, the workspace directory, and audit
+            records.
+          </FieldDescription>
+          <FieldError>{idError}</FieldError>
+        </Field>
+
+        <Field>
+          <FieldLabel>Display name</FieldLabel>
+          <Input
+            value={name}
+            placeholder="Research Agent"
+            onChange={(event) => setName(event.target.value)}
+          />
+        </Field>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => props.onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            disabled={!normalizedId || Boolean(idError)}
+            loading={createMutation.isPending}
+            onClick={() => createMutation.mutate()}
+          >
+            Create agent
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/console/src/routes/agent-scope-picker.tsx
+++ b/console/src/routes/agent-scope-picker.tsx
@@ -1,0 +1,248 @@
+/**
+ * Agent scope picker — the allowlist editor shared by the skills and tools
+ * cards on the agent configuration tab.
+ *
+ * The control has exactly two states and never blurs them: `null` means "no
+ * allowlist" (everything available now and everything added later), and an
+ * array means "only these". Unchecking an entry while in the `null` state
+ * snapshots the catalog minus that entry, so narrowing is always explicit.
+ *
+ * NOT a global enable/disable surface (`/admin/skills` and `tools.disabled`
+ * own that); entries this picker offers may still be off fleet-wide.
+ */
+import { useMemo, useState } from 'react';
+import { Button } from '../components/button';
+import { Checkbox } from '../components/checkbox';
+import { Input } from '../components/input';
+import { SegmentedToggle } from '../components/ui';
+import styles from './agent-config.module.css';
+
+export interface AgentScopeItem {
+  id: string;
+  label: string;
+  description?: string;
+  /** Short muted labels shown after the name (for example `mcp`, `off`). */
+  badges?: string[];
+}
+
+export interface AgentScopeGroup {
+  label: string;
+  items: AgentScopeItem[];
+}
+
+function matchesQuery(item: AgentScopeItem, query: string): boolean {
+  if (!query) return true;
+  const needle = query.toLowerCase();
+  return (
+    item.id.toLowerCase().includes(needle) ||
+    item.label.toLowerCase().includes(needle) ||
+    (item.description || '').toLowerCase().includes(needle)
+  );
+}
+
+export function AgentScopePicker(props: {
+  title: string;
+  description: string;
+  allLabel: string;
+  restrictedNote: string;
+  searchPlaceholder: string;
+  groups: AgentScopeGroup[];
+  /** `null` keeps every entry available, including entries added later. */
+  value: string[] | null;
+  loading?: boolean;
+  onChange: (value: string[] | null) => void;
+  /** Offers a free-text row for entries the catalog cannot list (MCP tools). */
+  allowCustomEntries?: boolean;
+}) {
+  const [query, setQuery] = useState('');
+  const [customEntry, setCustomEntry] = useState('');
+
+  const catalogIds = useMemo(
+    () => props.groups.flatMap((group) => group.items.map((item) => item.id)),
+    [props.groups],
+  );
+  const selectedIds = useMemo(
+    () => new Set(props.value ?? catalogIds),
+    [props.value, catalogIds],
+  );
+  const unrestricted = props.value === null;
+
+  const visibleGroups = useMemo(
+    () =>
+      props.groups
+        .map((group) => ({
+          label: group.label,
+          items: group.items.filter((item) => matchesQuery(item, query)),
+        }))
+        .filter((group) => group.items.length > 0),
+    [props.groups, query],
+  );
+
+  function setSelection(next: Set<string>): void {
+    const catalog = new Set(catalogIds);
+    const ordered = catalogIds.filter((id) => next.has(id));
+    const extras = [...next].filter((id) => !catalog.has(id));
+    props.onChange([...ordered, ...extras]);
+  }
+
+  function toggleItem(id: string, checked: boolean): void {
+    const next = new Set(selectedIds);
+    if (checked) next.add(id);
+    else next.delete(id);
+    setSelection(next);
+  }
+
+  function toggleGroup(group: AgentScopeGroup, checked: boolean): void {
+    const next = new Set(selectedIds);
+    for (const item of group.items) {
+      if (checked) next.add(item.id);
+      else next.delete(item.id);
+    }
+    setSelection(next);
+  }
+
+  function addCustomEntry(): void {
+    const name = customEntry.trim();
+    if (!name) return;
+    setCustomEntry('');
+    setSelection(new Set([...selectedIds, name]));
+  }
+
+  const selectedCount = selectedIds.size;
+  const totalCount = catalogIds.length;
+
+  return (
+    <section className={styles.scopeCard}>
+      <header className={styles.scopeHeader}>
+        <div>
+          <h3 className={styles.scopeTitle}>{props.title}</h3>
+          <p className="supporting-text">{props.description}</p>
+        </div>
+        <SegmentedToggle
+          ariaLabel={`${props.title} scope`}
+          size="sm"
+          value={unrestricted ? 'all' : 'custom'}
+          options={[
+            { value: 'all', label: props.allLabel },
+            { value: 'custom', label: 'Selected only' },
+          ]}
+          onChange={(mode) =>
+            props.onChange(mode === 'all' ? null : [...catalogIds])
+          }
+        />
+      </header>
+
+      <div className={styles.scopeToolbar}>
+        <Input
+          aria-label={props.searchPlaceholder}
+          placeholder={props.searchPlaceholder}
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+        <span className={styles.scopeCount}>
+          {unrestricted
+            ? `all ${totalCount} available`
+            : `${selectedCount} of ${totalCount} selected`}
+        </span>
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={unrestricted}
+          onClick={() => props.onChange(null)}
+        >
+          Reset to all
+        </Button>
+      </div>
+
+      {props.loading ? (
+        <div className="empty-state">Loading catalog...</div>
+      ) : visibleGroups.length === 0 ? (
+        <div className="empty-state">Nothing matches “{query}”.</div>
+      ) : (
+        <div className={styles.scopeGroups}>
+          {visibleGroups.map((group) => {
+            const checkedCount = group.items.filter((item) =>
+              selectedIds.has(item.id),
+            ).length;
+            return (
+              <div className={styles.scopeGroup} key={group.label}>
+                <div className={styles.scopeGroupHead}>
+                  <Checkbox
+                    aria-label={`Select all ${group.label}`}
+                    checked={
+                      checkedCount === group.items.length
+                        ? true
+                        : checkedCount === 0
+                          ? false
+                          : 'indeterminate'
+                    }
+                    onCheckedChange={(checked) => toggleGroup(group, checked)}
+                  />
+                  <strong>{group.label}</strong>
+                  <span className={styles.scopeCount}>
+                    {checkedCount}/{group.items.length}
+                  </span>
+                </div>
+                <div className={styles.scopeItems}>
+                  {group.items.map((item) => (
+                    <label className={styles.scopeItem} key={item.id}>
+                      <Checkbox
+                        checked={selectedIds.has(item.id)}
+                        onCheckedChange={(checked) =>
+                          toggleItem(item.id, checked)
+                        }
+                      />
+                      <span className={styles.scopeItemText}>
+                        <span className={styles.scopeItemName}>
+                          {item.label}
+                          {item.badges?.map((badge) => (
+                            <em className={styles.scopeBadge} key={badge}>
+                              {badge}
+                            </em>
+                          ))}
+                        </span>
+                        {item.description ? (
+                          <small>{item.description}</small>
+                        ) : null}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {props.allowCustomEntries ? (
+        <div className={styles.scopeToolbar}>
+          <Input
+            aria-label={`Add ${props.title.toLowerCase()} by name`}
+            placeholder="Add by exact name (for example github__create_issue)"
+            value={customEntry}
+            onChange={(event) => setCustomEntry(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key !== 'Enter') return;
+              event.preventDefault();
+              addCustomEntry();
+            }}
+          />
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!customEntry.trim()}
+            onClick={addCustomEntry}
+          >
+            Add
+          </Button>
+        </div>
+      ) : null}
+
+      <p className="supporting-text">
+        {unrestricted
+          ? `${props.allLabel} stay available.`
+          : props.restrictedNote}
+      </p>
+    </section>
+  );
+}

--- a/console/src/routes/agents-hub.test.tsx
+++ b/console/src/routes/agents-hub.test.tsx
@@ -38,6 +38,7 @@ function makeAgent(id: string, name: string, archived = false): AdminAgent {
     name,
     model: null,
     skills: null,
+    tools: null,
     chatbotId: null,
     enableRag: null,
     role: null,
@@ -75,7 +76,7 @@ describe('AgentsHubPage', () => {
       expect(selector.textContent).not.toContain('Retired');
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Archive agents' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Archive' }));
     expect(screen.queryByRole('checkbox', { name: /Main Agent/ })).toBeNull();
     fireEvent.click(screen.getByRole('checkbox', { name: /Writer/ }));
     fireEvent.click(screen.getByRole('button', { name: 'Archive selected' }));
@@ -95,9 +96,7 @@ describe('AgentsHubPage', () => {
     );
     renderWithProviders(<AgentsHubPage />);
 
-    fireEvent.click(
-      await screen.findByRole('button', { name: 'Archive agents' }),
-    );
+    fireEvent.click(await screen.findByRole('button', { name: 'Archive' }));
     fireEvent.click(screen.getByRole('button', { name: 'Restore' }));
 
     await waitFor(() => {

--- a/console/src/routes/agents-hub.tsx
+++ b/console/src/routes/agents-hub.tsx
@@ -13,12 +13,14 @@ import {
   DialogTitle,
 } from '../components/dialog';
 import { NativeSelect, NativeSelectOption } from '../components/native-select';
-import { TabbedPage } from '../components/tabbed-page';
+import { TabbedPage, TabbedPageActions } from '../components/tabbed-page';
 import { useToast } from '../components/toast';
 import { AGENT_TABS } from '../lib/admin-tabs';
 import { DEFAULT_AGENT_ID } from '../lib/chat-helpers';
 import { getErrorMessage } from '../lib/error-message';
 import { logNavigationError } from '../lib/navigation';
+import { AgentConfigPage } from './agent-config';
+import { AgentCreateDialog } from './agent-create-dialog';
 import { AgentsPage } from './agent-scoreboard';
 import { AgentFilesPage } from './agents';
 import { mergeRouteSearch, readRouteTab } from './tabbed-route';
@@ -36,6 +38,7 @@ export function AgentsHubPage() {
   const queryClient = useQueryClient();
   const toast = useToast();
   const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [selectedArchiveIds, setSelectedArchiveIds] = useState<Set<string>>(
     () => new Set(),
   );
@@ -51,11 +54,7 @@ export function AgentsHubPage() {
     () => (agentsQuery.data || []).filter((agent) => agent.archived),
     [agentsQuery.data],
   );
-  const activeTab = readRouteTab<AgentTab>(
-    search.tab,
-    AGENT_TABS,
-    'scoreboard',
-  );
+  const activeTab = readRouteTab<AgentTab>(search.tab, AGENT_TABS, 'configure');
   const selectedAgentId = activeAgents.some(
     (agent) => agent.id === search.agent,
   )
@@ -111,38 +110,50 @@ export function AgentsHubPage() {
       <TabbedPage
         tabs={AGENT_TABS}
         activeTab={activeTab}
+        description="Each agent has its own workspace, model, skills, and tools."
         actions={
-          <div className="header-actions">
-            <label className="header-actions">
-              <span className="supporting-text">Agent</span>
-              <NativeSelect
-                aria-label="Agent"
-                value={selectedAgentId || ''}
-                onChange={(event) =>
-                  updateSearch({ agent: event.target.value || undefined })
-                }
-              >
-                <NativeSelectOption value="">
-                  All active agents
-                </NativeSelectOption>
-                {activeAgents.map((agent) => (
-                  <NativeSelectOption key={agent.id} value={agent.id}>
-                    {agent.name ? `${agent.name} (${agent.id})` : agent.id}
-                  </NativeSelectOption>
-                ))}
-              </NativeSelect>
-            </label>
-            <Button
-              variant="outline"
-              onClick={() => setArchiveDialogOpen(true)}
-            >
-              Archive agents
+          <>
+            <Button variant="ghost" onClick={() => setArchiveDialogOpen(true)}>
+              Archive
             </Button>
-          </div>
+            <Button onClick={() => setCreateDialogOpen(true)}>New agent</Button>
+          </>
         }
         onTabChange={(tab) => updateSearch({ tab })}
       >
-        {activeTab === 'files' ? (
+        <TabbedPageActions>
+          <label className="agents-scope">
+            <span className="supporting-text">Agent</span>
+            <NativeSelect
+              size="sm"
+              aria-label="Agent"
+              value={selectedAgentId || ''}
+              onChange={(event) =>
+                updateSearch({ agent: event.target.value || undefined })
+              }
+            >
+              <NativeSelectOption value="">
+                {activeTab === 'scoreboard'
+                  ? 'All active agents'
+                  : 'Select an agent…'}
+              </NativeSelectOption>
+              {activeAgents.map((agent) => (
+                <NativeSelectOption key={agent.id} value={agent.id}>
+                  {agent.name ? `${agent.name} (${agent.id})` : agent.id}
+                </NativeSelectOption>
+              ))}
+            </NativeSelect>
+          </label>
+        </TabbedPageActions>
+
+        {activeTab === 'configure' ? (
+          <AgentConfigPage
+            selectedAgentId={selectedAgentId}
+            onAgentChange={(agentId) =>
+              updateSearch({ agent: agentId || undefined })
+            }
+          />
+        ) : activeTab === 'files' ? (
           <AgentFilesPage
             embedded
             selectedAgentId={selectedAgentId}
@@ -155,6 +166,15 @@ export function AgentsHubPage() {
           />
         )}
       </TabbedPage>
+
+      <AgentCreateDialog
+        open={createDialogOpen}
+        existingAgentIds={(agentsQuery.data || []).map((agent) => agent.id)}
+        onOpenChange={setCreateDialogOpen}
+        onCreated={(agentId) =>
+          updateSearch({ tab: 'configure', agent: agentId })
+        }
+      />
 
       <Dialog open={archiveDialogOpen} onOpenChange={setArchiveDialogOpen}>
         <DialogContent size="lg">

--- a/console/src/routes/agents.test.tsx
+++ b/console/src/routes/agents.test.tsx
@@ -68,6 +68,7 @@ function makeAgent(overrides: Partial<AdminAgent>): AdminAgent {
     name: 'Main Agent',
     model: 'gpt-5',
     skills: null,
+    tools: null,
     chatbotId: null,
     enableRag: true,
     role: null,

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -328,6 +328,7 @@ function makeAgent(overrides: Partial<AdminAgent> = {}): AdminAgent {
     name: 'Main',
     model: 'gpt-5',
     skills: [],
+    tools: null,
     chatbotId: null,
     enableRag: true,
     proxy: null,

--- a/console/src/routes/gateway.test.tsx
+++ b/console/src/routes/gateway.test.tsx
@@ -90,6 +90,7 @@ function makeAgent(overrides: Partial<AdminAgent> = {}): AdminAgent {
     name: 'Main Agent',
     model: 'gpt-5',
     skills: null,
+    tools: null,
     chatbotId: null,
     enableRag: true,
     role: null,

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -426,6 +426,21 @@ code {
   white-space: nowrap;
 }
 
+.agents-scope {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.agents-scope > span {
+  white-space: nowrap;
+}
+
+.agents-scope [data-slot="native-select-wrapper"] {
+  min-width: 200px;
+}
+
 .agents-archive-list,
 .agents-archived-section {
   display: grid;

--- a/docs/content/channels/admin-console.md
+++ b/docs/content/channels/admin-console.md
@@ -68,8 +68,16 @@ changes before navigation.
 - `/admin/agents` lets operators pick any registered agent and edit the
   allowlisted workspace bootstrap markdown files seeded into that agent's
   runtime workspace
-- `/admin/agents` combines the agent scoreboard and workspace files behind
-  tabs with a shared active-agent selector
+- `/admin/agents?tab=configure` edits one agent's display name, workspace
+  directory, pinned model, skill allowlist, and tool allowlist, and saves the
+  whole set in one request
+- `/admin/agents?tab=configure` treats an empty allowlist state as "everything
+  available": unchecking an entry converts the agent to an explicit allowlist,
+  and "Reset to all" clears it again so future skills and tools stay available
+- `/admin/agents` creates agents from the browser and deletes non-default
+  agents behind a typed-id confirmation
+- `/admin/agents` combines agent configuration, the scoreboard, and workspace
+  files behind tabs with a shared active-agent selector
 - `/admin/agents` archives non-default agents without deleting their files or
   history and removes archived agents from console selectors until restored
 - `/admin/agents` shows saved revisions for those markdown files and can
@@ -186,6 +194,8 @@ scoped to the built-in allowlist and is not a general workspace file browser.
 - you want to tune per-channel instructions such as spoken-style guidance for
   voice without editing prompt files
 - you want to verify saved settings without editing `config.json` directly
+- you want to change an agent's model, skills, or tools without editing
+  `config.json` or using `hybridclaw agent config`
 - you want to update an agent's workspace instructions from the browser
 - you want revision history before restoring an earlier agent prompt file
 - you want to inspect or roll back agent org-chart changes from the browser

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -198,6 +198,13 @@ saved revision history directly.
   HybridAI chatbot instead of running the local agent loop. Proxy agents
   require `kind: "hybridai"`, an HTTPS `baseUrl`, `chatbotId`, and a
   SecretRef-backed `apiKey`; `conversationScope` can be `channel` or `user`.
+- `agents.list[].skills` and `agents.list[].tools` restrict which skills that
+  agent may load and which tools it may call. Omit either key to leave the
+  agent unrestricted, including for skills and tools installed later; an empty
+  array means none. A configured tool allowlist is intersected with the
+  caller's allowlist, so it can only narrow a turn's toolset, and globally
+  disabled tools (`tools.disabled`) stay off regardless. Edit both from
+  `/admin/agents?tab=configure` or `hybridclaw agent config`.
 - `agents.list[].webSearch.searxngBaseUrl` and
   `agents.list[].webSearch.searxngBearerTokenRef` override the global SearXNG
   instance and bearer SecretRef for a specific agent

--- a/src/agent/conversation.ts
+++ b/src/agent/conversation.ts
@@ -29,7 +29,7 @@ import {
   type PromptRuntimeInfo,
   type SkillPromptMode,
 } from './prompt-hooks.js';
-import { mergeBlockedToolNames } from './tool-policy.js';
+import { mergeAllowedToolNames, mergeBlockedToolNames } from './tool-policy.js';
 
 interface HistoryMessage {
   role: string;
@@ -157,6 +157,10 @@ export function buildConversationContext(params: {
     scheduleCloudMemorySync(agentId);
   }
   const mergedBlockedTools = mergeBlockedToolNames({ explicit: blockedTools });
+  const mergedAllowedTools = mergeAllowedToolNames({
+    agentId,
+    explicit: allowedTools,
+  });
   const skills = loadSkills(
     agentId,
     normalizeSkillConfigChannelKind(runtimeInfo?.channel?.kind),
@@ -181,7 +185,7 @@ export function buildConversationContext(params: {
     omitPromptParts,
     extraSafetyText,
     runtimeInfo,
-    allowedTools,
+    allowedTools: mergedAllowedTools,
     blockedTools: mergedBlockedTools,
   });
 

--- a/src/agent/tool-policy.ts
+++ b/src/agent/tool-policy.ts
@@ -1,3 +1,17 @@
+/**
+ * Tool policy — the single answer to "which tools may this turn call".
+ *
+ * Two independent restrictions compose here and nowhere else: the runtime
+ * denylist (`tools.disabled`) plus any caller-supplied block list, and the
+ * per-agent allowlist (`agents.list[].tools`) intersected with the caller's
+ * allowlist. An agent without a configured allowlist stays unrestricted; an
+ * empty allowlist means no tools, never "all tools".
+ *
+ * NOT the approval policy (`.hybridclaw/policy.yaml` decides whether an
+ * allowed call needs a human); this module only decides whether the tool is
+ * offered to the model at all.
+ */
+import { resolveAgentConfig } from '../agents/agent-registry.js';
 import {
   getRuntimeConfig,
   getRuntimeDisabledToolNames,
@@ -15,4 +29,23 @@ export function mergeBlockedToolNames(params?: {
     ...normalizeTrimmedStringSet([...explicit, ...runtimeDisabled]),
   ];
   return merged.length > 0 ? merged : undefined;
+}
+
+/**
+ * Intersect the caller's allowlist with the agent's configured tool
+ * allowlist. Returns undefined when neither restricts the toolset.
+ */
+export function mergeAllowedToolNames(params: {
+  agentId?: string | null;
+  explicit?: readonly string[] | null;
+}): string[] | undefined {
+  const explicit = Array.isArray(params.explicit)
+    ? [...normalizeTrimmedStringSet(params.explicit)]
+    : null;
+  const configured = resolveAgentConfig(params.agentId).tools;
+  if (!Array.isArray(configured)) return explicit ?? undefined;
+  const agentAllowed = [...normalizeTrimmedStringSet(configured)];
+  if (!explicit) return agentAllowed;
+  const explicitSet = new Set(explicit);
+  return agentAllowed.filter((name) => explicitSet.has(name));
 }

--- a/src/agents/agent-config-command.ts
+++ b/src/agents/agent-config-command.ts
@@ -192,6 +192,11 @@ function applyAgentConfigFieldUpdates(
     if (skills !== undefined) next.skills = skills;
     else delete next.skills;
   }
+  if (Object.hasOwn(updates, 'tools')) {
+    const tools = normalizeOptionalStringArrayField('tools', updates.tools);
+    if (tools !== undefined) next.tools = tools;
+    else delete next.tools;
+  }
   if (Object.hasOwn(updates, 'workspace')) {
     const workspace = normalizeOptionalStringField(
       'workspace',

--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -181,6 +181,9 @@ function normalizeAgent(value: unknown): AgentConfig | null {
   const skills = normalizeOptionalTrimmedUniqueStringArray(
     (value as { skills?: unknown }).skills,
   );
+  const tools = normalizeOptionalTrimmedUniqueStringArray(
+    (value as { tools?: unknown }).tools,
+  );
   const owner = normalizeString((value as { owner?: unknown }).owner);
   const role = normalizeString((value as { role?: unknown }).role);
   const reportsTo = normalizeString(
@@ -211,6 +214,7 @@ function normalizeAgent(value: unknown): AgentConfig | null {
     ...buildOptionalAgentPresentation(displayName, imageAsset, emptyChatHeader),
     ...(model ? { model } : {}),
     ...(skills !== undefined ? { skills } : {}),
+    ...(tools !== undefined ? { tools } : {}),
     ...(workspace ? { workspace } : {}),
     ...(chatbotId ? { chatbotId } : {}),
     ...(typeof enableRag === 'boolean' ? { enableRag } : {}),
@@ -291,6 +295,7 @@ function fingerprintAgent(agent: AgentConfig): string {
     fingerprintString(agent.emptyChatHeader),
     fingerprintModel(agent.model),
     fingerprintStringArray(agent.skills),
+    fingerprintStringArray(agent.tools),
     fingerprintString(agent.workspace),
     fingerprintString(agent.chatbotId),
     typeof agent.enableRag === 'boolean' ? String(agent.enableRag) : '',
@@ -376,6 +381,7 @@ function normalizeAgentsConfig(config: AgentsConfig | undefined): {
 function applyDefaults(agent: AgentConfig): AgentConfig {
   const model = cloneModelConfig(agent.model ?? configuredDefaults.model);
   const skills = agent.skills ? [...agent.skills] : undefined;
+  const tools = agent.tools ? [...agent.tools] : undefined;
   const chatbotId = normalizeString(
     agent.chatbotId ?? configuredDefaults.chatbotId,
   );
@@ -403,6 +409,7 @@ function applyDefaults(agent: AgentConfig): AgentConfig {
     ),
     ...(model ? { model } : {}),
     ...(skills !== undefined ? { skills } : {}),
+    ...(tools !== undefined ? { tools } : {}),
     ...(agent.workspace ? { workspace: agent.workspace } : {}),
     ...(chatbotId ? { chatbotId } : {}),
     ...(typeof enableRag === 'boolean' ? { enableRag } : {}),
@@ -465,6 +472,7 @@ function configuredAgentForDatabase(agent: AgentConfig): AgentConfig {
     emptyChatHeader: agent.emptyChatHeader,
     model: cloneModelConfig(agent.model),
     skills: agent.skills,
+    tools: agent.tools,
     workspace: agent.workspace,
     chatbotId: agent.chatbotId,
     enableRag: agent.enableRag,
@@ -494,6 +502,7 @@ const DB_BACKED_OPTIONAL_AGENT_FIELDS = [
   'emptyChatHeader',
   'model',
   'skills',
+  'tools',
   'workspace',
   'chatbotId',
   'enableRag',

--- a/src/agents/agent-runtime-config.ts
+++ b/src/agents/agent-runtime-config.ts
@@ -36,6 +36,7 @@ function sameAgentConfig(a: AgentConfig | undefined, b: AgentConfig): boolean {
     a.emptyChatHeader === b.emptyChatHeader &&
     sameModelConfig(a.model, b.model) &&
     sameStringArray(a.skills, b.skills) &&
+    sameStringArray(a.tools, b.tools) &&
     a.workspace === b.workspace &&
     a.chatbotId === b.chatbotId &&
     a.enableRag === b.enableRag &&

--- a/src/agents/agent-types.ts
+++ b/src/agents/agent-types.ts
@@ -73,6 +73,7 @@ export interface AgentConfig {
   emptyChatHeader?: string;
   model?: AgentModelConfig;
   skills?: string[];
+  tools?: string[];
   workspace?: string;
   chatbotId?: string;
   enableRag?: boolean;

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -1465,7 +1465,7 @@ const DEFAULT_XIAOMI_MODEL_LIST = ['xiaomi/MiMo-7B-RL'] as const;
 const DEFAULT_KILO_MODEL_LIST = ['kilo/anthropic/claude-sonnet-4.6'] as const;
 const DEFAULT_UI_NAVIGATION_ITEMS: ReadonlyArray<RuntimeUiNavigationItem> = [
   { href: '/chat', label: 'Chat', icon: 'chat' },
-  { href: '/agents', label: 'Agents', icon: 'agents' },
+  { href: '/admin/agents', label: 'Agents', icon: 'agents' },
   { href: '/admin', label: 'Admin', icon: 'admin' },
   {
     href: 'https://github.com/HybridAIOne/hybridclaw',
@@ -2991,6 +2991,11 @@ function normalizeAgentConfig(
     : fallback?.skills
       ? [...fallback.skills]
       : undefined;
+  const tools = Object.hasOwn(value, 'tools')
+    ? normalizeOptionalTrimmedUniqueStringArray(value.tools)
+    : fallback?.tools
+      ? [...fallback.tools]
+      : undefined;
   const owner = normalizeString(value.owner, fallback?.owner ?? '', {
     allowEmpty: true,
   });
@@ -3047,6 +3052,7 @@ function normalizeAgentConfig(
     ...buildOptionalAgentPresentation(displayName, imageAsset, emptyChatHeader),
     ...(model ? { model } : {}),
     ...(skills !== undefined ? { skills } : {}),
+    ...(tools !== undefined ? { tools } : {}),
     ...(workspace ? { workspace } : {}),
     ...(chatbotId ? { chatbotId } : {}),
     ...(typeof enableRag === 'boolean' ? { enableRag } : {}),
@@ -5262,7 +5268,9 @@ function normalizeUiNavigationItems(
     const href = normalizeUiNavigationHref(rawItem.href);
     if (!label || !href) continue;
     const item: RuntimeUiNavigationItem = {
-      href,
+      // `/agents` only ever redirected into the admin console, so stored
+      // navigation pointing at it never matched the view it lands on.
+      href: href === '/agents' ? '/admin/agents' : href,
       label: label.slice(0, MAX_UI_NAVIGATION_LABEL_LENGTH),
     };
     const icon = normalizeUiNavigationIcon(rawItem.icon);

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -4967,6 +4967,7 @@ type ApiAdminAgentPayloadBody = {
   name?: unknown;
   model?: unknown;
   skills?: unknown;
+  tools?: unknown;
   chatbotId?: unknown;
   enableRag?: unknown;
   archived?: unknown;
@@ -4985,6 +4986,7 @@ type ApiAdminAgentPayload = {
   name?: string;
   model?: string;
   skills?: string[] | null;
+  tools?: string[] | null;
   chatbotId?: string;
   enableRag?: boolean;
   archived?: boolean;
@@ -5166,6 +5168,7 @@ async function readApiAdminAgentPayload(
     name: typeof body.name === 'string' ? body.name : undefined,
     model: typeof body.model === 'string' ? body.model : undefined,
     skills: normalizeApiAdminAgentSkills(body.skills),
+    tools: normalizeApiAdminAgentStringArray('tools', body.tools),
     chatbotId: typeof body.chatbotId === 'string' ? body.chatbotId : undefined,
     enableRag: typeof body.enableRag === 'boolean' ? body.enableRag : undefined,
     archived: typeof body.archived === 'boolean' ? body.archived : undefined,
@@ -5212,6 +5215,7 @@ async function handleApiAdminAgentCollectionResource(
           name: payload.name,
           model: payload.model,
           skills: payload.skills,
+          tools: payload.tools,
           chatbotId: payload.chatbotId,
           enableRag: payload.enableRag,
           proxy: payload.proxy,
@@ -5251,6 +5255,7 @@ async function handleApiAdminAgentResource(
           name: payload.name,
           model: payload.model,
           skills: payload.skills,
+          tools: payload.tools,
           chatbotId: payload.chatbotId,
           enableRag: payload.enableRag,
           archived: payload.archived,

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -1726,6 +1726,7 @@ function mapGatewayAdminAgent(
     emptyChatHeader: resolved.emptyChatHeader || null,
     model: resolveAgentModel(resolved) || null,
     skills: Array.isArray(resolved.skills) ? [...resolved.skills] : null,
+    tools: Array.isArray(resolved.tools) ? [...resolved.tools] : null,
     chatbotId: resolved.chatbotId || null,
     enableRag:
       typeof resolved.enableRag === 'boolean' ? resolved.enableRag : null,
@@ -5470,6 +5471,7 @@ export function createGatewayAdminAgent(params: {
   name?: string | null;
   model?: string | null;
   skills?: string[] | null;
+  tools?: string[] | null;
   chatbotId?: string | null;
   enableRag?: boolean | null;
   proxy?: AgentConfig['proxy'] | null;
@@ -5485,6 +5487,9 @@ export function createGatewayAdminAgent(params: {
     ...(params.model?.trim() ? { model: params.model.trim() } : {}),
     ...(params.skills !== undefined
       ? { skills: params.skills == null ? undefined : [...params.skills] }
+      : {}),
+    ...(params.tools !== undefined
+      ? { tools: params.tools == null ? undefined : [...params.tools] }
       : {}),
     ...(params.chatbotId?.trim() ? { chatbotId: params.chatbotId.trim() } : {}),
     ...(typeof params.enableRag === 'boolean'
@@ -5505,6 +5510,7 @@ export function updateGatewayAdminAgent(
     name?: string | null;
     model?: string | null;
     skills?: string[] | null;
+    tools?: string[] | null;
     chatbotId?: string | null;
     enableRag?: boolean | null;
     proxy?: AgentConfig['proxy'] | null;
@@ -5533,6 +5539,9 @@ export function updateGatewayAdminAgent(
       : {}),
     ...(params.skills !== undefined
       ? { skills: params.skills == null ? undefined : [...params.skills] }
+      : {}),
+    ...(params.tools !== undefined
+      ? { tools: params.tools == null ? undefined : [...params.tools] }
       : {}),
     ...(params.chatbotId !== undefined
       ? { chatbotId: params.chatbotId?.trim() || undefined }

--- a/src/gateway/gateway-types.ts
+++ b/src/gateway/gateway-types.ts
@@ -1325,6 +1325,7 @@ export interface GatewayAdminAgent {
   emptyChatHeader: string | null;
   model: string | null;
   skills: string[] | null;
+  tools: string[] | null;
   chatbotId: string | null;
   enableRag: boolean | null;
   proxy?: GatewayAdminAgentProxyConfig | null;

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -9,6 +9,7 @@ import type {
   ExecutorRequest,
   ExecutorSessionHealthSnapshot,
 } from '../agent/executor-types.js';
+import { mergeAllowedToolNames } from '../agent/tool-policy.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import {
   getGoogleWorkspaceRuntimeEnvRecoveryHint,
@@ -1042,6 +1043,10 @@ async function runContainerInner(
     maxWallClockMs,
     inactivityTimeoutMs,
   } = params;
+  const effectiveAllowedTools = mergeAllowedToolNames({
+    agentId,
+    explicit: allowedTools,
+  });
   const workspacePath = getContainerWorkspacePath({
     sessionId,
     agentId,
@@ -1176,7 +1181,7 @@ async function runContainerInner(
       }),
     ),
     skillCatalog: params.skillCatalog,
-    allowedTools,
+    allowedTools: effectiveAllowedTools,
     blockedTools,
     media,
     audioTranscriptsPrepended,

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -7,6 +7,7 @@ import type {
   ExecutorRequest,
   ExecutorSessionHealthSnapshot,
 } from '../agent/executor-types.js';
+import { mergeAllowedToolNames } from '../agent/tool-policy.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import {
   getGoogleWorkspaceRuntimeEnvRecoveryHint,
@@ -913,6 +914,10 @@ async function runHostProcessInner(
     maxWallClockMs,
     inactivityTimeoutMs,
   } = params;
+  const effectiveAllowedTools = mergeAllowedToolNames({
+    agentId,
+    explicit: allowedTools,
+  });
 
   const workspacePath = getHostWorkspacePath({
     sessionId,
@@ -1019,7 +1024,7 @@ async function runHostProcessInner(
       }),
     ),
     skillCatalog: params.skillCatalog,
-    allowedTools,
+    allowedTools: effectiveAllowedTools,
     blockedTools,
     media,
     audioTranscriptsPrepended,

--- a/src/memory/agents.ts
+++ b/src/memory/agents.ts
@@ -54,6 +54,7 @@ type AgentRow = {
   empty_chat_header: string | null;
   model: string | null;
   skills: string | null;
+  tools: string | null;
   chatbot_id: string | null;
   enable_rag: number | null;
   workspace: string | null;
@@ -197,7 +198,7 @@ function parseAgentStringArray(
   } catch {
     logger.warn(
       { fieldName, payloadLength: normalized.length },
-      'Failed to parse persisted agent org-chart relationship list',
+      'Failed to parse persisted agent string list',
     );
     return undefined;
   }
@@ -438,6 +439,7 @@ function mapAgentRow(row: AgentRow): AgentConfig {
   const emptyChatHeader = row.empty_chat_header?.trim() || '';
   const model = parseAgentModelConfig(row.model);
   const skills = parseAgentSkillsConfig(row.skills);
+  const tools = parseAgentStringArray(row.tools, 'tools');
   const chatbotId = row.chatbot_id?.trim() || '';
   const workspace = row.workspace?.trim() || '';
   const owner = row.owner?.trim() || '';
@@ -460,6 +462,7 @@ function mapAgentRow(row: AgentRow): AgentConfig {
     ...(emptyChatHeader ? { emptyChatHeader } : {}),
     ...(model ? { model } : {}),
     ...(skills !== undefined ? { skills } : {}),
+    ...(tools !== undefined ? { tools } : {}),
     ...(chatbotId ? { chatbotId } : {}),
     ...(workspace ? { workspace } : {}),
     ...(typeof row.enable_rag === 'number'
@@ -478,7 +481,7 @@ function mapAgentRow(row: AgentRow): AgentConfig {
 }
 
 const AGENT_SELECT_COLUMNS =
-  'id, archived, canonical_id, owner_user_id, name, display_name, image_asset, empty_chat_header, model, skills, chatbot_id, enable_rag, workspace, owner, role, reports_to, delegates_to, peers, cv, escalation_target, a2a, proxy, created_at, updated_at';
+  'id, archived, canonical_id, owner_user_id, name, display_name, image_asset, empty_chat_header, model, skills, tools, chatbot_id, enable_rag, workspace, owner, role, reports_to, delegates_to, peers, cv, escalation_target, a2a, proxy, created_at, updated_at';
 
 export function getAgentById(agentId: string): AgentConfig | null {
   const normalizedAgentId = agentId.trim();
@@ -511,6 +514,7 @@ interface SerializedAgentSettings {
   emptyChatHeader: string | null;
   model: string | null;
   skills: string | null;
+  tools: string | null;
   chatbotId: string | null;
   enableRag: number | null;
   workspace: string | null;
@@ -533,6 +537,7 @@ function serializeAgentSettings(agent: AgentConfig): SerializedAgentSettings {
     emptyChatHeader: agent.emptyChatHeader?.trim() || null,
     model: serializeAgentModelConfig(agent.model),
     skills: serializeAgentSkillsConfig(agent.skills),
+    tools: serializeAgentStringArray(agent.tools),
     chatbotId: agent.chatbotId?.trim() || null,
     enableRag:
       typeof agent.enableRag === 'boolean' ? (agent.enableRag ? 1 : 0) : null,
@@ -659,6 +664,7 @@ export function upsertAgent(
        empty_chat_header,
        model,
        skills,
+       tools,
        chatbot_id,
        enable_rag,
        workspace,
@@ -673,7 +679,7 @@ export function upsertAgent(
        proxy,
        created_at,
        updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
      ON CONFLICT(id) DO UPDATE SET
        archived = excluded.archived,
        canonical_id = excluded.canonical_id,
@@ -684,6 +690,7 @@ export function upsertAgent(
        empty_chat_header = excluded.empty_chat_header,
        model = excluded.model,
        skills = excluded.skills,
+       tools = excluded.tools,
        chatbot_id = excluded.chatbot_id,
        enable_rag = excluded.enable_rag,
        workspace = excluded.workspace,
@@ -709,6 +716,7 @@ export function upsertAgent(
       settings.emptyChatHeader,
       settings.model,
       settings.skills,
+      settings.tools,
       settings.chatbotId,
       settings.enableRag,
       settings.workspace,

--- a/src/memory/schema/migrations.ts
+++ b/src/memory/schema/migrations.ts
@@ -23,7 +23,7 @@ import {
 } from '../../session/session-key.js';
 import type { CanonicalSessionMessage, Session } from '../../types/session.js';
 
-export const DATABASE_SCHEMA_VERSION = 56;
+export const DATABASE_SCHEMA_VERSION = 57;
 const AGENT_CANONICAL_ID_COLLISION_LIMIT = 20;
 const AUDIT_ACTOR_MIGRATION_BATCH_SIZE = 500;
 const ACTOR_ID_MAX_LENGTH =
@@ -3500,6 +3500,28 @@ function migrateV56(database: Database.Database): void {
   );
 }
 
+function agentToolsNeedMigration(database: Database.Database): boolean {
+  return (
+    tableExists(database, 'agents') &&
+    !columnExists(database, 'agents', 'tools')
+  );
+}
+
+function migrateV57(
+  database: Database.Database,
+  opts?: InitDatabaseOptions,
+): void {
+  addColumnIfMissing({
+    database,
+    table: 'agents',
+    column: 'tools',
+    ddl: 'tools TEXT',
+    quiet: opts?.quiet === true,
+  });
+
+  recordMigration(database, 57, 'Persist per-agent tool allowlists');
+}
+
 export function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -3637,6 +3659,9 @@ export function runMigrations(
     migrateV55(database, opts);
   }
   if (currentVersion < 56) migrateV56(database);
+  if (currentVersion < 57 || agentToolsNeedMigration(database)) {
+    migrateV57(database, opts);
+  }
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);
   if (!quiet && currentVersion < DATABASE_SCHEMA_VERSION) {

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -325,6 +325,59 @@ test('agent skill allowlists persist through runtime config normalization and th
   expect(getAgentById('silent')?.skills).toEqual([]);
 });
 
+test('agent tool allowlists persist and narrow the effective toolset', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const { initDatabase } = await import('../src/memory/db.ts');
+  const { updateRuntimeConfig } = await import(
+    '../src/config/runtime-config.ts'
+  );
+  const { getAgentById, initAgentRegistry, resolveAgentConfig } = await import(
+    '../src/agents/agent-registry.ts'
+  );
+  const { mergeAllowedToolNames } = await import(
+    '../src/agent/tool-policy.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const list = [
+    { id: 'main', name: 'Main Agent' },
+    {
+      id: 'reader',
+      name: 'Reader Agent',
+      tools: [' read ', 'grep', 'read'],
+    },
+    { id: 'mute', name: 'Mute Agent', tools: [] },
+  ];
+  updateRuntimeConfig((draft) => {
+    draft.agents.list = list;
+  });
+  initAgentRegistry({ list });
+
+  expect(resolveAgentConfig('reader').tools).toEqual(['read', 'grep']);
+  expect(getAgentById('reader')?.tools).toEqual(['read', 'grep']);
+  expect(resolveAgentConfig('mute').tools).toEqual([]);
+
+  // No configured allowlist leaves the caller's request untouched.
+  expect(mergeAllowedToolNames({ agentId: 'main' })).toBeUndefined();
+  expect(mergeAllowedToolNames({ agentId: 'main', explicit: ['bash'] })).toEqual(
+    ['bash'],
+  );
+
+  // A configured allowlist applies on its own and intersects with the caller's.
+  expect(mergeAllowedToolNames({ agentId: 'reader' })).toEqual(['read', 'grep']);
+  expect(
+    mergeAllowedToolNames({ agentId: 'reader', explicit: ['grep', 'bash'] }),
+  ).toEqual(['grep']);
+
+  // An empty allowlist means no tools, never "every tool".
+  expect(mergeAllowedToolNames({ agentId: 'mute', explicit: ['read'] })).toEqual(
+    [],
+  );
+});
+
 test('agent owner, role, and CV persist through runtime config and registry', async () => {
   const homeDir = makeTempHome();
   process.env.HOME = homeDir;
@@ -1180,6 +1233,7 @@ test('database migration v6 adds agents and backfills legacy agent ids to main',
     true,
   );
   expect(agentColumns.some((column) => column.name === 'skills')).toBe(true);
+  expect(agentColumns.some((column) => column.name === 'tools')).toBe(true);
   expect(agentColumns.some((column) => column.name === 'archived')).toBe(true);
 
   const sessionRow = migratedDb

--- a/tests/config-reload.integration.test.ts
+++ b/tests/config-reload.integration.test.ts
@@ -95,7 +95,7 @@ describe('config reload integration', () => {
 
     expect(cfg.ui.navigation).toEqual([
       { href: '/chat', icon: 'chat', label: 'Chat' },
-      { href: '/agents', icon: 'agents', label: 'Agents' },
+      { href: '/admin/agents', icon: 'agents', label: 'Agents' },
       { href: '/admin', icon: 'admin', label: 'Admin' },
       {
         href: 'https://github.com/HybridAIOne/hybridclaw',
@@ -142,6 +142,20 @@ describe('config reload integration', () => {
         label: 'Cloud',
       },
       { href: 'https://example.com/', label: 'Bad image' },
+    ]);
+  });
+
+  it('rewrites stored navigation still pointing at the legacy agents path', () => {
+    writeConfig({
+      ui: {
+        navigation: [{ label: 'Agents', href: '/agents', icon: 'agents' }],
+      },
+    });
+
+    const cfg = configMod.reloadRuntimeConfig('test');
+
+    expect(cfg.ui.navigation).toEqual([
+      { href: '/admin/agents', icon: 'agents', label: 'Agents' },
     ]);
   });
 


### PR DESCRIPTION
## Summary

- **Problem:** an agent's model, skills, and tools could only be changed in
  `config.json` or through `hybridclaw agent config`, and per-agent tool
  restrictions did not exist at all.
- **Why it matters:** narrowing an agent to the tools it actually needs is a
  containment decision, and it should be reviewable at a glance.
- **What changed:** `/admin/agents` opens on a Configuration tab that edits
  identity, model, and grouped skill and tool allowlists, and can create and
  delete agents. `agents.list[].tools` is new and enforced at the runner
  boundary.
- **What did not change:** org chart, RAG, budget, and proxy settings stay
  config- and CLI-only.

## Screenshots

Pick an agent, or create one:

![Agent picker](https://raw.githubusercontent.com/HybridAIOne/hybridclaw/assets/pr-console-agent-configuration/01-agent-picker.png)

Identity, then skills grouped by category, searchable, with tri-state group
toggles:

![Identity and skills](https://raw.githubusercontent.com/HybridAIOne/hybridclaw/assets/pr-console-agent-configuration/02-identity-skills.png)

Tools work the same way. `bash` is unchecked here, putting this agent at 37 of
38; the free-text row adds MCP and plugin tools the catalog cannot enumerate:

![Tools](https://raw.githubusercontent.com/HybridAIOne/hybridclaw/assets/pr-console-agent-configuration/03-tools.png)

The save bar appears only while the draft is dirty:

![Unsaved changes](https://raw.githubusercontent.com/HybridAIOne/hybridclaw/assets/pr-console-agent-configuration/04-unsaved-changes.png)

Create, with live id validation. Delete, behind a typed-id confirmation and
hidden for the default agent:

![New agent](https://raw.githubusercontent.com/HybridAIOne/hybridclaw/assets/pr-console-agent-configuration/05-new-agent.png)

![Delete agent](https://raw.githubusercontent.com/HybridAIOne/hybridclaw/assets/pr-console-agent-configuration/06-delete-agent.png)

![Dark theme](https://raw.githubusercontent.com/HybridAIOne/hybridclaw/assets/pr-console-agent-configuration/07-dark-theme.png)

*Screenshots sit on the unmerged `assets/pr-console-agent-configuration`
branch to keep them out of `main`. Delete it when this PR closes.*

## Allowlists

Two states, and the UI names the one in force: **unset** means everything,
*including entries installed later*; an **explicit list** means only these.
Unchecking while unrestricted snapshots the catalog minus that entry, so
narrowing is always deliberate, and "Reset to all" clears it. `tools: []` means
no tools, never "all".

`agents.list[].tools` mirrors `agents.list[].skills` through the config
normalizer, agent registry, SQLite (migration 57), admin API, and
`hybridclaw agent config`. `mergeAllowedToolNames` intersects it with the
caller's allowlist where `ContainerInput` is assembled in both runners, and in
the prompt's tool summary so the model's toolset and its prompt agree.
`tools.disabled` still wins.

## Change Type

- [x] Bug fix
- [x] Feature
- [x] Docs
- [x] Tests

## Licensing

- [x] All commits are signed off (`git commit -s`) to certify the
      [DCO](https://developercertificate.org/); the contribution is licensed
      under the repository's MIT license.

## Validation

```bash
npm run typecheck   # root + console + desktop
npm run lint
npx --prefix console vitest run --root console     # 105 files, 937 tests
npx vitest run tests/agent-registry.test.ts tests/agent-config-command.test.ts \
  tests/agent-types.test.ts tests/config-reload.integration.test.ts \
  tests/gateway-http-server.test.ts                # 5 files, 456 tests
```

- **Verified manually:** drove the console against a throwaway gateway
  (`--sandbox=host`, isolated `HYBRIDCLAW_DATA_DIR`). Unchecked `bash` on an
  unrestricted agent, saved, and confirmed `37 of 38` persisted through
  `GET /api/admin/agents`; created and deleted an agent through the dialogs;
  checked light and dark at 1440px and 900px.
- **Edge cases:** `tools: []` persists as an empty allowlist rather than
  collapsing to unrestricted; the intersection cases are covered in
  `tests/agent-registry.test.ts`; configured-but-uninstalled entries render in a
  "Not in catalog" group instead of disappearing.
- **Skipped locally:** the full `npm run test:unit` sweep — CI's `test` job runs
  it and is green. The visual baselines under `console/visual/__screenshots__`
  are stale, since `/admin/agents` gained a default tab and a New agent button;
  `npm --prefix console run test:visual:update` still needs a pass, which I
  could not run here (the pinned Playwright wants chromium revision 1228, only
  1194 and 1234 were cached).

## Docs And Config Impact

- [x] README, docs, or examples updated
- [x] Config or environment behavior changed

`docs/content/reference/configuration.md` covers both allowlists and the
intersection; `docs/content/channels/admin-console.md` covers the Configuration
tab. Two behaviours changed:

- `agents.tools` is a new SQLite column, added by migration 57 behind the usual
  `addColumnIfMissing` guard. `DATABASE_SCHEMA_VERSION` goes 56 → 57.
- the default `ui.navigation` Agents entry now points at `/admin/agents`, and
  stored navigation still pointing at the `/agents` redirect is rewritten on
  load. Custom entries are untouched.

## Risk Notes

- **Security-sensitive paths touched?** Yes. **Gateway or container boundaries?**
  Yes.
- This only ever subtracts. The per-agent allowlist is intersected with the
  allowlist the caller already passed, so a bug in `mergeAllowedToolNames`
  yields fewer tools than intended, never more, and it cannot re-enable a
  globally disabled tool. The one inversion that would matter — `tools: []`
  falling through to "unrestricted" — is tested directly.
- Agent deletion is exposed to the console for the first time. It needs the
  exact agent id typed, is hidden for the default agent, and leaves workspace
  files and session history on disk.

## Evidence

- [x] Screenshot or recording (above)
- [x] New or updated test coverage

New tests in `console/src/routes/agent-config.test.tsx`,
`tests/agent-registry.test.ts`, and `tests/config-reload.integration.test.ts`.

The view-switcher fix needed a mock change to be testable at all: the suite
stubbed `Link` as a plain anchor, which hid the router's fuzzy prefix matching —
the actual reason Admin stayed highlighted on `/admin/agents`. The mock now
mirrors it, and the new assertion fails without `activeOptions={{ exact: true }}`.

---

*Built with Claude Code; reviewed before submission.*
