### PR TITLE
feat(console): redesign agent skill/tool allowlist picker

### DIFF
--- a/console/src/routes/agent-config.module.css
+++ b/console/src/routes/agent-config.module.css
@@ -34,17 +34,6 @@
   flex-wrap: wrap;
 }
 
-.scopeToolbar {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.scopeToolbar > :first-child {
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
 .scopeCount {
   font-size: 0.8125rem;
   color: var(--muted-foreground);
@@ -52,9 +41,75 @@
   white-space: nowrap;
 }
 
-.scopeGroups {
+.scopeModes {
   display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 8px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.scopeMode {
+  display: grid;
+  gap: 4px;
+  justify-items: start;
+  text-align: left;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel-bg);
+  color: var(--foreground);
+  font: inherit;
+  cursor: pointer;
+}
+
+.scopeMode:hover {
+  border-color: var(--line-strong);
+}
+
+.scopeMode small {
+  color: var(--muted-foreground);
+}
+
+.scopeModeActive.scopeModeActive {
+  border-color: var(--primary);
+  background: color-mix(in srgb, var(--primary) 5%, var(--panel-bg));
+}
+
+.scopeModeTitle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.875rem;
+}
+
+.scopeModeDot {
+  flex: none;
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  background: var(--panel-bg);
+}
+
+.scopeModeActive .scopeModeDot {
+  border: 4px solid var(--primary);
+}
+
+.scopeListActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.scopeListActions .scopeCount {
+  margin-left: auto;
+}
+
+.scopeList {
+  display: grid;
+  gap: 2px;
   max-height: 420px;
   overflow-y: auto;
   padding: 4px;
@@ -63,40 +118,49 @@
   background: var(--panel-muted);
 }
 
-.scopeGroup {
-  display: grid;
-  gap: 4px;
-  padding: 8px;
-}
-
-.scopeGroupHead {
+.scopeRow {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding-bottom: 4px;
-  border-bottom: 1px solid var(--line);
-}
-
-.scopeItems {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: 2px;
-}
-
-.scopeItem {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  padding: 8px;
+  padding: 6px 10px;
   border-radius: var(--radius-sm);
-  cursor: pointer;
 }
 
-.scopeItem:hover {
+.scopeRow:hover {
   background: var(--panel-bg);
 }
 
+.scopeRowGroup {
+  flex: none;
+  font-size: 0.72rem;
+  color: var(--muted-foreground);
+  white-space: nowrap;
+}
+
+.scopeRemove {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  font: inherit;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.scopeRemove:hover {
+  background: var(--panel-muted);
+  color: var(--danger);
+}
+
 .scopeItemText {
+  flex: 1 1 auto;
   display: grid;
   gap: 2px;
   min-width: 0;

--- a/console/src/routes/agent-config.test.tsx
+++ b/console/src/routes/agent-config.test.tsx
@@ -124,14 +124,23 @@ describe('AgentConfigPage', () => {
     expect(screen.getByText('all tools')).toBeTruthy();
   });
 
-  it('narrows an unrestricted allowlist when a tool is unchecked', async () => {
+  it('starts empty when restricting and adds entries via the palette', async () => {
     updateAdminAgentMock.mockResolvedValue(makeAgent({ tools: ['read'] }));
     renderWithProviders(
       <AgentConfigPage selectedAgentId="support" onAgentChange={() => {}} />,
     );
 
-    const bash = await screen.findByRole('checkbox', { name: 'bash' });
-    fireEvent.click(bash);
+    const restrictToggles = await screen.findAllByRole('button', {
+      name: /Selected only/,
+    });
+    fireEvent.click(restrictToggles[1]);
+    expect(screen.getByText(/Nothing selected/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add tools…' }));
+    fireEvent.click(await screen.findByRole('option', { name: /read/ }));
+    fireEvent.keyDown(screen.getByRole('combobox', { name: 'Search tools' }), {
+      key: 'Escape',
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
 
     await waitFor(() => {
@@ -143,6 +152,78 @@ describe('AgentConfigPage', () => {
     });
   });
 
+  it('restores the stashed selection when flipping back to selected only', async () => {
+    fetchAdminAgentsMock.mockResolvedValue([makeAgent({ tools: ['read'] })]);
+    renderWithProviders(
+      <AgentConfigPage selectedAgentId="support" onAgentChange={() => {}} />,
+    );
+
+    expect(await screen.findByRole('button', { name: 'Remove read' }));
+    fireEvent.click(screen.getByRole('button', { name: /All tools/ }));
+    expect(screen.queryByRole('button', { name: 'Remove read' })).toBeNull();
+
+    const restrictToggles = screen.getAllByRole('button', {
+      name: /Selected only/,
+    });
+    fireEvent.click(restrictToggles[1]);
+    expect(screen.getByRole('button', { name: 'Remove read' })).toBeTruthy();
+  });
+
+  it('adds a catalog entry through the search palette', async () => {
+    fetchAdminAgentsMock.mockResolvedValue([makeAgent({ tools: ['read'] })]);
+    updateAdminAgentMock.mockResolvedValue(
+      makeAgent({ tools: ['read', 'bash'] }),
+    );
+    renderWithProviders(
+      <AgentConfigPage selectedAgentId="support" onAgentChange={() => {}} />,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Add tools…' }));
+    fireEvent.click(await screen.findByRole('option', { name: /bash/ }));
+    fireEvent.keyDown(screen.getByRole('combobox', { name: 'Search tools' }), {
+      key: 'Escape',
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(updateAdminAgentMock).toHaveBeenCalledWith(
+        'test-token',
+        'support',
+        expect.objectContaining({ tools: ['read', 'bash'] }),
+      );
+    });
+  });
+
+  it('adds a custom tool by exact name through the palette', async () => {
+    fetchAdminAgentsMock.mockResolvedValue([makeAgent({ tools: ['read'] })]);
+    updateAdminAgentMock.mockResolvedValue(
+      makeAgent({ tools: ['read', 'github__create_issue'] }),
+    );
+    renderWithProviders(
+      <AgentConfigPage selectedAgentId="support" onAgentChange={() => {}} />,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Add tools…' }));
+    fireEvent.change(screen.getByRole('combobox', { name: 'Search tools' }), {
+      target: { value: 'github__create_issue' },
+    });
+    fireEvent.click(
+      screen.getByRole('option', { name: /Add “github__create_issue”/ }),
+    );
+    fireEvent.keyDown(screen.getByRole('combobox', { name: 'Search tools' }), {
+      key: 'Escape',
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(updateAdminAgentMock).toHaveBeenCalledWith(
+        'test-token',
+        'support',
+        expect.objectContaining({ tools: ['read', 'github__create_issue'] }),
+      );
+    });
+  });
+
   it('sends null when an allowlist is reset to everything', async () => {
     fetchAdminAgentsMock.mockResolvedValue([makeAgent({ skills: ['pdf'] })]);
     updateAdminAgentMock.mockResolvedValue(makeAgent());
@@ -150,10 +231,7 @@ describe('AgentConfigPage', () => {
       <AgentConfigPage selectedAgentId="support" onAgentChange={() => {}} />,
     );
 
-    const resetButtons = await screen.findAllByRole('button', {
-      name: 'Reset to all',
-    });
-    fireEvent.click(resetButtons[0]);
+    fireEvent.click(await screen.findByRole('button', { name: /All skills/ }));
     fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
 
     await waitFor(() => {

--- a/console/src/routes/agent-config.tsx
+++ b/console/src/routes/agent-config.tsx
@@ -349,10 +349,12 @@ export function AgentConfigPage(props: {
       </section>
 
       <AgentScopePicker
+        key={`skills:${agent.id}`}
         title="Skills"
         description="Skills this agent may load. Everything else stays out of its prompt."
         allLabel="All skills"
-        restrictedNote="Only the selected skills load. Skills installed later stay off for this agent until you add them here."
+        allNote="Every installed skill, including ones installed later."
+        restrictedNote="Only the skills on the list. New installs stay off until added."
         searchPlaceholder="Search skills"
         groups={withUnknownEntries(skillGroups, draft.skills)}
         value={draft.skills}
@@ -361,10 +363,12 @@ export function AgentConfigPage(props: {
       />
 
       <AgentScopePicker
+        key={`tools:${agent.id}`}
         title="Tools"
         description="Tools this agent may call. Globally disabled tools stay off regardless."
         allLabel="All tools"
-        restrictedNote="Only the selected tools are offered to the model. Plugin and MCP tools added later stay off for this agent until you add them here."
+        allNote="Every available tool, including plugin and MCP tools added later."
+        restrictedNote="Only the tools on the list. New plugin and MCP tools stay off until added."
         searchPlaceholder="Search tools"
         groups={withUnknownEntries(toolGroups, draft.tools)}
         value={draft.tools}

--- a/console/src/routes/agent-scope-picker.tsx
+++ b/console/src/routes/agent-scope-picker.tsx
@@ -4,17 +4,35 @@
  *
  * The control has exactly two states and never blurs them: `null` means "no
  * allowlist" (everything available now and everything added later), and an
- * array means "only these". Unchecking an entry while in the `null` state
- * snapshots the catalog minus that entry, so narrowing is always explicit.
+ * array means "only these". The mode cards make the choice explicit;
+ * "Selected only" starts empty (or restores the selection stashed when the
+ * mode last flipped to "all"), and nothing persists until the page is saved.
+ *
+ * Restricted mode shows only the enabled entries; additions go through a
+ * command-palette dialog that searches the catalog (and, for tools, accepts
+ * exact names the catalog cannot list, such as MCP tools).
  *
  * NOT a global enable/disable surface (`/admin/skills` and `tools.disabled`
  * own that); entries this picker offers may still be off fleet-wide.
  */
-import { useMemo, useState } from 'react';
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Button } from '../components/button';
-import { Checkbox } from '../components/checkbox';
-import { Input } from '../components/input';
-import { SegmentedToggle } from '../components/ui';
+import paletteStyles from '../components/command-palette.module.css';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '../components/dialog';
+import { Search } from '../components/icons';
+import { cx } from '../lib/cx';
 import styles from './agent-config.module.css';
 
 export interface AgentScopeItem {
@@ -30,13 +48,24 @@ export interface AgentScopeGroup {
   items: AgentScopeItem[];
 }
 
-function matchesQuery(item: AgentScopeItem, query: string): boolean {
+interface CatalogEntry extends AgentScopeItem {
+  group: string;
+}
+
+type PaletteRow =
+  | { kind: 'catalog'; entry: CatalogEntry }
+  | { kind: 'custom'; name: string };
+
+const MAX_PALETTE_ROWS = 50;
+
+function matchesQuery(entry: CatalogEntry, query: string): boolean {
   if (!query) return true;
   const needle = query.toLowerCase();
   return (
-    item.id.toLowerCase().includes(needle) ||
-    item.label.toLowerCase().includes(needle) ||
-    (item.description || '').toLowerCase().includes(needle)
+    entry.id.toLowerCase().includes(needle) ||
+    entry.label.toLowerCase().includes(needle) ||
+    entry.group.toLowerCase().includes(needle) ||
+    (entry.description || '').toLowerCase().includes(needle)
   );
 }
 
@@ -44,6 +73,9 @@ export function AgentScopePicker(props: {
   title: string;
   description: string;
   allLabel: string;
+  /** One-liner for the "all" mode card. */
+  allNote: string;
+  /** One-liner for the "selected only" mode card. */
   restrictedNote: string;
   searchPlaceholder: string;
   groups: AgentScopeGroup[];
@@ -54,62 +86,119 @@ export function AgentScopePicker(props: {
   /** Offers a free-text row for entries the catalog cannot list (MCP tools). */
   allowCustomEntries?: boolean;
 }) {
+  const listboxId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [addOpen, setAddOpen] = useState(false);
   const [query, setQuery] = useState('');
-  const [customEntry, setCustomEntry] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  /** Last custom selection, restored when flipping back from "all". */
+  const [stash, setStash] = useState<string[] | null>(null);
 
-  const catalogIds = useMemo(
-    () => props.groups.flatMap((group) => group.items.map((item) => item.id)),
+  const catalog = useMemo<CatalogEntry[]>(
+    () =>
+      props.groups.flatMap((group) =>
+        group.items.map((item) => ({ ...item, group: group.label })),
+      ),
     [props.groups],
   );
-  const selectedIds = useMemo(
-    () => new Set(props.value ?? catalogIds),
-    [props.value, catalogIds],
+  const catalogById = useMemo(
+    () => new Map(catalog.map((entry) => [entry.id, entry])),
+    [catalog],
   );
   const unrestricted = props.value === null;
-
-  const visibleGroups = useMemo(
-    () =>
-      props.groups
-        .map((group) => ({
-          label: group.label,
-          items: group.items.filter((item) => matchesQuery(item, query)),
-        }))
-        .filter((group) => group.items.length > 0),
-    [props.groups, query],
-  );
+  const selected = props.value ?? [];
+  const selectedIds = useMemo(() => new Set(selected), [selected]);
+  const totalCount = catalog.length;
 
   function setSelection(next: Set<string>): void {
-    const catalog = new Set(catalogIds);
-    const ordered = catalogIds.filter((id) => next.has(id));
-    const extras = [...next].filter((id) => !catalog.has(id));
+    const ordered = catalog
+      .map((entry) => entry.id)
+      .filter((id) => next.has(id));
+    const extras = [...next].filter((id) => !catalogById.has(id));
     props.onChange([...ordered, ...extras]);
   }
 
-  function toggleItem(id: string, checked: boolean): void {
+  function addEntry(id: string): void {
+    setSelection(new Set([...selectedIds, id]));
+  }
+
+  function removeEntry(id: string): void {
     const next = new Set(selectedIds);
-    if (checked) next.add(id);
-    else next.delete(id);
+    next.delete(id);
     setSelection(next);
   }
 
-  function toggleGroup(group: AgentScopeGroup, checked: boolean): void {
-    const next = new Set(selectedIds);
-    for (const item of group.items) {
-      if (checked) next.add(item.id);
-      else next.delete(item.id);
+  const paletteRows = useMemo<PaletteRow[]>(() => {
+    const trimmed = query.trim();
+    const rows: PaletteRow[] = catalog
+      .filter(
+        (entry) => !selectedIds.has(entry.id) && matchesQuery(entry, trimmed),
+      )
+      .slice(0, MAX_PALETTE_ROWS)
+      .map((entry) => ({ kind: 'catalog', entry }));
+    if (
+      props.allowCustomEntries &&
+      trimmed &&
+      !catalogById.has(trimmed) &&
+      !selectedIds.has(trimmed)
+    ) {
+      rows.push({ kind: 'custom', name: trimmed });
     }
-    setSelection(next);
+    return rows;
+  }, [catalog, catalogById, query, selectedIds, props.allowCustomEntries]);
+
+  const activeRow = Math.min(activeIndex, Math.max(paletteRows.length - 1, 0));
+
+  function closePalette(): void {
+    setAddOpen(false);
+    setQuery('');
+    setActiveIndex(0);
   }
 
-  function addCustomEntry(): void {
-    const name = customEntry.trim();
-    if (!name) return;
-    setCustomEntry('');
-    setSelection(new Set([...selectedIds, name]));
+  function pickRow(row: PaletteRow): void {
+    addEntry(row.kind === 'catalog' ? row.entry.id : row.name);
+    if (row.kind === 'custom') setQuery('');
+    inputRef.current?.focus();
   }
 
-  const selectedCount = selectedIds.size;
-  const totalCount = catalogIds.length;
+  function handlePaletteKeyDown(
+    event: ReactKeyboardEvent<HTMLInputElement>,
+  ): void {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveIndex(
+        paletteRows.length === 0 ? 0 : (activeRow + 1) % paletteRows.length,
+      );
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveIndex(
+        paletteRows.length === 0
+          ? 0
+          : (activeRow - 1 + paletteRows.length) % paletteRows.length,
+      );
+    } else if (event.key === 'Enter') {
+      const row = paletteRows[activeRow];
+      if (!row) return;
+      event.preventDefault();
+      pickRow(row);
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      closePalette();
+    }
+  }
+
+  function chooseAll(): void {
+    if (unrestricted) return;
+    setStash(selected);
+    props.onChange(null);
+  }
+
+  function chooseCustom(): void {
+    if (!unrestricted) return;
+    props.onChange(stash ?? []);
+  }
+
+  const lowerTitle = props.title.toLowerCase();
 
   return (
     <section className={styles.scopeCard}>
@@ -118,131 +207,209 @@ export function AgentScopePicker(props: {
           <h3 className={styles.scopeTitle}>{props.title}</h3>
           <p className="supporting-text">{props.description}</p>
         </div>
-        <SegmentedToggle
-          ariaLabel={`${props.title} scope`}
-          size="sm"
-          value={unrestricted ? 'all' : 'custom'}
-          options={[
-            { value: 'all', label: props.allLabel },
-            { value: 'custom', label: 'Selected only' },
-          ]}
-          onChange={(mode) =>
-            props.onChange(mode === 'all' ? null : [...catalogIds])
-          }
-        />
       </header>
 
-      <div className={styles.scopeToolbar}>
-        <Input
-          aria-label={props.searchPlaceholder}
-          placeholder={props.searchPlaceholder}
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-        />
-        <span className={styles.scopeCount}>
-          {unrestricted
-            ? `all ${totalCount} available`
-            : `${selectedCount} of ${totalCount} selected`}
-        </span>
-        <Button
-          size="sm"
-          variant="ghost"
-          disabled={unrestricted}
-          onClick={() => props.onChange(null)}
+      <fieldset
+        className={styles.scopeModes}
+        aria-label={`${props.title} scope`}
+      >
+        <button
+          type="button"
+          aria-pressed={unrestricted}
+          className={cx(
+            styles.scopeMode,
+            unrestricted && styles.scopeModeActive,
+          )}
+          onClick={chooseAll}
         >
-          Reset to all
-        </Button>
-      </div>
+          <span className={styles.scopeModeTitle}>
+            <span className={styles.scopeModeDot} aria-hidden="true" />
+            <strong>{props.allLabel}</strong>
+          </span>
+          <small>{props.allNote}</small>
+        </button>
+        <button
+          type="button"
+          aria-pressed={!unrestricted}
+          className={cx(
+            styles.scopeMode,
+            !unrestricted && styles.scopeModeActive,
+          )}
+          onClick={chooseCustom}
+        >
+          <span className={styles.scopeModeTitle}>
+            <span className={styles.scopeModeDot} aria-hidden="true" />
+            <strong>Selected only</strong>
+          </span>
+          <small>{props.restrictedNote}</small>
+        </button>
+      </fieldset>
 
       {props.loading ? (
         <div className="empty-state">Loading catalog...</div>
-      ) : visibleGroups.length === 0 ? (
-        <div className="empty-state">Nothing matches “{query}”.</div>
-      ) : (
-        <div className={styles.scopeGroups}>
-          {visibleGroups.map((group) => {
-            const checkedCount = group.items.filter((item) =>
-              selectedIds.has(item.id),
-            ).length;
-            return (
-              <div className={styles.scopeGroup} key={group.label}>
-                <div className={styles.scopeGroupHead}>
-                  <Checkbox
-                    aria-label={`Select all ${group.label}`}
-                    checked={
-                      checkedCount === group.items.length
-                        ? true
-                        : checkedCount === 0
-                          ? false
-                          : 'indeterminate'
-                    }
-                    onCheckedChange={(checked) => toggleGroup(group, checked)}
-                  />
-                  <strong>{group.label}</strong>
-                  <span className={styles.scopeCount}>
-                    {checkedCount}/{group.items.length}
-                  </span>
-                </div>
-                <div className={styles.scopeItems}>
-                  {group.items.map((item) => (
-                    <label className={styles.scopeItem} key={item.id}>
-                      <Checkbox
-                        checked={selectedIds.has(item.id)}
-                        onCheckedChange={(checked) =>
-                          toggleItem(item.id, checked)
-                        }
-                      />
-                      <span className={styles.scopeItemText}>
-                        <span className={styles.scopeItemName}>
-                          {item.label}
-                          {item.badges?.map((badge) => (
-                            <em className={styles.scopeBadge} key={badge}>
-                              {badge}
-                            </em>
-                          ))}
-                        </span>
-                        {item.description ? (
-                          <small>{item.description}</small>
-                        ) : null}
+      ) : unrestricted ? null : (
+        <>
+          <div className={styles.scopeListActions}>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setAddOpen(true)}
+            >
+              Add {lowerTitle}…
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={selected.length === 0}
+              onClick={() => props.onChange([])}
+            >
+              Clear all
+            </Button>
+            <span className={styles.scopeCount}>
+              {selected.length} of {totalCount} selected
+            </span>
+          </div>
+
+          {selected.length === 0 ? (
+            <div className="empty-state">
+              Nothing selected — this agent gets no {lowerTitle}.
+            </div>
+          ) : (
+            <div className={styles.scopeList}>
+              {selected.map((id) => {
+                const entry = catalogById.get(id);
+                return (
+                  <div className={styles.scopeRow} key={id}>
+                    <span className={styles.scopeItemText}>
+                      <span className={styles.scopeItemName}>
+                        {entry?.label ?? id}
+                        {entry?.badges?.map((badge) => (
+                          <em className={styles.scopeBadge} key={badge}>
+                            {badge}
+                          </em>
+                        ))}
                       </span>
-                    </label>
-                  ))}
-                </div>
-              </div>
-            );
-          })}
-        </div>
+                      {entry?.description ? (
+                        <small>{entry.description}</small>
+                      ) : null}
+                    </span>
+                    {entry ? (
+                      <span className={styles.scopeRowGroup}>
+                        {entry.group}
+                      </span>
+                    ) : null}
+                    <button
+                      type="button"
+                      className={styles.scopeRemove}
+                      aria-label={`Remove ${id}`}
+                      onClick={() => removeEntry(id)}
+                    >
+                      ×
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </>
       )}
 
-      {props.allowCustomEntries ? (
-        <div className={styles.scopeToolbar}>
-          <Input
-            aria-label={`Add ${props.title.toLowerCase()} by name`}
-            placeholder="Add by exact name (for example github__create_issue)"
-            value={customEntry}
-            onChange={(event) => setCustomEntry(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key !== 'Enter') return;
-              event.preventDefault();
-              addCustomEntry();
-            }}
-          />
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={!customEntry.trim()}
-            onClick={addCustomEntry}
-          >
-            Add
-          </Button>
-        </div>
-      ) : null}
-
-      <p className="supporting-text">
-        {unrestricted
-          ? `${props.allLabel} stay available.`
-          : props.restrictedNote}
-      </p>
+      <Dialog
+        open={addOpen}
+        onOpenChange={(open) => (open ? setAddOpen(true) : closePalette())}
+      >
+        <DialogContent
+          size="lg"
+          className={paletteStyles.dialog}
+          initialFocus={inputRef}
+        >
+          <DialogHeader visuallyHidden>
+            <DialogTitle>Add {lowerTitle}</DialogTitle>
+            <DialogDescription>
+              Search the catalog and pick entries to enable for this agent.
+            </DialogDescription>
+          </DialogHeader>
+          <div className={paletteStyles.searchBox}>
+            <Search width={18} height={18} />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(event) => {
+                setQuery(event.target.value);
+                setActiveIndex(0);
+              }}
+              onKeyDown={handlePaletteKeyDown}
+              placeholder={props.searchPlaceholder}
+              aria-label={props.searchPlaceholder}
+              role="combobox"
+              aria-expanded="true"
+              aria-controls={listboxId}
+              aria-activedescendant={
+                paletteRows[activeRow]
+                  ? `${listboxId}-option-${activeRow}`
+                  : undefined
+              }
+            />
+          </div>
+          <div id={listboxId} className={paletteStyles.results} role="listbox">
+            {paletteRows.map((row, index) => (
+              <button
+                id={`${listboxId}-option-${index}`}
+                key={
+                  row.kind === 'catalog' ? row.entry.id : `custom:${row.name}`
+                }
+                type="button"
+                role="option"
+                aria-selected={index === activeRow}
+                className={
+                  index === activeRow ? paletteStyles.active : undefined
+                }
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => pickRow(row)}
+              >
+                {row.kind === 'catalog' ? (
+                  <>
+                    <span>
+                      <strong>
+                        {row.entry.label}
+                        {row.entry.badges?.map((badge) => (
+                          <em className={styles.scopeBadge} key={badge}>
+                            {badge}
+                          </em>
+                        ))}
+                      </strong>
+                      {row.entry.description ? (
+                        <small>{row.entry.description}</small>
+                      ) : null}
+                    </span>
+                    <em>{row.entry.group}</em>
+                  </>
+                ) : (
+                  <>
+                    <span>
+                      <strong>Add “{row.name}”</strong>
+                      <small>Not in the catalog — enabled by exact name.</small>
+                    </span>
+                    <em>custom</em>
+                  </>
+                )}
+              </button>
+            ))}
+            {paletteRows.length === 0 ? (
+              <div className={paletteStyles.empty}>
+                {query.trim()
+                  ? `Nothing matches “${query.trim()}”.`
+                  : `Every catalog entry is already selected.`}
+              </div>
+            ) : null}
+          </div>
+          <div className={paletteStyles.hint}>
+            <span>↑↓ Navigate</span>
+            <span>↵ Add</span>
+            <span>Esc Done</span>
+          </div>
+        </DialogContent>
+      </Dialog>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Follow-up to #1437, which introduced the agent Configuration tab and has not
shipped in a release yet (merged 2026-08-28; latest tag `v0.29.3` predates it).
The allowlist picker it added is replaced outright rather than extended — no
compatibility shim, no second mode alongside the old one.

- **Problem:** #1437 rendered the skill and tool allowlists as grouped checkbox
  panels covering the whole catalog. With ~100 skills the card was a wall of
  checkboxes, and its "All skills / Selected only" segmented toggle silently
  snapshotted the entire catalog as selected — so restricting an agent meant
  unchecking 90-odd boxes.
- **Why it matters:** limiting an agent to a handful of skills or tools is the
  common case, and it was the most expensive thing to do in the UI. The
  future-installs semantics (`null` keeps picking up new installs, an array does
  not) were buried in a footer note that only rendered in one mode. Fixing this
  before the first release means no user ever sees the checkbox version.
- **What changed:** `AgentScopePicker` is rebuilt around two explanatory mode
  cards and a list of what is actually enabled. "Selected only" starts from an
  empty selection instead of a full-catalog snapshot; entries are added through
  a command-palette dialog and removed with a per-row `×`. The previous custom
  selection is stashed when flipping to "All", so switching modes back and forth
  is non-destructive within a draft.
- **What did not change:** everything #1437 established below the UI — the wire
  contract (`null` = unrestricted, array = allowlist, `[]` = nothing), the
  `agents.tools` column and migration 57, `mergeAllowedToolNames` at the runner
  boundary, the draft save/discard bar, `withUnknownEntries` handling for
  configured-but-uncatalogued entries, and the global enable surfaces
  (`/admin/skills`, `tools.disabled`) this picker deliberately does not own.
  This PR is confined to `console/src/routes`.

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [x] Tests
- [ ] Refactor required for the fix
- [ ] Tooling or workflow
- [ ] Security hardening

## Details

**Mode cards.** The segmented toggle is replaced by two `aria-pressed` cards that spell out the consequence rather than naming the state: "All skills — every installed skill, including ones installed later" vs. "Selected only — only the skills on the list. New installs stay off until added." Unrestricted mode renders no list at all, since there is nothing to curate.

**Enabled-only list.** Restricted mode shows one row per selected entry (label, description, source group, remove button) instead of the full catalog. Entries the catalog cannot describe still render by id. Alongside: `Add …`, `Clear all`, and an `n of N selected` count.

**Command-palette add dialog.** Additions go through a search dialog reusing `command-palette.module.css`: `combobox` + `listbox` roles with `aria-activedescendant`, ↑/↓ wrap-around navigation, Enter to add, Escape to close, and mouse hover tracking the active row. It stays open across additions for multi-add and filters out already-selected entries. Search now also matches the group label, and results cap at 50 rows.

**Custom names.** The separate "add by exact name" input is gone; when `allowCustomEntries` is set and the query matches nothing in the catalog, the palette offers an `Add "<name>"` row — the path for MCP tools the catalog cannot enumerate.

**Per-agent keying.** Both pickers are keyed on the agent id, so palette query and stash state reset when switching agents rather than leaking across them.

## Before / After

### Before

Grouped checkbox panels, always fully expanded; "Selected only" snapshotted all 99 entries as checked:

<img width="1567" alt="Before: skills card as grouped checkbox panels" src="https://github.com/user-attachments/assets/fede3109-9ebd-49a4-b417-234a7b82c53a" />

<img width="1567" alt="Before: checkbox wall scrolled further" src="https://github.com/user-attachments/assets/262c1e67-7df4-4104-a846-97b6f39e95b6" />

### After

Mode cards make the choice explicit; unrestricted mode needs no list at all:

<img width="1567" alt="After: mode cards, unrestricted" src="https://github.com/user-attachments/assets/1148a842-a735-4fb0-9cfe-1149c25156da" />

Restricted mode lists only the enabled entries with remove buttons and a count:

<img width="1567" alt="After: restricted list of enabled skills" src="https://github.com/user-attachments/assets/470fbdaf-5660-4b29-9e85-cefbdd9a50e5" />

Additions go through a command-palette search dialog:

<img width="1567" alt="After: command-palette add dialog" src="https://github.com/user-attachments/assets/5d9b7460-170a-4ca1-b77c-015bc07b355c" />

## Linked Context

- Related #1437 — introduced the Configuration tab and the picker this PR
  replaces. Unreleased, so per `CLAUDE.md` the superseded checkbox UI, its
  segmented toggle, and the separate "add by exact name" input are deleted
  rather than carried forward.

## Licensing

- [x] All commits are signed off (`git commit -s`) to certify the
      [DCO](https://developercertificate.org/); the contribution is licensed
      under the repository's MIT license.

## Validation

```bash
npm --workspace console run lint   # tsc --noEmit --noUnusedLocals --noUnusedParameters
npx biome check console/src/routes
npx vitest run --config vitest.config.ts   # 105 files, 944 tests pass
```

- **Verified manually:** ran the console against a scratch gateway (`HYBRIDCLAW_DEV_VITE_URL` dev setup) and clicked through mode switching, the empty state, palette search and add by mouse and by Enter, row removal, Clear all, stash restore on a mode flip, the draft save bar, and discard.
- **Edge cases checked:** configured entries missing from the catalog still render (existing "Not in catalog" handling); custom MCP tool names added by exact name; Escape closes the palette from inside the focused input; switching agents resets palette and stash state.
- **Skipped checks and why:** the Playwright visual suite was not run — its `/admin/agents` snapshot captures the page with no agent selected, which this PR does not touch.

## Docs And Config Impact

- [ ] README, docs, or examples updated
- [ ] Config or environment behavior changed
- [ ] Templates or workspace bootstrap files changed
- [x] No docs or config impact

## Risk Notes

- Security-sensitive paths touched? **No.** Console-side UI only; the picker
  narrows what it sends in the admin update payload #1437 already defined and
  cannot widen a grant. Enforcement stays server-side in
  `mergeAllowedToolNames`, untouched here.
- Gateway, audit, approval, or container boundaries touched? **No.**
- Migration or rollback surface? **None.** No config, schema, or API change, and
  the UI being replaced has never been in a release, so there is no stored state
  or user habit to migrate.

## Evidence

- [x] Screenshot or recording (above)
- [x] New or updated test coverage — `agent-config.test.tsx`: restricting starts empty and adds via the palette, catalog add through the palette, custom exact-name add, stash restore on mode flip, and reset-to-all still sending `null`.
