### PR TITLE
fix: honour the configured default agent on /v1/chat/completions and document the API

### DIFF
--- a/docs/content/guides/README.md
+++ b/docs/content/guides/README.md
@@ -1,6 +1,6 @@
 ---
 title: Guides
-description: Practical workflows for generated apps, local providers, remote access, MCP, bundled skills, Twilio voice, local speech tooling, and optional office tooling.
+description: Practical workflows for generated apps, local providers, remote access, MCP, bundled skills, Twilio voice, local speech tooling, the OpenAI-compatible API, and optional office tooling.
 sidebar_position: 1
 ---
 
@@ -32,5 +32,7 @@ These pages focus on common operator workflows after the base install works.
 - [Voice and TTS](./voice-tts.md) for voice reply and speech backend setup
 - [Realtime Voice for Web Apps](./voice-web-api.md) for browser voice
   sessions from your own web app via scoped API tokens
+- [OpenAI-Compatible API](./openai-compatible-api.md) for sending prompts
+  to an agent from an external system over `/v1/chat/completions`
 - [Optional Office Dependencies](./office-dependencies.md) for host-side
   office tooling

--- a/docs/content/guides/openai-compatible-api.md
+++ b/docs/content/guides/openai-compatible-api.md
@@ -1,0 +1,168 @@
+---
+title: OpenAI-Compatible API
+description: Send prompts to an agent from an external system over the gateway's OpenAI-compatible /v1 endpoints, using a scoped API token.
+sidebar_position: 9
+---
+
+# OpenAI-Compatible API
+
+The gateway exposes `/v1/models` and `/v1/chat/completions` in the OpenAI
+chat-completions shape. A request is a **real agent turn** — the selected agent
+answers with its own workspace, skills, tools, and approvals — so any external
+system that already speaks the OpenAI API can send a prompt and read the
+answer without a HybridClaw-specific client.
+
+Use it for backend-to-backend integrations: an ERP, a ticket system, a CRM
+workflow, an eval harness, or your own service calling the agent over HTTP.
+There is no SOAP endpoint; put an adapter in front of the gateway if a SOAP
+client is a hard requirement.
+
+For browser voice sessions see
+[Realtime Voice for Web Apps](./voice-web-api.md); for the chat UI transport
+see [Runtime](../developer-guide/runtime.md).
+
+## 1. Create a scoped API token
+
+Create a token that can only call the OpenAI-compatible surface:
+
+```bash
+hybridclaw token create --label "erp integration" --actions openai.api
+```
+
+- The `hck_` value is shown **once** at creation time; store it in your
+  caller's secret store.
+- `/admin/credentials?tab=api-tokens` offers the same create/list/revoke
+  workflow in the browser.
+- A token missing the `openai.api` action gets `403 Forbidden` from `/v1/*`.
+- `WEB_API_TOKEN` and `GATEWAY_API_TOKEN` are also accepted, but they are
+  broad master credentials — prefer a scoped token you can revoke on its own.
+
+Keep the token server-side. Every holder can spend model budget and run agent
+turns with tools on your gateway.
+
+## 2. Reach the gateway
+
+Locally that is the loopback listener:
+
+```bash
+curl http://127.0.0.1:9090/v1/models \
+  -H "Authorization: Bearer hck_..."
+```
+
+From another machine the gateway must be reachable over HTTPS — a
+[Tailscale Funnel](./tailscale-funnel.md), a
+[Cloudflare tunnel](./cloudflare-tunnel.md), an
+[SSH tunnel](./remote-access.md), or a hosted deployment's public hostname.
+Loopback is not an authentication boundary: `/v1/*` requires a bearer token
+either way.
+
+## 3. Send a prompt
+
+```bash
+curl https://gateway.example/v1/chat/completions \
+  -H "Authorization: Bearer hck_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hybridai/gpt-4.1-mini",
+    "messages": [{"role": "user", "content": "Summarize today's open tickets."}]
+  }'
+```
+
+- `model` is required and must be one the gateway can serve — list them with
+  `GET /v1/models`.
+- The final message must have role `user` (unless the request carries client
+  tool definitions).
+- `stream: true` returns standard SSE chunks; add
+  `"stream_options": {"include_usage": true}` for a final usage chunk.
+- `user` is optional and labels the turn in session history.
+- Image and file URLs in message content are passed through as media.
+
+Every request runs as a **fresh session**: earlier messages in the `messages`
+array are replayed as history for that turn, and nothing is carried over
+implicitly between calls. Your caller owns the conversation state — send the
+transcript you want the agent to see.
+
+Because these are OpenAI-shaped endpoints, the official OpenAI SDKs work by
+pointing `base_url` at `https://gateway.example/v1` and passing the `hck_`
+token as the API key.
+
+## 4. Choose which agent answers
+
+Without an explicit selection the turn runs as the built-in `main` agent. This
+is a fixed fallback on this endpoint: `agents.defaultAgentId` in the runtime
+config steers other surfaces, but `/v1/chat/completions` does **not** read it.
+
+Select a specific agent by appending an agent flag to the model id:
+
+```bash
+curl https://gateway.example/v1/chat/completions \
+  -H "Authorization: Bearer hck_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hybridai/gpt-4.1-mini__hc_eval=agent=support-desk",
+    "messages": [{"role": "user", "content": "Which orders are stuck?"}]
+  }'
+```
+
+The same profile can travel in a header instead, which keeps the model id
+clean for OpenAI SDKs that validate it:
+
+```bash
+-H "X-HybridClaw-Eval-Profile: agent=support-desk"
+```
+
+- The agent id is the workspace id shown by `hybridclaw agent list` — not the
+  display name.
+- An unknown id does **not** fail the request: it runs a default-shaped agent
+  under that id, so verify the id rather than trusting a 200.
+- Further flags are comma-separated after the marker (`fresh-agent`,
+  `ablate-system`, `include=`, `omit=`) — those belong to the eval harness, see
+  [Commands](../reference/commands.md).
+
+> **Tools are auto-approved when an agent profile is present.** The marker and
+> the header both flag the request as an eval-profile request, which runs the
+> turn with tool approvals bypassed. Only hand out tokens for agent-selected
+> integrations to callers you would also trust to approve that agent's tools.
+
+## 5. Handle delegated answers
+
+When the agent hands work to sub-agents, the completion returns an
+acknowledgement instead of the final answer, plus a delegation descriptor:
+
+```json
+{
+  "hybridclaw": { "delegation": { "id": "chatcmpl-…", "status": "queued" } }
+}
+```
+
+Non-streaming responses also set the `X-HybridClaw-Delegation-Id` header;
+streaming responses carry the same object on the final stop chunk. Poll the
+job until it finishes:
+
+```bash
+curl https://gateway.example/v1/chat/completions/<completion-id> \
+  -H "Authorization: Bearer hck_..."
+```
+
+- top-level `status` is one of `queued`, `in_progress`, `completed`, `failed`,
+  or `cancelled`
+- while queued or running, the retrieval returns the acknowledgement with
+  `finish_reason: null`; when completed it returns the synthesized final answer
+  with `finish_reason: "stop"`; a failed job carries a top-level OpenAI-shaped
+  `error`
+- poll every 1–5 seconds — a job may wait behind the delegation concurrency
+  limit before it starts
+
+A caller that ignores this path will occasionally store "Started 1 delegate
+job." as if it were the answer, so handle it before going live.
+
+## Troubleshooting
+
+| Symptom | Cause |
+| --- | --- |
+| `401` with `Unauthorized. Set 'Authorization: Bearer <WEB_API_TOKEN>'.` | No bearer token, or a revoked/expired one |
+| `403 Forbidden` | The token lacks the `openai.api` action |
+| `400` `Missing 'model' in request body.` | `model` is required on every request |
+| `400` `The final chat message must have role 'user'.` | Last entry in `messages` is not a user turn |
+| `400 Unknown HybridClaw eval profile flag` | Typo in the `__hc_eval=` flag list |
+| The wrong agent answers | No agent flag was sent, so the turn ran as `main` |

