### PR TITLE
fix: scope onboarding autostart to agent workspace

### DIFF
--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -693,6 +693,13 @@ const TRACE_EXPORT_ALL_CONCURRENCY = 4;
 const GATEWAY_PROCESS_STARTED_AT = new Date().toISOString();
 const MAX_HISTORY_MESSAGES = 40;
 const BOOTSTRAP_AUTOSTART_MARKER_KEY = 'gateway.bootstrap_autostart.v1';
+// Stable KV namespace (owner call, 2026-09-01): BOOTSTRAP belongs to the
+// agent workspace; per-session OPENING behavior remains unchanged.
+const BOOTSTRAP_AUTOSTART_WORKSPACE_CLAIM_SCOPE =
+  'gateway.bootstrap_autostart.workspace.v1';
+// 15m (owner call, 2026-09-01): comfortably exceeds the 5m default agent
+// timeout while allowing a crashed gateway's workspace claim to recover.
+const BOOTSTRAP_AUTOSTART_STARTED_CLAIM_TTL_MS = 15 * 60_000;
 const BOOTSTRAP_AUTOSTART_SOURCE = 'gateway.bootstrap';
 const BOOTSTRAP_PRELUDE_MAX_TOKENS = 48;
 const BOOTSTRAP_PRELUDE_TIMEOUT_MS = 5000;
@@ -707,7 +714,7 @@ const BOOTSTRAP_HATCHING_PROMPT_PARTS = [
 ] satisfies PromptPartName[];
 const OPENING_AUTOSTART_MAX_TOKENS = 512;
 const OPENING_AUTOSTART_TIMEOUT_MS = 5000;
-const activeBootstrapAutostartSessions = new Set<string>();
+const activeBootstrapAutostartSessions = new Map<string, string>();
 const assistantPresentationImagePathCache = new Map<string, string | null>();
 const ADMIN_AGENT_MARKDOWN_MAX_BYTES = 200_000;
 const ADMIN_AGENT_MARKDOWN_MAX_REVISIONS = 50;
