### PR TITLE
fix(discord): let embed-only alerts reach the agent through one inbound view

### DIFF
--- a/docs/content/channels/discord.md
+++ b/docs/content/channels/discord.md
@@ -59,6 +59,11 @@ an alerts channel fed by monitoring or CI webhooks. The agent's own messages
 are always ignored, including in these channels, so it can never reply to
 itself.
 
+Such alerts usually carry their payload in an **embed** rather than message
+text, so HybridClaw renders the embed for the agent to read, and allowlisted
+channels skip the `free`-mode relevance heuristics — a status line is not
+phrased as a request. A post with no readable text is still ignored.
+
 ```text
 /config set discord.botMessageChannels ["123456789012345678"]
 ```

--- a/docs/content/channels/discord.md
+++ b/docs/content/channels/discord.md
@@ -60,13 +60,26 @@ are always ignored, including in these channels, so it can never reply to
 itself.
 
 Such alerts usually carry their payload in an **embed** rather than message
-text, so HybridClaw renders the embed for the agent to read, and allowlisted
-channels skip the `free`-mode relevance heuristics — a status line is not
-phrased as a request. A post with no readable text is still ignored.
+text, so HybridClaw renders the embed (or, failing that, the attachment names)
+for the agent to read. In an allowlisted channel a bot post needs no mention
+and skips the `free`-mode relevance heuristics — a status line is not phrased
+as a request. A post with no readable text is still ignored, and
+`suppressPatterns` match the rendered embed text, so noisy alert types can be
+filtered out.
 
 ```text
 /config set discord.botMessageChannels ["123456789012345678"]
 ```
