### PR TITLE
feat(msteams): add showMemoryFooter setting

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -202,6 +202,7 @@
     "requireMention": true,
     "textChunkLimit": 4000,
     "replyStyle": "thread",
+    "showMemoryFooter": true,
     "mediaMaxMb": 20,
     "dangerouslyAllowNameMatching": false,
     "mediaAllowHosts": [

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -679,6 +679,7 @@ export interface AdminConfig {
     requireMention: boolean;
     textChunkLimit: number;
     replyStyle: 'thread' | 'top-level';
+    showMemoryFooter: boolean;
     mediaMaxMb: number;
     dangerouslyAllowNameMatching: boolean;
     mediaAllowHosts: string[];

--- a/console/src/generated/settings-registry.ts
+++ b/console/src/generated/settings-registry.ts
@@ -1824,6 +1824,12 @@ export const GENERATED_SETTINGS_REGISTRY: ReadonlyArray<GeneratedSettingEntry> =
       defaultValue: true,
     },
     {
+      path: 'msteams.showMemoryFooter',
+      section: 'msteams',
+      kind: 'boolean',
+      defaultValue: true,
+    },
+    {
       path: 'msteams.tab.allowFrom',
       section: 'msteams',
       kind: 'list',

--- a/console/src/routes/channels.test.tsx
+++ b/console/src/routes/channels.test.tsx
@@ -151,6 +151,7 @@ function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
       textChunkLimit: 4000,
       replyStyle: 'thread',
       mediaMaxMb: 20,
+      showMemoryFooter: true,
       dangerouslyAllowNameMatching: false,
       mediaAllowHosts: [],
       mediaAuthAllowHosts: [],

--- a/console/src/routes/channels.tsx
+++ b/console/src/routes/channels.tsx
@@ -2951,6 +2951,20 @@ function TeamsChannelEditor(props: {
                 </Field>
               )}
             />
+            <FormField
+              name="msteams.showMemoryFooter"
+              render={({ field }) => (
+                <Field orientation="horizontal">
+                  <Switch
+                    checked={Boolean(field.value)}
+                    onCheckedChange={field.onChange}
+                  />
+                  <FieldContent>
+                    <FieldLabel>Show memory footer</FieldLabel>
+                  </FieldContent>
+                </Field>
+              )}
+            />
           </div>
 
           <FormField

--- a/docs/content/channels/msteams.md
+++ b/docs/content/channels/msteams.md
@@ -167,6 +167,27 @@ JSON, CSV, Markdown, plain text, and XML retain their media type. Downloads are
 streamed into the managed cache with a default per-file limit of 100 MB,
 controlled by `msteams.mediaMaxMb` under **Advanced delivery settings**.
 
+## Memory footer
+
+Every Teams answer ends with a short memory-transparency footer such as
+`*Memory: Recalled 2 memories*` followed by the recalled `[mem:n]` previews and
+their confidence values. It is part of the memory transparency described in
+[Memory](../developer-guide/memory.md) and stays visible under `/show none`.
+
+Set `msteams.showMemoryFooter` to `false` (**Show memory footer** under the
+Teams channel settings in the admin console) to drop the footer from Teams
+replies. Memory recall itself is unchanged; the footer is only omitted from the
+delivered message. The `*Tools: …*` line is still controlled per session by
+`/show`.
+
+```json
+{
+  "msteams": {
+    "showMemoryFooter": false
+  }
+}
+```
+
 ## Rating answers
 
 Two ways to rate a HybridClaw answer from Teams:

--- a/docs/content/developer-guide/memory.md
+++ b/docs/content/developer-guide/memory.md
@@ -300,7 +300,10 @@ a compact memory footer with the recalled previews and confidence values. API
 clients receive the same data as structured `memoryAccess` result metadata.
 
 Memory transparency remains visible under `/show none`; that setting hides
-thinking and ordinary tool activity, not prompt-memory access. When a plugin
+thinking and ordinary tool activity, not prompt-memory access. Microsoft Teams
+deployments can drop the delivered footer with `msteams.showMemoryFooter:
+false`; the `memoryAccess` result metadata and the `memory_recall` activity are
+unaffected. When a plugin
 replaces built-in memory, the plugin owns its own access reporting and the
 built-in `memory_recall` event is not emitted.
 

--- a/src/channels/msteams/delivery.ts
+++ b/src/channels/msteams/delivery.ts
@@ -9,6 +9,8 @@ import {
 import { MSTEAMS_TEXT_CHUNK_LIMIT } from '../../config/config.js';
 import type { MSTeamsReplyStyle } from '../../config/runtime-config.js';
 import { chunkMessage } from '../../memory/chunk.js';
+import { formatMemoryAccessMarkdown } from '../../memory/recall-presentation.js';
+import type { MemoryAccess } from '../../types/memory.js';
 import { formatError } from '../../utils/text-format.js';
 import { sendMSTeamsActivityWithRetry } from './retry.js';
 
@@ -27,10 +29,23 @@ export interface BuildMSTeamsMessageActivityParams {
   replyToId?: string | null;
 }
 
-export function buildResponseText(text: string, toolsUsed?: string[]): string {
+export interface BuildMSTeamsResponseTextOptions {
+  /** `msteams.showMemoryFooter`; `false` drops the memory transparency footer. */
+  showMemoryFooter?: boolean;
+}
+
+export function buildResponseText(
+  text: string,
+  toolsUsed?: string[],
+  memoryAccess?: MemoryAccess,
+  options: BuildMSTeamsResponseTextOptions = {},
+): string {
   let body = text;
+  if (memoryAccess && options.showMemoryFooter !== false) {
+    body += `${body ? '\n\n' : ''}${formatMemoryAccessMarkdown(memoryAccess)}`;
+  }
   if (toolsUsed && toolsUsed.length > 0) {
-    body = `${body}\n*Tools: ${toolsUsed.join(', ')}*`;
+    body = `${body}${body ? '\n' : ''}*Tools: ${toolsUsed.join(', ')}*`;
   }
   return body;
 }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -351,6 +351,7 @@ export let MSTEAMS_REQUIRE_MENTION = true;
 export let MSTEAMS_TEXT_CHUNK_LIMIT = 4_000;
 export let MSTEAMS_REPLY_STYLE: RuntimeConfig['msteams']['replyStyle'] =
   'thread';
+export let MSTEAMS_SHOW_MEMORY_FOOTER = true;
 // 100 MB (owner call, 2026-08-21): Teams downloads stream to the managed
 // cache; the console upload limit remains 20 MB.
 export let MSTEAMS_MEDIA_MAX_MB = 100;
@@ -890,6 +891,7 @@ function applyRuntimeConfig(config: RuntimeConfig): void {
     Math.min(20_000, config.msteams.textChunkLimit),
   );
   MSTEAMS_REPLY_STYLE = config.msteams.replyStyle;
+  MSTEAMS_SHOW_MEMORY_FOOTER = config.msteams.showMemoryFooter;
   MSTEAMS_MEDIA_MAX_MB = Math.max(1, config.msteams.mediaMaxMb);
   MSTEAMS_DANGEROUSLY_ALLOW_NAME_MATCHING =
     config.msteams.dangerouslyAllowNameMatching;

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -612,6 +612,7 @@ export interface RuntimeMSTeamsConfig {
   requireMention: boolean;
   textChunkLimit: number;
   replyStyle: MSTeamsReplyStyle;
+  showMemoryFooter: boolean;
   mediaMaxMb: number;
   dangerouslyAllowNameMatching: boolean;
   mediaAllowHosts: string[];
@@ -1695,6 +1696,7 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
     requireMention: true,
     textChunkLimit: 4_000,
     replyStyle: 'thread',
+    showMemoryFooter: true,
     // 100 MB (owner call, 2026-08-21): Teams downloads stream to the managed
     // cache; the console upload limit remains 20 MB.
     mediaMaxMb: 100,
@@ -5034,6 +5036,10 @@ function normalizeMSTeamsConfig(
       },
     ),
     replyStyle: normalizeMSTeamsReplyStyle(raw.replyStyle, fallback.replyStyle),
+    showMemoryFooter: normalizeBoolean(
+      raw.showMemoryFooter,
+      fallback.showMemoryFooter,
+    ),
     mediaMaxMb: normalizeInteger(raw.mediaMaxMb, fallback.mediaMaxMb, {
       min: 1,
       max: 100,

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -77,6 +77,7 @@ import {
 } from '../channels/line/runtime.js';
 import { isLineChannelId } from '../channels/line/target.js';
 import {
+  buildResponseText as buildMSTeamsResponseText,
   buildMSTeamsSessionSwitcherCard,
   stripUnusableMSTeamsArtifactLinks,
 } from '../channels/msteams/delivery.js';
@@ -1797,12 +1798,19 @@ async function startMSTeamsIntegration(): Promise<boolean> {
             }),
           ),
         );
+        const memoryFooterOptions = {
+          showMemoryFooter: getConfigSnapshot().msteams.showMemoryFooter,
+        };
+        const memoryAccess = memoryFooterOptions.showMemoryFooter
+          ? result.memoryAccess
+          : undefined;
         if (result.status === 'error') {
           await context.stream.fail(
-            buildResponseText(
+            buildMSTeamsResponseText(
               formatAgentErrorReply(result.error),
               undefined,
-              result.memoryAccess,
+              memoryAccess,
+              memoryFooterOptions,
             ),
           );
           return;
@@ -1820,11 +1828,7 @@ async function startMSTeamsIntegration(): Promise<boolean> {
         const renderedText = stripSilentToken(String(result.result || ''));
         const artifacts = result.artifacts || [];
         const effectiveSessionId = result.sessionId || sessionId;
-        if (
-          !renderedText.trim() &&
-          artifacts.length === 0 &&
-          !result.memoryAccess
-        ) {
+        if (!renderedText.trim() && artifacts.length === 0 && !memoryAccess) {
           await context.stream.discard();
           return;
         }
@@ -1832,13 +1836,14 @@ async function startMSTeamsIntegration(): Promise<boolean> {
           memoryService.getSessionById(effectiveSessionId)?.show_mode,
         );
         let responseText =
-          renderedText.trim() || result.memoryAccess
-            ? buildResponseText(
+          renderedText.trim() || memoryAccess
+            ? buildMSTeamsResponseText(
                 stripUnusableMSTeamsArtifactLinks(renderedText),
                 sessionShowModeShowsTools(showMode)
                   ? result.toolsUsed
                   : undefined,
-                result.memoryAccess,
+                memoryAccess,
+                memoryFooterOptions,
               )
             : '';
         const pendingApproval = extractGatewayChatApprovalEvent(result);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -4328,6 +4328,7 @@ describe('CLI hybridai commands', () => {
         requireMention: true,
         textChunkLimit: 4000,
         replyStyle: 'thread',
+        showMemoryFooter: true,
         mediaMaxMb: 20,
         dangerouslyAllowNameMatching: false,
         mediaAllowHosts: [],

--- a/tests/msteams.delivery.test.ts
+++ b/tests/msteams.delivery.test.ts
@@ -178,3 +178,31 @@ test('sendChunkedReply retries transient Teams transport failures', async () => 
     vi.useRealTimers();
   }
 });
+
+test('buildResponseText appends the memory footer unless disabled', async () => {
+  const { buildResponseText } = await import('../src/channels/msteams/delivery.js');
+  const memoryAccess = {
+    semanticRecallAttempted: true,
+    summaryIncluded: false,
+    recalledMemories: [
+      {
+        ref: '[mem:1]',
+        memoryId: 1,
+        content: 'User prefers concise changelog entries.',
+        confidence: 0.9,
+      },
+    ],
+  };
+
+  expect(buildResponseText('Hello', ['search'], memoryAccess)).toBe(
+    'Hello\n\n*Memory: Recalled 1 memory*\n[mem:1]: User prefers concise changelog entries. (90%)\n*Tools: search*',
+  );
+  expect(
+    buildResponseText('Hello', ['search'], memoryAccess, {
+      showMemoryFooter: false,
+    }),
+  ).toBe('Hello\n*Tools: search*');
+  expect(
+    buildResponseText('', undefined, memoryAccess, { showMemoryFooter: false }),
+  ).toBe('');
+});


### PR DESCRIPTION
## Summary

Teams answers always end with the memory transparency footer (`*Memory: Recalled N memories*` plus the `[mem:n]` previews) since the recall-activity change in v0.30.1, and `/show none` deliberately leaves it in place. Some Teams deployments want plain answers.

- Add `msteams.showMemoryFooter` (default `true`, so behaviour is unchanged unless set).
- When `false`, Teams replies omit the footer. Memory recall, the `memoryAccess` result metadata and the `memory_recall` activity are untouched; the `*Tools: …*` line is still governed by `/show`.
- Console: "Show memory footer" switch in the Teams channel editor; settings registry regenerated.
- Docs: Teams channel page + developer memory guide.

## Test plan

- [x] `tests/msteams.delivery.test.ts` covers footer on/off and the empty-body case
- [x] `tests/cli.test.ts` and `console/src/routes/channels.test.tsx` fixtures updated
- [x] `tsc --noEmit` (root + console), biome clean