### PR TITLE
fix(langfuse): migrate trace reads to observations v2

### DIFF
--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -219,11 +219,13 @@ node skills/langfuse/langfuse.cjs --format json run list-traces --host https://u
   of scope. Use the Langfuse UI for those.
 - Page size is capped at 100; use `--page` (legacy) or `--cursor` (modern
   endpoints) to paginate. The helper rejects `--limit` above 100.
-- For broad trace queries that time out on Langfuse Cloud, prefer
-  `list-observations` (with `--trace-id` when traversing from a known trace).
-- In OpenTelemetry-instrumented apps, trace-level `input`/`output` can be null —
-  the content lives in a `GENERATION` observation, so read observations to see
-  prompts/outputs.
+- Trace reads use Langfuse's v2 Observations API. `list-traces` returns logical
+  root observation rows (one application root per trace); `get-trace` returns
+  every observation row sharing the requested trace ID. Follow `meta.cursor`
+  with `--cursor` when more rows are available.
+- Langfuse v4 has no separate trace-level `input`/`output`. Reconstruct them
+  from the root observation; prompts and outputs may instead live on a child
+  `GENERATION` observation.
 - Before creating a score config, list existing ones (`list-score-configs`);
   configs cannot be deleted.
 - Never print, inspect, or ask for `LANGFUSE_BASIC_AUTH`; the gateway injects it

--- a/skills/langfuse/langfuse.cjs
+++ b/skills/langfuse/langfuse.cjs
@@ -10,6 +10,7 @@ const BASIC_AUTH_SECRET = 'LANGFUSE_BASIC_AUTH';
 const HOST_ENV = 'LANGFUSE_HOST';
 const HOST_PLACEHOLDER = `<env:${HOST_ENV}>`;
 const EVAL_SCENARIOS_PATH = path.join(__dirname, 'evals', 'scenarios.json');
