### PR TITLE
fix(discord): include embeds in read tool action results

### DIFF
--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -31,6 +31,7 @@ Use HybridClaw's `message` tool for Discord work. This skill is for actions, not
 - Prefer explicit numeric `guildId`, `channelId`, `messageId`, and `userId` values.
 - If the user gives a channel name, include `guildId` so the tool can resolve it safely.
 - Read first, act second.
+- Alert and webhook messages (Monit, CI, deploy bots) usually have an empty `content` and carry their payload in `embeds`. `read` returns an `embeds` array per message (`title`, `description`, `url`, `timestamp`, `author.name`, `footer.text`, and `fields[].name`/`fields[].value`) — check it before concluding a message is empty. It is capped at 5 embeds per message and 10 fields per embed.
 - Keep outbound Discord copy short and conversational.
 - Do not use markdown tables in Discord messages.
 - Confirm before deleting, mass-posting, or editing a message that materially changes meaning.

--- a/src/channels/discord/tool-actions.ts
+++ b/src/channels/discord/tool-actions.ts
@@ -1,4 +1,4 @@
-import type { AttachmentBuilder, Client, GuildMember } from 'discord.js';
+import type { AttachmentBuilder, Client, Embed, GuildMember } from 'discord.js';
 import type {
   ResolveSendAllowedParams,
   ResolveSendAllowedResult,
@@ -489,6 +489,31 @@ async function resolveGuildMemberIdFromLookup(params: {
   return { ok: true, userId: matched[0].member.id };
 }
 
+const DISCORD_READ_EMBEDS_PER_MESSAGE_LIMIT = 5;
+const DISCORD_READ_FIELDS_PER_EMBED_LIMIT = 10;
+
+function normalizeReadEmbeds(
+  embeds: readonly Embed[] | null | undefined,
+): Array<Record<string, unknown>> {
+  if (!embeds || embeds.length === 0) return [];
+  return embeds
+    .slice(0, DISCORD_READ_EMBEDS_PER_MESSAGE_LIMIT)
+    .map((embed) => ({
+      title: embed.title || null,
+      description: embed.description || null,
+      url: embed.url || null,
+      timestamp: embed.timestamp || null,
+      author: embed.author?.name ? { name: embed.author.name } : null,
+      footer: embed.footer?.text ? { text: embed.footer.text } : null,
+      fields: (embed.fields ?? [])
+        .slice(0, DISCORD_READ_FIELDS_PER_EMBED_LIMIT)
+        .map((field) => ({
+          name: field?.name || null,
+          value: field?.value || null,
+        })),
+    }));
+}
+
 function normalizeDate(value: Date | null | undefined): string | null {
   if (!value) return null;
   const ms = value.getTime();
@@ -952,6 +977,7 @@ async function runDiscordReadAction(
           size: attachment.size,
         }),
       ),
+      embeds: normalizeReadEmbeds(message.embeds),
       mentions: {
         users: Array.from(message.mentions.users.values()).map((user) => ({
           id: user.id,

--- a/tests/discord.tool-actions-read-embeds.test.ts
+++ b/tests/discord.tool-actions-read-embeds.test.ts
@@ -1,0 +1,159 @@
+import type { Client } from 'discord.js';
+import { expect, test, vi } from 'vitest';
+
+import { createDiscordToolActionRunner } from '../src/channels/discord/tool-actions.js';
+
+const GUILD_ID = '123456789012345678';
+const CHANNEL_ID = '223456789012345678';
+const MESSAGE_ID = '323456789012345678';
+
+type EmbedFixture = {
+  title?: string | null;
+  description?: string | null;
+  url?: string | null;
+  timestamp?: string | null;
+  author?: { name: string } | null;
+  footer?: { text: string } | null;
+  fields?: Array<{ name: string; value: string }>;
+};
+
+function createReadRunner(embeds: EmbedFixture[]) {
+  const message = {
+    id: MESSAGE_ID,
+    channelId: CHANNEL_ID,
+    guildId: GUILD_ID,
+    content: '',
+    createdTimestamp: Date.parse('2026-08-29T10:00:00.000Z'),
+    editedAt: null,
+    author: {
+      id: '423456789012345678',
+      username: 'monit-alerts',
+      globalName: null,
+      bot: true,
+    },
+    member: null,
+    attachments: new Map(),
+    embeds,
+    mentions: {
+      users: new Map(),
+      roles: new Map(),
+      channels: new Map(),
+    },
+  };
+
+  const channel = {
+    id: CHANNEL_ID,
+    guildId: GUILD_ID,
+    messages: {
+      fetch: vi.fn(async () => new Map([[MESSAGE_ID, message]])),
+    },
+  };
+
+  const client = {
+    channels: {
+      fetch: vi.fn(async (channelId: string) =>
+        channelId === CHANNEL_ID ? channel : null,
+      ),
+      cache: new Map(),
+    },
+    guilds: { fetch: vi.fn() },
+  } as unknown as Client;
+
+  return createDiscordToolActionRunner({
+    requireDiscordClientReady: () => client,
+    getDiscordPresence: () => undefined,
+    sendToChannel: vi.fn(async () => {}),
+    resolveSendAllowed: () => ({ allowed: true }),
+  });
+}
+
+test('read action surfaces embed payloads for embed-only alert messages', async () => {
+  const runner = createReadRunner([
+    {
+      title: 'Monit alert: prod-app-1',
+      description: 'cpu usage of 97% matches resource limit',
+      url: 'https://monit.example.com/alerts/42',
+      timestamp: '2026-08-29T09:59:58.000Z',
+      author: { name: 'Monit' },
+      footer: { text: 'monit@prod-app-1' },
+      fields: [
+        { name: 'Host', value: 'prod-app-1' },
+        { name: 'Severity', value: 'critical' },
+      ],
+    },
+  ]);
+
+  const result = (await runner({
+    action: 'read',
+    channelId: CHANNEL_ID,
+    guildId: GUILD_ID,
+  })) as {
+    messages: Array<{
+      content: string;
+      embeds: Array<Record<string, unknown>>;
+    }>;
+  };
+
+  expect(result.messages).toHaveLength(1);
+  const [readMessage] = result.messages;
+  expect(readMessage.content).toBe('');
+  expect(readMessage.embeds).toEqual([
+    {
+      title: 'Monit alert: prod-app-1',
+      description: 'cpu usage of 97% matches resource limit',
+      url: 'https://monit.example.com/alerts/42',
+      timestamp: '2026-08-29T09:59:58.000Z',
+      author: { name: 'Monit' },
+      footer: { text: 'monit@prod-app-1' },
+      fields: [
+        { name: 'Host', value: 'prod-app-1' },
+        { name: 'Severity', value: 'critical' },
+      ],
+    },
+  ]);
+});
+
+test('read action returns an empty embeds array when a message has none', async () => {
+  const runner = createReadRunner([]);
+  const result = (await runner({
+    action: 'read',
+    channelId: CHANNEL_ID,
+    guildId: GUILD_ID,
+  })) as { messages: Array<{ embeds: unknown[] }> };
+  expect(result.messages[0].embeds).toEqual([]);
+});
+
+test('read action caps embeds per message and fields per embed', async () => {
+  const runner = createReadRunner(
+    Array.from({ length: 8 }, (_, embedIndex) => ({
+      title: `embed-${embedIndex}`,
+      description: null,
+      fields: Array.from({ length: 14 }, (_, fieldIndex) => ({
+        name: `field-${fieldIndex}`,
+        value: `value-${fieldIndex}`,
+      })),
+    })),
+  );
+
+  const result = (await runner({
+    action: 'read',
+    channelId: CHANNEL_ID,
+    guildId: GUILD_ID,
+  })) as {
+    messages: Array<{
+      embeds: Array<{ title: string; fields: Array<{ name: string }> }>;
+    }>;
+  };
+
+  const { embeds } = result.messages[0];
+  expect(embeds).toHaveLength(5);
+  expect(embeds.map((embed) => embed.title)).toEqual([
+    'embed-0',
+    'embed-1',
+    'embed-2',
+    'embed-3',
+    'embed-4',
+  ]);
+  expect(embeds[0].fields).toHaveLength(10);
+  expect(embeds[0].fields.at(-1)?.name).toBe('field-9');
+});


### PR DESCRIPTION
## Problem

Discord alert and webhook messages — Monit, CI notifiers, deploy bots — post with an empty `content` and put their entire payload in **embeds**. The `discord` tool's `read` action (`runDiscordReadAction` in `src/channels/discord/tool-actions.ts`) mapped each message to `{ id, channelId, guildId, content, createdAt, editedAt, author, member, attachments, mentions }` and dropped `embeds` entirely.

So an agent reading an alerts channel got `content: ""` and nothing else — the alert was invisible to it. This blocks an ops-alert triage agent.

## Change

Map `message.embeds` into every message of the `read` result as a plain serializable array:

```jsonc
"embeds": [
  {
    "title": "Monit alert: prod-app-1",
    "description": "cpu usage of 97% matches resource limit",
    "url": "https://monit.example.com/alerts/42",
    "timestamp": "2026-08-29T09:59:58.000Z",
    "author": { "name": "Monit" },
    "footer": { "text": "monit@prod-app-1" },
    "fields": [
      { "name": "Host", "value": "prod-app-1" },
      { "name": "Severity", "value": "critical" }
    ]
  }
]
```

- Absent values are normalized to `null` with the surrounding code's `|| null` / `?? null` style; `author` and `footer` are nested-or-`null` objects mirroring both Discord's own embed JSON and the existing `member` field.
- A message with no embeds gets `embeds: []`, matching how `attachments` and `mentions` already behave for the empty case — the shape stays predictable.
- Scope is the `read` action only; nothing else in the file changes.

## Caps

Bounded the same way the file already bounds things (`read`'s `limit` clamp, the `.slice(0, 5)` on attachment names in `runtime.ts`):

- **5 embeds per message** (Discord's own hard limit is 10; alert bots realistically post 1).
- **10 fields per embed** (Discord's own hard limit is 25).

Discord independently caps a single embed's combined title + description + fields + footer + author at 6000 characters, so those two count caps put a hard ~30 KB ceiling on the embed payload of any one message. No per-string truncation was added on top of that.

## Docs

`skills/discord/SKILL.md` gained one working-rule bullet telling the agent that alert/webhook messages carry their payload in `embeds` and to check it before concluding a message is empty, plus the caps. The `read` result shape is not documented in `docs/content/channels/discord.md` (that page is setup-only), so nothing there needed updating.

## Test

New `tests/discord.tool-actions-read-embeds.test.ts`, following the `tests/discord.tool-actions-*.test.ts` conventions (mock `Client`, `createDiscordToolActionRunner`):

1. an embed-only message (empty `content`, embed with title + description + url + timestamp + author + footer + fields) surfaces its full payload through `read`;
2. a message with no embeds returns `embeds: []`;
3. an 8-embed / 14-field-per-embed message is capped to 5 embeds and 10 fields.

## Follow-up (not in this PR)

The guild-history serializer in `src/channels/discord/runtime.ts` (~line 391) has a related but separate gap: it flattens embeds to `[embed] title — description` and drops embed **fields**, so inbound history context still loses the structured part of an alert payload. Deliberately left alone here to keep this PR minimal.