@@ -915,8 +922,56 @@ function getBootstrapAutostartMarker(params: {
 function getBootstrapAutostartLockKey(
   sessionId: string,
   agentId: string,
+  fileName: 'BOOTSTRAP.md' | 'OPENING.md',
 ): string {
-  return `${sessionId}:${agentId}`;
+  return fileName === 'BOOTSTRAP.md'
+    ? `workspace:${agentId}`
+    : `session:${sessionId}:${agentId}`;
+}
+
+function getBootstrapAutostartClaimScope(
+  sessionId: string,
+  fileName: 'BOOTSTRAP.md' | 'OPENING.md',
+): string {
+  return fileName === 'BOOTSTRAP.md'
+    ? BOOTSTRAP_AUTOSTART_WORKSPACE_CLAIM_SCOPE
+    : sessionId;
+}
+
+function claimBootstrapAutostartMarker(params: {
+  claimScope: string;
+  markerKey: string;
+  bootstrapFile: 'BOOTSTRAP.md' | 'OPENING.md';
+  fileFingerprint: string;
+  ownerSessionId: string;
+  startedAt: string;
+}): boolean {
+  const claimValue = {
+    status: 'started',
+    fileName: params.bootstrapFile,
+    fileFingerprint: params.fileFingerprint,
+    ownerSessionId: params.ownerSessionId,
+    at: params.startedAt,
+  };
+  if (claimMemoryValue(params.claimScope, params.markerKey, claimValue)) {
+    return true;
+  }
+  if (params.bootstrapFile !== 'BOOTSTRAP.md') return false;
+
+  const existing = getMemoryValue(params.claimScope, params.markerKey) as {
+    status?: unknown;
+    at?: unknown;
+  } | null;
+  const startedAtMs = Date.parse(
+    typeof existing?.at === 'string' ? existing.at : '',
+  );
+  const staleStartedClaim =
+    existing?.status === 'started' &&
+    Number.isFinite(startedAtMs) &&
+    Date.now() - startedAtMs >= BOOTSTRAP_AUTOSTART_STARTED_CLAIM_TTL_MS;
+  if (!staleStartedClaim) return false;
+  if (!deleteMemoryValue(params.claimScope, params.markerKey)) return false;
+  return claimMemoryValue(params.claimScope, params.markerKey, claimValue);
 }
 
 export function resolveOnboardingTurnModel(params: {
@@ -8787,11 +8842,16 @@ export async function ensureGatewayBootstrapAutostart(params: {
     fileName: bootstrapFile,
   });
   const markerKey = marker.key;
-  const lockKey = getBootstrapAutostartLockKey(session.id, resolved.agentId);
+  const claimScope = getBootstrapAutostartClaimScope(session.id, bootstrapFile);
+  const lockKey = getBootstrapAutostartLockKey(
+    session.id,
+    resolved.agentId,
+    bootstrapFile,
+  );
   if (activeBootstrapAutostartSessions.has(lockKey)) {
     return;
   }
-  activeBootstrapAutostartSessions.add(lockKey);
+  activeBootstrapAutostartSessions.set(lockKey, session.id);
   let onboardingAuditContext: BootstrapOnboardingAuditContext | null = null;
   let hatchingCompletion: BootstrapHatchingTurnResult | null = null;
   const recordPendingHatchingTerminalAudit = (): void => {
@@ -8804,11 +8864,13 @@ export async function ensureGatewayBootstrapAutostart(params: {
 
   try {
     const markerStartedAt = new Date().toISOString();
-    const claimed = claimMemoryValue(session.id, markerKey, {
-      status: 'started',
-      fileName: bootstrapFile,
+    const claimed = claimBootstrapAutostartMarker({
+      claimScope,
+      markerKey,
+      bootstrapFile,
       fileFingerprint: marker.fileFingerprint,
-      at: markerStartedAt,
+      ownerSessionId: session.id,
+      startedAt: markerStartedAt,
     });
     if (!claimed) return;
 
@@ -8880,7 +8942,7 @@ export async function ensureGatewayBootstrapAutostart(params: {
     const chatbotId = chatbotResolution.chatbotId;
 
     if (modelRequiresChatbotId(model) && !chatbotId) {
-      deleteMemoryValue(session.id, markerKey);
+      deleteMemoryValue(claimScope, markerKey);
       const error =
         chatbotResolution.error ||
         'No chatbot configured. Set `hybridai.defaultChatbotId` in ~/.hybridclaw/config.json or select a bot for this session.';
@@ -9080,7 +9142,7 @@ export async function ensureGatewayBootstrapAutostart(params: {
       });
 
       if (!openingResult) {
-        deleteMemoryValue(session.id, markerKey);
+        deleteMemoryValue(claimScope, markerKey);
         recordAuditEvent({
           sessionId: session.id,
           runId,
@@ -9145,8 +9207,11 @@ export async function ensureGatewayBootstrapAutostart(params: {
       const assistantMessageId = storeBootstrapAssistantMessage(
         openingResult.content,
       );
-      setMemoryValue(session.id, markerKey, {
+      setMemoryValue(claimScope, markerKey, {
         status: 'completed',
+        fileName: bootstrapFile,
+        fileFingerprint: marker.fileFingerprint,
+        ownerSessionId: session.id,
         assistantMessageId,
         completedAt: new Date().toISOString(),
       });
@@ -9285,7 +9350,7 @@ export async function ensureGatewayBootstrapAutostart(params: {
     }
 
     if (output.status !== 'success' || !resultText) {
-      deleteMemoryValue(session.id, markerKey);
+      deleteMemoryValue(claimScope, markerKey);
       recordPendingHatchingTerminalAudit();
       recordAuditEvent({
         sessionId: session.id,
@@ -9323,10 +9388,11 @@ export async function ensureGatewayBootstrapAutostart(params: {
       });
       recordPendingHatchingTerminalAudit();
     }
-    setMemoryValue(session.id, markerKey, {
+    setMemoryValue(claimScope, markerKey, {
       status: 'completed',
       fileName: bootstrapFile,
       fileFingerprint: marker.fileFingerprint,
+      ownerSessionId: session.id,
       assistantMessageId,
       completedAt: new Date().toISOString(),
     });
@@ -9355,7 +9421,7 @@ export async function ensureGatewayBootstrapAutostart(params: {
       },
     });
   } catch (error) {
-    deleteMemoryValue(session.id, markerKey);
+    deleteMemoryValue(claimScope, markerKey);
     recordPendingHatchingTerminalAudit();
     logger.warn(
       { sessionId: session.id, agentId: resolved.agentId, channelId, error },
@@ -9380,7 +9446,7 @@ export function getGatewayBootstrapAutostartState(params: {
   const { session, resolved, bootstrapFile } = context;
 
   const marker = getMemoryValue(
-    session.id,
+    getBootstrapAutostartClaimScope(session.id, bootstrapFile),
     getBootstrapAutostartMarker({
       agentId: resolved.agentId,
       fileName: bootstrapFile,
@@ -9696,8 +9762,8 @@ function isProtectedNoUserChatCleanupSession(session: Session): boolean {
   const sessionKey = String(session.session_key || '').trim();
   const agentId = String(session.agent_id || '').trim();
   const bootstrapAutostartActive = Array.from(
-    activeBootstrapAutostartSessions,
-  ).some((lockKey) => lockKey.startsWith(`${session.id}:`));
+    activeBootstrapAutostartSessions.values(),
+  ).includes(session.id);
   const hasStoredConversation =
     session.message_count > 0 ||
     String(session.session_summary || '').trim().length > 0;

--- a/tests/gateway-service.bootstrap-autostart.test.ts
+++ b/tests/gateway-service.bootstrap-autostart.test.ts
@@ -102,7 +102,7 @@ const { setupHome } = setupGatewayTest({
   },
 });
 
-test('ensureGatewayBootstrapAutostart stores prelude and bootstrap opener once per session', async () => {
+test('ensureGatewayBootstrapAutostart stores BOOTSTRAP opener once per agent workspace', async () => {
   setupHome();
 
   runAgentMock.mockResolvedValue({
@@ -112,12 +112,16 @@ test('ensureGatewayBootstrapAutostart stores prelude and bootstrap opener once p
     toolExecutions: [],
   });
 
-  const { getRecentStructuredAuditForSession, initDatabase } = await import(
-    '../src/memory/db.ts'
-  );
-  const { ensureGatewayBootstrapAutostart, getGatewayHistory } = await import(
-    '../src/gateway/gateway-service.ts'
-  );
+  const {
+    getRecentStructuredAuditForSession,
+    initDatabase,
+    listMemoryValues,
+  } = await import('../src/memory/db.ts');
+  const {
+    ensureGatewayBootstrapAutostart,
+    getGatewayBootstrapAutostartState,
+    getGatewayHistory,
+  } = await import('../src/gateway/gateway-service.ts');
   const { memoryService } = await import('../src/memory/memory-service.ts');
 
   initDatabase({ quiet: true });
@@ -276,9 +280,29 @@ test('ensureGatewayBootstrapAutostart stores prelude and bootstrap opener once p
   await ensureGatewayBootstrapAutostart({ sessionId });
   expect(runAgentMock).toHaveBeenCalledTimes(1);
   expect(getGatewayHistory(sessionId, 10).history).toHaveLength(2);
+
+  const secondSessionId =
+    'agent:main:channel:web:chat:dm:peer:bootstrap-test-second-session';
+  await ensureGatewayBootstrapAutostart({ sessionId: secondSessionId });
+  expect(runAgentMock).toHaveBeenCalledTimes(1);
+  expect(getGatewayHistory(secondSessionId, 10).history).toEqual([]);
+  expect(
+    getGatewayBootstrapAutostartState({ sessionId: secondSessionId }),
+  ).toEqual({ status: 'completed', fileName: 'BOOTSTRAP.md' });
+  expect(
+    listMemoryValues('gateway.bootstrap_autostart.workspace.v1'),
+  ).toEqual([
+    expect.objectContaining({
+      value: expect.objectContaining({
+        status: 'completed',
+        fileName: 'BOOTSTRAP.md',
+        ownerSessionId: storedSession?.id || sessionId,
+      }),
+    }),
+  ]);
 });
 
-test('ensureGatewayBootstrapAutostart retries after a failed opener without consuming a hatching turn', async () => {
+test('ensureGatewayBootstrapAutostart releases the workspace claim after a failed opener', async () => {
   setupHome();
 
   runAgentMock
@@ -303,12 +327,12 @@ test('ensureGatewayBootstrapAutostart retries after a failed opener without cons
 
   initDatabase({ quiet: true });
 
-  const sessionId =
+  const failedSessionId =
     'agent:main:channel:web:chat:dm:peer:bootstrap-retry-after-error';
-  await ensureGatewayBootstrapAutostart({ sessionId });
+  await ensureGatewayBootstrapAutostart({ sessionId: failedSessionId });
 
   expect(runAgentMock).toHaveBeenCalledTimes(1);
-  expect(getGatewayHistory(sessionId, 10).history).toEqual([
+  expect(getGatewayHistory(failedSessionId, 10).history).toEqual([
     expect.objectContaining({
       role: 'assistant',
       content: DEFAULT_GATEWAY_AUXILIARY_PRELUDE,
@@ -323,17 +347,70 @@ test('ensureGatewayBootstrapAutostart retries after a failed opener without cons
     'hatchingTurnsWithoutMessage',
   );
 
-  await ensureGatewayBootstrapAutostart({ sessionId });
+  const retrySessionId =
+    'agent:main:channel:web:chat:dm:peer:bootstrap-retry-after-error-second';
+  await ensureGatewayBootstrapAutostart({ sessionId: retrySessionId });
 
   expect(runAgentMock).toHaveBeenCalledTimes(2);
   expect(
-    getGatewayHistory(sessionId, 10).history.some(
+    getGatewayHistory(retrySessionId, 10).history.some(
       (message) => message.content === 'Recovered onboarding opener.',
     ),
   ).toBe(true);
   expect(JSON.parse(fs.readFileSync(statePath, 'utf8'))).toMatchObject({
     hatchingTurnsWithoutMessage: 1,
   });
+});
+
+test('ensureGatewayBootstrapAutostart reclaims a stale workspace claim', async () => {
+  setupHome();
+
+  runAgentMock.mockResolvedValue({
+    status: 'success',
+    result: 'Recovered from stale workspace claim.',
+    toolsUsed: [],
+    toolExecutions: [],
+  });
+
+  const { initDatabase, listMemoryValues, setMemoryValue } = await import(
+    '../src/memory/db.ts'
+  );
+  const { ensureGatewayBootstrapAutostart, getGatewayHistory } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+
+  const claimScope = 'gateway.bootstrap_autostart.workspace.v1';
+  const firstSessionId =
+    'agent:main:channel:web:chat:dm:peer:bootstrap-stale-first';
+  await ensureGatewayBootstrapAutostart({ sessionId: firstSessionId });
+  expect(runAgentMock).toHaveBeenCalledTimes(1);
+
+  const marker = listMemoryValues(claimScope)[0];
+  expect(marker).toBeTruthy();
+  if (!marker) throw new Error('Expected workspace autostart marker');
+  setMemoryValue(claimScope, marker.key, {
+    status: 'started',
+    fileName: 'BOOTSTRAP.md',
+    at: '2026-01-01T00:00:00.000Z',
+  });
+
+  const secondSessionId =
+    'agent:main:channel:web:chat:dm:peer:bootstrap-stale-second';
+  await ensureGatewayBootstrapAutostart({ sessionId: secondSessionId });
+
+  expect(runAgentMock).toHaveBeenCalledTimes(2);
+  expect(getGatewayHistory(secondSessionId, 10).history).toEqual([
+    expect.objectContaining({
+      role: 'assistant',
+      content: DEFAULT_GATEWAY_AUXILIARY_PRELUDE,
+    }),
+    expect.objectContaining({
+      role: 'assistant',
+      content: 'Recovered from stale workspace claim.',
+    }),
+  ]);
 });
 
 test('cleanupGatewayNoUserChatSessions preserves bootstrap autostart before its prelude is stored', async () => {
@@ -878,11 +955,19 @@ test('ensureGatewayBootstrapAutostart keeps bootstrap opener when auxiliary gene
 test('ensureGatewayBootstrapAutostart also kicks off from OPENING.md once per session', async () => {
   setupHome();
 
-  callAuxiliaryModelMock.mockResolvedValueOnce({
-    provider: 'hybridai',
-    model: 'auxiliary/test',
-    content: 'Why did the computer go to therapy?\nIt had too many unresolved issues.',
-  });
+  callAuxiliaryModelMock
+    .mockResolvedValueOnce({
+      provider: 'hybridai',
+      model: 'auxiliary/test',
+      content:
+        'Why did the computer go to therapy?\nIt had too many unresolved issues.',
+    })
+    .mockResolvedValueOnce({
+      provider: 'hybridai',
+      model: 'auxiliary/test',
+      content:
+        'Why did the computer go to therapy?\nIt had too many unresolved issues.',
+    });
 
   const { initDatabase } = await import('../src/memory/db.ts');
   const { ensureGatewayBootstrapAutostart, getGatewayHistory } = await import(
@@ -972,6 +1057,19 @@ test('ensureGatewayBootstrapAutostart also kicks off from OPENING.md once per se
   await ensureGatewayBootstrapAutostart({ sessionId });
   expect(runAgentMock).not.toHaveBeenCalled();
   expect(callAuxiliaryModelMock).toHaveBeenCalledTimes(1);
+
+  const secondSessionId =
+    'agent:main:channel:web:chat:dm:peer:boot-md-test-second';
+  await ensureGatewayBootstrapAutostart({ sessionId: secondSessionId });
+  expect(runAgentMock).not.toHaveBeenCalled();
+  expect(callAuxiliaryModelMock).toHaveBeenCalledTimes(2);
+  expect(getGatewayHistory(secondSessionId, 10).history).toEqual([
+    expect.objectContaining({
+      role: 'assistant',
+      content:
+        'Why did the computer go to therapy?\nIt had too many unresolved issues.',
+    }),
+  ]);
 });
 
 test('ensureGatewayBootstrapAutostart can hatch a selected agent in an existing session', async () => {
@@ -1281,7 +1379,7 @@ test('ensureGatewayBootstrapAutostart ignores BOOT.md even when it is customized
   expect(getGatewayHistory(sessionId, 10).history).toEqual([]);
 });
 
-test('ensureGatewayBootstrapAutostart prevents duplicate concurrent runs for the same fresh session', async () => {
+test('ensureGatewayBootstrapAutostart prevents concurrent BOOTSTRAP runs across sessions', async () => {
   setupHome();
 
   let resolveRun:
@@ -1309,9 +1407,16 @@ test('ensureGatewayBootstrapAutostart prevents duplicate concurrent runs for the
 
   initDatabase({ quiet: true });
 
-  const sessionId = 'agent:main:channel:web:chat:dm:peer:bootstrap-race-test';
-  const firstRun = ensureGatewayBootstrapAutostart({ sessionId });
-  const secondRun = ensureGatewayBootstrapAutostart({ sessionId });
+  const firstSessionId =
+    'agent:main:channel:web:chat:dm:peer:bootstrap-race-test-first';
+  const secondSessionId =
+    'agent:main:channel:web:chat:dm:peer:bootstrap-race-test-second';
+  const firstRun = ensureGatewayBootstrapAutostart({
+    sessionId: firstSessionId,
+  });
+  const secondRun = ensureGatewayBootstrapAutostart({
+    sessionId: secondSessionId,
+  });
   await vi.waitFor(() => {
     expect(runAgentMock).toHaveBeenCalledTimes(1);
   });
@@ -1325,7 +1430,7 @@ test('ensureGatewayBootstrapAutostart prevents duplicate concurrent runs for the
   await Promise.all([firstRun, secondRun]);
 
   expect(runAgentMock).toHaveBeenCalledTimes(1);
-  expect(getGatewayHistory(sessionId, 10).history).toEqual([
+  expect(getGatewayHistory(firstSessionId, 10).history).toEqual([
     expect.objectContaining({
       role: 'assistant',
       content: DEFAULT_GATEWAY_AUXILIARY_PRELUDE,
@@ -1335,4 +1440,5 @@ test('ensureGatewayBootstrapAutostart prevents duplicate concurrent runs for the
       content: 'Hello once.',
     }),
   ]);
+  expect(getGatewayHistory(secondSessionId, 10).history).toEqual([]);
 });


### PR DESCRIPTION
## Summary

- claim `BOOTSTRAP.md` autostart once per agent workspace instead of once per session
- keep `OPENING.md` autostart session-scoped
- prevent concurrent cross-session onboarding runs and recover stale started claims after 15 minutes
- preserve cleanup protection for the session that owns an active onboarding run

## Risk and boundaries

- the workspace claim key includes the agent ID and bootstrap fingerprint, so distinct agents remain isolated and recreating `BOOTSTRAP.md` can hatch again
- failed or interrupted runs release their claim; stale claims are recoverable
- no schema, config, console, or onboarding completion-policy changes
- legacy session-scoped markers are not migrated, so an unfinished pre-upgrade workspace can emit one final opener before the workspace marker takes over

## Validation

- `npm run format`
- `npm run lint`
- `vitest run tests/gateway-service.bootstrap-autostart.test.ts tests/gateway-service.chat-cleanup.test.ts` — 22 passed
- broader root unit run — 5,630 passed, 3 unrelated failures: Discord runtime-config initialization, missing container-local agent-browser dependency in this worktree, and a plugin singleton timeout; the plugin test passed standalone