### PR TITLE
fix(console): avoid PostCSS composition warning

### DIFF
--- a/console/design-system-contract.test.ts
+++ b/console/design-system-contract.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 const CONSOLE_ROOT = path.dirname(fileURLToPath(import.meta.url));
 const SRC_ROOT = path.join(CONSOLE_ROOT, 'src');
 const LEGACY_ACTION_CLASS = /\b(?:primary|secondary|ghost|danger)-button\b/u;
+const CROSS_FILE_COMPOSITION = /^\s*composes:.*\bfrom\b/mu;
 
 function sourceFiles(directory: string): string[] {
   return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -20,6 +21,17 @@ describe('console design-system contract', () => {
     const violations = sourceFiles(SRC_ROOT).flatMap((file) => {
       const source = fs.readFileSync(file, 'utf8');
       return LEGACY_ACTION_CLASS.test(source)
+        ? [path.relative(SRC_ROOT, file)]
+        : [];
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('imports shared CSS Module classes without cross-file composition', () => {
+    const violations = sourceFiles(SRC_ROOT).flatMap((file) => {
+      const source = fs.readFileSync(file, 'utf8');
+      return CROSS_FILE_COMPOSITION.test(source)
         ? [path.relative(SRC_ROOT, file)]
         : [];
     });

--- a/console/src/components/dialog/index.module.css
+++ b/console/src/components/dialog/index.module.css
@@ -195,9 +195,3 @@
 .drawerOpen {
   transform: translate(0);
 }
-
-/* Accessibility: screen-reader-only utility used by drawer header */
-
-.srOnly {
-  composes: srOnly from "../../lib/a11y.module.css";
-}

--- a/console/src/components/dialog/index.tsx
+++ b/console/src/components/dialog/index.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../hooks/useFocusTrap';
 import { useHideOthers } from '../../hooks/useHideOthers';
 import { useScrollLock } from '../../hooks/useScrollLock';
+import a11yStyles from '../../lib/a11y.module.css';
 import { cx } from '../../lib/cx';
 import styles from './index.module.css';
 
@@ -258,7 +259,7 @@ export function DialogHeader(props: {
   return (
     <div
       className={cx(
-        props.visuallyHidden ? styles.srOnly : styles.header,
+        props.visuallyHidden ? a11yStyles.srOnly : styles.header,
         props.className,
       )}
     >

--- a/console/src/components/whats-new.module.css
+++ b/console/src/components/whats-new.module.css
@@ -44,10 +44,6 @@
   text-transform: uppercase;
 }
 
-.srOnly {
-  composes: srOnly from "../lib/a11y.module.css";
-}
-
 .highlights {
   display: grid;
   gap: 10px;

--- a/console/src/components/whats-new.tsx
+++ b/console/src/components/whats-new.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import a11yStyles from '../lib/a11y.module.css';
 import { getReleaseHighlights, LATEST_RELEASE_NOTES } from '../release-notes';
 import { Button } from './button';
 import {
@@ -69,7 +70,7 @@ export function WhatsNew(props: {
             <span className={styles.eyebrow}>HybridClaw update</span>
             <DialogTitle>What&apos;s new in v{props.version}</DialogTitle>
           </div>
-          <DialogDescription className={styles.srOnly}>
+          <DialogDescription className={a11yStyles.srOnly}>
             Release highlights for HybridClaw v{props.version}.
           </DialogDescription>
         </DialogHeader>

--- a/console/src/routes/chat/chat-page.module.css
+++ b/console/src/routes/chat/chat-page.module.css
@@ -2113,10 +2113,6 @@ aside[data-state="collapsed"] .chatSidebarContent {
   color: var(--muted-foreground);
 }
 
-.slashLiveRegion {
-  composes: srOnly from "../../lib/a11y.module.css";
-}
-
 @media (max-width: 768px) {
   .approvalDetailRow {
     grid-template-columns: 1fr;

--- a/console/src/routes/chat/composer.tsx
+++ b/console/src/routes/chat/composer.tsx
@@ -24,6 +24,7 @@ import type {
   MediaItem,
 } from '../../api/chat-types';
 import { Popover, PopoverAnchor } from '../../components/popover';
+import a11yStyles from '../../lib/a11y.module.css';
 import { extractClipboardFiles } from '../../lib/chat-helpers';
 import { cx } from '../../lib/cx';
 import { pluralize } from '../../lib/format';
@@ -763,11 +764,7 @@ export function Composer(props: {
           />
         ) : null}
       </Popover>
-      <div
-        className={css.slashLiveRegion}
-        aria-live="polite"
-        aria-atomic="true"
-      >
+      <div className={a11yStyles.srOnly} aria-live="polite" aria-atomic="true">
         {liveMessage}
       </div>
     </div>


### PR DESCRIPTION
## Summary

- import the shared screen-reader-only CSS Module class directly at its React call sites
- remove cross-file CSS composition that produces source-less PostCSS declarations in Vite
- add a design-system contract test preventing cross-file composition from returning

## Testing

- corepack npm run lint
- corepack npm --workspace console run test (105 files, 945 tests)
- corepack npm --workspace console run build (passes without the PostCSS warning)