--- a/docs/content/guides/openai-compatible-api.md
+++ b/docs/content/guides/openai-compatible-api.md
@@ -88,9 +88,11 @@ token as the API key.
 
 ## 4. Choose which agent answers
 
-Without an explicit selection the turn runs as the built-in `main` agent. This
-is a fixed fallback on this endpoint: `agents.defaultAgentId` in the runtime
-config steers other surfaces, but `/v1/chat/completions` does **not** read it.
+Without an explicit selection the turn runs as the configured default agent:
+`agents.defaultAgentId` in the runtime config, as set by
+`hybridclaw agent activate <id>`. When nothing is configured, or the configured
+id is not in `agents.list`, the built-in `main` agent answers. Eval harnesses
+that need `main` regardless of configuration should select it explicitly.
 
 Select a specific agent by appending an agent flag to the model id:
 

--- a/docs/content/navigation.json
+++ b/docs/content/navigation.json
@@ -143,6 +143,10 @@
           "path": "guides/office-dependencies.md"
         },
         {
+          "title": "OpenAI-Compatible API",
+          "path": "guides/openai-compatible-api.md"
+        },
+        {
           "title": "TUI MCP",
           "path": "guides/tui-mcp.md"
         },

--- a/docs/content/reference/commands.md
+++ b/docs/content/reference/commands.md
@@ -247,9 +247,17 @@ curl http://127.0.0.1:9090/v1/chat/completions \
 
 - `/v1/models` and `/v1/chat/completions` use the same local gateway process;
   they are not a separate service
