### PR TITLE
fix(gateway): record proxied turns so ratings and session commands work for proxy agents

### DIFF
--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -198,6 +198,8 @@ saved revision history directly.
   HybridAI chatbot instead of running the local agent loop. Proxy agents
   require `kind: "hybridai"`, an HTTPS `baseUrl`, `chatbotId`, and a
   SecretRef-backed `apiKey`; `conversationScope` can be `channel` or `user`.
+  Proxied turns are still recorded in the local session, so `/thumbs` and
+  channel reactions rate them and the feedback is forwarded to that chatbot.
 - `agents.list[].skills` and `agents.list[].tools` restrict which skills that
   agent may load and which tools it may call. Omit either key to leave the
   agent unrestricted, including for skills and tools installed later; an empty

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -1174,8 +1174,30 @@ async function handleGatewayMessageInner(
         runId,
         abortSignal: activeGatewayRequest.signal,
       });
+      // Proxied turns skip the local agent loop, but the exchange still has
+      // to exist in this session so channel ratings (/thumbs, reactions) can
+      // find the answer and forward feedback to the upstream chatbot.
+      const userMessageId = memoryService.storeMessage({
+        sessionId: req.sessionId,
+        userId: req.userId,
+        username: req.username,
+        role: 'user',
+        content: req.content,
+      });
+      const assistantMessageId = result.result?.trim()
+        ? memoryService.storeMessage({
+            sessionId: req.sessionId,
+            userId: 'assistant',
+            username: null,
+            role: 'assistant',
+            content: result.result,
+            agentId,
+          })
+        : undefined;
       return attachSessionIdentity({
         ...result,
+        userMessageId,
+        assistantMessageId,
         assistantPresentation:
           getGatewayAssistantPresentationForMessageAgent(agentId),
       });

