### PR TITLE
fix(gateway): resolve session keys when answering pending approvals

### DIFF
--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -283,6 +283,7 @@ import {
 import {
   handleTextChannelApprovalCommand,
   renderTextChannelCommandResult,
+  resolvePendingApprovalSessionId,
   resolveTextChannelSlashCommands,
 } from './text-channel-commands.js';
 import { persistVoiceTranscript } from './voice-transcript-store.js';
@@ -786,7 +787,9 @@ function resolveImplicitNumericApprovalArgs(params: {
   userId: string;
   content: string;
 }): string[] | null {
-  const pending = getPendingApproval(params.sessionId);
+  const pending = getPendingApproval(
+    resolvePendingApprovalSessionId(params.sessionId),
+  );
   if (!pending || pending.userId !== params.userId) return null;
 
   const normalized = params.content.trim();

--- a/src/gateway/text-channel-commands.ts
+++ b/src/gateway/text-channel-commands.ts
@@ -6,6 +6,7 @@ import {
 } from '../approval-commands.js';
 import { buildResponseText } from '../channels/discord/delivery.js';
 import { parseIdArg, parseLowerArg } from '../command-parsing.js';
+import { memoryService } from '../memory/memory-service.js';
 import {
   mapTuiSlashCommandToGatewayArgs,
   parseTuiSlashCommand,
@@ -126,6 +127,24 @@ function buildApprovalUserMessage(params: {
   return null;
 }
 
+/**
+ * Channels address sessions by their session key while pending approvals are
+ * remembered under the resolved session instance id. Resolve the key so a
+ * bare numeric reply or `/approve` finds the prompt after a session rotation.
+ */
+export function resolvePendingApprovalSessionId(sessionId: string): string {
+  if (getPendingApproval(sessionId)) return sessionId;
+  const resolvedSessionId = memoryService.getSessionById(sessionId)?.id;
+  if (
+    resolvedSessionId &&
+    resolvedSessionId !== sessionId &&
+    getPendingApproval(resolvedSessionId)
+  ) {
+    return resolvedSessionId;
+  }
+  return sessionId;
+}
+
 export async function handleTextChannelApprovalCommand(params: {
   sessionId: string;
   guildId: string | null;
@@ -138,7 +157,8 @@ export async function handleTextChannelApprovalCommand(params: {
   if (parseLowerArg(args, 0) !== 'approve') return null;
 
   await cleanupExpiredPendingApprovals();
-  const pending = getPendingApproval(sessionId);
+  const pendingSessionId = resolvePendingApprovalSessionId(sessionId);
+  const pending = getPendingApproval(pendingSessionId);
   const action = parseLowerArg(args, 1, { defaultValue: 'view' });
   const providedApprovalId = parseIdArg(args, 2);
   const currentApprovalId = pending?.approvalId || '';
@@ -256,7 +276,7 @@ export async function handleTextChannelApprovalCommand(params: {
       };
     }
 
-    await clearPendingApproval(sessionId, { disableButtons: true });
+    await clearPendingApproval(pendingSessionId, { disableButtons: true });
     if (
       action === 'no' ||
       action === 'deny' ||

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -2545,6 +2545,72 @@ describe('gateway bootstrap', () => {
     await pendingApprovals.clearPendingApproval('teams:dm:user-aad-id');
   });
 
+  test('resolves Teams numeric approvals when the prompt is stored under the session instance id', async () => {
+    const state = await importFreshGatewayMain();
+    const pendingApprovals = await import(
+      '../src/gateway/pending-approvals.js'
+    );
+    const sessionKey = 'agent_main_channel_msteams_dm_user-aad-id';
+    const sessionInstanceId = 'sess_20260904_111833_744e0245';
+    const previousSessionId = state.currentSession.id;
+    state.currentSession.id = sessionInstanceId;
+    await pendingApprovals.setPendingApproval(sessionInstanceId, {
+      approvalId: 'approve123',
+      prompt: 'Need approval',
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+      userId: 'user-aad-id',
+      resolvedAt: null,
+      disableButtons: null,
+      disableTimeout: null,
+    });
+    state.handleGatewayMessage.mockResolvedValue({
+      status: 'success',
+      result: 'Approved.',
+      toolsUsed: [],
+      artifacts: [],
+    });
+    const stream = {
+      append: vi.fn(async () => {}),
+      discard: vi.fn(async () => {}),
+      fail: vi.fn(async () => {}),
+      finalize: vi.fn(async () => {}),
+    };
+    const reply = vi.fn(async () => {});
+    const context = {
+      abortSignal: new AbortController().signal,
+      activity: { id: 'activity-1' },
+      policy: { replyStyle: 'thread' },
+      stream,
+      turnContext: { sendActivities: vi.fn() },
+    };
+
+    try {
+      await state.teamsMessageHandler?.(
+        sessionKey,
+        null,
+        'a:teams-current-conversation',
+        'user-aad-id',
+        'alice',
+        '4',
+        [],
+        reply,
+        context,
+      );
+
+      expect(state.handleGatewayMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: 'yes approve123 for all',
+          sessionId: sessionKey,
+        }),
+      );
+      expect(reply).toHaveBeenCalledWith('Approved.');
+    } finally {
+      state.currentSession.id = previousSessionId;
+      await pendingApprovals.clearPendingApproval(sessionInstanceId);
+    }
+  });
+
   test('routes WhatsApp slash commands through the gateway command handler', async () => {
     const state = await importFreshGatewayMain({ whatsappLinked: true });
     const reply = vi.fn(async () => {});


### PR DESCRIPTION
## Problem

Chat channels address a conversation by its session key, while pending approval prompts are remembered under the resolved session instance id. After a session rotation the two differ, so a bare numeric reply such as `4` (or `/approve 4`) did not find the pending prompt. The reply was forwarded to the agent as a new message, the agent re-ran the tool, and the same approval was requested again. Observed on Microsoft Teams; the lookup is shared by the other text channels.

## Fix

Resolve the session key to its current session instance before looking up the pending approval, in both the implicit numeric reply path and the `/approve` command handler. Prompts stored under the key itself keep working unchanged.

## Tests

- New test: a Teams `4` reply finds a prompt stored under the session instance id and is routed as `yes <id> for all`. Fails without the fix.
- `tests/gateway-main.test.ts`, `tests/gateway-pending-approvals.test.ts`, `tests/gateway-service.plugins.test.ts` pass; `tsc --noEmit --noUnusedLocals --noUnusedParameters` clean.