### PR TITLE
feat(vonage-voice): gate inbound calls with a caller allowlist

### DIFF
--- a/plugins/vonage-voice/hybridclaw.plugin.yaml
+++ b/plugins/vonage-voice/hybridclaw.plugin.yaml
@@ -26,6 +26,15 @@ configSchema:
     publicBaseUrl:
       type: string
       pattern: '^https://'
+    callerPolicy:
+      type: string
+      enum: [open, allowlist, disabled]
+      default: open
+    allowFrom:
+      type: array
+      default: []
+      items:
+        type: string
     mode:
       type: string
       enum: [turn, realtime]
@@ -47,6 +56,11 @@ configSchema:
 configUiHints:
   applicationId:
     label: Application ID
+  callerPolicy:
+    label: Caller Policy
+  allowFrom:
+    label: Allowed Callers
+    placeholder: '+4915123456789'
   mode:
     label: Call Mode
   fromNumber:

--- a/plugins/vonage-voice/src/caller-policy.js
+++ b/plugins/vonage-voice/src/caller-policy.js
@@ -1,0 +1,48 @@
+/**
+ * Inbound caller gating for the Vonage voice channel.
+ *
+ * Mirrors the `dmPolicy` / `allowFrom` shape the messaging channels use:
+ * `open` accepts every caller, `disabled` rejects every caller, and
+ * `allowlist` accepts only numbers named in `allowFrom` — or any caller when
+ * that list contains `*`.
+ *
+ * Numbers are compared in a normalized `+<digits>` form, so allowlist entries
+ * written with spaces, dashes, or no leading `+` still match the E.164 value
+ * Vonage puts in the answer webhook's `from` field. A caller who withholds
+ * their number arrives with an empty `from` and is therefore never matched by
+ * an allowlist, which is the intended behaviour.
+ */
+const CALLER_POLICIES = ['open', 'allowlist', 'disabled'];
+
+export function isCallerPolicy(value) {
+  return CALLER_POLICIES.includes(value);
+}
+
+export function normalizeCallerIdentity(value) {
+  const candidate = String(value ?? '').replace(/[^\d+]/g, '');
+  if (!candidate) return null;
+  const digits = candidate.startsWith('+') ? candidate.slice(1) : candidate;
+  return digits ? `+${digits}` : null;
+}
+
+export function normalizeCallerAllowList(values) {
+  const list = [];
+  for (const value of values || []) {
+    if (String(value ?? '').trim() === '*') {
+      list.push('*');
+      continue;
+    }
+    const normalized = normalizeCallerIdentity(value);
+    if (normalized) list.push(normalized);
+  }
+  return [...new Set(list)];
+}
+
+export function isCallerAllowed(params) {
+  if (params.callerPolicy === 'disabled') return false;
+  if (params.callerPolicy === 'open') return true;
+  const allowFrom = normalizeCallerAllowList(params.allowFrom);
+  if (allowFrom.includes('*')) return true;
+  const caller = normalizeCallerIdentity(params.from);
+  return Boolean(caller) && allowFrom.includes(caller);
+}

