### PR TITLE
fix(gateway): persist user message and error placeholder for error turns

### DIFF
--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -154,6 +154,7 @@ import {
   prepareSessionAutoReset,
   readDynamicContextMessage,
   readSystemPromptMessage,
+  recordErrorTurn,
   recordSuccessfulTurn,
   resolveCanonicalContextScope,
   resolveChannelType,
@@ -2566,6 +2567,18 @@ async function handleGatewayMessageInner(
         },
       });
       recordPendingHatchingTerminalAudit();
+      const storedErrorTurn = recordErrorTurn({
+        sessionId: req.sessionId,
+        agentId,
+        channelId: req.channelId,
+        userId: req.userId,
+        username: req.username,
+        canonicalScopeId: canonicalContextScope,
+        userContent: storedUserContent,
+        error: errorMessage,
+        toolExecutions,
+        replaceBuiltInMemory: pluginMemoryBehavior.replacesBuiltInMemory,
+      });
       recordAuditEvent({
         sessionId: req.sessionId,
         runId,
@@ -2573,6 +2586,7 @@ async function handleGatewayMessageInner(
           type: 'turn.end',
           turnIndex,
           finishReason: 'error',
+          assistantMessageId: storedErrorTurn.assistantMessageId,
         },
       });
       recordAuditEvent({
@@ -2582,8 +2596,8 @@ async function handleGatewayMessageInner(
           type: 'session.end',
           reason: 'error',
           stats: {
-            userMessages: 0,
-            assistantMessages: 0,
+            userMessages: 1,
+            assistantMessages: 1,
             toolCalls: toolExecutions.length,
             durationMs,
           },
@@ -2616,6 +2630,7 @@ async function handleGatewayMessageInner(
         toolExecutions,
         tokenUsage: output.tokenUsage,
         error: errorMessage,
+        assistantMessageId: storedErrorTurn.assistantMessageId,
       };
       captureGatewayChatResultError({
         message: errorMessage,

--- a/src/gateway/gateway-chat-service.ts
+++ b/src/gateway/gateway-chat-service.ts
@@ -142,7 +142,9 @@ import {
   buildStoredTurnMessages,
   buildStoredUserTurnContent,
   buildTokenUsageAuditPayload,
+  type ErrorTurnToolRecord,
   enqueueDelegationBatchFromSideEffects,
+  errorTurnToolsFromExecutions,
   extractDelegationDepth,
   formatCanonicalContextPrompt,
   formatPluginPromptContext,
@@ -163,6 +165,7 @@ import {
   resolveOnboardingTurnModel,
   resolveSessionAutoResetPolicy,
   shouldForceNewTuiSession,
+  trackObservedToolCall,
 } from './gateway-service.js';
 import type {
   GatewayChatRequest,
@@ -2038,6 +2041,8 @@ async function handleGatewayMessageInner(
     | 'awaiting-agent-output'
     | 'processing-agent-output' = 'pre-agent';
   let hatchingCompletion: BootstrapHatchingTurnResult | null = null;
+  const observedToolCalls: ErrorTurnToolRecord[] = [];
+  let turnPersisted = false;
   const recordPendingHatchingTerminalAudit = (): void => {
     recordBootstrapHatchingTerminalAudit({
       audit: onboardingAuditContext,
@@ -2078,6 +2083,7 @@ async function handleGatewayMessageInner(
         ? (delta: string): void => req.onThinkingDelta?.(delta)
         : undefined;
     const onToolProgress = (event: ToolProgressEvent): void => {
+      trackObservedToolCall(observedToolCalls, event);
       emitGatewayToolProgress(event);
     };
     const onApprovalProgress = (approval: PendingApproval): void => {
@@ -2576,9 +2582,14 @@ async function handleGatewayMessageInner(
         canonicalScopeId: canonicalContextScope,
         userContent: storedUserContent,
         error: errorMessage,
-        toolExecutions,
+        tools:
+          toolExecutions.length > 0
+            ? errorTurnToolsFromExecutions(toolExecutions)
+            : observedToolCalls,
+        delegationAcknowledgement,
         replaceBuiltInMemory: pluginMemoryBehavior.replacesBuiltInMemory,
       });
+      turnPersisted = true;
       recordAuditEvent({
         sessionId: req.sessionId,
         runId,
@@ -2751,6 +2762,7 @@ async function handleGatewayMessageInner(
       startedAt,
       replaceBuiltInMemory: pluginMemoryBehavior.replacesBuiltInMemory,
     });
+    turnPersisted = true;
     if (onboardingAuditContext) {
       recordBootstrapOnboardingAssistantMessage(onboardingAuditContext, {
         turnIndex,
@@ -2900,6 +2912,28 @@ async function handleGatewayMessageInner(
       },
     });
     recordPendingHatchingTerminalAudit();
+    let storedErrorTurn: { assistantMessageId: number } | null = null;
+    if (!turnPersisted) {
+      try {
+        storedErrorTurn = recordErrorTurn({
+          sessionId: req.sessionId,
+          agentId,
+          channelId: req.channelId,
+          userId: req.userId,
+          username: req.username,
+          canonicalScopeId: canonicalContextScope,
+          userContent: buildStoredUserTurnContent(userTurnContent, media),
+          error: errorMsg,
+          tools: observedToolCalls,
+          replaceBuiltInMemory: pluginMemoryBehavior.replacesBuiltInMemory,
+        });
+      } catch (storeErr) {
+        logger.error(
+          { ...debugMeta, err: storeErr },
+          'Failed to persist error turn after gateway failure',
+        );
+      }
+    }
     recordAuditEvent({
       sessionId: req.sessionId,
       runId,
@@ -2907,6 +2941,9 @@ async function handleGatewayMessageInner(
         type: 'turn.end',
         turnIndex,
         finishReason: 'error',
+        ...(storedErrorTurn
+          ? { assistantMessageId: storedErrorTurn.assistantMessageId }
+          : {}),
       },
     });
     recordAuditEvent({
@@ -2916,9 +2953,9 @@ async function handleGatewayMessageInner(
         type: 'session.end',
         reason: 'error',
         stats: {
-          userMessages: 0,
-          assistantMessages: 0,
-          toolCalls: 0,
+          userMessages: storedErrorTurn ? 1 : 0,
+          assistantMessages: storedErrorTurn ? 1 : 0,
+          toolCalls: observedToolCalls.length,
           durationMs,
         },
       },
@@ -2952,6 +2989,9 @@ async function handleGatewayMessageInner(
       memoryAccess,
       toolExecutions: undefined,
       error: errorMsg,
+      ...(storedErrorTurn
+        ? { assistantMessageId: storedErrorTurn.assistantMessageId }
+        : {}),
     });
     captureGatewayChatResultError({
       message: errorMsg,

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -4009,26 +4009,97 @@ export function recordSuccessfulTurn(opts: {
   return storedTurn;
 }
 
+export type ErrorTurnToolOutcome =
+  | 'completed'
+  | 'failed'
+  | 'blocked'
+  | 'started, outcome unknown';
+
+export interface ErrorTurnToolRecord {
+  name: string;
+  outcome: ErrorTurnToolOutcome;
+  preview?: string;
+}
+
+const ERROR_TURN_PREVIEW_MAX_CHARS = 160;
+
+function compactErrorTurnPreview(raw: string | undefined): string | undefined {
+  const text = String(raw || '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!text) return undefined;
+  return text.length > ERROR_TURN_PREVIEW_MAX_CHARS
+    ? `${text.slice(0, ERROR_TURN_PREVIEW_MAX_CHARS - 1)}…`
+    : text;
+}
+
+export function errorTurnToolsFromExecutions(
+  toolExecutions: ToolExecution[],
+): ErrorTurnToolRecord[] {
+  return toolExecutions.map((execution) => ({
+    name: execution.name,
+    outcome: execution.blocked
+      ? 'blocked'
+      : execution.isError
+        ? 'failed'
+        : 'completed',
+    preview: compactErrorTurnPreview(
+      execution.blocked ? execution.blockedReason : execution.result,
+    ),
+  }));
+}
+
+export function trackObservedToolCall(
+  observed: ErrorTurnToolRecord[],
+  event: Pick<ToolProgressEvent, 'toolName' | 'phase' | 'preview'>,
+): void {
+  if (event.phase === 'start') {
+    observed.push({
+      name: event.toolName,
+      outcome: 'started, outcome unknown',
+      preview: compactErrorTurnPreview(event.preview),
+    });
+    return;
+  }
+  const preview = compactErrorTurnPreview(event.preview);
+  const outcome: ErrorTurnToolOutcome = /^error\b/i.test(preview || '')
+    ? 'failed'
+    : 'completed';
+  const open = observed.find(
+    (record) =>
+      record.name === event.toolName &&
+      record.outcome === 'started, outcome unknown',
+  );
+  if (open) {
+    open.outcome = outcome;
+    open.preview = preview ?? open.preview;
+    return;
+  }
+  observed.push({ name: event.toolName, outcome, preview });
+}
+
 export function buildErrorTurnPlaceholder(params: {
   error: string;
-  toolExecutions: ToolExecution[];
+  tools: ErrorTurnToolRecord[];
+  delegationAcknowledgement?: string | null;
 }): string {
   const lines = [
     `[This turn ended with an error before a reply was produced: ${params.error}]`,
   ];
-  if (params.toolExecutions.length > 0) {
+  if (params.tools.length > 0) {
     lines.push(
       'Tool calls that already ran during this turn (their effects may have been applied):',
     );
-    for (const execution of params.toolExecutions) {
-      const outcome = execution.blocked
-        ? 'blocked'
-        : execution.isError
-          ? 'failed'
-          : 'completed';
-      lines.push(`- ${execution.name}: ${outcome}`);
+    for (const tool of params.tools) {
+      lines.push(
+        tool.preview
+          ? `- ${tool.name}: ${tool.outcome}; result: ${tool.preview}`
+          : `- ${tool.name}: ${tool.outcome}`,
+      );
     }
   }
+  const ack = params.delegationAcknowledgement?.trim();
+  if (ack) lines.push(`Delegations were still started: ${ack}`);
   return lines.join('\n');
 }
 
@@ -4041,7 +4112,8 @@ export function recordErrorTurn(opts: {
   canonicalScopeId: string;
   userContent: string;
   error: string;
-  toolExecutions: ToolExecution[];
+  tools: ErrorTurnToolRecord[];
+  delegationAcknowledgement?: string | null;
   replaceBuiltInMemory?: boolean;
 }): {
   userMessageId: number;
@@ -4049,7 +4121,8 @@ export function recordErrorTurn(opts: {
 } {
   const placeholder = buildErrorTurnPlaceholder({
     error: opts.error,
-    toolExecutions: opts.toolExecutions,
+    tools: opts.tools,
+    delegationAcknowledgement: opts.delegationAcknowledgement,
   });
   const storedTurn =
     opts.replaceBuiltInMemory === true

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -4009,6 +4009,131 @@ export function recordSuccessfulTurn(opts: {
   return storedTurn;
 }
 
+export function buildErrorTurnPlaceholder(params: {
+  error: string;
+  toolExecutions: ToolExecution[];
+}): string {
+  const lines = [
+    `[This turn ended with an error before a reply was produced: ${params.error}]`,
+  ];
+  if (params.toolExecutions.length > 0) {
+    lines.push(
+      'Tool calls that already ran during this turn (their effects may have been applied):',
+    );
+    for (const execution of params.toolExecutions) {
+      const outcome = execution.blocked
+        ? 'blocked'
+        : execution.isError
+          ? 'failed'
+          : 'completed';
+      lines.push(`- ${execution.name}: ${outcome}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+export function recordErrorTurn(opts: {
+  sessionId: string;
+  agentId: string;
+  channelId: string;
+  userId: string;
+  username: string | null;
+  canonicalScopeId: string;
+  userContent: string;
+  error: string;
+  toolExecutions: ToolExecution[];
+  replaceBuiltInMemory?: boolean;
+}): {
+  userMessageId: number;
+  assistantMessageId: number;
+} {
+  const placeholder = buildErrorTurnPlaceholder({
+    error: opts.error,
+    toolExecutions: opts.toolExecutions,
+  });
+  const storedTurn =
+    opts.replaceBuiltInMemory === true
+      ? {
+          userMessageId: memoryService.storeMessage({
+            sessionId: opts.sessionId,
+            userId: opts.userId,
+            username: opts.username,
+            role: 'user',
+            content: opts.userContent,
+          }),
+          assistantMessageId: memoryService.storeMessage({
+            sessionId: opts.sessionId,
+            userId: 'assistant',
+            username: null,
+            role: 'assistant',
+            content: placeholder,
+            agentId: opts.agentId,
+          }),
+        }
+      : memoryService.storeTurn({
+          sessionId: opts.sessionId,
+          user: {
+            userId: opts.userId,
+            username: opts.username,
+            content: opts.userContent,
+          },
+          assistant: {
+            userId: 'assistant',
+            username: null,
+            agentId: opts.agentId,
+            content: placeholder,
+          },
+        });
+  if (opts.replaceBuiltInMemory !== true && opts.canonicalScopeId.trim()) {
+    try {
+      memoryService.appendCanonicalMessages({
+        agentId: opts.agentId,
+        userId: opts.canonicalScopeId,
+        newMessages: [
+          {
+            role: 'user',
+            content: opts.userContent,
+            sessionId: opts.sessionId,
+            channelId: opts.channelId,
+          },
+          {
+            role: 'assistant',
+            content: placeholder,
+            sessionId: opts.sessionId,
+            channelId: opts.channelId,
+          },
+        ],
+      });
+    } catch (err) {
+      logger.debug(
+        {
+          sessionId: opts.sessionId,
+          canonicalScopeId: opts.canonicalScopeId,
+          err,
+        },
+        'Failed to append canonical session memory for error turn',
+      );
+    }
+  }
+  appendSessionTranscript(opts.agentId, {
+    sessionId: opts.sessionId,
+    channelId: opts.channelId,
+    role: 'user',
+    userId: opts.userId,
+    username: opts.username,
+    content: opts.userContent,
+  });
+  appendSessionTranscript(opts.agentId, {
+    sessionId: opts.sessionId,
+    channelId: opts.channelId,
+    role: 'assistant',
+    userId: 'assistant',
+    username: null,
+    content: placeholder,
+  });
+  return storedTurn;
+}
+
 export function buildStoredTurnMessages(params: {
   sessionId: string;
   userId: string;

--- a/tests/gateway-service.audit.test.ts
+++ b/tests/gateway-service.audit.test.ts
@@ -884,6 +884,77 @@ test('handleGatewayMessage records agent handoff before agent-side timeouts', as
   });
 });
 
+test('handleGatewayMessage persists the user message and an assistant placeholder for error turns', async () => {
+  setupHome();
+
+  runAgentMock.mockResolvedValue({
+    status: 'error',
+    result: null,
+    toolsUsed: ['send_email', 'bash'],
+    toolExecutions: [
+      {
+        name: 'send_email',
+        arguments: '{"to":"bob@example.com"}',
+        result: 'sent',
+        durationMs: 12,
+      },
+      {
+        name: 'bash',
+        arguments: '{"command":"false"}',
+        result: 'exit 1',
+        durationMs: 3,
+        isError: true,
+      },
+    ],
+    error: 'Timeout waiting for agent output after 300000ms',
+  });
+
+  const {
+    getRecentMessages,
+    getRecentStructuredAuditForSession,
+    initDatabase,
+  } = await import('../src/memory/db.ts');
+  const { handleGatewayMessage } = await import(
+    '../src/gateway/gateway-chat-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const sessionId = 'session-error-turn-persisted';
+  const result = await handleGatewayMessage({
+    sessionId,
+    guildId: null,
+    channelId: 'web',
+    userId: 'user-1',
+    username: 'alice',
+    content: 'Email Bob the report',
+    model: 'test-model',
+    chatbotId: 'bot-1',
+  });
+
+  expect(result.status).toBe('error');
+  const messages = getRecentMessages(sessionId);
+  const userMessage = messages.find((message) => message.role === 'user');
+  const assistantMessage = messages.find(
+    (message) => message.role === 'assistant',
+  );
+  expect(userMessage?.content).toBe('Email Bob the report');
+  expect(assistantMessage?.content).toContain(
+    'ended with an error before a reply was produced: Timeout waiting for agent output after 300000ms',
+  );
+  expect(assistantMessage?.content).toContain('- send_email: completed');
+  expect(assistantMessage?.content).toContain('- bash: failed');
+  expect(result.assistantMessageId).toBe(assistantMessage?.id);
+
+  const turnEnd = getRecentStructuredAuditForSession(sessionId, 20).find(
+    (row) => row.event_type === 'turn.end',
+  );
+  expect(JSON.parse(turnEnd?.payload || '{}')).toMatchObject({
+    type: 'turn.end',
+    finishReason: 'error',
+    assistantMessageId: assistantMessage?.id,
+  });
+});
+
 test('handleGatewayMessage stores redacted request logs when enabled', async () => {
   setupHome({ HYBRIDCLAW_LOG_REQUESTS: '1' });
   const secret = 'supersecret1234567890';

--- a/tests/gateway-service.audit.test.ts
+++ b/tests/gateway-service.audit.test.ts
@@ -906,7 +906,7 @@ test('handleGatewayMessage persists the user message and an assistant placeholde
         isError: true,
       },
     ],
-    error: 'Timeout waiting for agent output after 300000ms',
+    error: 'Model request failed: HTTP 502',
   });
 
   const {
@@ -939,10 +939,12 @@ test('handleGatewayMessage persists the user message and an assistant placeholde
   );
   expect(userMessage?.content).toBe('Email Bob the report');
   expect(assistantMessage?.content).toContain(
-    'ended with an error before a reply was produced: Timeout waiting for agent output after 300000ms',
+    'ended with an error before a reply was produced: Model request failed: HTTP 502',
   );
-  expect(assistantMessage?.content).toContain('- send_email: completed');
-  expect(assistantMessage?.content).toContain('- bash: failed');
+  expect(assistantMessage?.content).toContain(
+    '- send_email: completed; result: sent',
+  );
+  expect(assistantMessage?.content).toContain('- bash: failed; result: exit 1');
   expect(result.assistantMessageId).toBe(assistantMessage?.id);
 
   const turnEnd = getRecentStructuredAuditForSession(sessionId, 20).find(
@@ -952,6 +954,130 @@ test('handleGatewayMessage persists the user message and an assistant placeholde
     type: 'turn.end',
     finishReason: 'error',
     assistantMessageId: assistantMessage?.id,
+  });
+});
+
+test('handleGatewayMessage records streamed tool calls when a timeout output carries no executions', async () => {
+  setupHome();
+
+  runAgentMock.mockImplementation(async (params: any) => {
+    params.onToolProgress?.({
+      sessionId: params.sessionId,
+      toolName: 'send_email',
+      phase: 'start',
+      preview: 'to=bob@example.com',
+    });
+    params.onToolProgress?.({
+      sessionId: params.sessionId,
+      toolName: 'send_email',
+      phase: 'finish',
+      durationMs: 12,
+      preview: 'sent',
+    });
+    params.onToolProgress?.({
+      sessionId: params.sessionId,
+      toolName: 'bash',
+      phase: 'start',
+      preview: 'sleep 999',
+    });
+    return {
+      status: 'error',
+      result: null,
+      toolsUsed: [],
+      error: 'Timeout waiting for agent output after 300000ms',
+    };
+  });
+
+  const { getRecentMessages, initDatabase } = await import(
+    '../src/memory/db.ts'
+  );
+  const { handleGatewayMessage } = await import(
+    '../src/gateway/gateway-chat-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const sessionId = 'session-error-turn-streamed-tools';
+  const result = await handleGatewayMessage({
+    sessionId,
+    guildId: null,
+    channelId: 'web',
+    userId: 'user-1',
+    username: 'alice',
+    content: 'Email Bob the report',
+    model: 'test-model',
+    chatbotId: 'bot-1',
+  });
+
+  expect(result.status).toBe('error');
+  const assistantMessage = getRecentMessages(sessionId).find(
+    (message) => message.role === 'assistant',
+  );
+  expect(assistantMessage?.content).toContain(
+    'Timeout waiting for agent output after 300000ms',
+  );
+  expect(assistantMessage?.content).toContain(
+    '- send_email: completed; result: sent',
+  );
+  expect(assistantMessage?.content).toContain(
+    '- bash: started, outcome unknown; result: sleep 999',
+  );
+});
+
+test('handleGatewayMessage persists the user message when the agent run throws', async () => {
+  setupHome();
+
+  runAgentMock.mockImplementation(async (params: any) => {
+    params.onToolProgress?.({
+      sessionId: params.sessionId,
+      toolName: 'write',
+      phase: 'start',
+      preview: 'notes.md',
+    });
+    throw new Error('container exited unexpectedly');
+  });
+
+  const {
+    getRecentMessages,
+    getRecentStructuredAuditForSession,
+    initDatabase,
+  } = await import('../src/memory/db.ts');
+  const { handleGatewayMessage } = await import(
+    '../src/gateway/gateway-chat-service.ts'
+  );
+
+  initDatabase({ quiet: true });
+  const sessionId = 'session-error-turn-thrown';
+  const result = await handleGatewayMessage({
+    sessionId,
+    guildId: null,
+    channelId: 'web',
+    userId: 'user-1',
+    username: 'alice',
+    content: 'Write my notes',
+    model: 'test-model',
+    chatbotId: 'bot-1',
+  });
+
+  expect(result.status).toBe('error');
+  expect(result.error).toBe('container exited unexpectedly');
+  const messages = getRecentMessages(sessionId);
+  const userMessage = messages.find((message) => message.role === 'user');
+  const assistantMessage = messages.find(
+    (message) => message.role === 'assistant',
+  );
+  expect(userMessage?.content).toBe('Write my notes');
+  expect(assistantMessage?.content).toContain('container exited unexpectedly');
+  expect(assistantMessage?.content).toContain(
+    '- write: started, outcome unknown; result: notes.md',
+  );
+  expect(result.assistantMessageId).toBe(assistantMessage?.id);
+
+  const sessionEnd = getRecentStructuredAuditForSession(sessionId, 20).find(
+    (row) => row.event_type === 'session.end',
+  );
+  expect(JSON.parse(sessionEnd?.payload || '{}')).toMatchObject({
+    reason: 'error',
+    stats: { userMessages: 1, assistantMessages: 1, toolCalls: 1 },
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #1476.

When the container returned `status: 'error'` (timeout, model error, interrupt), `handleGatewayMessage` recorded audit events and returned before `recordSuccessfulTurn`. Nothing was written to session history: not the user's message, not the tool calls that had already executed. Because `processSideEffects` and delegation enqueueing run before the error check, cron jobs and delegations from the turn were still created while the turn itself vanished, so on the next turn the model could not know the request was made or that tools already ran.

## Changes

- New `recordErrorTurn` in `gateway-service.ts` stores the user message and an assistant placeholder through the same `storeTurn` / `storeMessage` split as the success path, appends both to canonical memory, and writes them to the session transcript. It skips compaction and audit, which the error path already handles.
- The placeholder names the error and lists every executed tool call with its outcome (`completed`, `failed`, `blocked`), so the next turn can reason about duplicates.
- The error path now calls it before emitting `turn.end` / `session.end`; `turn.end` carries `assistantMessageId`, `session.end` stats report one user and one assistant message, and the `GatewayChatResult` exposes `assistantMessageId` as on success.

## Risk notes (high-risk path: `src/gateway/`)

- Error turns now increment the session's message count and appear in history, transcripts, and canonical memory. That is the intended behaviour change; nothing else in the error path moved.
- Partial assistant text is not available on error outputs (`result` is `null`), so the placeholder carries the tool ledger only.

## Tests

- New test in `tests/gateway-service.audit.test.ts` asserts the stored user message, the placeholder content with the tool ledger, the result's `assistantMessageId`, and the `turn.end` payload.
- `tsc --noEmit`, `npm run lint`, biome on the touched files, and the gateway-service, chat-approval, and audit suites pass.


## Follow-up after review

- Timeout and interrupt outputs from the runner carry no `toolExecutions`, so the placeholder previously listed nothing for exactly those cases. The chat service now tracks every streamed `onToolProgress` event for the turn and falls back to that list (`started, outcome unknown` for tools that never reported a finish) when the output has no executions.
- Placeholder lines now include a short result preview, so tool results such as the scheduled task id or the sent-message acknowledgement survive into the next turn. When a delegation was enqueued on an error turn, its acknowledgement text is appended.
- The outer `catch` (runAgent throwing, or post-agent code throwing before the turn was persisted) now goes through `recordErrorTurn` as well, with the streamed tool list, and reports the stored message id and real stats in the audit events.
- Tests: the original test now uses a container-reported error (the timeout-plus-executions shape cannot occur). New tests cover a timeout output with no executions but two streamed tools, and a thrown agent run persisting the user message.

```
npx vitest run --configLoader runner --project unit tests/gateway-service.audit.test.ts   # 22 passed
npx vitest run --configLoader runner --project unit tests/gateway-main.test.ts tests/gateway-service.scheduler.test.ts tests/message-activity-trace.test.ts   # 73 passed
npm run lint && npm run typecheck   # clean
```
