### PR TITLE
fix(pdf-skill): group extracted text by viewport position

### DIFF
--- a/skills/pdf/scripts/_pdf_runtime.mjs
+++ b/skills/pdf/scripts/_pdf_runtime.mjs
@@ -71,17 +71,43 @@ function normalizeText(value) {
     .trim();
 }
 
-function groupPageTextItems(items) {
+/**
+ * Project a text item's transform into viewport space so page rotation
+ * (`/Rotate`) and rotated text runs group into the lines a reader sees.
+ * Falls back to raw PDF user-space coordinates when no viewport is given.
+ */
+function positionTextItem(item, options) {
+  const transform = Array.isArray(item.transform) ? item.transform : [];
+  const width = Number(item.width || 0);
+  const rawHeight = Math.abs(Number(item.height || 0));
+  const { viewport, Util } = options;
+  if (!viewport || !Util || transform.length < 6) {
+    return {
+      x: Number(transform[4] || 0),
+      y: Number(transform[5] || 0),
+      width,
+      height: rawHeight,
+    };
+  }
+  const projected = Util.transform(viewport.transform, transform);
+  const height = Math.hypot(projected[2], projected[3]) || rawHeight;
+  // Viewport y grows downwards; negate it so "larger y is higher on the
+  // page" keeps holding for the line ordering below.
+  return {
+    x: Number(projected[4] || 0),
+    y: -Number(projected[5] || 0),
+    width,
+    height,
+  };
+}
+
+function groupPageTextItems(items, options = {}) {
   const positioned = items
     .map((item) => {
       if (!('str' in item)) return null;
       const text = normalizeText(item.str);
       if (!text) return null;
-      const transform = Array.isArray(item.transform) ? item.transform : [];
-      const x = Number(transform[4] || 0);
-      const y = Number(transform[5] || 0);
-      const width = Number(item.width || 0);
-      const height = Math.abs(Number(item.height || 0));
+      const { x, y, width, height } = positionTextItem(item, options);
       return {
         text,
         x,
@@ -135,12 +161,17 @@ export async function extractPdfText(inputPath, pageNumbers) {
   const selectedPages = parsePageSelection(pageNumbers, pdf.numPages);
   const pages = [];
 
+  const { Util } = await loadPdfJs();
+
   for (const pageNumber of selectedPages) {
     const page = await pdf.getPage(pageNumber);
     const textContent = await page.getTextContent();
     pages.push({
       pageNumber,
-      text: groupPageTextItems(textContent.items),
+      text: groupPageTextItems(textContent.items, {
+        viewport: page.getViewport({ scale: 1 }),
+        Util,
+      }),
     });
   }
 

--- a/tests/pdf-skill-node.test.ts
+++ b/tests/pdf-skill-node.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { PDFDocument } from 'pdf-lib';
+import { PDFDocument, degrees } from 'pdf-lib';
 import { afterEach, describe, expect, test } from 'vitest';
 
 import { openPdfDocument } from '../skills/pdf/scripts/_pdf_runtime.mjs';
@@ -73,6 +73,25 @@ async function createPlainPdf(outputPath) {
   page.drawText('Last Name', { x: 50, y: 330, size: 12 });
   page.drawText('Country', { x: 50, y: 280, size: 12 });
   page.drawText('Germany', { x: 140, y: 280, size: 12 });
+  fs.writeFileSync(outputPath, await pdfDoc.save());
+}
+
+/**
+ * Landscape price lists are often stored as portrait pages with `/Rotate 90`
+ * and text runs rotated to match. In PDF user space the visual rows share an
+ * x coordinate, so grouping by raw y turns columns into lines.
+ */
+async function createRotatedTablePdf(outputPath) {
+  const pdfDoc = await PDFDocument.create();
+  const page = pdfDoc.addPage([400, 400]);
+  page.setRotation(degrees(90));
+  const rotated = { size: 12, rotate: degrees(90) };
+  page.drawText('LDD-200', { x: 60, y: 40, ...rotated });
+  page.drawText('2 Weeks', { x: 60, y: 140, ...rotated });
+  page.drawText('$72.00', { x: 60, y: 240, ...rotated });
+  page.drawText('LDD-400', { x: 90, y: 40, ...rotated });
+  page.drawText('2 Weeks', { x: 90, y: 140, ...rotated });
+  page.drawText('$94.00', { x: 90, y: 240, ...rotated });
   fs.writeFileSync(outputPath, await pdfDoc.save());
 }
 
@@ -372,5 +391,25 @@ describe('PDF skill Node scripts', () => {
     expect(fs.statSync(outputPdf).size).toBeGreaterThan(
       fs.statSync(inputPdf).size,
     );
+  });
+
+  test('extracts rotated pages as the rows a reader sees', async () => {
+    const dir = makeTempDir();
+    const inputPdf = path.join(dir, 'rotated-table.pdf');
+
+    await createRotatedTablePdf(inputPdf);
+
+    const result = runNodeScript([
+      'skills/pdf/scripts/extract_pdf_text.mjs',
+      inputPdf,
+      '--json',
+    ]);
+    const extracted = JSON.parse(result.stdout);
+
+    expect(extracted.pageCount).toBe(1);
+    expect(extracted.pages[0].text.split('\n')).toEqual([
+      'LDD-200 2 Weeks $72.00',
+      'LDD-400 2 Weeks $94.00',
+    ]);
   });
 });


### PR DESCRIPTION
## Problem

`extract_pdf_text.mjs` grouped text items into lines by their raw PDF user-space coordinates. Pages stored with `/Rotate` (common for landscape price lists and tables) draw their text rotated, so visual rows share an x coordinate. The grouping turned every column into a line and tables came out scrambled, e.g. a row of prices from one quantity column instead of one part per line. The same runtime backs the gateway's PDF context injection, so in-chat PDF questions were affected too.

## Fix

Project each text item through the page viewport (`Util.transform(viewport.transform, item.transform)`) before grouping, so rotated pages and rotated text runs come out as the rows a reader sees. Unrotated pages are unchanged.

## Tests

- New test builds a `/Rotate 90` page with rotated text runs and expects the two visual rows. Fails without the fix.
- `tests/pdf-skill-node.test.ts` and `tests/pdf-context.test.ts` pass. Verified additionally on a real 5-page rotated distributor price list (not committed).