### PR TITLE
feat: send session/run/agent/channel correlation headers on hybridai model calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- **HybridAI model calls carry correlation headers**: Every request the agent
+  runtime sends to the `hybridai` provider includes `X-HybridClaw-Session-Id`,
+  `X-HybridClaw-Run-Id`, `X-HybridClaw-Agent-Id`, and `X-HybridClaw-Channel-Id`.
+  The values match the session and run ids in the audit `wire.jsonl`, so the
+  backend traces behind one HybridClaw turn can be grouped and linked back to
+  the local session. Other providers are unaffected.
+
 ## [0.30.0](https://github.com/HybridAIOne/hybridclaw/tree/v0.30.0) - 2026-08-31
 
 ### Added

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -47,6 +47,7 @@ import {
   isHybridAIEmptyVisibleCompletion,
   ProviderRequestError,
   summarizeHybridAICompletionForDebug,
+  withHybridAICorrelationHeaders,
 } from './providers/shared.js';
 import { buildRalphPrompt, normalizeMessageContentToText } from './ralph.js';
 import { injectRuntimeCapabilitiesMessage } from './runtime-capabilities.js';
@@ -1969,6 +1970,14 @@ async function main(): Promise<void> {
   applyRuntimeEnv(firstInput.runtimeEnv);
   storedApiKey = firstInput.apiKey;
   storedRequestHeaders = { ...(firstInput.requestHeaders || {}) };
+  const firstRequestHeaders = withHybridAICorrelationHeaders({
+    provider: firstInput.provider,
+    sessionId: firstInput.sessionId,
+    runId: firstInput.runId,
+    agentId: firstInput.agentId,
+    channelId: firstInput.channelId,
+    requestHeaders: storedRequestHeaders,
+  });
   const firstTaskModels = resolveTaskModelsForRequest(firstInput.taskModels);
 
   console.error(
@@ -2003,7 +2012,7 @@ async function main(): Promise<void> {
     storedApiKey,
     firstInput.model,
     firstInput.chatbotId,
-    storedRequestHeaders,
+    firstRequestHeaders,
     firstInput.maxTokens,
     firstInput.modelBehavior,
     firstInput.debugModelResponses === true,
@@ -2060,7 +2069,7 @@ async function main(): Promise<void> {
       model: firstInput.model,
       chatbotId: firstInput.chatbotId,
       enableRag: firstInput.enableRag,
-      requestHeaders: storedRequestHeaders,
+      requestHeaders: firstRequestHeaders,
       ...inputRuntimeContext(firstInput),
       tools: resolveTools(firstInput),
       taskModels: firstTaskModels,
@@ -2156,10 +2165,17 @@ async function main(): Promise<void> {
 
     // Use stored apiKey — IPC file no longer contains it
     const apiKey = input.apiKey || storedApiKey;
-    const requestHeaders =
-      input.requestHeaders && Object.keys(input.requestHeaders).length > 0
-        ? input.requestHeaders
-        : storedRequestHeaders;
+    const requestHeaders = withHybridAICorrelationHeaders({
+      provider: input.provider,
+      sessionId: input.sessionId,
+      runId: input.runId,
+      agentId: input.agentId,
+      channelId: input.channelId,
+      requestHeaders:
+        input.requestHeaders && Object.keys(input.requestHeaders).length > 0
+          ? input.requestHeaders
+          : storedRequestHeaders,
+    });
     if (input.apiKey) storedApiKey = input.apiKey;
     if (input.requestHeaders && Object.keys(input.requestHeaders).length > 0) {
       storedRequestHeaders = { ...input.requestHeaders };

--- a/container/src/providers/shared.ts
+++ b/container/src/providers/shared.ts
@@ -7,6 +7,7 @@ import { normalizeMessageContentToText } from '../ralph.js';
 import type {
   ChatCompletionResponse,
   ChatMessage,
+  ContainerInput,
   ToolDefinition,
 } from '../types.js';
 import { isRuntimeProvider, type RuntimeProvider } from './provider-ids.js';
@@ -277,6 +278,39 @@ function normalizeCallModelBehavior(
     ...(rawBehavior || {}),
     ...(thinkingFormat ? { thinkingFormat } : {}),
   });
+}
+
+const HYBRIDAI_CORRELATION_HEADERS = {
+  sessionId: 'X-HybridClaw-Session-Id',
+  runId: 'X-HybridClaw-Run-Id',
+  agentId: 'X-HybridClaw-Agent-Id',
+  channelId: 'X-HybridClaw-Channel-Id',
+} as const;
+
+type HybridAICorrelationKey = keyof typeof HYBRIDAI_CORRELATION_HEADERS;
+
+function normalizeHeaderValue(value: string | undefined): string {
+  return String(value ?? '')
+    .replace(/[^\x20-\x7e]/g, '')
+    .trim()
+    .slice(0, 256);
+}
+
+export function withHybridAICorrelationHeaders(
+  params: Partial<Record<HybridAICorrelationKey, string>> & {
+    provider: ContainerInput['provider'];
+    requestHeaders?: Record<string, string>;
+  },
+): Record<string, string> | undefined {
+  if (params.provider !== 'hybridai') return params.requestHeaders;
+  const headers = { ...(params.requestHeaders || {}) };
+  for (const key of Object.keys(
+    HYBRIDAI_CORRELATION_HEADERS,
+  ) as HybridAICorrelationKey[]) {
+    const value = normalizeHeaderValue(params[key]);
+    if (value) headers[HYBRIDAI_CORRELATION_HEADERS[key]] = value;
+  }
+  return headers;
 }
 
 export function buildRequestHeaders(

--- a/container/src/types.ts
+++ b/container/src/types.ts
@@ -230,6 +230,7 @@ export interface ContainerInput {
     nonce: string;
   };
   sessionId: string;
+  runId?: string;
   agentId?: string;
   messages: ChatMessage[];
   chatbotId: string;

--- a/docs/content/developer-guide/runtime.md
+++ b/docs/content/developer-guide/runtime.md
@@ -356,6 +356,10 @@ HybridClaw records forensic audit events by default:
   `~/.hybridclaw/data/audit/<session>/wire.jsonl`
 - tamper-evident hash chain from `_prevHash` to `_hash`
 - normalized SQLite tables: `audit_events` and `approvals`
+- model calls to the `hybridai` provider carry `X-HybridClaw-Session-Id`,
+  `X-HybridClaw-Run-Id`, `X-HybridClaw-Agent-Id`, and `X-HybridClaw-Channel-Id`
+  headers whose values match the `sessionId` and `runId` of the wire log, so
+  backend traces of one turn can be linked to the local audit trail
 - first-run `BOOTSTRAP.md` hatching emits structured `onboarding.*` events
   for lifecycle state, visible messages, welcome mail, workspace file updates,
   completion, and abort paths

--- a/src/agent/executor-types.ts
+++ b/src/agent/executor-types.ts
@@ -15,6 +15,7 @@ import type { ScheduledTask } from '../types/scheduler.js';
 
 export interface ExecutorRequest {
   sessionId: string;
+  runId?: string;
   messages: ChatMessage[];
   chatbotId: string;
   enableRag: boolean;

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -2063,6 +2063,7 @@ async function handleGatewayMessageInner(
     }) =>
       runAgent({
         sessionId: req.executionSessionId || req.sessionId,
+        runId,
         messages,
         chatbotId: params.chatbotId,
         enableRag,
@@ -2167,6 +2168,7 @@ async function handleGatewayMessageInner(
     } else {
       output = await runAgent({
         sessionId: req.executionSessionId || req.sessionId,
+        runId,
         messages,
         chatbotId,
         enableRag,

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -9193,6 +9193,7 @@ export async function ensureGatewayBootstrapAutostart(params: {
 
     const output = await runAgent({
       sessionId: session.id,
+      runId,
       messages,
       chatbotId,
       enableRag,

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -1133,6 +1133,7 @@ async function runContainerInner(
 
   const input: ContainerInput = {
     sessionId,
+    runId: params.runId,
     agentId,
     messages,
     chatbotId: modelRuntime.chatbotId,

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -976,6 +976,7 @@ async function runHostProcessInner(
 
   const input: ContainerInput = {
     sessionId,
+    runId: params.runId,
     agentId,
     messages,
     chatbotId: modelRuntime.chatbotId,

--- a/src/scheduler/heartbeat.ts
+++ b/src/scheduler/heartbeat.ts
@@ -279,6 +279,7 @@ export function startHeartbeat(
       });
       const output = await runAgent({
         sessionId,
+        runId,
         messages,
         chatbotId,
         enableRag,

--- a/src/scheduler/scheduled-task-runner.ts
+++ b/src/scheduler/scheduled-task-runner.ts
@@ -128,6 +128,7 @@ export async function runIsolatedScheduledTask(params: {
   try {
     const output = await runAgent({
       sessionId: activeSessionId,
+      runId,
       messages,
       chatbotId,
       enableRag: false,

--- a/src/types/container.ts
+++ b/src/types/container.ts
@@ -67,6 +67,7 @@ export interface ContainerInput {
     nonce: string;
   };
   sessionId: string;
+  runId?: string;
   agentId?: string;
   messages: ChatMessage[];
   chatbotId: string;

--- a/tests/container.hybridai-correlation-headers.test.ts
+++ b/tests/container.hybridai-correlation-headers.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from 'vitest';
+import { withHybridAICorrelationHeaders } from '../container/src/providers/shared.js';
+
+const BASE = { 'User-Agent': 'hybridclaw-test' };
+
+test('hybridai calls carry session, run, agent, and channel correlation headers', () => {
+  expect(
+    withHybridAICorrelationHeaders({
+      provider: 'hybridai',
+      sessionId: 'discord:guild:1:channel:2',
+      runId: 'turn_1725000000000_abcd1234',
+      agentId: 'main',
+      channelId: 'discord',
+      requestHeaders: BASE,
+    }),
+  ).toEqual({
+    'User-Agent': 'hybridclaw-test',
+    'X-HybridClaw-Session-Id': 'discord:guild:1:channel:2',
+    'X-HybridClaw-Run-Id': 'turn_1725000000000_abcd1234',
+    'X-HybridClaw-Agent-Id': 'main',
+    'X-HybridClaw-Channel-Id': 'discord',
+  });
+});
+
+test('correlation headers are provider-scoped to hybridai', () => {
+  expect(
+    withHybridAICorrelationHeaders({
+      provider: 'openai',
+      sessionId: 'session-1',
+      runId: 'turn_1',
+      agentId: 'main',
+      channelId: 'console',
+      requestHeaders: BASE,
+    }),
+  ).toBe(BASE);
+  expect(
+    withHybridAICorrelationHeaders({
+      provider: 'anthropic',
+      sessionId: 'session-1',
+    }),
+  ).toBeUndefined();
+});
+
+test('missing or unsafe correlation values are omitted or sanitized', () => {
+  expect(
+    withHybridAICorrelationHeaders({
+      provider: 'hybridai',
+      sessionId: 'session-1',
+      runId: undefined,
+      agentId: '',
+      channelId: 'bad\r\nX-Injected: 1',
+      requestHeaders: BASE,
+    }),
+  ).toEqual({
+    'User-Agent': 'hybridclaw-test',
+    'X-HybridClaw-Session-Id': 'session-1',
+    'X-HybridClaw-Channel-Id': 'badX-Injected: 1',
+  });
+});


### PR DESCRIPTION
## Problem

The `hybridai` provider only sent `User-Agent` on model calls. The backend already parses `X-HybridClaw-Session-Id`, `X-HybridClaw-Run-Id`, `X-HybridClaw-Agent-Id`, and `X-HybridClaw-Channel-Id` and attaches them to its LLM traces, but HybridClaw never set them, so the 5–15 backend traces behind one turn could not be grouped or linked back to the session / audit `wire.jsonl` (issue #1455).

## Why not in `resolveHybridAIRuntimeCredentials`

The issue proposes adding the headers on the host side in the provider. That does not work for pooled workers:

- `requestHeaders` feeds `computeWorkerSignature`, so per-turn values would respawn the worker on every turn.
- Later turns are written to the IPC input file with `requestHeaders: {}` (secret redaction), and the container falls back to the headers stored from the first request. Per-turn correlation would be stale after the first turn.

So the headers are attached inside the runtime from the per-turn `ContainerInput`, which already carries `sessionId`, `agentId`, and `channelId`. Only the run id needed plumbing.

## Fix

Two commits, gateway and container kept separate per AGENTS.md.

**Gateway**
- `ExecutorRequest` and `ContainerInput` gain `runId?: string`.
- Chat, heartbeat, cron, and bootstrap paths pass their existing audit `runId` into `runAgent`, and both executors forward it into the container input. The worker signature is untouched.

**Container**
- `withHybridAICorrelationHeaders()` in `providers/shared.ts` merges the four headers onto the base headers for `provider === 'hybridai'` only. Values are trimmed, stripped of non-printable characters (so a stray CR/LF cannot inject a header), and capped at 256 chars. Empty values are omitted.
- `index.ts` applies it on the first stdin request and on every IPC turn, and passes the merged set to `setModelContext`, so in-container auxiliary calls to HybridAI carry the same ids. `storedRequestHeaders` keeps only the host-supplied base headers.
- Docs note under the audit section of `developer-guide/runtime.md`, changelog entry under Unreleased.

`traceparent` from the issue's optional proposal is left out to keep this minimal.

## Tests

- New `container.hybridai-correlation-headers` suite: headers attached for hybridai, untouched for other providers, empty values omitted, CR/LF stripped.
- Ran `container.hybridai-provider`, `container-runner.redaction`, `hybridai-retry`, `npm run lint`, container lint, and biome.
- `host-runner.worker-restart` fails in my environment identically on `main` (spawn mocks never called), unrelated to this change.

Closes #1455
