### PR TITLE
feat(discord): opt-in per-channel allowlist for bot-authored messages

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -142,6 +142,7 @@
     "sendPolicy": "open",
     "sendAllowedChannelIds": [],
     "freeResponseChannels": [],
+    "botMessageChannels": [],
     "textChunkLimit": 2000,
     "maxLinesPerMessage": 17,
     "humanDelay": {

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -598,6 +598,7 @@ export interface AdminConfig {
     sendPolicy: 'open' | 'allowlist' | 'disabled';
     sendAllowedChannelIds: string[];
     freeResponseChannels: string[];
+    botMessageChannels: string[];
     textChunkLimit: number;
     maxLinesPerMessage: number;
     humanDelay: {

--- a/console/src/generated/settings-registry.ts
+++ b/console/src/generated/settings-registry.ts
@@ -875,6 +875,12 @@ export const GENERATED_SETTINGS_REGISTRY: ReadonlyArray<GeneratedSettingEntry> =
       defaultValue: 'group-mentions',
     },
     {
+      path: 'discord.botMessageChannels',
+      section: 'discord',
+      kind: 'list',
+      defaultValue: [],
+    },
+    {
       path: 'discord.commandAllowedUserIds',
       section: 'discord',
       kind: 'list',

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -90,6 +90,7 @@ function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
       sendPolicy: 'open',
       sendAllowedChannelIds: [],
       freeResponseChannels: [],
+      botMessageChannels: [],
       textChunkLimit: 2000,
       maxLinesPerMessage: 17,
       humanDelay: {

--- a/docs/content/channels/discord.md
+++ b/docs/content/channels/discord.md
@@ -45,8 +45,22 @@ Local config equivalent:
 /config set discord.commandUserId ""
 /config set discord.groupPolicy "disabled"
 /config set discord.freeResponseChannels []
+/config set discord.botMessageChannels []
 /config set discord.guilds {}
 /config set discord.prefix "!claw"
+```
+
+## Optional: Let Bots Wake The Agent In Alert Channels
+
+Messages written by other bots and webhooks are ignored everywhere by default.
+List a channel ID in `discord.botMessageChannels` to let bot- and
+webhook-authored messages trigger the agent in that channel only — useful for
+an alerts channel fed by monitoring or CI webhooks. The agent's own messages
+are always ignored, including in these channels, so it can never reply to
+itself.
+
+```text
+/config set discord.botMessageChannels ["123456789012345678"]
 ```
 
 ## Step 2: Start Or Restart The Gateway

--- a/docs/content/channels/discord.md
+++ b/docs/content/channels/discord.md
@@ -63,6 +63,11 @@ itself.
 /config set discord.botMessageChannels ["123456789012345678"]
 ```
 
+Do not allowlist a channel that HybridClaw itself posts into through
+`discordWebhook`. Those messages arrive authored by the webhook rather than by
+the bot user, so the self-reply guard cannot recognize them as ours and the
+agent would answer its own notifications.
+
 ## Step 2: Start Or Restart The Gateway
 
 ```bash

--- a/src/channels/discord/inbound.ts
+++ b/src/channels/discord/inbound.ts
@@ -259,3 +259,33 @@ export function isTrigger(params: {
   if (params.hasBotMention) return true;
   return false;
 }
+
+/**
+ * Decides whether a bot-authored message may trigger the agent.
+ *
+ * Bot/webhook authors are ignored by default. They only pass in channels that
+ * are explicitly listed in `discord.botMessageChannels`, so alert channels can
+ * wake the agent without changing behavior anywhere else.
+ *
+ * The agent's own messages are ALWAYS ignored, allowlist or not: replying to
+ * ourselves would create an infinite self-reply loop.
+ */
+export function shouldIgnoreBotAuthoredMessage(params: {
+  authorId: string;
+  authorIsBot: boolean;
+  botUserId: string | null;
+  channelId: string;
+  botMessageChannels: string[];
+}): boolean {
+  const botId = params.botUserId?.trim() || '';
+  if (botId && params.authorId === botId) return true;
+  if (!params.authorIsBot) return false;
+  // Fail closed: if we cannot identify ourselves yet, never let a bot author
+  // through, because it could be us.
+  if (!botId) return true;
+
+  const allowed = new Set(
+    params.botMessageChannels.map((entry) => entry.trim()).filter(Boolean),
+  );
+  return !allowed.has(params.channelId);
+}

--- a/src/channels/discord/runtime.ts
+++ b/src/channels/discord/runtime.ts
@@ -15,6 +15,7 @@ import { parseLowerArg } from '../../command-parsing.js';
 import {
   DISCORD_ACK_REACTION,
   DISCORD_ACK_REACTION_SCOPE,
+  DISCORD_BOT_MESSAGE_CHANNELS,
   DISCORD_COMMAND_ALLOWED_USER_IDS,
   DISCORD_COMMAND_MODE,
   DISCORD_COMMAND_USER_ID,
@@ -91,6 +92,7 @@ import {
   isTrigger as isTriggerInbound,
   type ParsedCommand,
   parseCommand as parseCommandInbound,
+  shouldIgnoreBotAuthoredMessage as shouldIgnoreBotAuthoredMessageInbound,
   shouldReplyInFreeMode as shouldReplyInFreeModeInbound,
   shouldSkipFreeReplyBecauseOtherUsersMentioned as shouldSkipFreeReplyBecauseOtherUsersMentionedInbound,
 } from './inbound.js';
@@ -2391,7 +2393,20 @@ export async function initDiscord(
   };
 
   client.on('messageCreate', async (msg: DiscordMessage) => {
-    if (msg.author.bot) return;
+    // Bot/webhook authors are ignored unless their channel opts in via
+    // discord.botMessageChannels. Our own messages are always ignored, even in
+    // an allowlisted channel, so the agent can never reply to itself.
+    if (
+      shouldIgnoreBotAuthoredMessageInbound({
+        authorId: msg.author.id,
+        authorIsBot: Boolean(msg.author.bot),
+        botUserId: client.user?.id || null,
+        channelId: msg.channelId,
+        botMessageChannels: DISCORD_BOT_MESSAGE_CHANNELS,
+      })
+    ) {
+      return;
+    }
 
     const sessionId = getSessionId(msg);
     const guildId = msg.guild?.id || null;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -290,6 +290,7 @@ export let DISCORD_GROUP_POLICY: RuntimeConfig['discord']['groupPolicy'] =
 export let DISCORD_SEND_POLICY: RuntimeConfig['discord']['sendPolicy'] = 'open';
 export let DISCORD_SEND_ALLOWED_CHANNEL_IDS: string[] = [];
 export let DISCORD_FREE_RESPONSE_CHANNELS: string[] = [];
+export let DISCORD_BOT_MESSAGE_CHANNELS: string[] = [];
 export let DISCORD_TEXT_CHUNK_LIMIT = 1_900;
 export let DISCORD_MAX_LINES_PER_MESSAGE = 17;
 export let DISCORD_HUMAN_DELAY: RuntimeConfig['discord']['humanDelay'] = {
@@ -838,6 +839,7 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
   DISCORD_SEND_POLICY = config.discord.sendPolicy;
   DISCORD_SEND_ALLOWED_CHANNEL_IDS = [...config.discord.sendAllowedChannelIds];
   DISCORD_FREE_RESPONSE_CHANNELS = [...config.discord.freeResponseChannels];
+  DISCORD_BOT_MESSAGE_CHANNELS = [...config.discord.botMessageChannels];
   DISCORD_TEXT_CHUNK_LIMIT = Math.max(
     200,
     Math.min(1_900, config.discord.textChunkLimit),

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -1096,6 +1096,7 @@ export interface RuntimeConfig {
     sendPolicy: DiscordSendPolicy;
     sendAllowedChannelIds: string[];
     freeResponseChannels: string[];
+    botMessageChannels: string[];
     textChunkLimit: number;
     maxLinesPerMessage: number;
     humanDelay: RuntimeDiscordHumanDelayConfig;
@@ -1613,6 +1614,7 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
     sendPolicy: 'open',
     sendAllowedChannelIds: [],
     freeResponseChannels: [],
+    botMessageChannels: [],
     textChunkLimit: 1_900,
     maxLinesPerMessage: 17,
     humanDelay: {
@@ -7784,6 +7786,10 @@ function normalizeRuntimeConfig(
       freeResponseChannels: normalizeStringArray(
         rawDiscord.freeResponseChannels,
         DEFAULT_RUNTIME_CONFIG.discord.freeResponseChannels,
+      ),
+      botMessageChannels: normalizeStringArray(
+        rawDiscord.botMessageChannels,
+        DEFAULT_RUNTIME_CONFIG.discord.botMessageChannels,
       ),
       textChunkLimit: normalizeInteger(
         rawDiscord.textChunkLimit,

--- a/tests/discord.basic.test.ts
+++ b/tests/discord.basic.test.ts
@@ -9,6 +9,7 @@ import {
   isAuthorizedCommandUser,
   isTrigger,
   parseCommand,
+  shouldIgnoreBotAuthoredMessage,
   shouldReplyInFreeMode,
   shouldSkipFreeReplyBecauseOtherUsersMentioned,
 } from '../src/channels/discord/inbound.js';
@@ -387,4 +388,68 @@ test('command access uses legacy commandUserId in restricted mode', () => {
     legacyCommandUserId: '777',
   });
   expect(authorized).toBe(true);
+});
+
+const BOT_SELF_ID = '999999999999999999';
+const ALERTS_CHANNEL_ID = '111111111111111111';
+const GENERAL_CHANNEL_ID = '222222222222222222';
+
+test('bot-authored messages stay ignored in non-allowlisted channels', () => {
+  expect(
+    shouldIgnoreBotAuthoredMessage({
+      authorId: '333333333333333333',
+      authorIsBot: true,
+      botUserId: BOT_SELF_ID,
+      channelId: GENERAL_CHANNEL_ID,
+      botMessageChannels: [ALERTS_CHANNEL_ID],
+    }),
+  ).toBe(true);
+});
+
+test('bot-authored messages trigger in allowlisted channels', () => {
+  expect(
+    shouldIgnoreBotAuthoredMessage({
+      authorId: '333333333333333333',
+      authorIsBot: true,
+      botUserId: BOT_SELF_ID,
+      channelId: ALERTS_CHANNEL_ID,
+      botMessageChannels: [ALERTS_CHANNEL_ID],
+    }),
+  ).toBe(false);
+});
+
+test('our own messages are ignored even in allowlisted channels', () => {
+  expect(
+    shouldIgnoreBotAuthoredMessage({
+      authorId: BOT_SELF_ID,
+      authorIsBot: true,
+      botUserId: BOT_SELF_ID,
+      channelId: ALERTS_CHANNEL_ID,
+      botMessageChannels: [ALERTS_CHANNEL_ID],
+    }),
+  ).toBe(true);
+});
+
+test('bot-authored messages are ignored while our own user id is unknown', () => {
+  expect(
+    shouldIgnoreBotAuthoredMessage({
+      authorId: '333333333333333333',
+      authorIsBot: true,
+      botUserId: null,
+      channelId: ALERTS_CHANNEL_ID,
+      botMessageChannels: [ALERTS_CHANNEL_ID],
+    }),
+  ).toBe(true);
+});
+
+test('human messages are unaffected by the bot allowlist', () => {
+  expect(
+    shouldIgnoreBotAuthoredMessage({
+      authorId: '444444444444444444',
+      authorIsBot: false,
+      botUserId: BOT_SELF_ID,
+      channelId: GENERAL_CHANNEL_ID,
+      botMessageChannels: [],
+    }),
+  ).toBe(false);
 });


### PR DESCRIPTION
## Problem

`src/channels/discord/runtime.ts`'s `messageCreate` handler started with an unconditional `if (msg.author.bot) return;`. A HybridClaw agent in a Discord channel could therefore never be triggered by a bot or webhook message.

That blocks a real use case: an agent watching an alerts channel. Those channels are 100% bot/webhook traffic — Monit, deploy notifiers, CI result webhooks — so the agent simply never woke up.

## Design: opt in, per channel

New config key `discord.botMessageChannels: string[]`, default `[]`. Bot- and webhook-authored messages can trigger the agent only in channels whose id is listed there.

**The default is unchanged.** With an empty list the guard drops every bot-authored message exactly as before, so existing deployments behave byte-for-byte identically.

## Self-loop guard

The agent's own Discord messages are also bot messages, and the old blanket `return` was what kept the agent from replying to itself forever. The replacement preserves that explicitly:

- `shouldIgnoreBotAuthoredMessage()` ignores any message whose `authorId` equals the bot's own user id **first**, before the allowlist is consulted — so our own messages are dropped even in an allowlisted channel.
- The bot's own id comes from `client.user?.id`, the same accessor the rest of `runtime.ts` uses (e.g. `buildParticipantContext`).
- The check is **fail-closed**: if `client.user` is not resolved yet, no bot-authored message passes at all, because it could be us.

Covered by a dedicated test.

## Scope

The gate logic lives in `src/channels/discord/inbound.ts` as a pure function, matching how the other Discord trigger predicates (`isTrigger`, `shouldReplyInFreeMode`, …) are factored and unit-tested.

The other `msg.author.bot` check in that file (`buildParticipantContext`) is participant bookkeeping — it tags bot participants for the context block, it is not a trigger gate — so it is left alone. Same for the `messageUpdate` and reaction handlers: no behavior change there.

## Tests

Added to `tests/discord.basic.test.ts`:

- bot message in a non-allowlisted channel is still ignored
- bot message in an allowlisted channel triggers
- the bot's own message is ignored even in an allowlisted channel
- bot messages are ignored while our own user id is unknown (fail-closed)
- human messages are unaffected by the allowlist

`npm run lint` (root + console + desktop typecheck, incl. `registry:check`) and `npx biome check .` are clean. `npm run test:unit`: 5615 passed. The 12 failures in `tests/admin-terminal.test.ts`, `tests/eval-command.test.ts`, `tests/host-runner.redaction.test.ts` and `tests/host-runner.worker-restart.test.ts` reproduce identically on an unmodified tree — pre-existing, unrelated to this change.
