### PR TITLE
fix(console): resolve approval cards immediately

### DIFF
--- a/console/src/routes/chat/chat-page.test.tsx
+++ b/console/src/routes/chat/chat-page.test.tsx
@@ -481,6 +481,68 @@ describe('ChatPage', () => {
     );
   });
 
+  it('marks an approval resolved before the resumed model turn completes', async () => {
+    fetchChatHistoryMock.mockResolvedValue({
+      sessionId: 'session-a',
+      history: [
+        {
+          id: 101,
+          role: 'assistant',
+          content: [
+            'Approval needed for: deploy the release',
+            'Approval ID: approval-1',
+            'Reply `yes` to approve once.',
+          ].join('\n'),
+        },
+      ],
+    });
+    let finishSend: ((sent: boolean) => void) | undefined;
+    sendMessageMock.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        finishSend = resolve;
+      }),
+    );
+
+    renderChatPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Allow once' }));
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      '/approve yes approval-1',
+      [],
+      { hideUser: true },
+    );
+    expect(screen.queryByRole('button', { name: 'Allow once' })).toBeNull();
+
+    await act(async () => finishSend?.(true));
+  });
+
+  it('restores an approval when the resumed model turn cannot start', async () => {
+    fetchChatHistoryMock.mockResolvedValue({
+      sessionId: 'session-a',
+      history: [
+        {
+          id: 101,
+          role: 'assistant',
+          content: [
+            'Approval needed for: deploy the release',
+            'Approval ID: approval-1',
+            'Reply `yes` to approve once.',
+          ].join('\n'),
+        },
+      ],
+    });
+    sendMessageMock.mockResolvedValue(false);
+
+    renderChatPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Allow once' }));
+
+    expect(await screen.findByRole('button', { name: 'Allow once' })).not.toBe(
+      null,
+    );
+  });
+
   it('prefills the composer from the prompt search param', async () => {
     window.history.replaceState(
       null,

--- a/console/src/routes/chat/chat-page.tsx
+++ b/console/src/routes/chat/chat-page.tsx
@@ -872,20 +872,25 @@ export function ChatPage() {
       const cmd = buildApprovalCommand(action, approvalId);
       if (!cmd) return;
       setApprovalBusy(true);
+      setResolvedApprovals((prev) => {
+        const next = new Map(prev);
+        next.set(approvalId, action);
+        return next;
+      });
+      let sent = false;
       try {
         jumpToBottom();
-        const sent = await stream.sendMessage(cmd, [], { hideUser: true });
-        // Mark it handled only once the send succeeds — a failed send (e.g.
-        // another run already in flight) leaves it unresolved so the user
-        // can retry.
-        if (sent) {
+        sent = await stream.sendMessage(cmd, [], { hideUser: true });
+      } finally {
+        // A send rejected before it starts (for example, because another run
+        // is active) restores the pending card so the user can retry.
+        if (!sent) {
           setResolvedApprovals((prev) => {
             const next = new Map(prev);
-            next.set(approvalId, action);
+            if (next.get(approvalId) === action) next.delete(approvalId);
             return next;
           });
         }
-      } finally {
         setApprovalBusy(false);
       }
     },


### PR DESCRIPTION
## Summary

- mark console chat approvals resolved as soon as an approval action is submitted
- restore the pending card when the resumed turn cannot start
- cover both immediate feedback and rollback behavior with chat-page tests

## Testing

- `npm --prefix console test -- src/routes/chat/chat-page.test.tsx` (45 tests passed)
- `npm --prefix console run lint`
- `npm run lint`