### PR TITLE
fix(msteams): clear the file consent card after allow or decline

### DIFF
--- a/src/channels/msteams/attachments.ts
+++ b/src/channels/msteams/attachments.ts
@@ -1093,6 +1093,22 @@ export async function buildTeamsUploadedFileAttachment(params: {
   };
 }
 
+async function removeFileConsentCard(
+  turnContext: TurnContext,
+  activity: Partial<Activity>,
+): Promise<void> {
+  const consentActivityId = normalizeValue(activity.replyToId);
+  if (!consentActivityId) return;
+  try {
+    await turnContext.deleteActivity(consentActivityId);
+  } catch (error) {
+    logger.debug(
+      { error, activityId: consentActivityId },
+      'Failed to remove Teams file consent card',
+    );
+  }
+}
+
 export async function maybeHandleMSTeamsFileConsentInvoke(
   turnContext: TurnContext,
 ): Promise<boolean> {
@@ -1106,6 +1122,7 @@ export async function maybeHandleMSTeamsFileConsentInvoke(
     type: 'invokeResponse',
     value: { status: 200 },
   });
+  await removeFileConsentCard(turnContext, activity);
 
   const uploadId = normalizeValue(
     typeof consent.context?.uploadId === 'string'
@@ -1136,6 +1153,9 @@ export async function maybeHandleMSTeamsFileConsentInvoke(
 
   if (consent.action === 'decline') {
     removePendingFileUpload(uploadId);
+    await turnContext.sendActivity(
+      `Skipped sending ${pendingUpload.filename}.`,
+    );
     return true;
   }
 

--- a/tests/msteams.attachments.test.ts
+++ b/tests/msteams.attachments.test.ts
@@ -383,11 +383,13 @@ test('maybeHandleMSTeamsFileConsentInvoke uploads the pending file and sends a f
   const fetchMock = vi.fn(async () => new Response('', { status: 200 }));
   vi.stubGlobal('fetch', fetchMock);
   const sendActivity = vi.fn(async () => ({ id: 'reply-1' }));
+  const deleteActivity = vi.fn(async () => {});
   const handled = await maybeHandleMSTeamsFileConsentInvoke({
     activity: {
       type: 'invoke',
       name: 'fileConsent/invoke',
       conversation: { id: 'conversation-123' },
+      replyToId: 'consent-card-1',
       value: {
         type: 'fileUpload',
         action: 'accept',
@@ -404,9 +406,11 @@ test('maybeHandleMSTeamsFileConsentInvoke uploads the pending file and sends a f
       },
     },
     sendActivity,
+    deleteActivity,
   } as never);
 
   expect(handled).toBe(true);
+  expect(deleteActivity).toHaveBeenCalledWith('consent-card-1');
   expect(fetchMock).toHaveBeenCalledWith(
     'https://upload.example.com/file',
     expect.objectContaining({
@@ -438,6 +442,59 @@ test('maybeHandleMSTeamsFileConsentInvoke uploads the pending file and sends a f
       ],
     }),
   );
+});
+
+test('maybeHandleMSTeamsFileConsentInvoke clears the consent card when declined', async () => {
+  const {
+    buildTeamsUploadedFileAttachment,
+    maybeHandleMSTeamsFileConsentInvoke,
+  } = await importAttachmentsModule();
+  const tempDir = makeTempDir('hybridclaw-msteams-');
+  const filePath = path.join(tempDir, 'report.pdf');
+  fs.writeFileSync(filePath, Buffer.from([1, 2, 3, 4]));
+
+  const consentCard = await buildTeamsUploadedFileAttachment({
+    turnContext: {
+      activity: {
+        conversation: {
+          id: 'conversation-123',
+          conversationType: 'personal',
+        },
+        serviceUrl: 'https://smba.trafficmanager.net/de/tenant-id/',
+      },
+    } as never,
+    filePath,
+    mimeType: 'application/pdf',
+  });
+  const uploadId = String(
+    (consentCard as { content?: { declineContext?: { uploadId?: string } } })
+      .content?.declineContext?.uploadId || '',
+  );
+
+  const fetchMock = vi.fn(async () => new Response('', { status: 200 }));
+  vi.stubGlobal('fetch', fetchMock);
+  const sendActivity = vi.fn(async () => ({ id: 'reply-1' }));
+  const deleteActivity = vi.fn(async () => {});
+  const handled = await maybeHandleMSTeamsFileConsentInvoke({
+    activity: {
+      type: 'invoke',
+      name: 'fileConsent/invoke',
+      conversation: { id: 'conversation-123' },
+      replyToId: 'consent-card-1',
+      value: {
+        type: 'fileUpload',
+        action: 'decline',
+        context: { uploadId },
+      },
+    },
+    sendActivity,
+    deleteActivity,
+  } as never);
+
+  expect(handled).toBe(true);
+  expect(fetchMock).not.toHaveBeenCalled();
+  expect(deleteActivity).toHaveBeenCalledWith('consent-card-1');
+  expect(sendActivity).toHaveBeenNthCalledWith(2, 'Skipped sending report.pdf.');
 });
 
 test('buildTeamsAttachmentContext accepts direct Microsoft CDN image attachments', async () => {


### PR DESCRIPTION
## Problem

After clicking **Allow** on the Teams "HybridClaw needs permission to upload this file to your OneDrive" card, the card stayed in the chat with both buttons still live, sitting right above the uploaded file. Same on **Decline** — nothing changed and the user got no feedback.

Teams does not retire a file consent card on its own; the bot has to remove it once it handles the `fileConsent/invoke` (this is what the Bot Framework Teams file-upload sample does).

## Fix

- Delete the consent card activity (`activity.replyToId`) as soon as the invoke is acknowledged, for both accept and decline. Failures are logged at debug and never break the upload.
- On decline, confirm the skipped send so the card does not just vanish silently.

## Test

- `tests/msteams.attachments.test.ts`: accept deletes the card and still posts the file info card; new decline case asserts no upload, the card removal, and the confirmation.
- `npx vitest run tests/msteams.attachments.test.ts`, `npm run lint`