-- requests must include `Authorization: Bearer <WEB_API_TOKEN>` or
-  `Authorization: Bearer <GATEWAY_API_TOKEN>`; loopback address alone does not
-  authenticate API requests
+- requests must include `Authorization: Bearer <token>`; loopback address alone
+  does not authenticate API requests. Accepted credentials are a scoped `hck_`
+  token carrying the `openai.api` action (preferred), `WEB_API_TOKEN`, or
+  `GATEWAY_API_TOKEN`
+- without an agent selection the turn runs as the built-in `main` agent;
+  `agents.defaultAgentId` steers other surfaces but is **not** read here.
+  Select one by appending `__hc_eval=agent=<agent-id>` to the model id or
+  sending `X-HybridClaw-Eval-Profile: agent=<agent-id>` — which also marks the
+  request as an eval request and auto-approves that turn's tool calls
+- each request runs in a fresh session; earlier entries in `messages` are
+  replayed as history for that turn and nothing persists between calls
 - delegated chat completions return an acknowledgement and include
   `hybridclaw.delegation` with `{ "id": "<completion-id>", "status": "queued" }`;
   non-streaming responses also set `X-HybridClaw-Delegation-Id`
@@ -264,8 +272,10 @@ curl http://127.0.0.1:9090/v1/chat/completions \
   top-level OpenAI-shaped `error`
 - polling intervals around 1-5 seconds are appropriate for delegated jobs,
   which may wait behind the delegation concurrency limit before running
-- these endpoints are intended for local tooling and eval harnesses rather than
-  public exposure
+- the same endpoints serve external integrations over a reachable HTTPS
+  hostname; see [OpenAI-Compatible API](../guides/openai-compatible-api.md) for
+  the token, agent-selection, and delegation-polling details a third-party
+  caller needs
 
 ## Auth And Providers
 

--- a/docs/content/reference/commands.md
+++ b/docs/content/reference/commands.md
@@ -251,8 +251,8 @@ curl http://127.0.0.1:9090/v1/chat/completions \
   does not authenticate API requests. Accepted credentials are a scoped `hck_`
   token carrying the `openai.api` action (preferred), `WEB_API_TOKEN`, or
   `GATEWAY_API_TOKEN`
-- without an agent selection the turn runs as the built-in `main` agent;
-  `agents.defaultAgentId` steers other surfaces but is **not** read here.
+- without an agent selection the turn runs as the configured default agent
+  (`agents.defaultAgentId`), falling back to the built-in `main` agent.
   Select one by appending `__hc_eval=agent=<agent-id>` to the model id or
   sending `X-HybridClaw-Eval-Profile: agent=<agent-id>` — which also marks the
   request as an eval request and auto-approves that turn's tool calls