--- a/plugins/vonage-voice/src/config.js
+++ b/plugins/vonage-voice/src/config.js
@@ -1,3 +1,5 @@
+import { isCallerPolicy } from './caller-policy.js';
+
 const E164_RE = /^\+[1-9]\d{7,14}$/;
 
 export function resolveConfig(api) {
@@ -23,6 +25,15 @@ export function resolveConfig(api) {
   }
   if (!privateKey) throw new Error('VONAGE_PRIVATE_KEY is required.');
   if (!signatureSecret) throw new Error('VONAGE_SIGNATURE_SECRET is required.');
+  const callerPolicy = String(config.callerPolicy || 'open').trim() || 'open';
+  if (!isCallerPolicy(callerPolicy)) {
+    throw new Error(
+      'Vonage callerPolicy must be "open", "allowlist", or "disabled".',
+    );
+  }
+  const allowFrom = Array.isArray(config.allowFrom)
+    ? config.allowFrom.map((value) => String(value))
+    : [];
   const mode = String(config.mode || 'turn').trim() || 'turn';
   if (mode !== 'turn' && mode !== 'realtime') {
     throw new Error('Vonage mode must be "turn" or "realtime".');
@@ -33,6 +44,8 @@ export function resolveConfig(api) {
     publicBaseUrl,
     privateKey,
     signatureSecret,
+    callerPolicy,
+    allowFrom,
     mode,
     language: String(config.language || 'en-US').trim() || 'en-US',
     welcomeGreeting:

--- a/plugins/vonage-voice/src/runtime.js
+++ b/plugins/vonage-voice/src/runtime.js
@@ -1,4 +1,5 @@
 import { transferVonageCallToNcco } from './api.js';
+import { isCallerAllowed, normalizeCallerIdentity } from './caller-policy.js';
 import {
   extractBearerToken,
   verifyVonageWebhookJwt,
@@ -18,6 +19,8 @@ import { createVonageRealtimeStreams } from './realtime.js';
 import { buildVoiceSessionKey } from './utils.js';
 
 const MAX_BODY_BYTES = 256 * 1024;
+const CALLER_REFUSED_MESSAGE =
+  'Sorry, this number is not available for your call. Goodbye.';
 const MAX_SILENT_TIMEOUTS = 3;
 
 function sendJson(res, status, body) {
@@ -142,6 +145,33 @@ export function createVonageRuntime(api, config) {
       const answer = parseVonageAnswerWebhook(body);
       if (!answer) {
         sendJson(ctx.res, 400, { error: 'Invalid answer payload.' });
+        return;
+      }
+      if (
+        !isCallerAllowed({
+          callerPolicy: config.callerPolicy,
+          allowFrom: config.allowFrom,
+          from: answer.from,
+        })
+      ) {
+        // The refused number is logged so an operator can add a legitimate
+        // caller to allowFrom; without it the allowlist is undiagnosable.
+        ctx.logger.warn(
+          {
+            callUuid: answer.uuid,
+            callerPolicy: config.callerPolicy,
+            caller: normalizeCallerIdentity(answer.from) || 'withheld',
+          },
+          'Vonage call refused: caller not permitted by callerPolicy',
+        );
+        sendJson(
+          ctx.res,
+          200,
+          buildGoodbyeNcco({
+            message: CALLER_REFUSED_MESSAGE,
+            language: config.language,
+          }),
+        );
         return;
       }
       if (

--- a/tests/vonage-voice-caller-policy.test.ts
+++ b/tests/vonage-voice-caller-policy.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from 'vitest';
+
+import {
+  isCallerAllowed,
+  isCallerPolicy,
+  normalizeCallerAllowList,
+  normalizeCallerIdentity,
+} from '../plugins/vonage-voice/src/caller-policy.js';
+
+const LISTED = '+4915123456789';
+
+test('open accepts every caller and disabled rejects every caller', () => {
+  expect(
+    isCallerAllowed({ callerPolicy: 'open', allowFrom: [], from: '4915999999' }),
+  ).toBe(true);
+  expect(
+    isCallerAllowed({
+      callerPolicy: 'disabled',
+      allowFrom: [LISTED],
+      from: LISTED,
+    }),
+  ).toBe(false);
+});
+
+test('allowlist matches regardless of caller-id formatting', () => {
+  for (const entry of [LISTED, '4915123456789', '+49 151 234 567-89']) {
+    expect(
+      isCallerAllowed({
+        callerPolicy: 'allowlist',
+        allowFrom: [entry],
+        // Vonage delivers the E.164 digits without a leading '+'.
+        from: '4915123456789',
+      }),
+    ).toBe(true);
+  }
+});
+
+test('allowlist rejects unlisted callers', () => {
+  expect(
+    isCallerAllowed({
+      callerPolicy: 'allowlist',
+      allowFrom: [LISTED],
+      from: '4930000000000',
+    }),
+  ).toBe(false);
+});
+
+test('a wildcard entry accepts any caller', () => {
+  expect(
+    isCallerAllowed({
+      callerPolicy: 'allowlist',
+      allowFrom: ['*'],
+      from: '4930000000000',
+    }),
+  ).toBe(true);
+});
+
+test('a withheld number never satisfies an allowlist', () => {
+  for (const from of ['', undefined, null, 'anonymous']) {
+    expect(
+      isCallerAllowed({
+        callerPolicy: 'allowlist',
+        allowFrom: [LISTED],
+        from,
+      }),
+    ).toBe(false);
+  }
+});
+
+test('normalizeCallerIdentity yields a canonical +digits form', () => {
+  expect(normalizeCallerIdentity('+49 151 234 567-89')).toBe(LISTED);
+  expect(normalizeCallerIdentity('4915123456789')).toBe(LISTED);
+  expect(normalizeCallerIdentity('   ')).toBeNull();
+  expect(normalizeCallerIdentity('anonymous')).toBeNull();
+});
+
+test('normalizeCallerAllowList dedupes, canonicalizes, and keeps the wildcard', () => {
+  expect(
+    normalizeCallerAllowList([LISTED, '4915123456789', ' ', 'nope', '*']),
+  ).toEqual([LISTED, '*']);
+});
+
+test('isCallerPolicy guards the three supported policies', () => {
+  expect(['open', 'allowlist', 'disabled'].every(isCallerPolicy)).toBe(true);
+  expect(isCallerPolicy('everyone')).toBe(false);
+});


### PR DESCRIPTION
The Vonage voice channel accepts every inbound caller. Any number that reaches the linked Vonage number opens a realtime session and can consult the agent, with `maxConcurrentCalls` as the only limit. Every messaging channel already has a gate for this; voice did not.

## Change

Adds the same shape the messaging channels use (`dmPolicy` + `allowFrom`):

```yaml
callerPolicy: open | allowlist | disabled   # default: open
allowFrom: []                               # E.164 numbers, or '*'
```

Enforced in the answer webhook **ahead of the capacity check**, so a refused call does not consume a concurrency slot. The caller hears a short spoken refusal and the call ends.

Numbers are compared in a canonical `+<digits>` form, so allowlist entries written with spaces, dashes, or no leading `+` still match the value Vonage puts in `from`. A caller who withholds their number arrives with an empty `from` and therefore never matches an allowlist.

The refused number is logged. Without it the allowlist is undiagnosable — an operator has no way to learn which number to add.

Defaults to `open`, so existing deployments keep their current behaviour. Operators fronting an agent with tools will want `allowlist`.

## Tests

`tests/vonage-voice-caller-policy.test.ts` — 8 cases covering the policy matrix, formatting-tolerant matching, the wildcard, withheld numbers, normalization, and dedupe.

## Notes for reviewers

- The helpers are local to the plugin, matching the existing per-channel precedent (`normalizeAllowList` / `matchesAllowList` are defined locally in each of signal, telegram, slack, imessage rather than shared).
- An allowlist gates unknown callers; it is not a defence against caller-ID spoofing. Operators fronting anything sensitive should still restrict the agent's tools.
- Two related gaps are **not** addressed here: the admin console has no plugin-config UI at all (nothing reads `configSchema`/`configUiHints`), and `hybridclaw plugin config` cannot set array values (`plugin config.allowFrom must be array`). Today the allowlist can only be edited by hand in `plugins.list[].config`. Happy to split those out.