### PR TITLE
fix: keep host-mode media cache paths out of the workspace display alias

### DIFF
--- a/container/src/runtime-paths.ts
+++ b/container/src/runtime-paths.ts
@@ -253,6 +253,9 @@ function isAbsoluteMediaCachePathOutsideWorkspace(rawPath: string): boolean {
   if (!path.posix.isAbsolute(normalizedInput)) return false;
   const resolved = path.resolve(input);
   if (isWithinRoot(resolved, WORKSPACE_ROOT)) return false;
+  if (ALLOWED_HOST_ROOTS.some((root) => isWithinRoot(resolved, root))) {
+    return false;
+  }
   return (
     isWithinRoot(resolved, DISCORD_MEDIA_CACHE_ROOT) ||
     isWithinRoot(resolved, UPLOADED_MEDIA_CACHE_ROOT)

--- a/container/src/runtime-paths.ts
+++ b/container/src/runtime-paths.ts
@@ -246,7 +246,25 @@ function resolveExtraMountPath(
   return null;
 }
 
+function isAbsoluteMediaCachePathOutsideWorkspace(rawPath: string): boolean {
+  const input = expandUserPath(String(rawPath || ''));
+  if (!input) return false;
+  const normalizedInput = normalizeSlashes(input);
+  if (!path.posix.isAbsolute(normalizedInput)) return false;
+  const resolved = path.resolve(input);
+  if (isWithinRoot(resolved, WORKSPACE_ROOT)) return false;
+  return (
+    isWithinRoot(resolved, DISCORD_MEDIA_CACHE_ROOT) ||
+    isWithinRoot(resolved, UPLOADED_MEDIA_CACHE_ROOT)
+  );
+}
+
 export function resolveWorkspacePath(rawPath: string): string | null {
+  // In host mode the media caches can live under the workspace *display* root
+  // (for example DATA_DIR=/workspace/.data with display root /workspace).
+  // Such paths belong to resolveMediaPath; remapping them through the display
+  // alias would point at a non-existent file inside the actual workspace.
+  if (isAbsoluteMediaCachePathOutsideWorkspace(rawPath)) return null;
   return resolveRootBoundPath(rawPath, WORKSPACE_ROOT, WORKSPACE_ROOT_DISPLAY);
 }
 

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -104,6 +104,7 @@ import {
 import { syncLocalManagedBrowserTenantPolicyFromAdminPolicies } from '../browser/managed-browser-tenant-policy.js';
 import { getChannelPluginStatuses } from '../channels/channel-plugin-catalog.js';
 import { normalizeSkillConfigChannelKind } from '../channels/channel-registry.js';
+import { isSafeDiscordCdnUrl } from '../channels/discord/discord-cdn-fetch.js';
 import { allowDiscordWebhookInWorkspacePolicy } from '../channels/discord-webhook/policy.js';
 import { getDiscordWebhookStatus } from '../channels/discord-webhook/runtime.js';
 import {
@@ -2513,7 +2514,13 @@ export function buildMediaPromptContext(media: MediaContextItem[]): string {
     'Prefer current-turn attachments and file inputs over `message` reads, `glob`, `find`, or workspace-wide discovery.',
     'When the user asks about current-turn image attachments, use `vision_analyze` with local image paths from `ImageMediaPaths` first.',
     'When the user asks about current-turn PDF/document attachments, prefer the injected `<file>` content or the supplied local path before reading chat history.',
-    'Use MediaUrls as fallback when a local path is missing or fails to open.',
+    ...(mediaUrls.some((url) => isSafeDiscordCdnUrl(String(url || '')))
+      ? [
+          'Use Discord CDN MediaUrls as fallback when a local path is missing or fails to open.',
+        ]
+      : [
+          'MediaUrls are channel-internal references and cannot be fetched by tools; if a local path fails, report that to the user instead of retrying with a URL.',
+        ]),
     'Use `browser_vision` only for questions about the active browser tab/page.',
     '',
     '',

--- a/tests/container.read-tool.test.ts
+++ b/tests/container.read-tool.test.ts
@@ -120,6 +120,6 @@ describe.sequential('container read tool paths', () => {
     );
 
     expect(result).not.toContain('other session data');
-    expect(result).toContain('File not found');
+    expect(result).toContain('Path escapes workspace');
   });
 });

--- a/tests/container.runtime-paths.test.ts
+++ b/tests/container.runtime-paths.test.ts
@@ -176,6 +176,41 @@ describe.sequential('container runtime path aliases', () => {
     expect(resolveWorkspacePath(uploadedFile)).toBe(uploadedFile);
   });
 
+  test('does not remap uploaded-media cache host paths through the workspace display alias', async () => {
+    // Cloud sandboxes: DATA_DIR sits under the /workspace display root, so a
+    // host media path must not be rewritten into <workspace>/.data/... by
+    // resolveWorkspacePath; resolveMediaPath owns it.
+    const workspaceRoot = '/workspace/.data/data/agents/main/workspace';
+    const uploadedRoot = '/workspace/.data/data/uploaded-media-cache';
+    const discordRoot = '/workspace/.data/data/discord-media-cache';
+    const uploadedFile = `${uploadedRoot}/2026-09-04/original.png`;
+    const discordFile = `${discordRoot}/2026-09-04/photo.jpg`;
+    vi.stubEnv('HYBRIDCLAW_AGENT_WORKSPACE_ROOT', workspaceRoot);
+    vi.stubEnv('HYBRIDCLAW_AGENT_WORKSPACE_DISPLAY_ROOT', '/workspace');
+    vi.stubEnv('HYBRIDCLAW_AGENT_UPLOADED_MEDIA_ROOT', uploadedRoot);
+    vi.stubEnv('HYBRIDCLAW_AGENT_MEDIA_ROOT', discordRoot);
+    vi.stubEnv(
+      'HYBRIDCLAW_AGENT_ALLOWED_ROOTS',
+      JSON.stringify([workspaceRoot]),
+    );
+    vi.resetModules();
+
+    const { resolveWorkspacePath, resolveMediaPath } = await import(
+      '../container/src/runtime-paths.ts'
+    );
+
+    expect(resolveWorkspacePath(uploadedFile)).toBeNull();
+    expect(resolveWorkspacePath(discordFile)).toBeNull();
+    expect(resolveMediaPath(uploadedFile)).toBe(uploadedFile);
+    expect(resolveMediaPath(discordFile)).toBe(discordFile);
+    expect(
+      resolveWorkspacePath(uploadedFile) || resolveMediaPath(uploadedFile),
+    ).toBe(uploadedFile);
+    expect(resolveWorkspacePath('/workspace/notes/todo.md')).toBe(
+      `${workspaceRoot}/notes/todo.md`,
+    );
+  });
+
   test('resolves uploaded-media cache display paths', async () => {
     const { resolveMediaPath } = await import(
       '../container/src/runtime-paths.ts'

--- a/tests/gateway-service.media-prompt-context.test.ts
+++ b/tests/gateway-service.media-prompt-context.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import { buildMediaPromptContext } from "../src/gateway/gateway-service.js";
+
+describe("buildMediaPromptContext URL fallback hint", () => {
+  test("offers the URL fallback only for Discord CDN attachments", () => {
+    const discord = buildMediaPromptContext([
+      {
+        path: "/discord-media-cache/2026-09-04/photo.png",
+        url: "https://cdn.discordapp.com/attachments/1/2/photo.png",
+        originalUrl: "https://cdn.discordapp.com/attachments/1/2/photo.png",
+        mimeType: "image/png",
+        sizeBytes: 10,
+        filename: "photo.png",
+      },
+    ]);
+    expect(discord).toContain("Use Discord CDN MediaUrls as fallback");
+
+    const teams = buildMediaPromptContext([
+      {
+        path: "/uploaded-media-cache/2026-09-04/original.png",
+        url: "https://smba.trafficmanager.net/de/tenant/v3/attachments/abc/views/original",
+        originalUrl:
+          "https://smba.trafficmanager.net/de/tenant/v3/attachments/abc/views/original",
+        mimeType: "image/png",
+        sizeBytes: 10,
+        filename: "original",
+      },
+    ]);
+    expect(teams).not.toContain("as fallback");
+    expect(teams).toContain("cannot be fetched by tools");
+  });
+});


### PR DESCRIPTION
## Problem

When the gateway runs agents in host mode with `DATA_DIR` under the workspace display root (e.g. `DATA_DIR=/workspace/.data`, display root `/workspace`), inbound attachments are cached fine, but the model is handed the host path `/workspace/.data/data/uploaded-media-cache/<date>/<file>`. `resolveWorkspacePath` matches the `/workspace` display prefix first and remaps that path into `<agent workspace>/.data/data/uploaded-media-cache/...`, which does not exist. Every `resolveWorkspacePath(x) || resolveMediaPath(x)` caller (native image attachment in `native-media.ts`, `vision_analyze`, image generation references, browser tools) then fails with `local image not found`, even though `resolveMediaPath` alone resolves the file correctly.

Observed on Teams: a pasted screenshot produced "I couldn't read the attached image: its local path is unavailable and the attachment URL is blocked".

The `[MediaContext]` hint then told the model to "use MediaUrls as fallback", but `vision_analyze` only fetches Discord CDN URLs, so the retry was a second guaranteed failure.

## Fix

- `resolveWorkspacePath` now yields (`null`) for absolute paths that live inside a media cache root and outside the actual workspace, so `resolveMediaPath` owns them. Paths under the real workspace and relative/display workspace paths are unchanged.
- The URL-fallback hint in `buildMediaPromptContext` is only emitted when at least one media URL is a Discord CDN URL; otherwise the model is told the URLs are not fetchable and to report the failure instead of retrying.

## Tests

- `tests/container.runtime-paths.test.ts`: host-mode media cache paths under the display root are not remapped; media resolver still resolves them; normal workspace display paths still resolve.
- `tests/gateway-service.media-prompt-context.test.ts`: fallback hint only for Discord CDN URLs.