--- a/src/gateway/openai-compatible.ts
+++ b/src/gateway/openai-compatible.ts
@@ -8,6 +8,10 @@ import { createSilentReplyStreamFilter } from '../agent/silent-reply-stream.js';
 import { DEFAULT_AGENT_ID } from '../agents/agent-types.js';
 import { HYBRIDAI_MODEL, MAX_CONCURRENT_CONTAINERS } from '../config/config.js';
 import {
+  getRuntimeConfig,
+  resolveDefaultAgentId,
+} from '../config/runtime-config.js';
+import {
   EVAL_MODEL_PROFILE_MARKER,
   parseEvalProfileModel,
 } from '../evals/eval-profile.js';
@@ -228,6 +232,28 @@ function acquireOpenAIExecutionSession(params: {
   };
 }
 
+/**
+ * Agent that answers an OpenAI-compatible request.
+ *
+ * An eval profile pins the agent explicitly; otherwise the gateway's own
+ * configured default applies, exactly as it does for chat channels and fresh
+ * web sessions. Falling back to the `main` constant here instead would pin the
+ * request session to `main` and pre-empt `agents.defaultAgentId`, because the
+ * session agent id outranks the configured default in
+ * `resolveAgentForRequest`.
+ */
+export function resolveOpenAICompatibleAgentId(params: {
+  freshAgentId?: string | null;
+  profileAgentId?: string | null;
+}): string {
+  return (
+    params.freshAgentId?.trim() ||
+    params.profileAgentId?.trim() ||
+    resolveDefaultAgentId(getRuntimeConfig()) ||
+    DEFAULT_AGENT_ID
+  );
+}
+
 function prepareOpenAICompatibleRequest(
   input: Awaited<ReturnType<typeof readOpenAICompatibleChatRequest>>,
 ): {
@@ -266,7 +292,10 @@ function prepareOpenAICompatibleRequest(
     profile.workspaceMode === 'fresh-agent'
       ? `eval-${randomUUID().replace(/-/g, '').slice(0, 16)}`
       : null;
-  const requestAgentId = freshAgentId || profile.agentId || DEFAULT_AGENT_ID;
+  const requestAgentId = resolveOpenAICompatibleAgentId({
+    freshAgentId,
+    profileAgentId: profile.agentId,
+  });
   const sessionId = buildSessionKey(
     requestAgentId,
     'openai',

--- a/tests/openai-compatible-default-agent.test.ts
+++ b/tests/openai-compatible-default-agent.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const resolveDefaultAgentId = vi.fn(() => 'main');
+
+vi.mock('../src/config/runtime-config.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../src/config/runtime-config.js')>();
+  return {
+    ...actual,
+    resolveDefaultAgentId: (...args: unknown[]) =>
+      resolveDefaultAgentId(...(args as [])),
+  };
+});
+
+const { resolveOpenAICompatibleAgentId } = await import(
+  '../src/gateway/openai-compatible.js'
+);
+
+describe('resolveOpenAICompatibleAgentId', () => {
+  beforeEach(() => {
+    resolveDefaultAgentId.mockReset();
+    resolveDefaultAgentId.mockReturnValue('main');
+  });
+
+  it('uses the gateway default agent when the request selects none', () => {
+    resolveDefaultAgentId.mockReturnValue('docmoritz-hc');
+
+    expect(resolveOpenAICompatibleAgentId({})).toBe('docmoritz-hc');
+  });
+
+  it('keeps an explicitly profiled agent', () => {
+    resolveDefaultAgentId.mockReturnValue('docmoritz-hc');
+
+    expect(
+      resolveOpenAICompatibleAgentId({ profileAgentId: 'support-desk' }),
+    ).toBe('support-desk');
+  });
+
+  it('prefers a fresh eval workspace over both', () => {
+    resolveDefaultAgentId.mockReturnValue('docmoritz-hc');
+
+    expect(
+      resolveOpenAICompatibleAgentId({
+        freshAgentId: 'eval-0123456789abcdef',
+        profileAgentId: 'support-desk',
+      }),
+    ).toBe('eval-0123456789abcdef');
+  });
+
+  it('falls back to main when no default agent is configured', () => {
+    resolveDefaultAgentId.mockReturnValue('');
+
+    expect(resolveOpenAICompatibleAgentId({})).toBe('main');
+  });
+
+  it('ignores blank selections', () => {
+    resolveDefaultAgentId.mockReturnValue('docmoritz-hc');
+
+    expect(
+      resolveOpenAICompatibleAgentId({ freshAgentId: '  ', profileAgentId: '' }),
+    ).toBe('docmoritz-hc');
+  });
+});


### PR DESCRIPTION
Combines the default-agent fix with the external-caller documentation (formerly #1487).

## The bug

`hybridclaw agent activate <id>` writes `agents.defaultAgentId` and is documented as making that agent "the default for new requests and fresh web sessions that do not specify an agent explicitly" (`docs/content/extensibility/agent-packages.md:517`). `/v1/chat/completions` did not participate:

```ts
// src/gateway/openai-compatible.ts (before)
const requestAgentId = freshAgentId || profile.agentId || DEFAULT_AGENT_ID;
```

That constant then got pinned onto the request's session via `memoryService.getOrCreateSession(sessionId, null, 'openai', requestAgentId)`, and `resolveAgentForRequest` ranks `sessionAgentId` above `configuredDefaultAgentId` (`src/agents/agent-registry.ts:702`), so the pin pre-empted the configured default. On a gateway whose only real agent is, say, `support-desk`, every API call was answered by `main` with a bare workspace unless the caller appended `__hc_eval=agent=support-desk` to the model id.

Found while answering an integrator who wanted their agent reachable over REST.

## The fix

Resolve the same default every other surface uses: `resolveDefaultAgentId(getRuntimeConfig())`, as in `memory/sessions.ts`, `webchat-voice.ts`, and `gateway-http-server.ts`.

Priority is unchanged where it was already explicit: a fresh eval workspace outranks a profiled agent, which outranks the configured default. `resolveDefaultAgentId` returns `main` when nothing is configured (and when the configured id isn't in `agents.list`), so a gateway without agent config behaves exactly as before. Extracted as `resolveOpenAICompatibleAgentId` so the precedence is testable without standing up a request.

## Behaviour change worth a second opinion

On a gateway with a non-`main` `agents.defaultAgentId`, an unprofiled `/v1` request now reaches that agent instead of `main`. Eval harnesses that relied on "`/v1` is always `main`" should pin `__hc_eval=agent=main` (or `fresh-agent`). `hybridclaw eval` sends an explicit profile, so it is unaffected.

## Docs

A customer asked how an external system can send a prompt to their agent and read the response over REST. The docs could not answer it: `/v1/models` and `/v1/chat/completions` appeared only in `reference/commands.md` under *Local Eval Workflows*, with a loopback example and a line saying they are "intended for local tooling and eval harnesses rather than public exposure".

New guide `guides/openai-compatible-api.md` covers: scoped `hck_` token with the `openai.api` action, reaching the gateway over HTTPS, a minimal completion, agent selection (default-agent fallback plus both explicit forms) with the auto-approval warning, the fresh-session-per-request semantics, the delegation acknowledgement + polling path, and a troubleshooting table. Registered in the guides index and `navigation.json`.

Corrections to `reference/commands.md`, verified against the code:

- `/v1` accepts a scoped `hck_` token carrying `openai.api`, not only `WEB_API_TOKEN`/`GATEWAY_API_TOKEN` (`resolveAuthContext` + `isAdminActionAllowed(payload, 'openai.api')`)
- without an agent selection the turn runs as the configured default agent, falling back to `main`

## Tests

- `npx vitest run tests/openai-compatible-default-agent.test.ts` — 5 cases over the precedence chain; the interesting two fail against the old `DEFAULT_AGENT_ID` fallback
- `npx vitest run tests/gateway-http-server.test.ts` — 397 passed
- `npx vitest run tests/eval-command.test.ts tests/agent-risk-native.test.ts tests/locomo-native.test.ts` — 111 passed
- `npx vitest run tests/docs-viewer.test.ts tests/gateway-http-docs.integration.test.ts` — every markdown file under docs/content renders and internal links resolve
