### PR TITLE
fix(container): keep idle watchdog alive during long silent tool calls

### DIFF
--- a/container/src/codex-app-server.ts
+++ b/container/src/codex-app-server.ts
@@ -10,6 +10,7 @@ import {
   isRecord,
   readString as readUnknownString,
 } from './codex-app-utils.js';
+import { withToolActivityHeartbeat } from './tool-activity-heartbeat.js';
 import type {
   ChatMessage,
   ContainerInput,
@@ -73,6 +74,7 @@ interface RunCodexAppServerTurnParams {
   providerCredentials?: ContainerInput['providerCredentials'];
   streamTextDeltas?: boolean;
   onTextDelta?: (delta: string) => void;
+  onActivity?: () => void;
 }
 
 const CODEX_REQUEST_TIMEOUT_MS = 30_000;
@@ -1049,7 +1051,7 @@ function errorOutputFromProjection(
 export async function resumePendingCodexAppServerApproval(
   params: Pick<
     RunCodexAppServerTurnParams,
-    'sessionId' | 'messages' | 'streamTextDeltas' | 'onTextDelta'
+    'sessionId' | 'messages' | 'streamTextDeltas' | 'onTextDelta' | 'onActivity'
   >,
 ): Promise<ContainerOutput | null> {
   const effectiveUserPrompt = buildCodexTurnText(params.messages);
@@ -1062,7 +1064,7 @@ export async function resumePendingCodexAppServerApproval(
   if (!directive) return null;
   try {
     respondToCodexApproval(pending, directive);
-    const next = await pending.client.waitForCompletionOrApproval();
+    const next = await waitWithActivity(pending.client, params.onActivity);
     if (next.kind === 'approval') {
       pending.projection.pendingApproval = buildPendingApproval(
         next.approvalId,
@@ -1094,6 +1096,14 @@ export async function resumePendingCodexAppServerApproval(
       error,
     );
   }
+}
+
+function waitWithActivity(
+  client: CodexAppServerClient,
+  onActivity: (() => void) | undefined,
+): ReturnType<CodexAppServerClient['waitForCompletionOrApproval']> {
+  const wait = () => client.waitForCompletionOrApproval();
+  return onActivity ? withToolActivityHeartbeat(wait, onActivity) : wait();
 }
 
 async function checkCodexCliAvailable(): Promise<void> {
@@ -1202,7 +1212,7 @@ export async function runCodexAppServerTurn(
 
     const next = projection.completed
       ? { kind: 'completed' as const, projection }
-      : await client.waitForCompletionOrApproval();
+      : await waitWithActivity(client, params.onActivity);
     if (next.kind === 'approval') {
       projection.pendingApproval = buildPendingApproval(
         next.approvalId,

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -77,7 +77,10 @@ import {
   readChatCompletionUsageTokens,
   recordPerformanceSample,
 } from './token-usage.js';
-import { withToolActivityHeartbeat } from './tool-activity-heartbeat.js';
+import {
+  emitStreamActivityLine,
+  withToolActivityHeartbeat,
+} from './tool-activity-heartbeat.js';
 import {
   type ApprovalPrelude,
   approvalRuntime,
@@ -406,7 +409,7 @@ function emitStreamThinkingDelta(delta: string): void {
 }
 
 function emitStreamActivity(): void {
-  console.error('[stream-activity]');
+  emitStreamActivityLine();
 }
 
 function latestUserPrompt(messages: ChatMessage[]): string {
@@ -1108,6 +1111,7 @@ async function processRequest(
       messages: history,
       streamTextDeltas,
       onTextDelta: emitStreamDelta,
+      onActivity: emitStreamActivity,
     });
     if (resumed) {
       resumed.codexRuntime = 'app-server';
@@ -1143,6 +1147,7 @@ async function processRequest(
       providerCredentials,
       streamTextDeltas,
       onTextDelta: emitStreamDelta,
+      onActivity: emitStreamActivity,
     });
     output.codexRuntime = 'app-server';
     await emitRuntimeEvent({

--- a/container/src/index.ts
+++ b/container/src/index.ts
@@ -77,6 +77,7 @@ import {
   readChatCompletionUsageTokens,
   recordPerformanceSample,
 } from './token-usage.js';
+import { withToolActivityHeartbeat } from './tool-activity-heartbeat.js';
 import {
   type ApprovalPrelude,
   approvalRuntime,
@@ -698,7 +699,10 @@ async function executePreparedToolCall(
           output: loopGuard.message,
           isError: true,
         }
-      : await executeToolWithMetadata(toolName, argsJson);
+      : await withToolActivityHeartbeat(
+          () => executeToolWithMetadata(toolName, argsJson),
+          emitStreamActivity,
+        );
   const toolDuration = Date.now() - toolStart;
   const result = runtimeResult.output;
   const isError = runtimeResult.isError;

--- a/container/src/tool-activity-heartbeat.ts
+++ b/container/src/tool-activity-heartbeat.ts
@@ -1,4 +1,9 @@
 export const TOOL_ACTIVITY_HEARTBEAT_MS = 10_000;
+export const STREAM_ACTIVITY_LINE = '[stream-activity]';
+
+export function emitStreamActivityLine(): void {
+  console.error(STREAM_ACTIVITY_LINE);
+}
 
 /**
  * Run a tool while periodically emitting an activity signal so the gateway's

--- a/container/src/tool-activity-heartbeat.ts
+++ b/container/src/tool-activity-heartbeat.ts
@@ -1,0 +1,20 @@
+export const TOOL_ACTIVITY_HEARTBEAT_MS = 10_000;
+
+/**
+ * Run a tool while periodically emitting an activity signal so the gateway's
+ * inactivity watchdog keeps extending its idle deadline. Tools that stay
+ * silent for longer than the idle window (long shell commands, MCP calls,
+ * browser or video work) would otherwise be killed mid-execution.
+ */
+export async function withToolActivityHeartbeat<T>(
+  run: () => Promise<T>,
+  emitActivity: () => void,
+  intervalMs = TOOL_ACTIVITY_HEARTBEAT_MS,
+): Promise<T> {
+  const timer = setInterval(emitActivity, intervalMs);
+  try {
+    return await run();
+  } finally {
+    clearInterval(timer);
+  }
+}

--- a/src/gateway/channel-gateway-failure.ts
+++ b/src/gateway/channel-gateway-failure.ts
@@ -4,7 +4,7 @@ import { classifyGatewayError } from './gateway-error-utils.js';
 const INTERRUPTED_GATEWAY_FAILURE_RE =
   /interrupted by user|timed out|timeout waiting for agent output|terminated|abort/i;
 export const DEFAULT_CHANNEL_INTERRUPTED_REPLY =
-  'The request was interrupted before I could reply. Please send it again.';
+  'The request was interrupted before I could reply. Tools I had already started may have completed, so check before sending it again.';
 export const DEFAULT_CHANNEL_TRANSIENT_FAILURE_REPLY =
   'The model request failed before I could reply. Please try again.';
 

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -896,14 +896,14 @@ function getOrSpawnContainer(
         entry.activity?.notify();
         continue;
       }
+      if (isStreamActivityLine(line)) {
+        entry.activity?.notify();
+        continue;
+      }
       rememberStderrLine(entry, line);
       emitTextDelta(entry, line);
       emitThinkingDelta(entry, line);
       if (isThinkingDeltaLine(line)) {
-        entry.activity?.notify();
-        continue;
-      }
-      if (isStreamActivityLine(line)) {
         entry.activity?.notify();
         continue;
       }
@@ -933,13 +933,14 @@ function getOrSpawnContainer(
       } else if (consumeModelResponseDebugFileLine(tail)) {
         entry.activity?.notify();
         entry.stderrBuffer = '';
+      } else if (isStreamActivityLine(tail)) {
+        entry.activity?.notify();
+        entry.stderrBuffer = '';
       } else {
         rememberStderrLine(entry, tail);
         emitTextDelta(entry, tail);
         emitThinkingDelta(entry, tail);
-        if (isStreamActivityLine(tail)) {
-          entry.activity?.notify();
-        } else if (isThinkingDeltaLine(tail)) {
+        if (isThinkingDeltaLine(tail)) {
           entry.activity?.notify();
         } else if (
           !consumeCollapsedStreamDebugLine(

--- a/src/infra/host-runner.ts
+++ b/src/infra/host-runner.ts
@@ -751,14 +751,14 @@ function getOrSpawnHostProcess(
         entry.activity?.notify();
         continue;
       }
+      if (isStreamActivityLine(line)) {
+        entry.activity?.notify();
+        continue;
+      }
       rememberStderrLine(entry, line);
       emitTextDelta(entry, line);
       emitThinkingDelta(entry, line);
       if (isThinkingDeltaLine(line)) {
-        entry.activity?.notify();
-        continue;
-      }
-      if (isStreamActivityLine(line)) {
         entry.activity?.notify();
         continue;
       }
@@ -791,13 +791,14 @@ function getOrSpawnHostProcess(
       } else if (consumeModelResponseDebugFileLine(tail)) {
         entry.activity?.notify();
         entry.stderrBuffer = '';
+      } else if (isStreamActivityLine(tail)) {
+        entry.activity?.notify();
+        entry.stderrBuffer = '';
       } else {
         rememberStderrLine(entry, tail);
         emitTextDelta(entry, tail);
         emitThinkingDelta(entry, tail);
-        if (isStreamActivityLine(tail)) {
-          entry.activity?.notify();
-        } else if (isThinkingDeltaLine(tail)) {
+        if (isThinkingDeltaLine(tail)) {
           entry.activity?.notify();
         } else if (
           !consumeCollapsedStreamDebugLine(

--- a/tests/codex-app-runtime.test.ts
+++ b/tests/codex-app-runtime.test.ts
@@ -370,6 +370,79 @@ describe('Codex app-server runtime helpers', () => {
     ).toHaveLength(1);
   });
 
+  test('reports activity while an app-server turn is outstanding', async () => {
+    vi.resetModules();
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
+    let appServer: ReturnType<typeof createMockChild> | null = null;
+    const spawn = vi.fn((_command: string, args: string[]) => {
+      const child = createMockChild();
+      if (args[0] === '--version') {
+        queueMicrotask(() => child.emit('exit', 0));
+        return child;
+      }
+      appServer = child;
+      child.stdin.write = vi.fn((line: string) => {
+        const message = JSON.parse(line) as { id?: number; method?: string };
+        if (message.method === 'initialize') {
+          writeJsonLine(child, { id: message.id, result: {} });
+        } else if (message.method === 'thread/start') {
+          writeJsonLine(child, {
+            id: message.id,
+            result: { thread: { id: 'thread-heartbeat' } },
+          });
+        } else if (message.method === 'turn/start') {
+          writeJsonLine(child, {
+            id: message.id,
+            result: { turn: { id: 'turn-heartbeat', status: 'in_progress' } },
+          });
+        }
+        return true;
+      });
+      return child;
+    });
+    vi.doMock('node:child_process', () => ({ spawn }));
+    const { runCodexAppServerTurn } = await import(
+      '../container/src/codex-app-server.js'
+    );
+    const onActivity = vi.fn();
+    try {
+      const turn = runCodexAppServerTurn({
+        sessionId: 'session-heartbeat',
+        messages: [{ role: 'user', content: 'run a long tool' }],
+        model: 'openai-codex/gpt-5.4',
+        cwd: '/workspace',
+        provider: 'openai-codex',
+        onActivity,
+      });
+      await vi.waitFor(() => {
+        const child = appServer as ReturnType<typeof createMockChild> | null;
+        expect(child).not.toBeNull();
+        expect(child?.stdin.write).toHaveBeenCalledTimes(3);
+      });
+      expect(onActivity).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(25_000);
+      expect(onActivity).toHaveBeenCalledTimes(2);
+
+      const child = appServer as unknown as ReturnType<typeof createMockChild>;
+      writeJsonLine(child, {
+        method: 'item/completed',
+        params: { item: { type: 'agentMessage', text: 'done' } },
+      });
+      writeJsonLine(child, {
+        method: 'turn/completed',
+        params: { turn: { status: 'completed' } },
+      });
+      const output = await turn;
+      expect(output.result).toBe('done');
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(onActivity).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test('migrates user MCP servers without embedding sensitive environment values', () => {
     const args = buildCodexAppServerArgs(
       {

--- a/tests/container-runner.redaction.test.ts
+++ b/tests/container-runner.redaction.test.ts
@@ -1303,3 +1303,109 @@ test('ContainerExecutor forwards disabled inactivity timeout to the IPC output r
     expect.any(Object),
   );
 });
+
+test('ContainerExecutor treats heartbeat lines as activity without evicting stderr context', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const proc = makeFakeChildProcess();
+  const spawn = vi.fn(() => proc as never);
+  const notifiedAfterHeartbeat: number[] = [];
+  const readOutput = vi.fn(
+    async (
+      _sessionId: string,
+      _timeoutMs: number,
+      opts?: {
+        activity?: { lastActivityMs: number; notify: () => void };
+        terminalError?: () => string | null;
+      },
+    ) => {
+      proc.stderr.emit(
+        'data',
+        Buffer.from('Error: tool crashed while uploading report.pdf\n'),
+      );
+      const activity = opts?.activity;
+      if (activity) activity.lastActivityMs = 0;
+      for (let i = 0; i < 25; i += 1) {
+        proc.stderr.emit('data', Buffer.from('[stream-activity]\n'));
+      }
+      if (activity) notifiedAfterHeartbeat.push(activity.lastActivityMs);
+      proc.exitCode = 1;
+      proc.emit('close', 1, null);
+      return {
+        status: 'error' as const,
+        result: null,
+        toolsUsed: [],
+        artifacts: [],
+        error: opts?.terminalError?.() || 'missing terminal error',
+      };
+    },
+  );
+  const resolveModelRuntimeCredentials = vi.fn(async () => ({
+    provider: 'hybridai' as const,
+    apiKey: '',
+    baseUrl: 'https://hybridai.one',
+    chatbotId: 'bot-a',
+    enableRag: false,
+    requestHeaders: {},
+    agentId: 'default',
+    isLocal: false,
+    contextWindow: 128_000,
+    thinkingFormat: undefined,
+  }));
+
+  vi.doMock('node:child_process', async () => {
+    const actual =
+      await vi.importActual<typeof import('node:child_process')>(
+        'node:child_process',
+      );
+    return {
+      ...actual,
+      spawn,
+    };
+  });
+  vi.doMock('../src/infra/ipc.js', async () => {
+    const actual = await vi.importActual<typeof import('../src/infra/ipc.js')>(
+      '../src/infra/ipc.js',
+    );
+    return {
+      ...actual,
+      readOutput,
+    };
+  });
+  vi.doMock('../src/providers/factory.js', async () => {
+    const actual = await vi.importActual<
+      typeof import('../src/providers/factory.js')
+    >('../src/providers/factory.js');
+    return {
+      ...actual,
+      resolveModelRuntimeCredentials,
+    };
+  });
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  }));
+  const { ContainerExecutor } = await import('../src/infra/container-runner.js');
+  const executor = new ContainerExecutor();
+  const output = await executor.exec({
+    sessionId: 'session-heartbeat-history',
+    messages: [{ role: 'user', content: 'hello' }],
+    chatbotId: 'bot-a',
+    enableRag: false,
+    model: 'gpt-5',
+    agentId: 'default',
+    channelId: 'tui',
+  });
+
+  expect(notifiedAfterHeartbeat).toHaveLength(1);
+  expect(notifiedAfterHeartbeat[0]).toBeGreaterThan(0);
+  expect(output.status).toBe('error');
+  expect(output.error).toContain('tool crashed while uploading report.pdf');
+  expect(output.error).not.toContain('[stream-activity]');
+});

--- a/tests/container.tool-activity-heartbeat.test.ts
+++ b/tests/container.tool-activity-heartbeat.test.ts
@@ -55,3 +55,31 @@ test('stops the heartbeat when the tool rejects', async () => {
   await vi.advanceTimersByTimeAsync(5_000);
   expect(emit).toHaveBeenCalledTimes(1);
 });
+
+test('heartbeat writes the exact stderr line the gateway watchdog matches', async () => {
+  const { emitStreamActivityLine } = await import(
+    '../container/src/tool-activity-heartbeat.js'
+  );
+  const { isStreamActivityLine } = await import('../src/infra/stream-debug.js');
+  const stderr = vi.spyOn(console, 'error').mockImplementation(() => {});
+  let finish: (value: string) => void = () => {};
+
+  const promise = withToolActivityHeartbeat(
+    () =>
+      new Promise<string>((resolve) => {
+        finish = resolve;
+      }),
+    emitStreamActivityLine,
+    1_000,
+  );
+
+  await vi.advanceTimersByTimeAsync(2_500);
+  expect(stderr).toHaveBeenCalledTimes(2);
+  for (const [line] of stderr.mock.calls) {
+    expect(isStreamActivityLine(String(line).trim())).toBe(true);
+  }
+
+  finish('done');
+  await expect(promise).resolves.toBe('done');
+  stderr.mockRestore();
+});

--- a/tests/container.tool-activity-heartbeat.test.ts
+++ b/tests/container.tool-activity-heartbeat.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import { withToolActivityHeartbeat } from '../container/src/tool-activity-heartbeat.js';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test('emits activity while the tool is running and stops once it resolves', async () => {
+  const emit = vi.fn();
+  let finish: (value: string) => void = () => {};
+  const run = vi.fn(
+    () =>
+      new Promise<string>((resolve) => {
+        finish = resolve;
+      }),
+  );
+
+  const promise = withToolActivityHeartbeat(run, emit, 1_000);
+  expect(run).toHaveBeenCalledTimes(1);
+  expect(emit).not.toHaveBeenCalled();
+
+  await vi.advanceTimersByTimeAsync(3_500);
+  expect(emit).toHaveBeenCalledTimes(3);
+
+  finish('done');
+  await expect(promise).resolves.toBe('done');
+
+  await vi.advanceTimersByTimeAsync(5_000);
+  expect(emit).toHaveBeenCalledTimes(3);
+});
+
+test('stops the heartbeat when the tool rejects', async () => {
+  const emit = vi.fn();
+  let fail: (error: Error) => void = () => {};
+  const promise = withToolActivityHeartbeat(
+    () =>
+      new Promise<never>((_resolve, reject) => {
+        fail = reject;
+      }),
+    emit,
+    1_000,
+  );
+
+  await vi.advanceTimersByTimeAsync(1_000);
+  expect(emit).toHaveBeenCalledTimes(1);
+
+  fail(new Error('tool failed'));
+  await expect(promise).rejects.toThrow('tool failed');
+
+  await vi.advanceTimersByTimeAsync(5_000);
+  expect(emit).toHaveBeenCalledTimes(1);
+});

--- a/tests/gateway-main.test.ts
+++ b/tests/gateway-main.test.ts
@@ -2802,7 +2802,7 @@ describe('gateway bootstrap', () => {
     );
 
     expect(reply).toHaveBeenCalledWith(
-      'The request was interrupted before I could reply. Please send it again.',
+      'The request was interrupted before I could reply. Tools I had already started may have completed, so check before sending it again.',
     );
   });
 

--- a/tests/host-runner.redaction.test.ts
+++ b/tests/host-runner.redaction.test.ts
@@ -1304,3 +1304,110 @@ test('HostExecutor forwards disabled inactivity timeout to the IPC output reader
     expect.any(Object),
   );
 });
+
+test('HostExecutor treats heartbeat lines as activity without evicting stderr context', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.resetModules();
+
+  const proc = makeFakeChildProcess();
+  const spawn = vi.fn(() => proc as never);
+  const notifiedAfterHeartbeat: number[] = [];
+  const readOutput = vi.fn(
+    async (
+      _sessionId: string,
+      _timeoutMs: number,
+      opts?: {
+        activity?: { lastActivityMs: number; notify: () => void };
+        terminalError?: () => string | null;
+      },
+    ) => {
+      proc.stderr.emit(
+        'data',
+        Buffer.from('Error: tool crashed while uploading report.pdf\n'),
+      );
+      const activity = opts?.activity;
+      if (activity) activity.lastActivityMs = 0;
+      for (let i = 0; i < 25; i += 1) {
+        proc.stderr.emit('data', Buffer.from('[stream-activity]\n'));
+      }
+      if (activity) notifiedAfterHeartbeat.push(activity.lastActivityMs);
+      proc.exitCode = 1;
+      proc.emit('close', 1, null);
+      return {
+        status: 'error' as const,
+        result: null,
+        toolsUsed: [],
+        artifacts: [],
+        error: opts?.terminalError?.() || 'missing terminal error',
+      };
+    },
+  );
+  const resolveModelRuntimeCredentials = vi.fn(async () => ({
+    provider: 'hybridai' as const,
+    apiKey: '',
+    baseUrl: 'https://hybridai.one',
+    chatbotId: 'bot-a',
+    enableRag: false,
+    requestHeaders: {},
+    agentId: 'default',
+    isLocal: false,
+    contextWindow: 128_000,
+    thinkingFormat: undefined,
+  }));
+
+  vi.doMock('node:child_process', async () => {
+    const actual =
+      await vi.importActual<typeof import('node:child_process')>(
+        'node:child_process',
+      );
+    return {
+      ...actual,
+      spawn,
+    };
+  });
+  vi.doMock('../src/infra/ipc.js', async () => {
+    const actual = await vi.importActual<typeof import('../src/infra/ipc.js')>(
+      '../src/infra/ipc.js',
+    );
+    return {
+      ...actual,
+      readOutput,
+    };
+  });
+  vi.doMock('../src/providers/factory.js', async () => {
+    const actual = await vi.importActual<
+      typeof import('../src/providers/factory.js')
+    >('../src/providers/factory.js');
+    return {
+      ...actual,
+      resolveModelRuntimeCredentials,
+    };
+  });
+  vi.doMock('../src/logger.js', () => ({
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  }));
+  mockHostRuntimeReady();
+  const { HostExecutor } = await import('../src/infra/host-runner.js');
+  const executor = new HostExecutor();
+  const output = await executor.exec({
+    sessionId: 'session-heartbeat-history',
+    messages: [{ role: 'user', content: 'hello' }],
+    chatbotId: 'bot-a',
+    enableRag: false,
+    model: 'gpt-5',
+    agentId: 'default',
+    channelId: 'tui',
+  });
+
+  expect(notifiedAfterHeartbeat).toHaveLength(1);
+  expect(notifiedAfterHeartbeat[0]).toBeGreaterThan(0);
+  expect(output.status).toBe('error');
+  expect(output.error).toContain('tool crashed while uploading report.pdf');
+  expect(output.error).not.toContain('[stream-activity]');
+});

--- a/tests/ipc.test.ts
+++ b/tests/ipc.test.ts
@@ -203,3 +203,42 @@ test('readOutput does not time out when inactivity and wall-clock timeouts are d
     }),
   );
 });
+
+test('readOutput outlives a silence longer than the inactivity window while activity is reported', async () => {
+  const homeDir = makeTempHome();
+  process.env.HOME = homeDir;
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-03-11T00:00:00Z'));
+  vi.resetModules();
+
+  const { ensureSessionDirs, createActivityTracker, readOutput } = await import(
+    '../src/infra/ipc.ts'
+  );
+
+  ensureSessionDirs('session-1');
+  const outputPath = path.join(
+    homeDir,
+    '.hybridclaw',
+    'data',
+    'sessions',
+    'session-1',
+    'ipc',
+    'output.json',
+  );
+  const activity = createActivityTracker();
+  const heartbeat = setInterval(() => activity.notify(), 50);
+  setTimeout(() => {
+    clearInterval(heartbeat);
+    fs.writeFileSync(
+      outputPath,
+      JSON.stringify({ status: 'success', result: 'ok', toolsUsed: [] }),
+    );
+  }, 300);
+
+  const outputPromise = readOutput('session-1', 100, { activity });
+  await vi.advanceTimersByTimeAsync(360);
+
+  await expect(outputPromise).resolves.toEqual(
+    expect.objectContaining({ status: 'success', result: 'ok' }),
+  );
+});


### PR DESCRIPTION
## Summary

Fixes #1475.

The gateway's inactivity watchdog in `readOutput` only resets when the container writes a stderr line. During tool execution the container logged one `[tool] …` line at start and nothing until the tool returned, so any single tool call that stayed silent longer than `container.timeoutMs` (default 300 s) hit "Timeout waiting for agent output", the container was stopped mid-tool, and the channel user was told to resend. Resending re-ran side effects that had already completed.

## Changes

- New `container/src/tool-activity-heartbeat.ts`: `withToolActivityHeartbeat` runs a tool while emitting an activity signal every 10 s and clears the timer when the tool settles.
- `executePreparedToolCall` wraps `executeToolWithMetadata` in it, emitting `[stream-activity]`, which both the container and host runners already treat as activity without logging or forwarding it.
- `DEFAULT_CHANNEL_INTERRUPTED_REPLY` now says that tools already started may have completed, so the user checks before resending.

## Risk notes (`container/src/`, `src/gateway/`)

- The hard wall-clock deadline (4× the idle window, 20 min by default, or `maxWallClockMs`) is unchanged and still bounds a runaway tool. The bash tool's own 15 min cap stays inside it.
- The heartbeat only runs while a tool is in flight; no other stderr traffic changes.

## Tests

- `tests/container.tool-activity-heartbeat.test.ts` covers heartbeat cadence, stop on resolve, and stop on reject with fake timers.
- Updated the literal in `tests/gateway-main.test.ts`; `tests/channel-gateway-failure.test.ts` compares against the constant.
- `tsc --noEmit`, `npm run lint`, `npm --prefix container run lint`, biome on touched files, and the gateway-main, warm-runner-utils, ipc, and channel-gateway-failure suites pass.


## Follow-up after review

- **Codex app-server runtime is covered.** `runCodexAppServerTurn` and the approval-resume path accept `onActivity` and run the wait for turn completion under `withToolActivityHeartbeat`, so the container process itself emits `[stream-activity]` while Codex is executing tools in the MCP bridge. The bridge's own stderr never reaches the gateway, so the heartbeat is emitted from our side of the app-server protocol rather than forwarded.
- **Heartbeat lines no longer evict stderr context.** Both runners notify the activity tracker on `[stream-activity]` before the line reaches `stderrHistory`, so a long tool call no longer pushes the last real stderr lines out of terminal-error messages.
- **Scenario tests added.** The heartbeat helper is checked against `isStreamActivityLine` so container and gateway agree on the line; the container and host runners are driven with a real stderr line followed by 25 heartbeats and must both reset the tracker and keep the real line in the exit error; `readOutput` is shown to outlive a silence longer than the inactivity window while activity is reported; and the Codex client is shown to report activity every 10 s while a turn is outstanding and stop once it completes.
