### PR TITLE
fix(msteams): stop the typing indicator once the reply is delivered

### DIFF
--- a/src/channels/msteams/runtime.ts
+++ b/src/channels/msteams/runtime.ts
@@ -702,13 +702,16 @@ async function handleIncomingMessage(turnContext: TurnContext): Promise<void> {
     }
 
     const abortController = new AbortController();
+    const typingController = createMSTeamsTypingController(turnContext);
     const stream = new MSTeamsStreamManager(turnContext, {
       replyStyle: policy.replyStyle,
       replyToId: activity.id,
       nativeStreaming: isDm,
       onNativeCancellation: () => abortController.abort(),
+      onMessageDelivered: () => {
+        typingController.stop();
+      },
     });
-    const typingController = createMSTeamsTypingController(turnContext);
     let legacyTypingStarted = false;
     if (isDm) {
       await stream.updateInformative();

--- a/src/channels/msteams/stream.ts
+++ b/src/channels/msteams/stream.ts
@@ -35,6 +35,7 @@ export interface MSTeamsStreamOptions {
   editIntervalMs?: number;
   nativeStreaming?: boolean;
   onNativeCancellation?: () => void;
+  onMessageDelivered?: () => void;
 }
 
 export class MSTeamsStreamManager {
@@ -44,6 +45,7 @@ export class MSTeamsStreamManager {
   private readonly editIntervalMs: number;
   private readonly nativeStreaming: boolean;
   private readonly onNativeCancellation?: () => void;
+  private readonly onMessageDelivered?: () => void;
 
   private readonly sent: SentActivityRef[] = [];
   private content = '';
@@ -66,6 +68,7 @@ export class MSTeamsStreamManager {
     this.replyToId = options.replyToId;
     this.nativeStreaming = options.nativeStreaming === true;
     this.onNativeCancellation = options.onNativeCancellation;
+    this.onMessageDelivered = options.onMessageDelivered;
     this.editIntervalMs = Math.max(
       250,
       options.editIntervalMs ??
@@ -273,6 +276,7 @@ export class MSTeamsStreamManager {
           throw new Error('Teams sendActivity did not return an activity id.');
         }
         this.sent.push({ id: activityId, text: chunk.text });
+        this.notifyMessageDelivered();
         continue;
       }
 
@@ -422,6 +426,15 @@ export class MSTeamsStreamManager {
     );
     const finalId = String(response?.id || '').trim();
     if (finalId) this.nativeFinalId = finalId;
+  }
+
+  private notifyMessageDelivered(): void {
+    if (!this.onMessageDelivered) return;
+    try {
+      this.onMessageDelivered();
+    } catch (error) {
+      logger.debug({ error }, 'Teams stream delivery callback failed');
+    }
   }
 
   private async disableNativeStreaming(error: unknown): Promise<void> {

--- a/tests/msteams.stream.test.ts
+++ b/tests/msteams.stream.test.ts
@@ -357,3 +357,36 @@ test('stream retries transient Teams send and update failures', async () => {
     vi.useRealTimers();
   }
 });
+
+test('reports the first delivered Teams message so the typing indicator can stop', async () => {
+  vi.useFakeTimers();
+  try {
+    const onMessageDelivered = vi.fn();
+    const sendActivity = vi.fn(async () => ({ id: 'activity-1' }));
+    const updateActivity = vi.fn(async () => {});
+    const turnContext = {
+      sendActivity,
+      updateActivity,
+      deleteActivity: vi.fn(async () => {}),
+    };
+
+    const stream = new MSTeamsStreamManager(turnContext as never, {
+      replyStyle: 'thread',
+      replyToId: 'incoming-1',
+      editIntervalMs: 500,
+      onMessageDelivered,
+    });
+
+    await stream.append('Hello');
+    expect(onMessageDelivered).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onMessageDelivered).toHaveBeenCalledTimes(1);
+
+    await stream.finalize('Hello world');
+    expect(updateActivity).toHaveBeenCalledTimes(1);
+    expect(onMessageDelivered).toHaveBeenCalledTimes(1);
+  } finally {
+    vi.useRealTimers();
+  }
+});


### PR DESCRIPTION
## Problem

In a Teams 1:1 chat the bot avatar with the typing dots stayed pinned above the compose box after the reply had already been delivered.

Teams clears a bot typing indicator only when the bot posts a **new** message. The legacy stream path (used whenever native `streaminfo` streaming is unavailable) posts one message and then *edits* it for every subsequent chunk, so the 4s typing ticks kept firing behind the visible reply and the final tick left the indicator stuck with nothing after it to clear it.

## Fix

`MSTeamsStreamManager` now reports the first message it delivers (`onMessageDelivered`), and the runtime uses that to stop the typing loop as soon as the reply is on screen.

## Test

- `tests/msteams.stream.test.ts`: the callback fires exactly once, on the initial send and not on later edits.
- `npx vitest run tests/msteams.stream.test.ts tests/msteams.runtime.test.ts`, `npm run lint`
