### PR TITLE
fix(memory): serialize concurrent workspace memory writes

### DIFF
--- a/container/shared/memory-file.d.ts
+++ b/container/shared/memory-file.d.ts
@@ -1,0 +1,3 @@
+export function lockMemoryFile(filePath: string): () => void;
+export function waitForMemoryFileLock(filePath: string): Promise<() => void>;
+export function writeMemoryFileAtomic(filePath: string, content: string): void;

--- a/container/shared/memory-file.js
+++ b/container/shared/memory-file.js
@@ -1,0 +1,57 @@
+/**
+ * Cooperative memory-file transactions shared by host and container processes.
+ * Locks cover the entire read/modify/write; rename alone cannot prevent lost updates.
+ * This is not a workspace access policy and cannot serialize external editors.
+ */
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { setTimeout } from 'node:timers/promises';
+
+export function lockMemoryFile(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const lockPath = `${filePath}.lock`;
+  try {
+    fs.mkdirSync(lockPath);
+  } catch (err) {
+    if (err.code === 'EEXIST') {
+      throw new Error(
+        `Memory file is locked: ${filePath}. Retry later; after a crashed writer, remove the .lock directory only when no writer is running.`,
+      );
+    }
+    throw err;
+  }
+  return () => fs.rmdirSync(lockPath);
+}
+
+export async function waitForMemoryFileLock(filePath) {
+  // 5s/25ms (implementation decision, 2026-09-08, issue #1477): bound tool
+  // contention without blocking the event loop; automatic stale-lock stealing deferred.
+  const deadline = Date.now() + 5_000;
+  for (;;) {
+    try {
+      return lockMemoryFile(filePath);
+    } catch (err) {
+      if (
+        !err.message.startsWith('Memory file is locked:') ||
+        Date.now() >= deadline
+      )
+        throw err;
+      await setTimeout(25);
+    }
+  }
+}
+
+export function writeMemoryFileAtomic(filePath, content) {
+  const temporary = `${filePath}.${randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(temporary, content, {
+      encoding: 'utf8',
+      flag: 'wx',
+      mode: 0o600,
+    });
+    fs.renameSync(temporary, filePath);
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
+}

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -4,6 +4,10 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {
+  waitForMemoryFileLock,
+  writeMemoryFileAtomic,
+} from '../shared/memory-file.js';
+import {
   formatMessageToolChannelList,
   normalizeMessageToolChannelKinds,
 } from '../shared/message-tool-channels.js';
@@ -3099,79 +3103,89 @@ async function executeToolInternal(
         return `${relativePath}\n\n${content || '(empty)'}`;
       }
 
-      if (action === 'append') {
-        const content =
-          typeof args.content === 'string' ? args.content.trim() : '';
-        if (!content)
-          return failTool('Error: content is required for memory append');
+      const release = isMemoryWriteAction(action)
+        ? await waitForMemoryFileLock(filePath)
+        : undefined;
+      try {
+        if (action === 'append') {
+          const content =
+            typeof args.content === 'string' ? args.content.trim() : '';
+          if (!content)
+            return failTool('Error: content is required for memory append');
 
-        fs.mkdirSync(path.dirname(filePath), { recursive: true });
-        const existing = fs.existsSync(filePath)
-          ? fs.readFileSync(filePath, 'utf-8')
-          : '';
-        let next = existing.replace(/\s+$/, '');
-        if (next.length > 0) next += '\n\n';
-        next += `${content}\n`;
-        const limit = memoryCharLimit(relativePath);
-        if (next.length > limit) {
-          return failTool(
-            `Error: ${relativePath} would exceed ${limit} chars. Shorten content or remove older entries first.`,
-          );
+          fs.mkdirSync(path.dirname(filePath), { recursive: true });
+          const existing = fs.existsSync(filePath)
+            ? fs.readFileSync(filePath, 'utf-8')
+            : '';
+          let next = existing.replace(/\s+$/, '');
+          if (next.length > 0) next += '\n\n';
+          next += `${content}\n`;
+          const limit = memoryCharLimit(relativePath);
+          if (next.length > limit) {
+            return failTool(
+              `Error: ${relativePath} would exceed ${limit} chars. Shorten content or remove older entries first.`,
+            );
+          }
+          writeMemoryFileAtomic(filePath, next);
+          return `Appended ${content.length} chars to ${relativePath}`;
         }
-        fs.writeFileSync(filePath, next, 'utf-8');
-        return `Appended ${content.length} chars to ${relativePath}`;
-      }
 
-      if (action === 'write') {
-        const content = typeof args.content === 'string' ? args.content : '';
-        const limit = memoryCharLimit(relativePath);
-        if (content.length > limit) {
-          return failTool(
-            `Error: ${relativePath} exceeds ${limit} char limit.`,
-          );
+        if (action === 'write') {
+          const content = typeof args.content === 'string' ? args.content : '';
+          const limit = memoryCharLimit(relativePath);
+          if (content.length > limit) {
+            return failTool(
+              `Error: ${relativePath} exceeds ${limit} char limit.`,
+            );
+          }
+          fs.mkdirSync(path.dirname(filePath), { recursive: true });
+          writeMemoryFileAtomic(filePath, content);
+          return `Wrote ${content.length} chars to ${relativePath}`;
         }
-        fs.mkdirSync(path.dirname(filePath), { recursive: true });
-        fs.writeFileSync(filePath, content, 'utf-8');
-        return `Wrote ${content.length} chars to ${relativePath}`;
-      }
 
-      if (action === 'replace') {
-        const oldText = typeof args.old_text === 'string' ? args.old_text : '';
-        const newText = typeof args.new_text === 'string' ? args.new_text : '';
-        if (!oldText)
-          return failTool('Error: old_text is required for memory replace');
-        if (!fs.existsSync(filePath))
-          return failTool(`Error: File not found: ${relativePath}`);
-        const content = fs.readFileSync(filePath, 'utf-8');
-        if (!content.includes(oldText))
-          return failTool(`Error: old_text not found in ${relativePath}`);
-        const next = content.replace(oldText, newText);
-        const limit = memoryCharLimit(relativePath);
-        if (next.length > limit) {
-          return failTool(
-            `Error: replacement would exceed ${limit} chars for ${relativePath}.`,
-          );
+        if (action === 'replace') {
+          const oldText =
+            typeof args.old_text === 'string' ? args.old_text : '';
+          const newText =
+            typeof args.new_text === 'string' ? args.new_text : '';
+          if (!oldText)
+            return failTool('Error: old_text is required for memory replace');
+          if (!fs.existsSync(filePath))
+            return failTool(`Error: File not found: ${relativePath}`);
+          const content = fs.readFileSync(filePath, 'utf-8');
+          if (!content.includes(oldText))
+            return failTool(`Error: old_text not found in ${relativePath}`);
+          const next = content.replace(oldText, newText);
+          const limit = memoryCharLimit(relativePath);
+          if (next.length > limit) {
+            return failTool(
+              `Error: replacement would exceed ${limit} chars for ${relativePath}.`,
+            );
+          }
+          writeMemoryFileAtomic(filePath, next);
+          return `Updated ${relativePath}`;
         }
-        fs.writeFileSync(filePath, next, 'utf-8');
-        return `Updated ${relativePath}`;
-      }
 
-      if (action === 'remove') {
-        const oldText = typeof args.old_text === 'string' ? args.old_text : '';
-        if (!oldText)
-          return failTool('Error: old_text is required for memory remove');
-        if (!fs.existsSync(filePath))
-          return failTool(`Error: File not found: ${relativePath}`);
-        const content = fs.readFileSync(filePath, 'utf-8');
-        if (!content.includes(oldText))
-          return failTool(`Error: old_text not found in ${relativePath}`);
-        fs.writeFileSync(filePath, content.replace(oldText, ''), 'utf-8');
-        return `Removed matching text from ${relativePath}`;
-      }
+        if (action === 'remove') {
+          const oldText =
+            typeof args.old_text === 'string' ? args.old_text : '';
+          if (!oldText)
+            return failTool('Error: old_text is required for memory remove');
+          if (!fs.existsSync(filePath))
+            return failTool(`Error: File not found: ${relativePath}`);
+          const content = fs.readFileSync(filePath, 'utf-8');
+          if (!content.includes(oldText))
+            return failTool(`Error: old_text not found in ${relativePath}`);
+          writeMemoryFileAtomic(filePath, content.replace(oldText, ''));
+          return `Removed matching text from ${relativePath}`;
+        }
 
-      return failTool(
-        `Error: unknown memory action "${action}". Use read, append, write, replace, remove, list, or search.`,
-      );
+        return failTool(
+          `Error: unknown memory action "${action}". Use read, append, write, replace, remove, list, or search.`,
+        );
+      } finally {
+        release?.();
+      }
     }
 
     case 'message': {

--- a/docs/content/developer-guide/memory.md
+++ b/docs/content/developer-guide/memory.md
@@ -433,3 +433,17 @@ skip parts of the native memory injection and compaction flow. Plugins that
 layer on top of native memory, such as additive external memory providers, do
 not change the built-in behavior described above unless they explicitly replace
 it.
+
+### Concurrent memory writes
+
+The memory tool and consolidation coordinate file updates through a sibling
+`<filename>.lock` directory shared by the host and container mount. The lock
+covers reading, validation, and atomic replacement, so independent chat,
+heartbeat, and scheduled sessions cannot silently overwrite each other's
+read/modify/write updates. Tools retry contention for up to five seconds;
+consolidation skips a busy file. Model cleanup discards its result if the source
+MEMORY.md changed during the model call.
+
+Locks are cooperative: shell commands and external editors do not participate.
+A crashed writer can leave a lock directory behind. Remove that directory only
+after verifying that no writer is running; locks are never stolen based on age.

--- a/src/memory/memory-consolidation.ts
+++ b/src/memory/memory-consolidation.ts
@@ -1,5 +1,15 @@
+/**
+ * Consolidation owns durable MEMORY.md updates, unlike daily-note tool writes.
+ * File transactions serialize cooperating writers; model results are committed only
+ * if their input snapshot is still current. External editors do not take this lock.
+ */
+
 import fs from 'node:fs';
 import path from 'node:path';
+import {
+  lockMemoryFile,
+  writeMemoryFileAtomic,
+} from '../../container/shared/memory-file.js';
 
 import {
   currentDateStampInTimezone,
@@ -683,15 +693,20 @@ export class MemoryConsolidationEngine {
       try {
         const entries = collectDailyMemoryEntries(workspaceDir);
         const memoryPath = path.join(workspaceDir, 'MEMORY.md');
-        const existing = fs.existsSync(memoryPath)
-          ? fs.readFileSync(memoryPath, 'utf-8')
-          : readMemoryTemplate();
-        const next = buildMemoryContent({ existing, entries });
-        dailyFilesCompiled += entries.length;
-        if (next === existing) continue;
-        fs.mkdirSync(path.dirname(memoryPath), { recursive: true });
-        fs.writeFileSync(memoryPath, next, 'utf-8');
-        workspacesUpdated += 1;
+        const release = lockMemoryFile(memoryPath);
+        try {
+          const existing = fs.existsSync(memoryPath)
+            ? fs.readFileSync(memoryPath, 'utf-8')
+            : readMemoryTemplate();
+          const next = buildMemoryContent({ existing, entries });
+          dailyFilesCompiled += entries.length;
+          if (next === existing) continue;
+          fs.mkdirSync(path.dirname(memoryPath), { recursive: true });
+          writeMemoryFileAtomic(memoryPath, next);
+          workspacesUpdated += 1;
+        } finally {
+          release();
+        }
       } catch (err) {
         logger.warn(
           { agentId: agent.id, workspaceDir, err },
@@ -772,9 +787,23 @@ export class MemoryConsolidationEngine {
         }
 
         if (next === existing) continue;
-        fs.mkdirSync(path.dirname(memoryPath), { recursive: true });
-        fs.writeFileSync(memoryPath, next, 'utf-8');
-        workspacesUpdated += 1;
+        const release = lockMemoryFile(memoryPath);
+        try {
+          const current = fs.existsSync(memoryPath)
+            ? fs.readFileSync(memoryPath, 'utf-8')
+            : null;
+          if (current !== (hasExistingMemory ? existing : null)) {
+            logger.warn(
+              { agentId: agent.id },
+              'Memory changed during cleanup; skipping stale rewrite',
+            );
+            continue;
+          }
+          writeMemoryFileAtomic(memoryPath, next);
+          workspacesUpdated += 1;
+        } finally {
+          release();
+        }
       } catch (err) {
         logger.warn(
           { agentId: agent.id, workspaceDir, err },

--- a/tests/container.memory-tool.test.ts
+++ b/tests/container.memory-tool.test.ts
@@ -69,6 +69,22 @@ describe.sequential('container memory tool', () => {
     ).toContain('- Durable fact.');
   });
 
+  test('concurrent appends keep every note and release locks after validation failures', async () => {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-appends-'));
+    vi.stubEnv('HYBRIDCLAW_AGENT_WORKSPACE_ROOT', workspaceRoot);
+    const { executeTool } = await import('../container/src/tools.js');
+    const file_path = `memory/${currentLocalDateStamp()}.md`;
+    const results = await Promise.all(Array.from({ length: 5 }, (_, index) =>
+      executeTool('memory', JSON.stringify({ action: 'append', file_path, content: `entry ${index}` }))));
+    expect(results.every(result => result.includes('Appended'))).toBe(true);
+    const content = fs.readFileSync(path.join(workspaceRoot, file_path), 'utf8');
+    for (let index = 0; index < 5; index++) expect(content).toContain(`entry ${index}`);
+    const failure = await executeTool('memory', JSON.stringify({ action: 'append', file_path, content: 'x'.repeat(24_000) }));
+    expect(failure).toContain('would exceed');
+    expect(fs.existsSync(path.join(workspaceRoot, `${file_path}.lock`))).toBe(false);
+    expect(fs.readFileSync(path.join(workspaceRoot, file_path), 'utf8')).toBe(content);
+  });
+
   test('memoizes USER.md timezone reads while the file is unchanged', async () => {
     workspaceRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), 'hybridclaw-memory-workspace-'),

--- a/tests/memory-consolidation.test.ts
+++ b/tests/memory-consolidation.test.ts
@@ -307,6 +307,26 @@ describe.sequential('memory consolidation', () => {
     );
   });
 
+  test('does not overwrite memory changed while the cleanup model runs', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-cleanup-race-'));
+    try {
+      const memoryPath = path.join(workspaceDir, 'MEMORY.md');
+      fs.writeFileSync(memoryPath, '## Facts\n- Original fact.\n');
+      const { MemoryConsolidationEngine } = await loadConsolidationModule(workspaceDir);
+      const { callAuxiliaryModel } = await import('../src/providers/auxiliary.js');
+      vi.mocked(callAuxiliaryModel).mockImplementationOnce(async () => {
+        fs.writeFileSync(memoryPath, '## Facts\n- Concurrent update.\n');
+        return { provider: 'hybridai', model: 'gpt-5-nano', content: JSON.stringify({ facts: ['Stale result'], decisions: [], patterns: [] }) };
+      });
+      const engine = new MemoryConsolidationEngine(makeBackend(), { decayRate: 0.1, staleAfterDays: 30, minConfidence: 0.1 });
+      expect((await engine.consolidateWithCleanup()).workspacesUpdated).toBe(0);
+      expect(fs.readFileSync(memoryPath, 'utf8')).toBe('## Facts\n- Concurrent update.\n');
+      expect(fs.existsSync(`${memoryPath}.lock`)).toBe(false);
+    } finally {
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   test('model-backed cleanup rewrites MEMORY.md without the daily digest block', async () => {
     const workspaceDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'hybridclaw-memory-consolidation-llm-'),

--- a/tests/memory-file.test.ts
+++ b/tests/memory-file.test.ts
@@ -1,0 +1,57 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, expect, test, vi } from 'vitest';
+import { lockMemoryFile, writeMemoryFileAtomic } from '../container/shared/memory-file.js';
+
+const directories: string[] = [];
+function temporaryFile() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-transaction-'));
+  directories.push(directory);
+  return path.join(directory, 'note.md');
+}
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const directory of directories.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test('serializes read-modify-write across independent processes', async () => {
+  const file = temporaryFile();
+  const moduleUrl = new URL('../container/shared/memory-file.js', import.meta.url).href;
+  await Promise.all(Array.from({ length: 8 }, (_, index) => new Promise<void>((resolve, reject) => {
+    const child = spawn(process.execPath, ['--input-type=module', '-e', `
+      import fs from 'node:fs';
+      import { waitForMemoryFileLock, writeMemoryFileAtomic } from ${JSON.stringify(moduleUrl)};
+      const file = process.argv[1];
+      const release = await waitForMemoryFileLock(file);
+      try {
+        const before = fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
+        await new Promise(resolve => setTimeout(resolve, 10));
+        writeMemoryFileAtomic(file, before + process.argv[2] + '\\n');
+      } finally { release(); }
+    `, file, String(index)], { stdio: 'pipe' });
+    let error = '';
+    child.stderr.on('data', chunk => { error += chunk; });
+    child.on('error', reject);
+    child.on('exit', code => code === 0 ? resolve() : reject(new Error(error)));
+  })));
+  expect(fs.readFileSync(file, 'utf8').trim().split('\n').sort()).toEqual(['0','1','2','3','4','5','6','7']);
+});
+
+test('does not steal a held lock and permits acquisition after release', () => {
+  const file = temporaryFile();
+  const release = lockMemoryFile(file);
+  expect(() => lockMemoryFile(file)).toThrow('Memory file is locked');
+  release();
+  lockMemoryFile(file)();
+});
+
+test('failed rename preserves the original and removes the temporary file', () => {
+  const file = temporaryFile();
+  fs.writeFileSync(file, 'original');
+  vi.spyOn(fs, 'renameSync').mockImplementation(() => { throw new Error('rename failed'); });
+  expect(() => writeMemoryFileAtomic(file, 'replacement')).toThrow('rename failed');
+  expect(fs.readFileSync(file, 'utf8')).toBe('original');
+  expect(fs.readdirSync(path.dirname(file))).toEqual(['note.md']);
+});


### PR DESCRIPTION
Concurrent chat, heartbeat, and scheduled sessions share an agent workspace. Memory updates now take a cross-process file lock across read/modify/write and publish with atomic rename, preventing lost appends and partial reads. Model consolidation rejects a rewrite when MEMORY.md changed during its model call.

Closes #1477.

Validation: 26 targeted tests passed (memory tool, consolidation, separate-process contention, failed rename, and IPC); root lint/typecheck, container lint, and full build passed. Live provider and Docker deployment tests were not needed for the filesystem transaction change.

Risk notes: locks coordinate the memory tool and consolidation, not arbitrary shell writes or external editors. Busy tools retry for five seconds; consolidation skips contention. Locks left by crashed writers require manual removal after verifying the writer has stopped; no age-based lock stealing. Memory path restrictions and approval policy remain unchanged.
