### PR TITLE
fix(vonage-voice): correct over-escaped fromNumber pattern

### DIFF
--- a/plugins/vonage-voice/hybridclaw.plugin.yaml
+++ b/plugins/vonage-voice/hybridclaw.plugin.yaml
@@ -22,7 +22,7 @@ configSchema:
       minLength: 1
     fromNumber:
       type: string
-      pattern: '^\\+[1-9][0-9]{7,14}$'
+      pattern: '^\+[1-9][0-9]{7,14}$'
     publicBaseUrl:
       type: string
       pattern: '^https://'


### PR DESCRIPTION
The `vonage-voice` plugin cannot load with any valid configuration.

`hybridclaw.plugin.yaml` declared:

```yaml
fromNumber:
  type: string
  pattern: '^\\+[1-9][0-9]{7,14}$'
```

YAML single-quoted scalars do not process backslash escapes, so the value
reaching the schema validator is the regex `^\\+[1-9][0-9]{7,14}$` — `\\`
matches a literal backslash and `+` quantifies it, so the pattern requires one
or more literal backslashes before the digits. No E.164 number can match, and
every install fails at startup with:

```
Plugin failed to load … plugin config.fromNumber must match pattern "^\\+[1-9][0-9]{7,14}$"
```

Using a single backslash lets the escape reach the regex engine as intended.

Verified against the parsed manifest:

| input | before | after |
| --- | --- | --- |
| `+4915123456789` | ✗ | ✓ |
| `4915123456789` (no `+`) | ✗ | ✗ |
| `+0915123456789` (leading zero) | ✗ | ✗ |

The sibling `publicBaseUrl` pattern (`'^https://'`) has no escapes and is
unaffected.