+const TRACE_OBSERVATION_FIELDS = 'core,basic,io,trace_context';
 
 const COST_MEASUREMENT = {
   system: 'UsageTotals',
@@ -226,14 +227,22 @@ function buildHttpRequest(operation, { base, secretName, url, method = 'GET', js
   return payload;
 }
 
-function parsePagination(args, query) {
+function parsePagination(args, query, { cursorOnly = false } = {}) {
   const page = popFlag(args, '--page');
-  if (page !== undefined) query.page = parsePositiveInteger(page, '--page');
+  if (page !== undefined) {
+    if (cursorOnly) {
+      die('--page is not supported by Langfuse v2; pass meta.cursor with --cursor.');
+    }
+    query.page = parsePositiveInteger(page, '--page');
+  }
   const limit = popFlag(args, '--limit');
   if (limit !== undefined) {
     const value = parsePositiveInteger(limit, '--limit');
     if (value > 100) {
-      die('--limit cannot exceed 100 (Langfuse page-size cap); use --page to paginate.');
+      const paginationFlag = cursorOnly ? '--cursor' : '--page';
+      die(
+        `--limit cannot exceed 100 (Langfuse page-size cap); use ${paginationFlag} to paginate.`,
+      );
     }
     query.limit = value;
   }
@@ -301,26 +310,73 @@ function commandHttpRequest(args) {
       payload = build({ url: '/api/public/projects' });
       break;
     case 'list-traces': {
-      const query = {};
-      parsePagination(args, query);
-      query.userId = popFlag(args, '--user-id');
-      query.name = popFlag(args, '--name');
-      query.sessionId = popFlag(args, '--session-id');
-      query.fromTimestamp = popFlag(args, '--from-timestamp');
-      query.toTimestamp = popFlag(args, '--to-timestamp');
-      query.environment = popRepeatedFlag(args, '--environment');
-      query.tags = popRepeatedFlag(args, '--tag');
-      query.version = popFlag(args, '--version');
-      query.release = popFlag(args, '--release');
-      query.orderBy = popFlag(args, '--order-by');
-      payload = build({ url: appendQuery('/api/public/traces', query) });
+      const query = { fields: TRACE_OBSERVATION_FIELDS };
+      parsePagination(args, query, { cursorOnly: true });
+      query.fromStartTime = popFlag(args, '--from-timestamp');
+      query.toStartTime = popFlag(args, '--to-timestamp');
+
+      const filters = [
+        {
+          type: 'boolean',
+          column: 'isRootObservation',
+          operator: '=',
+          value: true,
+        },
+      ];
+      const userId = popFlag(args, '--user-id');
+      if (userId !== undefined) {
+        filters.push({ type: 'string', column: 'userId', operator: '=', value: userId });
+      }
+      const name = popFlag(args, '--name');
+      if (name !== undefined) {
+        filters.push({
+          type: 'stringOptions',
+          column: 'traceName',
+          operator: 'any of',
+          value: [name],
+        });
+      }
+      const sessionId = popFlag(args, '--session-id');
+      if (sessionId !== undefined) {
+        filters.push({
+          type: 'string',
+          column: 'sessionId',
+          operator: '=',
+          value: sessionId,
+        });
+      }
+      const environments = popRepeatedFlag(args, '--environment');
+      if (environments.length > 0) {
+        filters.push({
+          type: 'stringOptions',
+          column: 'environment',
+          operator: 'any of',
+          value: environments,
+        });
+      }
+      const tags = popRepeatedFlag(args, '--tag');
+      if (tags.length > 0) {
+        filters.push({
+          type: 'arrayOptions',
+          column: 'tags',
+          operator: 'all of',
+          value: tags,
+        });
+      }
+      query.filter = JSON.stringify(filters);
+      payload = build({ url: appendQuery('/api/public/v2/observations', query) });
       break;
     }
-    case 'get-trace':
+    case 'get-trace': {
+      const query = {
+        fields: TRACE_OBSERVATION_FIELDS,
+        traceId: requireText(popFlag(args, '--trace-id'), '--trace-id'),
+      };
       payload = build({
-        url: `/api/public/traces/${encodeSegment(popFlag(args, '--trace-id'), '--trace-id')}`,
+        url: appendQuery('/api/public/v2/observations', query),
       });
       break;
+    }
     case 'list-observations': {
       const query = {};
       parsePagination(args, query);
@@ -791,7 +847,7 @@ Pagination (list operations):
 Read operations (green):
   health
   get-project
-  list-traces [--user-id u] [--name n] [--session-id s] [--from-timestamp iso] [--to-timestamp iso] [--tag t]... [--environment e]... [--page p] [--limit l]
+  list-traces [--user-id u] [--name n] [--session-id s] [--from-timestamp iso] [--to-timestamp iso] [--tag t]... [--environment e]... [--cursor c] [--limit l]
   get-trace --trace-id id
   list-observations [--name n] [--type GENERATION|SPAN|EVENT] [--trace-id id] [--user-id u] [--from-start-time iso] [--page p] [--limit l]
   get-observation --observation-id id

--- a/skills/langfuse/references/cli.md
+++ b/skills/langfuse/references/cli.md
@@ -6,7 +6,7 @@ Documentation: https://langfuse.com/docs/api-and-data-platform/features/cli
 > instead of `langfuse-cli`, and do not export `LANGFUSE_PUBLIC_KEY` /
 > `LANGFUSE_SECRET_KEY` — the gateway injects credentials from
 > `LANGFUSE_BASIC_AUTH`. The endpoint, pagination (`--page` / `--cursor`,
-> `--limit` ≤ 100), and v2-vs-legacy guidance below still describes the REST API
+> `--limit` ≤ 100), and API-version guidance below still describes the REST API
 > the helper calls. See SKILL.md section 1.
 
 ## Install
@@ -55,5 +55,5 @@ export LANGFUSE_BASE_URL=https://cloud.langfuse.com
 - Prefer `observations` over `legacy-observations-v1s` — `observations` is the modern high-performance endpoint (cursor pagination, selective field groups); `legacy-observations-v1s` is the deprecated v1
 - Prefer `metrics` over `legacy-metrics-v1s` for the same reason
 - Prefer `scores` over `legacy-score-v1s` for list/get operations
-- For broad trace queries, `traces list` can time out on Langfuse Cloud — use `observations list` (with `--trace-id` if you're traversing from a known trace) instead. See the [Observations API docs](https://langfuse.com/docs/api-and-data-platform/features/observations-api) for the v1 → v2 mapping.
-- Pagination: legacy v1 endpoints use `--limit` and `--page`; modern endpoints (`observations`, `metrics`, `scores`) use cursor-based pagination — pass `--limit`, then thread `meta.cursor` from the response into the next request's `--cursor`
+- `list-traces` and `get-trace` use the v2 Observations API. The list operation returns logical root rows; the get operation returns all rows sharing a trace ID. See the [deprecated API migration guide](https://langfuse.com/faq/all/deprecated-api-migration#traces) for the response-shape change.
+- Pagination: legacy v1 endpoints use `--limit` and `--page`; modern endpoints (`traces`, `observations`, `metrics`, `scores`) use cursor-based pagination — pass `--limit`, then thread `meta.cursor` from the response into the next request's `--cursor`

--- a/skills/langfuse/references/error-analysis.md
+++ b/skills/langfuse/references/error-analysis.md
@@ -103,5 +103,5 @@ When a category warrants an evaluator setup, propose the type of evaluator and o
 | `objectType: TRACE` in queue | Use `objectType: OBSERVATION` with GENERATION obs ID |
 | Creating score config without checking existing | `GET /api/public/score-configs` first; can't delete |
 | Queue created before score configs | Create configs → collect IDs → create queue |
-| `--limit` > 100 on traces list | API hard cap; paginate with `--page` |
+| `--limit` > 100 on traces list | Helper safety cap; paginate with `--cursor` |
 | No rate limiting on queue item creation | `sleep 0.4` between calls to avoid 429 |

--- a/tests/langfuse-skill.test.ts
+++ b/tests/langfuse-skill.test.ts
@@ -115,6 +115,10 @@ test('langfuse helper enforces the 100 page-size cap and forwards cursor', () =>
   expect(overLimit.status).not.toBe(0);
   expect(overLimit.stderr).toContain('cannot exceed 100');
 
+  const tracePage = build(['list-traces', '--page', '2']);
+  expect(tracePage.status).not.toBe(0);
+  expect(tracePage.stderr).toContain('pass meta.cursor with --cursor');
+
   const cursored = build(['list-observations', '--limit', '100', '--cursor', 'abc']);
   expect(cursored.status).toBe(0);
   expect(JSON.parse(cursored.stdout).httpRequest.url).toBe(
@@ -163,7 +167,25 @@ test('langfuse helper runs when copied as a standalone skill package', () => {
 });
 
 test('langfuse helper builds gateway-backed reads with placeholder auth and host', () => {
-  const traces = build(['list-traces', '--user-id', 'alice', '--limit', '50']);
+  const traces = build([
+    'list-traces',
+    '--user-id',
+    'alice',
+    '--name',
+    'support-chat',
+    '--session-id',
+    'session-1',
+    '--tag',
+    'production',
+    '--environment',
+    'prod',
+    '--from-timestamp',
+    '2026-09-01T00:00:00Z',
+    '--to-timestamp',
+    '2026-09-02T00:00:00Z',
+    '--limit',
+    '50',
+  ]);
   const prompt = build([
     'get-prompt',
     '--host',
@@ -180,7 +202,6 @@ test('langfuse helper builds gateway-backed reads with placeholder auth and host
     operation: 'list-traces',
     stakesTier: 'green',
     httpRequest: {
-      url: '<env:LANGFUSE_HOST>/api/public/traces?limit=50&userId=alice',
       method: 'GET',
       headers: { Authorization: 'Basic <secret:LANGFUSE_BASIC_AUTH>' },
       skillName: 'langfuse',
@@ -197,10 +218,57 @@ test('langfuse helper builds gateway-backed reads with placeholder auth and host
   expect(tracesPayload.httpRequest).not.toHaveProperty('secretHeaders');
   expect(traces.stdout).not.toContain('Bearer');
 
+  const tracesUrl = new URL(
+    tracesPayload.httpRequest.url.replace('<env:LANGFUSE_HOST>', 'https://example.com'),
+  );
+  expect(tracesUrl.pathname).toBe('/api/public/v2/observations');
+  expect(tracesUrl.searchParams.get('fields')).toBe('core,basic,io,trace_context');
+  expect(tracesUrl.searchParams.get('limit')).toBe('50');
+  expect(tracesUrl.searchParams.get('fromStartTime')).toBe('2026-09-01T00:00:00Z');
+  expect(tracesUrl.searchParams.get('toStartTime')).toBe('2026-09-02T00:00:00Z');
+  expect(JSON.parse(tracesUrl.searchParams.get('filter') || '[]')).toEqual([
+    { type: 'boolean', column: 'isRootObservation', operator: '=', value: true },
+    { type: 'string', column: 'userId', operator: '=', value: 'alice' },
+    {
+      type: 'stringOptions',
+      column: 'traceName',
+      operator: 'any of',
+      value: ['support-chat'],
+    },
+    { type: 'string', column: 'sessionId', operator: '=', value: 'session-1' },
+    {
+      type: 'stringOptions',
+      column: 'environment',
+      operator: 'any of',
+      value: ['prod'],
+    },
+    {
+      type: 'arrayOptions',
+      column: 'tags',
+      operator: 'all of',
+      value: ['production'],
+    },
+  ]);
+
   expect(prompt.status).toBe(0);
   expect(JSON.parse(prompt.stdout).httpRequest.url).toBe(
     'https://us.cloud.langfuse.com/api/public/v2/prompts/team%2Fsupport%20reply?label=production',
   );
+});
+
+test('langfuse helper gets a trace through v2 observations', () => {
+  const result = build(['get-trace', '--trace-id', 'trace/id']);
+
+  expect(result.status).toBe(0);
+  const url = new URL(
+    JSON.parse(result.stdout).httpRequest.url.replace(
+      '<env:LANGFUSE_HOST>',
+      'https://example.com',
+    ),
+  );
+  expect(url.pathname).toBe('/api/public/v2/observations');
+  expect(url.searchParams.get('traceId')).toBe('trace/id');
+  expect(url.searchParams.get('fields')).toBe('core,basic,io,trace_context');
 });
 
 test('langfuse helper forwards metrics query and rejects invalid JSON', () => {
@@ -357,11 +425,13 @@ test('langfuse helper run executes requests through the gateway', async () => {
     expect(result.status).toBe(0);
     expect(receivedAuthorization).toBe('Bearer gateway-token');
     expect(receivedBody).toMatchObject({
-      url: '<env:LANGFUSE_HOST>/api/public/traces?userId=alice',
       method: 'GET',
       headers: { Authorization: 'Basic <secret:LANGFUSE_BASIC_AUTH>' },
       skillName: 'langfuse',
     });
+    expect(String(receivedBody?.url)).toContain(
+      '<env:LANGFUSE_HOST>/api/public/v2/observations?',
+    );
     expect(JSON.parse(result.stdout)).toMatchObject({
       command: 'run',
       operation: 'list-traces',


### PR DESCRIPTION
## Summary

- route `list-traces` and `get-trace` through Langfuse's supported `GET /api/public/v2/observations` endpoint
- translate trace filters to the v2 filter schema and return logical root observations for trace lists
- request trace context explicitly and use cursor pagination
- update the bundled skill guidance and regression coverage for the v4 response shape

Langfuse Cloud reported 110 recent calls from this helper to the deprecated `GET /api/public/traces` endpoint. That endpoint is scheduled to stop working after November 16, 2026.

## Validation

- `npm exec vitest -- run tests/langfuse-skill.test.ts`
- `npm run lint`
- `npm exec tsx src/cli.ts skill list`
- `npm run format`

Docs: https://langfuse.com/faq/all/deprecated-api-migration#traces