--- a/src/gateway/response-ratings.ts
+++ b/src/gateway/response-ratings.ts
@@ -1,3 +1,4 @@
+import { findAgentConfig } from '../agents/agent-registry.js';
 import { makeAuditRunId, recordAuditEvent } from '../audit/audit-events.js';
 import {
   getHybridAIApiKey,
@@ -50,11 +51,25 @@ const HYBRIDAI_CHAT_FEEDBACK_URL = `${normalizeBaseUrl(
   HYBRIDAI_BASE_URL,
 )}/api/chat_feedback`;
 
-function resolveHybridAIChatFeedbackBotId(
-  sessionChatbotId: string | null | undefined,
+function resolveProxyAgentChatbotId(
+  agentId: string | null | undefined,
 ): string {
+  if (!agentId?.trim()) return '';
+  try {
+    return findAgentConfig(agentId)?.proxy?.chatbotId?.trim() || '';
+  } catch {
+    return '';
+  }
+}
+
+function resolveHybridAIChatFeedbackBotId(
+  target: Pick<ResponseRatingTarget, 'agent_id' | 'chatbot_id'>,
+): string {
+  // A proxy agent's answers come from its upstream chatbot, so feedback has
+  // to land there rather than on the session's (usually unset) chatbot.
   return (
-    sessionChatbotId?.trim() ||
+    resolveProxyAgentChatbotId(target.agent_id) ||
+    target.chatbot_id?.trim() ||
     OBSERVABILITY_BOT_ID.trim() ||
     HYBRIDAI_CHATBOT_ID.trim() ||
     ''
@@ -90,7 +105,7 @@ async function forwardHybridAIChatFeedbackForRating(input: {
     return;
   }
 
-  const chatbotId = resolveHybridAIChatFeedbackBotId(input.target.chatbot_id);
+  const chatbotId = resolveHybridAIChatFeedbackBotId(input.target);
   if (!chatbotId) return;
 
   const agentId = input.target.agent_id?.trim();

--- a/tests/gateway-proxy-agent.test.ts
+++ b/tests/gateway-proxy-agent.test.ts
@@ -136,8 +136,12 @@ test('handleGatewayMessage forwards proxy agents to HybridAI without running loc
   );
   vi.stubGlobal('fetch', fetchMock);
 
-  const { initDatabase, getConversationHistory, getSessionById } =
-    await import('../src/memory/db.ts');
+  const {
+    initDatabase,
+    getConversationHistory,
+    getLatestAssistantMessageId,
+    getSessionById,
+  } = await import('../src/memory/db.ts');
   const { updateRuntimeConfig } = await import(
     '../src/config/runtime-config.ts'
   );
@@ -207,10 +211,18 @@ test('handleGatewayMessage forwards proxy agents to HybridAI without running loc
     stream: true,
   });
   expect(getSessionById(result.sessionId || 'session-proxy')?.message_count).toBe(
-    0,
+    2,
   );
-  expect(getConversationHistory(result.sessionId || 'session-proxy', 10)).toEqual(
-    [],
+  expect(
+    getConversationHistory(result.sessionId || 'session-proxy', 10).map(
+      (message) => [message.role, message.agent_id, message.content],
+    ),
+  ).toEqual([
+    ['assistant', 'support', 'Hello from HybridAI'],
+    ['user', null, 'Help me'],
+  ]);
+  expect(result.assistantMessageId).toBe(
+    getLatestAssistantMessageId(result.sessionId || 'session-proxy'),
   );
 });
 

--- a/tests/response-ratings.test.ts
+++ b/tests/response-ratings.test.ts
@@ -430,6 +430,55 @@ describe('response ratings', () => {
     });
   });
 
+  test('forwards proxy agent ratings to the upstream chatbot', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const service = await setup({
+      apiKey: 'hai-feedback-test-key',
+      hybridAIBaseUrl: 'https://hybridai.example/',
+      chatbotId: null,
+    });
+    const { updateRuntimeConfig } = await import(
+      '../src/config/runtime-config.js'
+    );
+    const { initAgentRegistry } = await import(
+      '../src/agents/agent-registry.js'
+    );
+    const proxy = {
+      kind: 'hybridai',
+      baseUrl: 'https://app.hybridai.one',
+      chatbotId: 'bot-upstream',
+      apiKey: '<secret:HYBRIDAI_API_KEY>',
+    };
+    updateRuntimeConfig((draft) => {
+      draft.agents.list = [{ id: 'main', proxy }];
+    });
+    initAgentRegistry({ list: [{ id: 'main', proxy }] });
+
+    service.submitResponseRating({
+      sessionId: service.sessionId,
+      messageId: service.assistantMessageId,
+      operatorUserId: 'operator-a',
+      rating: 'down',
+      comment: 'Expected 200',
+      sourceSurface: 'msteams',
+    });
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    const [, request] = fetchMock.mock.calls[0] as [
+      string,
+      RequestInit & { body: string },
+    ];
+    expect(JSON.parse(request.body)).toMatchObject({
+      chatbot_id: 'bot-upstream',
+      rating: 'down',
+      better_response: 'Expected 200',
+    });
+  });
+
   test('forwards non-HybridAI model ratings when a HybridAI bot is active', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,


### PR DESCRIPTION
## Problem

Agents configured with `agents.list[].proxy` (HybridAI proxy agents) forward each turn upstream and return the reply without storing the exchange in the local session. Several channel features are built on the local message history, so on proxy agents they silently do nothing:

- `/thumbs up|down` and Teams 👍/👎 reactions resolve the latest assistant message of the session. With none stored they always answer **"Nothing To Rate: There is no assistant answer in this session to rate yet."**, and nothing is forwarded to the chat feedback endpoint.
- `/new` refuses to rotate a session that has no user messages, so it always answers **"This is already a fresh session."** and never starts a new one.
- `/sessions list` shows every session as `0 msgs` with no snippet, so there is nothing meaningful to switch between.

The upstream conversation id is derived from the HybridClaw session id, so session rotation and switching *would* map onto distinct upstream conversations. The plumbing is there, it just never fires without local messages.

Reproduced on a live gateway (v0.30.0): all Teams sessions of a proxy agent had `message_count: 0` and an empty `response_ratings` table despite daily use.

## Fix

- `gateway-chat-service.ts`: the proxy branch now stores the user and assistant messages (same shape as the A2A branch) and returns `userMessageId` / `assistantMessageId`. This is what makes `/thumbs`, reactions, `/new` and `/sessions list|switch` work on proxy agents.
- `response-ratings.ts`: chat feedback forwarding prefers the agent's `proxy.chatbotId`, falling back to the session chatbot and the existing defaults. Session `chatbot_id` is normally unset for proxy agents, so feedback previously would have landed on the observability/default bot.
- Docs: one line under `agents.list[].proxy`.

Scope note: a proxy agent stays a thin gateway to the upstream chatbot. The local history is only used for ratings and the session list; it is never fed back into prompts, so there is no drift between the two copies. Features that need agent state, skills or tools remain unavailable in proxy mode by design.

## Tests

- Proxy forwarding test now asserts the stored turn and that `getLatestAssistantMessageId` matches the returned id (it previously asserted nothing was stored).
- New `response-ratings` test: rating an answer from a proxy agent posts `chatbot_id` = the proxy's chatbot.
- Ran `response-ratings`, `gateway-proxy-agent`, `gateway-service.thumbs-command`, `msteams.reactions` suites plus `tsc --noEmit --noUnusedLocals --noUnusedParameters` and biome.