+
+The allowlist only lifts the mention requirement. Guild message handling must
+still be on for the channel: `discord.commandsOnly` must be `false`, and the
+channel's mode must resolve to `mention` or `free` (so not `groupPolicy:
+"disabled"`, and with `groupPolicy: "allowlist"` the channel needs an entry in
+`discord.guilds`).
+
+Bot- and webhook-authored messages never invoke `!claw` or slash commands, and
+edits to bot messages are not re-read, so a bot that updates an alert in place
+is seen only in its original state.
 
 Do not allowlist a channel that HybridClaw itself posts into through
 `discordWebhook`. Those messages arrive authored by the webhook rather than by

--- a/src/channels/discord/inbound.ts
+++ b/src/channels/discord/inbound.ts
@@ -190,6 +190,7 @@ export function shouldReplyInFreeMode(params: {
   hasPrefixInvocation: boolean;
   isReplyToBot: boolean;
   hasAttachments: boolean;
+  isAllowlistedBotMessage?: boolean;
 }): boolean {
   if (params.guildMessageMode !== 'free') return true;
   if (params.hasPrefixInvocation) return true;
@@ -200,6 +201,8 @@ export function shouldReplyInFreeMode(params: {
 
   const normalized = params.content.trim();
   if (!normalized) return false;
+  // After the empty check, so a textless bot post stays dropped.
+  if (params.isAllowlistedBotMessage) return true;
   if (FREE_MODE_ACK_ONLY_RE.test(normalized)) return false;
   if (URL_ONLY_RE.test(normalized)) return false;
   if (params.isAddressedToChannel) return true;
@@ -288,4 +291,53 @@ export function shouldIgnoreBotAuthoredMessage(params: {
     params.botMessageChannels.map((entry) => entry.trim()).filter(Boolean),
   );
   return !allowed.has(params.channelId);
+}
+
+export interface DiscordEmbedLike {
+  title?: string | null;
+  description?: string | null;
+  url?: string | null;
+  author?: { name?: string | null } | null;
+  footer?: { text?: string | null } | null;
+  fields?: ReadonlyArray<{
+    name?: string | null;
+    value?: string | null;
+  } | null> | null;
+}
+
+const EMBED_SUMMARY_MAX_EMBEDS = 3;
+const EMBED_SUMMARY_MAX_FIELDS = 6;
+const EMBED_SUMMARY_MAX_CHARS_PER_EMBED = 600;
+
+function summarizeEmbed(embed: DiscordEmbedLike): string {
+  const lines: string[] = [];
+  const push = (value: string | null | undefined): void => {
+    const trimmed = (value || '').trim();
+    if (trimmed) lines.push(trimmed);
+  };
+
+  push(embed.author?.name);
+  push(embed.title);
+  push(embed.description);
+  for (const field of (embed.fields ?? []).slice(0, EMBED_SUMMARY_MAX_FIELDS)) {
+    const name = (field?.name || '').trim();
+    const value = (field?.value || '').trim();
+    if (name && value) lines.push(`${name}: ${value}`);
+    else push(name || value);
+  }
+  push(embed.footer?.text);
+  push(embed.url);
+
+  const text = lines.join('\n');
+  if (text.length <= EMBED_SUMMARY_MAX_CHARS_PER_EMBED) return text;
+  return `${text.slice(0, EMBED_SUMMARY_MAX_CHARS_PER_EMBED - 1).trimEnd()}…`;
+}
+
+/** Plain-text rendering of a message's embeds; '' when they carry no text. */
+export function summarizeEmbeds(embeds: readonly DiscordEmbedLike[]): string {
+  return embeds
+    .slice(0, EMBED_SUMMARY_MAX_EMBEDS)
+    .map((embed) => summarizeEmbed(embed))
+    .filter(Boolean)
+    .join('\n\n');
 }

--- a/src/channels/discord/inbound.ts
+++ b/src/channels/discord/inbound.ts
@@ -171,10 +171,12 @@ export function shouldSkipFreeReplyBecauseOtherUsersMentioned(params: {
   hasPrefixInvocation: boolean;
   botUserId: string | null;
   mentionedUserIds: string[];
+  isAllowlistedBotMessage?: boolean;
 }): boolean {
   if (params.guildMessageMode !== 'free') return false;
   if (params.hasBotMention) return false;
   if (params.hasPrefixInvocation) return false;
+  if (params.isAllowlistedBotMessage) return false;
   if (params.mentionedUserIds.length === 0) return false;
 
   const botId = params.botUserId?.trim() || '';
@@ -230,8 +232,14 @@ export function isAuthorizedCommandUser(params: {
   return allowed.has(params.userId);
 }
 
+/**
+ * `content` is the raw message content and drives command detection. `text`
+ * is the rendered message text (content, else embeds, else attachments) and
+ * drives suppress patterns, so an embed-only alert can be suppressed too.
+ */
 export function isTrigger(params: {
   content: string;
+  text?: string;
   isDm: boolean;
   commandsOnly: boolean;
   guildMessageMode: DiscordGuildMessageMode;
@@ -239,8 +247,10 @@ export function isTrigger(params: {
   botMentionRegex: RegExp | null;
   hasBotMention: boolean;
   suppressPatterns?: string[];
+  isAllowlistedBotMessage?: boolean;
 }): boolean {
-  const stripped = stripBotMentions(params.content, params.botMentionRegex);
+  const stripped =
+    params.text ?? stripBotMentions(params.content, params.botMentionRegex);
   const hasPrefixed = hasPrefixInvocation(
     params.content,
     params.botMentionRegex,
@@ -259,6 +269,7 @@ export function isTrigger(params: {
   if (shouldSuppressAutoReply(stripped, params.suppressPatterns)) return false;
   if (params.guildMessageMode === 'off') return false;
   if (params.guildMessageMode === 'free') return true;
+  if (params.isAllowlistedBotMessage) return true;
   if (params.hasBotMention) return true;
   return false;
 }
@@ -340,4 +351,42 @@ export function summarizeEmbeds(embeds: readonly DiscordEmbedLike[]): string {
     .map((embed) => summarizeEmbed(embed))
     .filter(Boolean)
     .join('\n\n');
+}
+
+const MESSAGE_TEXT_MAX_ATTACHMENT_NAMES = 5;
+
+/**
+ * Single text projection of an inbound message, used for triggering, history
+ * snapshots and reply context alike: cleaned content, else embeds, else
+ * attachment names, else system text. '' when nothing is readable.
+ */
+export function renderMessageText(params: {
+  content: string | null | undefined;
+  embeds: readonly DiscordEmbedLike[];
+  attachmentNames: readonly (string | null | undefined)[];
+  systemContent?: string | null;
+  botMentionRegex: RegExp | null;
+  prefix: string;
+}): string {
+  const plainText = cleanIncomingContent(
+    params.content || '',
+    params.botMentionRegex,
+    params.prefix,
+  ).trim();
+  if (plainText) return plainText;
+
+  const embedSummary = summarizeEmbeds(params.embeds);
+  if (embedSummary) return `[embed] ${embedSummary}`;
+
+  const attachmentNames = params.attachmentNames
+    .map((name) => (name || '').trim())
+    .filter(Boolean)
+    .slice(0, MESSAGE_TEXT_MAX_ATTACHMENT_NAMES);
+  if (attachmentNames.length > 0) {
+    return `[attachments] ${attachmentNames.join(', ')}`;
+  }
+
+  const systemContent = (params.systemContent || '').trim();
+  if (systemContent) return `[system] ${systemContent}`;
+  return '';
 }

--- a/src/channels/discord/runtime.ts
+++ b/src/channels/discord/runtime.ts
@@ -95,6 +95,7 @@ import {
   shouldIgnoreBotAuthoredMessage as shouldIgnoreBotAuthoredMessageInbound,
   shouldReplyInFreeMode as shouldReplyInFreeModeInbound,
   shouldSkipFreeReplyBecauseOtherUsersMentioned as shouldSkipFreeReplyBecauseOtherUsersMentionedInbound,
+  summarizeEmbeds as summarizeEmbedsInbound,
 } from './inbound.js';
 import {
   addMentionAlias,
@@ -371,6 +372,10 @@ function buildPendingHistoryContext(
   ].join('\n');
 }
 
+function prefixEmbedSummary(summary: string): string {
+  return summary ? `[embed] ${summary}` : '';
+}
+
 async function buildInboundHistorySnapshot(
   msg: DiscordMessage,
   excludeMessageIds: Set<string>,
@@ -390,18 +395,10 @@ async function buildInboundHistorySnapshot(
       const plainText = cleanIncomingContent(recent.content || '').trim();
       if (plainText) return plainText;
 
-      const embedChunks = recent.embeds
-        .map((embed) =>
-          [embed.title?.trim(), embed.description?.trim()]
-            .filter(Boolean)
-            .join(' — '),
-        )
-        .map((part) => part.trim())
-        .filter(Boolean)
-        .slice(0, 3);
-      if (embedChunks.length > 0) {
-        return `[embed] ${embedChunks.join(' | ')}`;
-      }
+      const embedSummary = prefixEmbedSummary(
+        summarizeEmbedsInbound(recent.embeds),
+      );
+      if (embedSummary) return embedSummary;
 
       const attachmentNames = Array.from(recent.attachments.values())
         .map((attachment) => attachment.name?.trim())
@@ -835,6 +832,7 @@ function shouldHandleFreeModeMessage(
   msg: DiscordMessage,
   behavior: ResolvedChannelBehavior,
   content: string,
+  isAllowlistedBotMessage: boolean = false,
 ): boolean {
   if (!msg.guild) return true;
 
@@ -875,6 +873,7 @@ function shouldHandleFreeModeMessage(
     hasPrefixInvocation: hasPrefixedInvocation,
     isReplyToBot,
     hasAttachments: msg.attachments.size > 0,
+    isAllowlistedBotMessage,
   });
 }
 
@@ -2412,7 +2411,10 @@ export async function initDiscord(
     const guildId = msg.guild?.id || null;
     const channelId = msg.channelId;
     const behavior = resolveChannelBehavior(msg);
-    const content = cleanIncomingContent(msg.content);
+    // Commands below parse `msg.content`, never this fallback.
+    const content =
+      cleanIncomingContent(msg.content) ||
+      prefixEmbedSummary(summarizeEmbedsInbound(msg.embeds));
     observeMessageParticipants(msg, content);
     const immediateMentionLookup = buildMentionLookup(
       [msg],
@@ -2557,7 +2559,16 @@ export async function initDiscord(
       return;
     }
 
-    if (!shouldHandleFreeModeMessage(msg, behavior, content)) {
+    // A bot author only reaches here from an allowlisted channel.
+    const isAllowlistedBotMessage = Boolean(msg.author.bot);
+    if (
+      !shouldHandleFreeModeMessage(
+        msg,
+        behavior,
+        content,
+        isAllowlistedBotMessage,
+      )
+    ) {
       logger.debug(
         {
           channelId: msg.channelId,

--- a/src/channels/discord/runtime.ts
+++ b/src/channels/discord/runtime.ts
@@ -81,7 +81,6 @@ import {
 import type { HumanDelayConfig } from './human-delay.js';
 import {
   buildSessionIdFromContext as buildSessionIdFromContextInbound,
-  cleanIncomingContent as cleanIncomingContentInbound,
   type DiscordGuildMessageMode,
   hasDiscordMessageContentChanged,
   hasLooseBotMention as hasLooseBotMentionInbound,
@@ -92,10 +91,10 @@ import {
   isTrigger as isTriggerInbound,
   type ParsedCommand,
   parseCommand as parseCommandInbound,
+  renderMessageText as renderMessageTextInbound,
   shouldIgnoreBotAuthoredMessage as shouldIgnoreBotAuthoredMessageInbound,
   shouldReplyInFreeMode as shouldReplyInFreeModeInbound,
   shouldSkipFreeReplyBecauseOtherUsersMentioned as shouldSkipFreeReplyBecauseOtherUsersMentionedInbound,
-  summarizeEmbeds as summarizeEmbedsInbound,
 } from './inbound.js';
 import {
   addMentionAlias,
@@ -372,10 +371,6 @@ function buildPendingHistoryContext(
   ].join('\n');
 }
 
-function prefixEmbedSummary(summary: string): string {
-  return summary ? `[embed] ${summary}` : '';
-}
-
 async function buildInboundHistorySnapshot(
   msg: DiscordMessage,
   excludeMessageIds: Set<string>,
@@ -392,26 +387,8 @@ async function buildInboundHistorySnapshot(
     let hiddenBotTextCount = 0;
 
     const summarizeHistoryMessageContent = (recent: DiscordMessage): string => {
-      const plainText = cleanIncomingContent(recent.content || '').trim();
-      if (plainText) return plainText;
-
-      const embedSummary = prefixEmbedSummary(
-        summarizeEmbedsInbound(recent.embeds),
-      );
-      if (embedSummary) return embedSummary;
-
-      const attachmentNames = Array.from(recent.attachments.values())
-        .map((attachment) => attachment.name?.trim())
-        .filter((name): name is string => Boolean(name))
-        .slice(0, 5);
-      if (attachmentNames.length > 0) {
-        return `[attachments] ${attachmentNames.join(', ')}`;
-      }
-
-      const systemContent = recent.system
-        ? (recent.cleanContent || '').trim()
-        : '';
-      if (systemContent) return `[system] ${systemContent}`;
+      const text = renderDiscordMessageText(recent);
+      if (text) return text;
 
       hiddenTextCount += 1;
       if (recent.author?.bot) hiddenBotTextCount += 1;
@@ -812,53 +789,114 @@ function resolveChannelBehavior(msg: DiscordMessage): ResolvedChannelBehavior {
   };
 }
 
+/**
+ * Everything the inbound pipeline needs to know about a message, derived once
+ * so triggering, gating, debouncing and prompt building all read the same
+ * projection instead of re-deriving it from `msg.content`.
+ *
+ * Built only after `shouldIgnoreBotAuthoredMessage`, so a bot author here is
+ * one that an allowlisted channel let through.
+ */
+interface InboundDiscordMessage {
+  msg: DiscordMessage;
+  rawContent: string;
+  text: string;
+  isBotAuthored: boolean;
+  hasAttachments: boolean;
+  hasPrefixInvocation: boolean;
+  hasCommandInvocation: boolean;
+  hasBotMention: boolean;
+  isReplyToBot: boolean;
+  mentionedUserIds: string[];
+}
+
+function renderDiscordMessageText(msg: DiscordMessage): string {
+  return renderMessageTextInbound({
+    content: msg.content,
+    embeds: msg.embeds,
+    attachmentNames: Array.from(msg.attachments.values()).map(
+      (attachment) => attachment.name,
+    ),
+    systemContent: msg.system ? msg.cleanContent : null,
+    botMentionRegex,
+    prefix: DISCORD_PREFIX,
+  });
+}
+
+function describeInboundMessage(msg: DiscordMessage): InboundDiscordMessage {
+  const rawContent = msg.content || '';
+  const isBotAuthored = Boolean(msg.author.bot);
+  // Bot authors never invoke commands, so a webhook cannot run `!claw ...`.
+  const hasPrefixed = !isBotAuthored && hasPrefixInvocation(rawContent);
+  const hasSlash = !isBotAuthored && hasSlashCommandInvocation(rawContent);
+  return {
+    msg,
+    rawContent,
+    text: renderDiscordMessageText(msg),
+    isBotAuthored,
+    hasAttachments: msg.attachments.size > 0,
+    hasPrefixInvocation: hasPrefixed,
+    hasCommandInvocation: hasPrefixed || hasSlash,
+    hasBotMention: Boolean(client.user && msg.mentions.has(client.user)),
+    isReplyToBot: Boolean(
+      client.user && msg.mentions.repliedUser?.id === client.user.id,
+    ),
+    mentionedUserIds: Array.from(msg.mentions.users.keys()),
+  };
+}
+
+function isExplicitlyAddressed(inbound: InboundDiscordMessage): boolean {
+  return (
+    !inbound.msg.guild ||
+    inbound.isBotAuthored ||
+    inbound.hasPrefixInvocation ||
+    inbound.hasBotMention ||
+    inbound.isReplyToBot
+  );
+}
+
 function isTrigger(
-  msg: DiscordMessage,
+  inbound: InboundDiscordMessage,
   behavior: ResolvedChannelBehavior,
 ): boolean {
   return isTriggerInbound({
-    content: msg.content,
-    isDm: !msg.guild,
+    content: inbound.rawContent,
+    text: inbound.text,
+    isDm: !inbound.msg.guild,
     commandsOnly: DISCORD_COMMANDS_ONLY,
     guildMessageMode: behavior.guildMessageMode,
     prefix: DISCORD_PREFIX,
     botMentionRegex,
-    hasBotMention: Boolean(client.user && msg.mentions.has(client.user)),
+    hasBotMention: inbound.hasBotMention,
     suppressPatterns: behavior.suppressPatterns,
+    isAllowlistedBotMessage: inbound.isBotAuthored,
   });
 }
 
 function shouldHandleFreeModeMessage(
-  msg: DiscordMessage,
+  inbound: InboundDiscordMessage,
   behavior: ResolvedChannelBehavior,
-  content: string,
-  isAllowlistedBotMessage: boolean = false,
 ): boolean {
+  const { msg, text } = inbound;
   if (!msg.guild) return true;
 
-  const hasPrefixedInvocation = hasPrefixInvocation(msg.content || '');
-  const hasBotMention = Boolean(client.user && msg.mentions.has(client.user));
   const hasLooseBotMention =
     client.user != null
-      ? hasLooseBotMentionInbound(content, [
+      ? hasLooseBotMentionInbound(text, [
           client.user.username,
           client.user.globalName || '',
           msg.guild?.members.me?.displayName || '',
         ])
       : false;
-  const isReplyToBot = Boolean(
-    client.user && msg.mentions.repliedUser?.id === client.user.id,
-  );
-  const mentionedUserIds = Array.from(msg.mentions.users.keys());
-  const botUserId = client.user?.id ?? null;
 
   if (
     shouldSkipFreeReplyBecauseOtherUsersMentionedInbound({
       guildMessageMode: behavior.guildMessageMode,
-      hasBotMention,
-      hasPrefixInvocation: hasPrefixedInvocation,
-      botUserId,
-      mentionedUserIds,
+      hasBotMention: inbound.hasBotMention,
+      hasPrefixInvocation: inbound.hasPrefixInvocation,
+      botUserId: client.user?.id ?? null,
+      mentionedUserIds: inbound.mentionedUserIds,
+      isAllowlistedBotMessage: inbound.isBotAuthored,
     })
   ) {
     return false;
@@ -866,14 +904,14 @@ function shouldHandleFreeModeMessage(
 
   return shouldReplyInFreeModeInbound({
     guildMessageMode: behavior.guildMessageMode,
-    content,
-    hasBotMention,
+    content: text,
+    hasBotMention: inbound.hasBotMention,
     hasLooseBotMention,
-    isAddressedToChannel: isAddressedToChannelInbound(content),
-    hasPrefixInvocation: hasPrefixedInvocation,
-    isReplyToBot,
-    hasAttachments: msg.attachments.size > 0,
-    isAllowlistedBotMessage,
+    isAddressedToChannel: isAddressedToChannelInbound(text),
+    hasPrefixInvocation: inbound.hasPrefixInvocation,
+    isReplyToBot: inbound.isReplyToBot,
+    hasAttachments: inbound.hasAttachments,
+    isAllowlistedBotMessage: inbound.isBotAuthored,
   });
 }
 
@@ -912,16 +950,21 @@ function parseCommand(content: string): ParsedCommand {
   return parseCommandInbound(content, botMentionRegex, DISCORD_PREFIX);
 }
 
-function cleanIncomingContent(content: string): string {
-  return cleanIncomingContentInbound(content, botMentionRegex, DISCORD_PREFIX);
-}
-
 function summarizeContextMessage(msg: DiscordMessage): string {
   const author = msg.author?.username || 'user';
-  const content = (msg.content || '').trim();
-  const snippet =
-    content.length > 500 ? `${content.slice(0, 497)}...` : content;
+  const text = renderDiscordMessageText(msg);
+  const snippet = text.length > 500 ? `${text.slice(0, 497)}...` : text;
   return `${author}: ${snippet || '(no text)'}`;
+}
+
+function formatQueuedContent(item: {
+  msg: DiscordMessage;
+  content: string;
+}): string {
+  if (!item.msg.author.bot) return item.content;
+  const kind = item.msg.webhookId ? 'webhook' : 'bot';
+  const author = item.msg.author.username || kind;
+  return `[Posted by ${kind} ${author}, not a person]\n${item.content}`;
 }
 
 function buildChannelInfoContext(msg: DiscordMessage): string {
@@ -1470,17 +1513,18 @@ export async function initDiscord(
   };
 
   const maybeHandleReadWithoutReply = async (
-    msg: DiscordMessage,
-    content: string,
+    inbound: InboundDiscordMessage,
   ): Promise<boolean> => {
-    if (!content.trim()) return false;
+    const { msg } = inbound;
+    const text = inbound.text.trim();
+    if (!text) return false;
     if (!msg.guild) return false;
-    if (msg.attachments.size > 0) return false;
-    if (hasPrefixInvocation(msg.content || '')) return false;
-    if (hasSlashCommandInvocation(msg.content || '')) return false;
-    if (client.user && msg.mentions.has(client.user)) return false;
-    if (content.trim().length > 80) return false;
-    if (!READ_WITHOUT_REPLY_RE.test(content.trim())) return false;
+    if (inbound.isBotAuthored) return false;
+    if (inbound.hasAttachments) return false;
+    if (inbound.hasCommandInvocation) return false;
+    if (inbound.hasBotMention) return false;
+    if (text.length > 80) return false;
+    if (!READ_WITHOUT_REPLY_RE.test(text)) return false;
     if (Math.random() > READ_WITHOUT_REPLY_PROBABILITY) return false;
 
     try {
@@ -1955,9 +1999,12 @@ export async function initDiscord(
     const batchedContent =
       items.length > 1
         ? items
-            .map((item, index) => `Message ${index + 1}:\n${item.content}`)
+            .map(
+              (item, index) =>
+                `Message ${index + 1}:\n${formatQueuedContent(item)}`,
+            )
             .join('\n\n')
-        : sourceItem.content;
+        : formatQueuedContent(sourceItem);
     const channelInfoContext = buildChannelInfoContext(msg);
     const replyContext = await buildReplyContext(msg);
     const feedbackNote = negativeFeedbackByChannel.get(channelId) || '';
@@ -2194,10 +2241,10 @@ export async function initDiscord(
   };
 
   const queueConversationMessage = async (
-    msg: DiscordMessage,
-    content: string,
+    inbound: InboundDiscordMessage,
     behavior: ResolvedChannelBehavior,
   ): Promise<void> => {
+    const { msg, text: content } = inbound;
     const key = `${msg.channelId}:${msg.author.id}`;
     const cooldownKey = buildConversationCooldownKey(
       msg.channelId,
@@ -2211,11 +2258,7 @@ export async function initDiscord(
       ...behavior,
       humanDelay: adjustedHumanDelay,
     };
-    const wasExplicitlyAddressed =
-      !msg.guild ||
-      hasPrefixInvocation(msg.content || '') ||
-      Boolean(client.user && msg.mentions.has(client.user)) ||
-      Boolean(client.user && msg.mentions.repliedUser?.id === client.user.id);
+    const wasExplicitlyAddressed = isExplicitlyAddressed(inbound);
 
     let clearAckReaction: () => Promise<void> = async () => {};
     if (client.user && shouldApplyAckReaction(msg, behavior)) {
@@ -2239,9 +2282,9 @@ export async function initDiscord(
     };
     const existing = pendingBatches.get(key);
     const shouldDebounceMessage = shouldDebounceInbound({
-      content: msg.content || '',
-      hasAttachments: msg.attachments.size > 0,
-      isPrefixedCommand: hasPrefixInvocation(msg.content || ''),
+      content,
+      hasAttachments: inbound.hasAttachments,
+      isPrefixedCommand: inbound.hasPrefixInvocation,
     });
 
     if (!existing) {
@@ -2353,10 +2396,11 @@ export async function initDiscord(
 
   const updatePendingMessage = async (
     messageId: string,
-    nextMsg: DiscordMessage,
+    next: InboundDiscordMessage,
     nextContent: string,
     nextBehavior: ResolvedChannelBehavior,
   ): Promise<boolean> => {
+    const nextMsg = next.msg;
     for (const [key, pending] of pendingBatches) {
       const index = pending.items.findIndex(
         (item) => item.msg.id === messageId,
@@ -2371,9 +2415,7 @@ export async function initDiscord(
         pending.items[index].content = nextContent;
         pending.items[index].behavior = nextBehavior;
         pending.items[index].wasExplicitlyAddressed =
-          !nextMsg.guild ||
-          hasPrefixInvocation(nextMsg.content || '') ||
-          Boolean(client.user && nextMsg.mentions.has(client.user));
+          isExplicitlyAddressed(next);
         pending.items[index].cooldownKey = buildConversationCooldownKey(
           nextMsg.channelId,
           nextMsg.author.id,
@@ -2407,14 +2449,12 @@ export async function initDiscord(
       return;
     }
 
+    const inbound = describeInboundMessage(msg);
+    const { text: content } = inbound;
     const sessionId = getSessionId(msg);
     const guildId = msg.guild?.id || null;
     const channelId = msg.channelId;
     const behavior = resolveChannelBehavior(msg);
-    // Commands below parse `msg.content`, never this fallback.
-    const content =
-      cleanIncomingContent(msg.content) ||
-      prefixEmbedSummary(summarizeEmbedsInbound(msg.embeds));
     observeMessageParticipants(msg, content);
     const immediateMentionLookup = buildMentionLookup(
       [msg],
@@ -2451,9 +2491,7 @@ export async function initDiscord(
     };
 
     const parsed = parseCommand(msg.content);
-    const hasPrefixedInvocation = hasPrefixInvocation(msg.content);
-    const hasSlashInvocation = hasSlashCommandInvocation(msg.content);
-    const hasCommandInvocation = hasPrefixedInvocation || hasSlashInvocation;
+    const { hasCommandInvocation } = inbound;
     logger.debug(
       {
         sessionId,
@@ -2521,7 +2559,7 @@ export async function initDiscord(
       return;
     }
 
-    if (!isTrigger(msg, behavior)) {
+    if (!isTrigger(inbound, behavior)) {
       logger.debug(
         {
           sessionId,
@@ -2559,16 +2597,7 @@ export async function initDiscord(
       return;
     }
 
-    // A bot author only reaches here from an allowlisted channel.
-    const isAllowlistedBotMessage = Boolean(msg.author.bot);
-    if (
-      !shouldHandleFreeModeMessage(
-        msg,
-        behavior,
-        content,
-        isAllowlistedBotMessage,
-      )
-    ) {
+    if (!shouldHandleFreeModeMessage(inbound, behavior)) {
       logger.debug(
         {
           channelId: msg.channelId,
@@ -2585,18 +2614,14 @@ export async function initDiscord(
       return;
     }
 
-    const readWithoutReplyHandled = await maybeHandleReadWithoutReply(
-      msg,
-      content,
-    );
-    if (readWithoutReplyHandled) {
+    if (await maybeHandleReadWithoutReply(inbound)) {
       return;
     }
 
     const rateLimitAllowed = await enforcePerUserRateLimit(msg, behavior);
     if (!rateLimitAllowed) return;
 
-    await queueConversationMessage(msg, content, behavior);
+    await queueConversationMessage(inbound, behavior);
   });
 
   client.on('messageUpdate', async (oldMsg, nextMsg) => {
@@ -2610,25 +2635,26 @@ export async function initDiscord(
       return;
     }
 
-    const updatedContent = cleanIncomingContent(fetched.content || '');
+    const inbound = describeInboundMessage(fetched);
+    const updatedContent = inbound.text;
     const behavior = resolveChannelBehavior(fetched);
     observeMessageParticipants(fetched, updatedContent);
-    if (!isTrigger(fetched, behavior)) {
-      await updatePendingMessage(fetched.id, fetched, '', behavior);
+    if (!isTrigger(inbound, behavior)) {
+      await updatePendingMessage(fetched.id, inbound, '', behavior);
       return;
     }
     if (
-      hasPrefixInvocation(fetched.content || '') &&
+      inbound.hasPrefixInvocation &&
       !isAuthorizedCommandUserId(fetched.author.id)
     ) {
-      await updatePendingMessage(fetched.id, fetched, '', behavior);
+      await updatePendingMessage(fetched.id, inbound, '', behavior);
       return;
     }
-    if (!shouldHandleFreeModeMessage(fetched, behavior, updatedContent)) {
-      await updatePendingMessage(fetched.id, fetched, '', behavior);
+    if (!shouldHandleFreeModeMessage(inbound, behavior)) {
+      await updatePendingMessage(fetched.id, inbound, '', behavior);
       return;
     }
-    await updatePendingMessage(fetched.id, fetched, updatedContent, behavior);
+    await updatePendingMessage(fetched.id, inbound, updatedContent, behavior);
 
     const inFlight = inFlightByMessageId.get(fetched.id);
     if (!inFlight || inFlight.aborted) return;
@@ -2644,7 +2670,7 @@ export async function initDiscord(
     if (updatedContent) {
       const rateLimitAllowed = await enforcePerUserRateLimit(fetched, behavior);
       if (!rateLimitAllowed) return;
-      await queueConversationMessage(fetched, updatedContent, behavior);
+      await queueConversationMessage(inbound, behavior);
     }
   });
 

--- a/tests/discord.basic.test.ts
+++ b/tests/discord.basic.test.ts
@@ -12,6 +12,7 @@ import {
   shouldIgnoreBotAuthoredMessage,
   shouldReplyInFreeMode,
   shouldSkipFreeReplyBecauseOtherUsersMentioned,
+  summarizeEmbeds,
 } from '../src/channels/discord/inbound.js';
 import {
   type MentionLookup,
@@ -451,5 +452,71 @@ test('human messages are unaffected by the bot allowlist', () => {
       channelId: GENERAL_CHANNEL_ID,
       botMessageChannels: [],
     }),
+  ).toBe(false);
+});
+
+// --- Embed-only messages (alert webhooks) ---------------------------------
+// Unassuming prose on purpose: no question mark, request verb, problem signal
+// or inline code, so it exercises the relevance gate the way an alert does.
+const ALERT_EMBED = {
+  author: { name: 'CI' },
+  title: 'Build succeeded',
+  description: 'Pipeline finished in 4m 12s',
+  url: 'https://example.com/runs/1',
+  footer: { text: 'triggered by scheduler' },
+  fields: [{ name: 'Environment', value: 'staging' }],
+};
+
+test('summarizeEmbeds renders an embed as text', () => {
+  expect(summarizeEmbeds([ALERT_EMBED])).toBe(
+    [
+      'CI',
+      'Build succeeded',
+      'Pipeline finished in 4m 12s',
+      'Environment: staging',
+      'triggered by scheduler',
+      'https://example.com/runs/1',
+    ].join('\n'),
+  );
+});
+
+test('summarizeEmbeds renders nothing for an embed with no text', () => {
+  // e.g. an image-only embed — the agent must not be handed a blank turn.
+  for (const embeds of [[], [{}], [{ title: '  ' }]]) {
+    expect(summarizeEmbeds(embeds)).toBe('');
+  }
+});
+
+test('summarizeEmbeds bounds what one message can contribute', () => {
+  const many = summarizeEmbeds([1, 2, 3, 4].map((n) => ({ title: `e${n}` })));
+  expect(many).toContain('e3');
+  expect(many).not.toContain('e4');
+
+  const fields = summarizeEmbeds([
+    { fields: Array.from({ length: 12 }, (_u, i) => ({ name: `f${i}`, value: 'v' })) },
+  ]);
+  expect(fields).toContain('f5: v');
+  expect(fields).not.toContain('f6: v');
+
+  const long = summarizeEmbeds([{ title: 'x'.repeat(5000) }]);
+  expect(long.length).toBeLessThanOrEqual(600);
+  expect(long.endsWith('…')).toBe(true);
+});
+
+test('the free-mode gate lets an allowlisted alert through, but not an empty one', () => {
+  const base = {
+    guildMessageMode: 'free' as const,
+    hasBotMention: false,
+    hasPrefixInvocation: false,
+    isReplyToBot: false,
+    hasAttachments: false,
+  };
+  const content = summarizeEmbeds([ALERT_EMBED]);
+  expect(shouldReplyInFreeMode({ ...base, content })).toBe(false);
+  expect(
+    shouldReplyInFreeMode({ ...base, content, isAllowlistedBotMessage: true }),
+  ).toBe(true);
+  expect(
+    shouldReplyInFreeMode({ ...base, content: '', isAllowlistedBotMessage: true }),
   ).toBe(false);
 });

--- a/tests/discord.basic.test.ts
+++ b/tests/discord.basic.test.ts
@@ -9,6 +9,7 @@ import {
   isAuthorizedCommandUser,
   isTrigger,
   parseCommand,
+  renderMessageText,
   shouldIgnoreBotAuthoredMessage,
   shouldReplyInFreeMode,
   shouldSkipFreeReplyBecauseOtherUsersMentioned,
@@ -519,4 +520,100 @@ test('the free-mode gate lets an allowlisted alert through, but not an empty one
   expect(
     shouldReplyInFreeMode({ ...base, content: '', isAllowlistedBotMessage: true }),
   ).toBe(false);
+});
+
+test('an allowlisted bot message triggers in mention mode but not when handling is off', () => {
+  const base = {
+    content: '',
+    text: '[embed] Build failed',
+    isDm: false,
+    commandsOnly: false,
+    prefix: '!claw',
+    botMentionRegex: null,
+    hasBotMention: false,
+    isAllowlistedBotMessage: true,
+  };
+  expect(isTrigger({ ...base, guildMessageMode: 'mention' })).toBe(true);
+  expect(isTrigger({ ...base, guildMessageMode: 'off' })).toBe(false);
+  expect(
+    isTrigger({
+      ...base,
+      guildMessageMode: 'mention',
+      isAllowlistedBotMessage: false,
+    }),
+  ).toBe(false);
+});
+
+test('suppress patterns match the rendered text of an embed-only message', () => {
+  expect(
+    isTrigger({
+      content: '',
+      text: '[embed] Build succeeded',
+      isDm: false,
+      commandsOnly: false,
+      guildMessageMode: 'free',
+      prefix: '!claw',
+      botMentionRegex: null,
+      hasBotMention: false,
+      suppressPatterns: ['build succeeded'],
+      isAllowlistedBotMessage: true,
+    }),
+  ).toBe(false);
+});
+
+test('an allowlisted alert that pings other users is not skipped', () => {
+  const base = {
+    guildMessageMode: 'free' as const,
+    hasBotMention: false,
+    hasPrefixInvocation: false,
+    botUserId: 'bot',
+    mentionedUserIds: ['oncall'],
+  };
+  expect(shouldSkipFreeReplyBecauseOtherUsersMentioned(base)).toBe(true);
+  expect(
+    shouldSkipFreeReplyBecauseOtherUsersMentioned({
+      ...base,
+      isAllowlistedBotMessage: true,
+    }),
+  ).toBe(false);
+});
+
+test('renderMessageText falls back from content to embeds to attachments to system text', () => {
+  const base = { botMentionRegex: null, prefix: '!claw' };
+  expect(
+    renderMessageText({
+      ...base,
+      content: '!claw hello',
+      embeds: [ALERT_EMBED],
+      attachmentNames: ['a.png'],
+    }),
+  ).toBe('hello');
+  expect(
+    renderMessageText({
+      ...base,
+      content: '',
+      embeds: [ALERT_EMBED],
+      attachmentNames: [],
+    }),
+  ).toBe(`[embed] ${summarizeEmbeds([ALERT_EMBED])}`);
+  expect(
+    renderMessageText({
+      ...base,
+      content: ' ',
+      embeds: [{}],
+      attachmentNames: ['a.png', null, ' b.pdf '],
+    }),
+  ).toBe('[attachments] a.png, b.pdf');
+  expect(
+    renderMessageText({
+      ...base,
+      content: '',
+      embeds: [],
+      attachmentNames: [],
+      systemContent: 'pinned a message',
+    }),
+  ).toBe('[system] pinned a message');
+  expect(
+    renderMessageText({ ...base, content: '', embeds: [], attachmentNames: [] }),
+  ).toBe('');
 });


### PR DESCRIPTION
Follow-up to #1441, which wakes the agent for bot- and webhook-authored messages in an allowlisted channel. Pointing that at a real alerts channel still produced nothing, and tracing why showed one structural cause rather than one bug: the handler derives a rendered `content` once, then `isTrigger`, the debounce check, the reply/thread context, the history snapshot and the read tool each go back to `msg.content` with their own fallback. Every embed-only alert falls into a different gap on each path.

## What was broken on `main`

An alert webhook posts `content: ''` with the payload in an embed.

1. The inbound trigger and the history summarizer rendered embeds differently from the `read` tool (#1440), or not at all.
2. `shouldReplyInFreeMode` dropped the alert on empty content, or in a non-free mode answered *"How can I help?"* into the alerts channel.
3. `isTrigger` ignores bot status, so the allowlist alone never triggered anything in the default `mention` mode. The channel also had to be in `freeResponseChannels`, which the docs did not say.
4. Alerts that ping a user were dropped by the other-users-mentioned gate.
5. `shouldDebounceInbound` saw `msg.content` (empty), so every alert bypassed debouncing and became its own agent turn. An alert storm was N concurrent runs.
6. Suppress patterns matched `msg.content`, so noisy alert types could not be filtered.
7. A human replying to an alert embed handed the agent `GitHub: (no text)` as reply context.
8. Attachment-only posts (a bot graph, or a human DMing a photo) passed the gate on `hasAttachments`, then hit `!content` and got *"How can I help?"* instead of the attachment.

## Changes

- **`renderMessageText()`** in `inbound.ts` is the single text projection: cleaned content, else embeds (author, title, description, `name: value` fields, footer, url; capped at 3 embeds / 6 fields / 600 chars), else attachment names, else system text, else `''`. The trigger, history snapshot and reply/thread context all use it.
- **`describeInboundMessage()`** in `runtime.ts` builds one `InboundDiscordMessage` view per message (raw content, rendered text, bot author, attachments, command invocation, bot mention, reply-to-bot, mentioned users). `isTrigger`, `shouldHandleFreeModeMessage`, `maybeHandleReadWithoutReply`, `queueConversationMessage`, `updatePendingMessage` and both event handlers read from it instead of re-deriving from `msg.content`.
- **Allowlisted bot messages** count as a trigger whenever guild handling is on for the channel (`mention` or `free`; not `off`, not `commandsOnly`), skip the free-mode relevance heuristics and the other-users-mentioned gate, are treated as explicitly addressed so selective silence cannot randomly drop them, and are labelled `[Posted by webhook GitHub, not a person]` in the prompt. A post with no readable text is still ignored.
- **Bot authors never invoke commands**, so neither embed text nor a webhook's `content` can become a `!claw` invocation.
- Suppress patterns and debouncing operate on the rendered text, so embed-only alerts are filterable and batch like any other message.
- Docs list the prerequisites and note that edits to bot messages are not re-read.

## Not in this PR

- Loop protection beyond the self-ID guard: two HybridClaw instances in one allowlisted channel, or any bot that answers our replies, would loop. Planned: ignore bot messages that reply to or mention us, plus a per-channel bot-trigger budget.
- Thread scoping: `botMessageChannels` and `freeResponseChannels` match `msg.channelId` only, so integrations that post into threads never match. Planned: resolve via the parent channel as well.
