### PR TITLE
feat(memory): persist a tool ledger with each assistant turn

### DIFF
--- a/docs/content/developer-guide/memory.md
+++ b/docs/content/developer-guide/memory.md
@@ -143,6 +143,17 @@ Important properties:
 - HybridClaw keeps only a bounded recent slice for prompt assembly
 - that slice is further compressed by character limits before sending
 - older turns are eventually compacted out of raw history
+- each assistant turn carries a compact tool ledger (`tool_ledger_json`):
+  per tool call the tool name, identifying arguments, ok/error, and a short
+  result or failure excerpt, capped at 24 entries / 2,000 chars per turn
+
+The ledger is rendered into prompt history as a trailer on the assistant
+message (`[tool ledger: 2 call(s), 1 failed; message send to:… → ok: …; cron
+add → error: …]`) so a follow-up turn sees what actually happened rather than
+the model's own prose claim. Stored message content stays clean; the trailer
+is derived from the stored ledger at prompt time, so it is identical on every
+later turn and does not disturb prompt caching. Web chat and transcript exports
+do not render the trailer; they receive the structured `toolLedger` field.
 
 This is the highest-fidelity memory for the current session, but it is the
 least durable because it is the first thing that gets compacted.

--- a/src/agent/conversation.ts
+++ b/src/agent/conversation.ts
@@ -15,6 +15,10 @@ import {
 } from '../skills/skills.js';
 import type { ChatMessage } from '../types/api.js';
 import {
+  appendToolLedgerTrailer,
+  type ToolLedgerEntry,
+} from '../types/tool-ledger.js';
+import {
   formatCurrentTime,
   loadRecentDailyMemoryFiles,
   loadStaticBootstrapFiles,
@@ -34,6 +38,14 @@ import { mergeAllowedToolNames, mergeBlockedToolNames } from './tool-policy.js';
 interface HistoryMessage {
   role: string;
   content: ChatMessage['content'];
+  toolLedger?: ToolLedgerEntry[];
+}
+
+function renderHistoryContent(msg: HistoryMessage): ChatMessage['content'] {
+  if (msg.role !== 'assistant' || typeof msg.content !== 'string') {
+    return msg.content;
+  }
+  return appendToolLedgerTrailer(msg.content, msg.toolLedger);
 }
 
 const HOSTNAME = sanitizeDynamicContextValue(os.hostname());
@@ -201,7 +213,7 @@ export function buildConversationContext(params: {
   const historyMessages = [...history].reverse().map(
     (msg): ChatMessage => ({
       role: msg.role as ChatMessage['role'],
-      content: msg.content,
+      content: renderHistoryContent(msg),
     }),
   );
 

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -2733,6 +2733,7 @@ async function handleGatewayMessageInner(
       resultText,
       artifacts: output.artifacts,
       toolCallCount: toolExecutions.length,
+      toolExecutions,
       startedAt,
       replaceBuiltInMemory: pluginMemoryBehavior.replacesBuiltInMemory,
     });

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -470,6 +470,7 @@ import type {
   DelegationSideEffect,
   DelegationTaskSpec,
 } from '../types/side-effects.js';
+import { buildToolLedger } from '../types/tool-ledger.js';
 import type { TokenUsageStats } from '../types/usage.js';
 import { buildMediaGenerationUsageEvents } from '../usage/media-generation-usage.js';
 import {
@@ -3873,12 +3874,14 @@ export function recordSuccessfulTurn(opts: {
   resultText: string;
   artifacts?: ArtifactMetadata[] | null;
   toolCallCount: number;
+  toolExecutions?: ToolExecution[];
   startedAt: number;
   replaceBuiltInMemory?: boolean;
 }): {
   userMessageId: number;
   assistantMessageId: number;
 } {
+  const toolLedger = buildToolLedger(opts.toolExecutions);
   const storedTurn =
     opts.replaceBuiltInMemory === true
       ? {
@@ -3897,6 +3900,7 @@ export function recordSuccessfulTurn(opts: {
             content: opts.resultText,
             agentId: opts.agentId,
             artifacts: opts.artifacts,
+            toolLedger,
           }),
         }
       : memoryService.storeTurn({
@@ -3912,6 +3916,7 @@ export function recordSuccessfulTurn(opts: {
             agentId: opts.agentId,
             content: opts.resultText,
             artifacts: opts.artifacts,
+            toolLedger,
           },
         });
   if (opts.replaceBuiltInMemory !== true) {
@@ -3962,6 +3967,7 @@ export function recordSuccessfulTurn(opts: {
     userId: 'assistant',
     username: null,
     content: opts.resultText,
+    toolLedger,
   });
 
   if (opts.replaceBuiltInMemory !== true) {

--- a/src/memory/memory-service.ts
+++ b/src/memory/memory-service.ts
@@ -29,6 +29,7 @@ import type {
   Session,
   StoredMessage,
 } from '../types/session.js';
+import type { ToolLedgerEntry } from '../types/tool-ledger.js';
 import { compactConversation } from './compaction.js';
 import {
   addKnowledgeEntity as dbAddKnowledgeEntity,
@@ -176,6 +177,7 @@ export interface MemoryBackend {
     agentId?: string | null,
     artifacts?: ArtifactMetadata[] | null,
     source?: string | null,
+    toolLedger?: ToolLedgerEntry[] | null,
   ) => number;
   storeSemanticMemory: (params: {
     sessionId: string;
@@ -249,6 +251,7 @@ export interface StoreTurnParams {
     agentId?: string | null;
     content: string;
     artifacts?: ArtifactMetadata[] | null;
+    toolLedger?: ToolLedgerEntry[] | null;
   };
 }
 
@@ -733,6 +736,7 @@ export class MemoryService {
     agentId?: string | null;
     artifacts?: ArtifactMetadata[] | null;
     source?: string | null;
+    toolLedger?: ToolLedgerEntry[] | null;
   }): number {
     return this.backend.storeMessage(
       params.sessionId,
@@ -743,6 +747,7 @@ export class MemoryService {
       params.agentId,
       params.artifacts,
       params.source,
+      params.toolLedger,
     );
   }
 
@@ -792,6 +797,7 @@ export class MemoryService {
       content: params.assistant.content,
       agentId: params.assistant.agentId,
       artifacts: params.assistant.artifacts,
+      toolLedger: params.assistant.toolLedger,
     });
 
     const interactionText = this.normalizeSemanticContent(

--- a/src/memory/messages.ts
+++ b/src/memory/messages.ts
@@ -12,6 +12,11 @@ import type {
   ResponseRatingValue,
   StoredMessage,
 } from '../types/session.js';
+import {
+  parseToolLedger,
+  serializeToolLedger,
+  type ToolLedgerEntry,
+} from '../types/tool-ledger.js';
 import { normalizeNonNegativeInteger } from '../utils/number-normalization.js';
 import { withMemoryDatabase } from './database.js';
 import { ensureSessionBranchesTable } from './schema/migrations.js';
@@ -31,7 +36,16 @@ interface ConversationHistoryPageRow {
   content: string | null;
   artifacts_json: string | null;
   activity_trace_json: string | null;
+  tool_ledger_json: string | null;
   created_at: string | null;
+}
+
+type StoredMessageRow = StoredMessage & { tool_ledger_json?: string | null };
+
+function hydrateStoredMessageRow(row: StoredMessageRow): StoredMessage {
+  const { tool_ledger_json, ...message } = row;
+  const toolLedger = parseToolLedger(tool_ledger_json);
+  return toolLedger ? { ...message, toolLedger } : message;
 }
 
 interface ResponseRatingRow {
@@ -150,6 +164,7 @@ export function storeMessage(
   agentId?: string | null,
   artifacts?: ArtifactMetadata[] | null,
   source?: string | null,
+  toolLedger?: ToolLedgerEntry[] | null,
 ): number {
   const resolvedSessionId = resolveSessionIdCompat(sessionId);
   const normalizedAgentId = agentId?.trim() || null;
@@ -164,9 +179,10 @@ export function storeMessage(
          agent_id,
          content,
          artifacts_json,
+         tool_ledger_json,
          source,
          created_at
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%d %H:%M:%f', 'now'))`,
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%d %H:%M:%f', 'now'))`,
     )
     .run(
       resolvedSessionId,
@@ -176,6 +192,7 @@ export function storeMessage(
       normalizedAgentId,
       content,
       artifactsJson,
+      serializeToolLedger(toolLedger),
       source?.trim() || null,
     );
 
@@ -207,12 +224,12 @@ export function getConversationHistory(
   limit = 50,
 ): StoredMessage[] {
   const resolvedSessionId = resolveSessionIdCompat(sessionId);
-  return queryAll<StoredMessage, [string, number]>(
+  return queryAll<StoredMessageRow, [string, number]>(
     getMessageDatabase(),
     'SELECT * FROM messages WHERE session_id = ? ORDER BY id DESC LIMIT ?',
     resolvedSessionId,
     limit,
-  );
+  ).map(hydrateStoredMessageRow);
 }
 
 export function getLatestAssistantMessageId(sessionId: string): number | null {
@@ -568,6 +585,7 @@ export function getConversationHistoryPage(
          m.content,
          m.artifacts_json,
          m.activity_trace_json,
+         m.tool_ledger_json,
          m.created_at
        FROM sessions s
        LEFT JOIN (
@@ -610,6 +628,7 @@ export function getConversationHistoryPage(
       continue;
     }
     const activityTrace = parseActivityTrace(row.activity_trace_json);
+    const toolLedger = parseToolLedger(row.tool_ledger_json);
     history.push({
       id: row.id,
       session_id: row.session_id,
@@ -620,6 +639,7 @@ export function getConversationHistoryPage(
       content: row.content,
       artifacts: parseMessageArtifacts(row.artifacts_json),
       ...(activityTrace ? { activityTrace } : {}),
+      ...(toolLedger ? { toolLedger } : {}),
       created_at: row.created_at,
     });
   }
@@ -645,19 +665,19 @@ export function getRecentMessages(
       : null;
 
   if (boundedLimit == null) {
-    return queryAll<StoredMessage, [string]>(
+    return queryAll<StoredMessageRow, [string]>(
       getMessageDatabase(),
       'SELECT * FROM messages WHERE session_id = ? ORDER BY id ASC',
       resolvedSessionId,
-    );
+    ).map(hydrateStoredMessageRow);
   }
 
-  const rows = queryAll<StoredMessage, [string, number]>(
+  const rows = queryAll<StoredMessageRow, [string, number]>(
     getMessageDatabase(),
     'SELECT * FROM messages WHERE session_id = ? ORDER BY id DESC LIMIT ?',
     resolvedSessionId,
     boundedLimit,
-  );
+  ).map(hydrateStoredMessageRow);
   return rows.reverse();
 }
 

--- a/src/memory/schema/migrations.ts
+++ b/src/memory/schema/migrations.ts
@@ -23,7 +23,7 @@ import {
 } from '../../session/session-key.js';
 import type { CanonicalSessionMessage, Session } from '../../types/session.js';
 
-export const DATABASE_SCHEMA_VERSION = 57;
+export const DATABASE_SCHEMA_VERSION = 58;
 const AGENT_CANONICAL_ID_COLLISION_LIMIT = 20;
 const AUDIT_ACTOR_MIGRATION_BATCH_SIZE = 500;
 const ACTOR_ID_MAX_LENGTH =
@@ -972,6 +972,7 @@ function migrateV1(database: Database.Database): void {
       content TEXT NOT NULL,
       artifacts_json TEXT,
       activity_trace_json TEXT,
+      tool_ledger_json TEXT,
       source TEXT,
       created_at TEXT DEFAULT (datetime('now'))
     );
@@ -3522,6 +3523,20 @@ function migrateV57(
   recordMigration(database, 57, 'Persist per-agent tool allowlists');
 }
 
+function migrateV58(
+  database: Database.Database,
+  opts?: InitDatabaseOptions,
+): void {
+  addColumnIfMissing({
+    database,
+    table: 'messages',
+    column: 'tool_ledger_json',
+    ddl: 'tool_ledger_json TEXT',
+    quiet: opts?.quiet === true,
+  });
+  recordMigration(database, 58, 'Persist tool ledgers per assistant message');
+}
+
 export function runMigrations(
   database: Database.Database,
   opts?: InitDatabaseOptions,
@@ -3661,6 +3676,13 @@ export function runMigrations(
   if (currentVersion < 56) migrateV56(database);
   if (currentVersion < 57 || agentToolsNeedMigration(database)) {
     migrateV57(database, opts);
+  }
+  if (
+    currentVersion < 58 ||
+    (tableExists(database, 'messages') &&
+      !columnExists(database, 'messages', 'tool_ledger_json'))
+  ) {
+    migrateV58(database, opts);
   }
 
   setSchemaVersion(database, DATABASE_SCHEMA_VERSION);

--- a/src/memory/sessions.ts
+++ b/src/memory/sessions.ts
@@ -671,8 +671,8 @@ export function forkSessionBranch(
     copySessionKvStore(sourceSession.id, nextSessionId);
     getSessionDatabase()
       .prepare(
-        `INSERT INTO messages (session_id, user_id, username, role, agent_id, content, artifacts_json, activity_trace_json, created_at)
-       SELECT ?, user_id, username, role, agent_id, content, artifacts_json, activity_trace_json, created_at
+        `INSERT INTO messages (session_id, user_id, username, role, agent_id, content, artifacts_json, activity_trace_json, tool_ledger_json, created_at)
+       SELECT ?, user_id, username, role, agent_id, content, artifacts_json, activity_trace_json, tool_ledger_json, created_at
        FROM messages
        WHERE session_id = ?
          AND id < ?

--- a/src/scheduler/heartbeat.ts
+++ b/src/scheduler/heartbeat.ts
@@ -41,6 +41,7 @@ import { buildSessionKey } from '../session/session-key.js';
 import { maybeCompactSession } from '../session/session-maintenance.js';
 import { appendSessionTranscript } from '../session/session-transcripts.js';
 import { runPeriodicSkillInspection } from '../skills/skills-inspection.js';
+import { buildToolLedger } from '../types/tool-ledger.js';
 import { hasActionableHeartbeatFile } from '../workspace.js';
 import { HEARTBEAT_POLL_PROMPT } from './heartbeat-prompt.js';
 import {
@@ -389,6 +390,7 @@ export function startHeartbeat(
       }
 
       // Real content — persist and deliver
+      const toolLedger = buildToolLedger(output.toolExecutions);
       memoryService.storeTurn({
         sessionId,
         user: {
@@ -401,6 +403,7 @@ export function startHeartbeat(
           username: null,
           agentId: resolvedAgentId,
           content: result,
+          toolLedger,
         },
       });
       appendSessionTranscript(resolvedAgentId, {
@@ -418,6 +421,7 @@ export function startHeartbeat(
         userId: 'assistant',
         username: null,
         content: result,
+        toolLedger,
       });
       await maybeCompactSession({
         sessionId,

--- a/src/scheduler/scheduled-task-runner.ts
+++ b/src/scheduler/scheduled-task-runner.ts
@@ -17,9 +17,9 @@ import {
 } from '../session/session-key.js';
 import { appendSessionTranscript } from '../session/session-transcripts.js';
 import { buildEligibleSkillCatalog } from '../skills/skill-catalog.js';
+import { buildToolLedger } from '../types/tool-ledger.js';
 import { buildMediaGenerationUsageEvents } from '../usage/media-generation-usage.js';
 import { resolveUsageCostUsdAfterMetadataRefresh } from '../usage/model-cost.js';
-import { buildToolLedger } from '../types/tool-ledger.js';
 import { enqueueTokenUsage } from '../usage/token-usage-buffer.js';
 import {
   buildModelUsageAuditStats,

--- a/src/scheduler/scheduled-task-runner.ts
+++ b/src/scheduler/scheduled-task-runner.ts
@@ -19,6 +19,7 @@ import { appendSessionTranscript } from '../session/session-transcripts.js';
 import { buildEligibleSkillCatalog } from '../skills/skill-catalog.js';
 import { buildMediaGenerationUsageEvents } from '../usage/media-generation-usage.js';
 import { resolveUsageCostUsdAfterMetadataRefresh } from '../usage/model-cost.js';
+import { buildToolLedger } from '../types/tool-ledger.js';
 import { enqueueTokenUsage } from '../usage/token-usage-buffer.js';
 import {
   buildModelUsageAuditStats,
@@ -182,6 +183,7 @@ export async function runIsolatedScheduledTask(params: {
     }
 
     if (output.status === 'success' && output.result) {
+      const toolLedger = buildToolLedger(output.toolExecutions);
       memoryService.storeTurn({
         sessionId: activeSessionId,
         user: {
@@ -194,6 +196,7 @@ export async function runIsolatedScheduledTask(params: {
           username: null,
           agentId,
           content: output.result,
+          toolLedger,
         },
       });
       appendSessionTranscript(agentId, {
@@ -211,6 +214,7 @@ export async function runIsolatedScheduledTask(params: {
         userId: 'assistant',
         username: null,
         content: output.result,
+        toolLedger,
       });
       await onResult({
         text: output.result,

--- a/src/session/session-transcripts.ts
+++ b/src/session/session-transcripts.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import { agentWorkspaceDir, ensureAgentDirs } from '../infra/ipc.js';
 import { logger } from '../logger.js';
+import type { ToolLedgerEntry } from '../types/tool-ledger.js';
 
 const TRANSCRIPTS_DIR_NAME = '.session-transcripts';
 
@@ -13,6 +14,7 @@ export interface TranscriptEntry {
   userId: string;
   username: string | null;
   content: string;
+  toolLedger?: ToolLedgerEntry[];
   createdAt?: string;
 }
 
@@ -42,6 +44,9 @@ export function appendSessionTranscript(
       userId: entry.userId,
       username: entry.username,
       content: entry.content,
+      ...(entry.toolLedger && entry.toolLedger.length > 0
+        ? { toolLedger: entry.toolLedger }
+        : {}),
       createdAt: entry.createdAt || new Date().toISOString(),
     };
     fs.appendFileSync(filePath, `${JSON.stringify(row)}\n`, 'utf-8');

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -1,5 +1,6 @@
 import type { ActivityTrace } from './activity-trace.js';
 import type { ArtifactMetadata } from './execution.js';
+import type { ToolLedgerEntry } from './tool-ledger.js';
 
 export type SessionShowMode = 'all' | 'thinking' | 'tools' | 'none';
 
@@ -46,6 +47,8 @@ export interface StoredMessage {
   artifacts?: ArtifactMetadata[];
   /** Web-chat activity trace (thinking + tool calls) for assistant turns. */
   activityTrace?: ActivityTrace;
+  /** Compact tool outcomes for assistant turns, rendered into later prompts. */
+  toolLedger?: ToolLedgerEntry[];
   /** Provenance of the turn, e.g. 'voice' for realtime speech transcripts. */
   source?: string | null;
   created_at: string;

--- a/src/types/tool-ledger.ts
+++ b/src/types/tool-ledger.ts
@@ -1,0 +1,226 @@
+/**
+ * Tool ledger — the compact, persisted record of what an assistant turn
+ * actually did with its tools, stored beside the assistant message.
+ *
+ * Built once when the turn is recorded, then rendered verbatim into later
+ * prompts so a follow-up turn sees the real outcome of every call rather
+ * than the model's own prose claim. Stored content is never rewritten: the
+ * ledger lives in its own column and the trailer is appended only at prompt
+ * time. Bounded so a tool-heavy turn cannot crowd out history.
+ *
+ * NOT the web-chat activity trace (`activity-trace.ts`), which keeps full
+ * previews for the UI and never re-enters the prompt.
+ */
+
+import { redactCredentialSecrets } from '../security/redact.js';
+import type { ToolExecution } from './execution.js';
+
+export interface ToolLedgerEntry {
+  tool: string;
+  /** Identifying arguments, e.g. `send to:+49…` or `add cron:"0 7 * * *"`. */
+  args?: string;
+  ok: boolean;
+  /** Short result excerpt (success) or failure reason (error). */
+  note?: string;
+}
+
+// Caps (owner call, 2026-09-06): 24 entries / 2,000 chars keeps one turn's
+// trailer under a tenth of the 24,000-char prompt history budget; richer
+// per-call detail stays in the activity trace.
+export const TOOL_LEDGER_MAX_ENTRIES = 24;
+export const TOOL_LEDGER_MAX_CHARS = 2_000;
+const ARGS_MAX_CHARS = 80;
+const NOTE_MAX_CHARS = 160;
+const ARG_VALUE_MAX_CHARS = 48;
+
+const DIGEST_ARG_KEYS = [
+  'action',
+  'channel',
+  'channelId',
+  'to',
+  'recipient',
+  'taskId',
+  'cron',
+  'at',
+  'every',
+  'path',
+  'filePath',
+  'file',
+  'url',
+  'query',
+  'name',
+  'command',
+] as const;
+
+function parseJsonObject(raw: unknown): Record<string, unknown> | null {
+  if (typeof raw !== 'string' || !raw.trim()) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function collapse(text: string, maxChars: number): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, maxChars - 1).trimEnd()}…`;
+}
+
+function formatArgValue(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? collapse(trimmed, ARG_VALUE_MAX_CHARS) : null;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return null;
+}
+
+function buildArgsDigest(rawArguments: string): string | undefined {
+  const args = parseJsonObject(rawArguments);
+  if (!args) return undefined;
+  const parts: string[] = [];
+  for (const key of DIGEST_ARG_KEYS) {
+    const formatted = formatArgValue(args[key]);
+    if (!formatted) continue;
+    parts.push(key === 'action' ? formatted : `${key}:${formatted}`);
+    if (parts.length >= 4) break;
+  }
+  if (parts.length === 0) return undefined;
+  return collapse(redactCredentialSecrets(parts.join(' ')), ARGS_MAX_CHARS);
+}
+
+function resolveOutcome(execution: ToolExecution): {
+  ok: boolean;
+  note?: string;
+} {
+  if (execution.blocked) {
+    return {
+      ok: false,
+      note: collapse(
+        redactCredentialSecrets(
+          execution.blockedReason || 'blocked by security policy',
+        ),
+        NOTE_MAX_CHARS,
+      ),
+    };
+  }
+  const result = String(execution.result ?? '');
+  const parsed = parseJsonObject(result);
+  const structuredFailure =
+    parsed != null && (parsed.ok === false || parsed.success === false);
+  const failed =
+    execution.isError === true ||
+    structuredFailure ||
+    /^\s*error:/i.test(result);
+  let note = result;
+  if (structuredFailure && typeof parsed.error === 'string') {
+    note = parsed.error;
+  } else if (failed) {
+    note = result.replace(/^\s*error:\s*/i, '');
+  }
+  const collapsed = collapse(redactCredentialSecrets(note), NOTE_MAX_CHARS);
+  return collapsed ? { ok: !failed, note: collapsed } : { ok: !failed };
+}
+
+export function buildToolLedger(
+  toolExecutions: ToolExecution[] | null | undefined,
+): ToolLedgerEntry[] {
+  if (!Array.isArray(toolExecutions) || toolExecutions.length === 0) return [];
+  const entries: ToolLedgerEntry[] = [];
+  let totalChars = 0;
+  for (const execution of toolExecutions) {
+    if (entries.length >= TOOL_LEDGER_MAX_ENTRIES) break;
+    const tool = String(execution.name || '').trim() || 'tool';
+    const args = buildArgsDigest(execution.arguments);
+    const outcome = resolveOutcome(execution);
+    const entry: ToolLedgerEntry = {
+      tool,
+      ...(args ? { args } : {}),
+      ok: outcome.ok,
+      ...(outcome.note ? { note: outcome.note } : {}),
+    };
+    const entryChars = renderToolLedgerEntry(entry).length;
+    if (totalChars + entryChars > TOOL_LEDGER_MAX_CHARS) break;
+    totalChars += entryChars;
+    entries.push(entry);
+  }
+  return entries;
+}
+
+export function serializeToolLedger(
+  ledger: ToolLedgerEntry[] | null | undefined,
+): string | null {
+  return Array.isArray(ledger) && ledger.length > 0
+    ? JSON.stringify(ledger)
+    : null;
+}
+
+export function parseToolLedger(
+  raw: string | null | undefined,
+): ToolLedgerEntry[] | undefined {
+  if (!raw) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return undefined;
+    const entries: ToolLedgerEntry[] = [];
+    for (const item of parsed) {
+      if (!item || typeof item !== 'object') continue;
+      const record = item as Record<string, unknown>;
+      const tool = typeof record.tool === 'string' ? record.tool.trim() : '';
+      if (!tool) continue;
+      entries.push({
+        tool,
+        ...(typeof record.args === 'string' && record.args
+          ? { args: record.args }
+          : {}),
+        ok: record.ok === true,
+        ...(typeof record.note === 'string' && record.note
+          ? { note: record.note }
+          : {}),
+      });
+    }
+    return entries.length > 0 ? entries : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function renderToolLedgerEntry(entry: ToolLedgerEntry): string {
+  const head = entry.args ? `${entry.tool} ${entry.args}` : entry.tool;
+  const status = entry.ok ? 'ok' : 'error';
+  return entry.note
+    ? `${head} → ${status}: ${entry.note}`
+    : `${head} → ${status}`;
+}
+
+/**
+ * Renders the ledger as one bracketed trailer line. Deterministic for a given
+ * stored ledger, so appending it never changes a cached history prefix.
+ */
+export function renderToolLedgerTrailer(
+  ledger: ToolLedgerEntry[] | null | undefined,
+): string {
+  if (!Array.isArray(ledger) || ledger.length === 0) return '';
+  const failed = ledger.filter((entry) => !entry.ok).length;
+  const summary =
+    failed > 0
+      ? `${ledger.length} call(s), ${failed} failed`
+      : `${ledger.length} call(s), all ok`;
+  return `[tool ledger: ${summary}; ${ledger.map(renderToolLedgerEntry).join('; ')}]`;
+}
+
+export function appendToolLedgerTrailer(
+  content: string,
+  ledger: ToolLedgerEntry[] | null | undefined,
+): string {
+  const trailer = renderToolLedgerTrailer(ledger);
+  if (!trailer) return content;
+  const base = content.trimEnd();
+  return base ? `${base}\n\n${trailer}` : trailer;
+}

--- a/tests/gateway-service.scheduler.test.ts
+++ b/tests/gateway-service.scheduler.test.ts
@@ -492,7 +492,14 @@ test('scheduled agent turns persist outputs for admin jobs detail', async () => 
     status: 'success',
     result:
       'HybridClaw.io focuses on a personal AI assistant with a gateway, TUI, and sandboxed container runtime.',
-    toolExecutions: [],
+    toolExecutions: [
+      {
+        name: 'web_fetch',
+        arguments: '{"url":"https://hybridclaw.io"}',
+        result: '<html>HybridClaw</html>',
+        isError: false,
+      },
+    ],
     artifacts: [],
   });
 
@@ -551,6 +558,18 @@ test('scheduled agent turns persist outputs for admin jobs detail', async () => 
       role: 'assistant',
       content:
         'HybridClaw.io focuses on a personal AI assistant with a gateway, TUI, and sandboxed container runtime.',
+    },
+  ]);
+  expect(
+    memoryService
+      .getConversationHistory(session.id)
+      .find((message) => message.role === 'assistant')?.toolLedger,
+  ).toEqual([
+    {
+      tool: 'web_fetch',
+      args: 'url:https://hybridclaw.io',
+      ok: true,
+      note: '<html>HybridClaw</html>',
     },
   ]);
   expect(

--- a/tests/heartbeat.test.ts
+++ b/tests/heartbeat.test.ts
@@ -211,7 +211,14 @@ test('delivers substantive heartbeat messages', async () => {
   mocks.runAgent.mockResolvedValue({
     status: 'success',
     result: 'Review the queued tasks today.',
-    toolExecutions: [],
+    toolExecutions: [
+      {
+        name: 'message',
+        arguments: '{"action":"send","channel":"telegram","to":"ops"}',
+        result: 'Error: channel not linked',
+        isError: true,
+      },
+    ],
   });
 
   const { startHeartbeat, stopHeartbeat } = await import(
@@ -225,7 +232,22 @@ test('delivers substantive heartbeat messages', async () => {
 
   expect(onMessage).toHaveBeenCalledWith('Review the queued tasks today.');
   expect(mocks.memoryService.storeTurn).toHaveBeenCalledTimes(1);
+  const expectedLedger = [
+    {
+      tool: 'message',
+      args: 'send channel:telegram to:ops',
+      ok: false,
+      note: 'channel not linked',
+    },
+  ];
+  expect(mocks.memoryService.storeTurn.mock.calls[0]?.[0]).toMatchObject({
+    assistant: { toolLedger: expectedLedger },
+  });
   expect(mocks.appendSessionTranscript).toHaveBeenCalledTimes(2);
+  expect(mocks.appendSessionTranscript.mock.calls[1]?.[1]).toMatchObject({
+    role: 'assistant',
+    toolLedger: expectedLedger,
+  });
   expect(mocks.maybeCompactSession).toHaveBeenCalledTimes(1);
 });
 

--- a/tests/message-activity-trace.test.ts
+++ b/tests/message-activity-trace.test.ts
@@ -59,6 +59,64 @@ describe('message activity trace persistence', () => {
     expect(user?.activityTrace).toBeUndefined();
   });
 
+  it('round-trips an assistant tool ledger through history and prompt loading', async () => {
+    const dbModule = await import('../src/memory/db.js');
+    const { buildToolLedger } = await import('../src/types/tool-ledger.js');
+    const dbPath = path.join(makeTempDir(), 'hybridclaw.db');
+    dbModule.initDatabase({ quiet: true, dbPath });
+
+    const session = dbModule.getOrCreateSession(
+      'agent:main:channel:web:chat:dm:peer:tool-ledger',
+      null,
+      'web',
+      'main',
+    );
+    dbModule.storeMessage(session.id, 'user_a', 'User A', 'user', 'Send it');
+    const ledger = buildToolLedger([
+      {
+        name: 'message',
+        arguments: '{"action":"send","to":"+49 151"}',
+        result: '{"ok":false,"error":"recipient unknown"}',
+        durationMs: 5,
+      },
+    ]);
+    const assistantId = dbModule.storeMessage(
+      session.id,
+      'assistant',
+      null,
+      'assistant',
+      'Done.',
+      'main',
+      null,
+      null,
+      ledger,
+    );
+
+    const history = dbModule.getConversationHistory(session.id, 10);
+    const assistant = history.find((m) => m.role === 'assistant');
+    expect(assistant?.id).toBe(assistantId);
+    expect(assistant?.toolLedger).toEqual([
+      {
+        tool: 'message',
+        args: 'send to:+49 151',
+        ok: false,
+        note: 'recipient unknown',
+      },
+    ]);
+    expect(assistant?.content).toBe('Done.');
+    expect(assistant).not.toHaveProperty('tool_ledger_json');
+    expect(history.find((m) => m.role === 'user')?.toolLedger).toBeUndefined();
+
+    const page = dbModule.getConversationHistoryPage(session.id, 50);
+    expect(
+      page.history.find((m) => m.role === 'assistant')?.toolLedger,
+    ).toEqual(assistant?.toolLedger);
+    expect(
+      dbModule.getRecentMessages(session.id).find((m) => m.role === 'assistant')
+        ?.toolLedger,
+    ).toEqual(assistant?.toolLedger);
+  });
+
   it('preserves activity traces when a session is branched', async () => {
     const dbModule = await import('../src/memory/db.js');
     const dbPath = path.join(makeTempDir(), 'hybridclaw.db');

--- a/tests/prompt-hooks-stability.test.ts
+++ b/tests/prompt-hooks-stability.test.ts
@@ -113,6 +113,38 @@ test('system prompt blocks isolate workspace memory updates from the static core
   expect(first[1]).not.toBe(second[1]);
 });
 
+test('buildConversationContext renders stored tool ledgers into assistant history', async () => {
+  const agentId = 'tool-ledger-agent';
+  await createWorkspaceWithBootstrapFiles(agentId);
+  const { buildConversationContext } = await import(
+    '../src/agent/conversation.js'
+  );
+
+  const ledger = [
+    { tool: 'message', args: 'send to:+49 151', ok: true, note: 'accepted' },
+  ];
+  const context = buildConversationContext({
+    agentId,
+    history: [
+      { role: 'assistant', content: 'Sent.', toolLedger: ledger },
+      { role: 'user', content: 'Send it' },
+      { role: 'assistant', content: 'Hi' },
+    ],
+    runtimeInfo: {
+      model: 'openai-codex/gpt-5.4',
+      workspacePath: '/workspace/tool-ledger-agent',
+    },
+  });
+
+  const assistantMessages = context.messages.filter(
+    (message) => message.role === 'assistant',
+  );
+  expect(assistantMessages.map((message) => message.content)).toEqual([
+    'Hi',
+    'Sent.\n\n[tool ledger: 1 call(s), all ok; message send to:+49 151 → ok: accepted]',
+  ]);
+});
+
 test('buildConversationContext appends dynamic context after unchanged history', async () => {
   vi.useFakeTimers();
 

--- a/tests/tool-ledger.next-turn.test.ts
+++ b/tests/tool-ledger.next-turn.test.ts
@@ -1,0 +1,81 @@
+import { expect, test, vi } from 'vitest';
+import { useCleanMocks, useTempDir } from './test-utils.ts';
+
+const ORIGINAL_HOME = process.env.HOME;
+const makeTempHome = useTempDir('hybridclaw-tool-ledger-next-turn-');
+
+useCleanMocks({
+  cleanup: () => {
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+    else process.env.HOME = ORIGINAL_HOME;
+  },
+  resetModules: true,
+});
+
+test('a recorded turn renders its tool ledger into the next prompt', async () => {
+  process.env.HOME = makeTempHome();
+  vi.resetModules();
+
+  const { initDatabase, getOrCreateSession } = await import(
+    '../src/memory/db.ts'
+  );
+  const { memoryService } = await import('../src/memory/memory-service.ts');
+  const { recordSuccessfulTurn } = await import(
+    '../src/gateway/gateway-service.ts'
+  );
+  const { buildConversationContext } = await import(
+    '../src/agent/conversation.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const session = getOrCreateSession(
+    'agent:main:channel:web:chat:dm:peer:ledger',
+    null,
+    'web',
+    'main',
+  );
+
+  recordSuccessfulTurn({
+    sessionId: session.id,
+    channelId: 'web',
+    agentId: 'main',
+    chatbotId: '',
+    enableRag: false,
+    model: 'openai/gpt-5.4',
+    userId: 'user_a',
+    username: 'User A',
+    canonicalScopeId: 'user_a',
+    userContent: 'Send the report to +49 151',
+    resultText: 'Sent.',
+    toolCallCount: 2,
+    toolExecutions: [
+      {
+        name: 'message',
+        arguments: '{"action":"send","channel":"whatsapp","to":"+49 151"}',
+        result: '{"ok":false,"error":"WhatsApp is not linked"}',
+        isError: false,
+      },
+      {
+        name: 'write',
+        arguments: '{"path":"report.md"}',
+        result: 'Wrote 12 lines',
+        isError: false,
+      },
+    ],
+    startedAt: Date.now(),
+  });
+
+  const history = memoryService.getConversationHistory(session.id);
+  const context = buildConversationContext({
+    agentId: 'main',
+    history,
+    runtimeInfo: { model: 'openai/gpt-5.4', workspacePath: '/workspace/main' },
+  });
+
+  const assistant = context.messages.find(
+    (message) => message.role === 'assistant',
+  );
+  expect(assistant?.content).toBe(
+    'Sent.\n\n[tool ledger: 2 call(s), 1 failed; message send channel:whatsapp to:+49 151 → error: WhatsApp is not linked; write path:report.md → ok: Wrote 12 lines]',
+  );
+});

--- a/tests/tool-ledger.test.ts
+++ b/tests/tool-ledger.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ToolExecution } from '../src/types/execution.js';
+import {
+  appendToolLedgerTrailer,
+  buildToolLedger,
+  parseToolLedger,
+  renderToolLedgerTrailer,
+  serializeToolLedger,
+  TOOL_LEDGER_MAX_CHARS,
+  TOOL_LEDGER_MAX_ENTRIES,
+} from '../src/types/tool-ledger.js';
+
+function execution(overrides: Partial<ToolExecution>): ToolExecution {
+  return {
+    name: 'tool',
+    arguments: '{}',
+    result: '',
+    durationMs: 1,
+    ...overrides,
+  };
+}
+
+describe('buildToolLedger', () => {
+  it('records a successful send with its identifying arguments', () => {
+    const ledger = buildToolLedger([
+      execution({
+        name: 'message',
+        arguments: JSON.stringify({
+          action: 'send',
+          channel: 'whatsapp',
+          to: '+49 151 0000000',
+          text: 'Hello there, long message body that must not leak',
+        }),
+        result: JSON.stringify({
+          ok: true,
+          action: 'send',
+          recipient: '+49 151 0000000',
+          deliveryStatus: 'accepted_by_linked_device',
+        }),
+      }),
+    ]);
+
+    expect(ledger).toEqual([
+      {
+        tool: 'message',
+        args: 'send channel:whatsapp to:+49 151 0000000',
+        ok: true,
+        note: expect.stringContaining('accepted_by_linked_device'),
+      },
+    ]);
+    expect(ledger[0]?.note).not.toContain('long message body');
+  });
+
+  it('marks isError, blocked, "Error:" and ok:false results as failures', () => {
+    const ledger = buildToolLedger([
+      execution({ name: 'write', isError: true, result: 'disk full' }),
+      execution({
+        name: 'bash',
+        blocked: true,
+        blockedReason: 'denied by policy',
+        result: '',
+      }),
+      execution({
+        name: 'cron',
+        arguments: JSON.stringify({ action: 'add', cron: '0 7 * * *' }),
+        result: 'Error: invalid cron expression',
+      }),
+      execution({
+        name: 'message',
+        result: JSON.stringify({ ok: false, error: 'recipient unknown' }),
+      }),
+    ]);
+
+    expect(ledger.map((entry) => [entry.ok, entry.note])).toEqual([
+      [false, 'disk full'],
+      [false, 'denied by policy'],
+      [false, 'invalid cron expression'],
+      [false, 'recipient unknown'],
+    ]);
+    expect(ledger[2]?.args).toBe('add cron:0 7 * * *');
+  });
+
+  it('truncates long results and collapses whitespace', () => {
+    const ledger = buildToolLedger([
+      execution({ name: 'read', result: `line one\n\n${'x'.repeat(500)}` }),
+    ]);
+    const note = ledger[0]?.note || '';
+    expect(note.length).toBeLessThanOrEqual(160);
+    expect(note.startsWith('line one x')).toBe(true);
+    expect(note.endsWith('…')).toBe(true);
+  });
+
+  it('redacts secrets from arguments and results', () => {
+    const ledger = buildToolLedger([
+      execution({
+        name: 'http',
+        arguments: JSON.stringify({
+          url: 'https://example.com?api_key=sk-1234567890abcdefghijklmnopqrstuv',
+        }),
+        result: 'Authorization: Bearer abcdefghijklmnopqrstuvwxyz0123456789',
+      }),
+    ]);
+    expect(ledger[0]?.args).not.toContain('sk-1234567890abcdefghijklmnopqrstuv');
+    expect(ledger[0]?.note).not.toContain(
+      'abcdefghijklmnopqrstuvwxyz0123456789',
+    );
+  });
+
+  it('caps the entry count and the total rendered size', () => {
+    const many = Array.from({ length: TOOL_LEDGER_MAX_ENTRIES + 10 }, (_, i) =>
+      execution({ name: `tool${i}`, result: 'ok' }),
+    );
+    expect(buildToolLedger(many)).toHaveLength(TOOL_LEDGER_MAX_ENTRIES);
+
+    const heavy = Array.from({ length: 20 }, () =>
+      execution({ name: 'read', result: 'y'.repeat(200) }),
+    );
+    const ledger = buildToolLedger(heavy);
+    const rendered = ledger
+      .map((entry) => `${entry.tool} → ok: ${entry.note}`)
+      .join('');
+    expect(ledger.length).toBeLessThan(20);
+    expect(rendered.length).toBeLessThanOrEqual(TOOL_LEDGER_MAX_CHARS);
+  });
+
+  it('returns an empty ledger for turns without tool calls', () => {
+    expect(buildToolLedger([])).toEqual([]);
+    expect(buildToolLedger(undefined)).toEqual([]);
+    expect(serializeToolLedger([])).toBeNull();
+  });
+});
+
+describe('tool ledger serialization and rendering', () => {
+  it('round-trips through JSON and drops malformed entries', () => {
+    const ledger = buildToolLedger([
+      execution({ name: 'memory', arguments: '{"action":"append"}', result: 'ok' }),
+    ]);
+    expect(parseToolLedger(serializeToolLedger(ledger))).toEqual(ledger);
+    expect(parseToolLedger(null)).toBeUndefined();
+    expect(parseToolLedger('not json')).toBeUndefined();
+    expect(parseToolLedger('[{"ok":true},{"tool":"x","ok":"yes"}]')).toEqual([
+      { tool: 'x', ok: false },
+    ]);
+  });
+
+  it('renders a deterministic trailer with a failure summary', () => {
+    const ledger = [
+      { tool: 'message', args: 'send to:+49', ok: true, note: 'accepted' },
+      { tool: 'cron', args: 'add', ok: false, note: 'invalid cron' },
+    ];
+    const trailer = renderToolLedgerTrailer(ledger);
+    expect(trailer).toBe(
+      '[tool ledger: 2 call(s), 1 failed; message send to:+49 → ok: accepted; cron add → error: invalid cron]',
+    );
+    expect(renderToolLedgerTrailer(ledger)).toBe(trailer);
+    expect(appendToolLedgerTrailer('Sent it.\n', ledger)).toBe(
+      `Sent it.\n\n${trailer}`,
+    );
+    expect(appendToolLedgerTrailer('Plain answer', [])).toBe('Plain answer');
+    expect(renderToolLedgerTrailer(undefined)).toBe('');
+  });
+});


### PR DESCRIPTION
## Why

Tool executions were dropped when a turn was persisted: `recordSuccessfulTurn` stored only the user text and the assistant's final text, and the next turn rebuilt context from `role`/`content` alone. In a follow-up turn the model had no evidence of whether an earlier `message`/`cron`/`write` call succeeded or failed, so "did you actually send it?" could only be answered by repeating its own claim. The web-chat activity trace stores previews at rest but is UI-only and never re-enters the prompt.

Closes #1469

## What

- **`src/types/tool-ledger.ts`** (new): builds a compact ledger from `ToolExecution[]` — per call the tool name, an identifying args digest (action, channel/to/recipient, taskId, cron/at/every, path, url, query, name, command), `ok`/`error` (isError, blocked, `Error:` prefix, `ok:false`/`success:false`), and a short result or failure excerpt. Credential redaction applies to args and notes. Capped at 24 entries / 2,000 chars per turn (decision-provenance comment in the file). Also serialize/parse and the deterministic `[tool ledger: …]` trailer renderer.
- **Persistence**: migration V58 adds `messages.tool_ledger_json` (same `addColumnIfMissing` pattern as `activity_trace_json`). `storeMessage`/`storeTurn` accept `toolLedger`; `recordSuccessfulTurn` builds it from the turn's `toolExecutions` and the chat service passes them. Session branching copies the column. The JSONL session transcript row carries `toolLedger` too.
- **Loading**: `getConversationHistory`, `getRecentMessages`, and `getConversationHistoryPage` expose a structured `toolLedger` field on `StoredMessage` (raw column stripped). Stored `content` is untouched, so web chat and exports do not see the trailer.
- **Prompt rendering**: `buildConversationContext` appends the trailer to assistant history messages that have a ledger, e.g. `Sent.\n\n[tool ledger: 2 call(s), 1 failed; message send to:+49… → ok: …; cron add cron:0 7 * * * → error: invalid cron expression]`. Turns without tool calls get no trailer. The trailer is derived from stored data, so it is byte-identical on every later turn and does not disturb prompt caching.
- **Docs**: note in `docs/content/developer-guide/memory.md` under Raw Session History.
- **Tests**: `tests/tool-ledger.test.ts` (ok/error detection, truncation, redaction, caps, round-trip, rendering); persistence round-trip through `getConversationHistory`/`getConversationHistoryPage`/`getRecentMessages` in `tests/message-activity-trace.test.ts`; conversation-context rendering in `tests/prompt-hooks-stability.test.ts`.

## Validation

- `npm run format`, `npm run lint`, `npm run typecheck`: clean
- `npx vitest run` on tool-ledger, message-activity-trace, prompt-hooks-stability, memory-service, session-trace-export, database-session.integration, gateway-history-summary, session-maintenance, heartbeat, activity-trace, board-card-store, session-reset, response-ratings, gateway-chat-approval, token-efficiency.basic, database-wal-selfheal.integration, gateway-service.media-history, gateway-service.memory-inspect, cloud-memory: all passing

## Not in scope

- Canonical cross-channel memory and session-summary compaction still see plain assistant text; the ledger is only rendered into the raw recent-history slice.
- Scheduler / side-effect reporting paths (#1461, #1464) are handled separately.


## Follow-up after review

- Scheduled-task and heartbeat turns now build a ledger from their `toolExecutions` and pass it into `storeTurn` and the assistant transcript row, so a cron run that sent a message leaves the same evidence as a chat turn.
- New end-to-end test `tests/tool-ledger.next-turn.test.ts`: `recordSuccessfulTurn` with a failed message send and a successful write, then `buildConversationContext` from the stored history, asserting the trailer text. Scheduler and heartbeat suites assert the ledger reaches `storeTurn`.
- Delegation completion rows are left without a ledger: the delegation run result only carries tool names (`toolsUsed`), not outcomes, and those names are already listed in the stored `tools_used:` line.
- `parseToolLedger` still reads a missing `ok` as a failure. The entry type requires a boolean and treating an unknown outcome as success would be the worse error, so this is unchanged.
