### PR TITLE
fix(memory): make daily note saves safe and timezone consistent

### DIFF
--- a/container/shared/workspace-time.js
+++ b/container/shared/workspace-time.js
@@ -71,7 +71,7 @@ function getTimezoneOffsetMs(timezone, date) {
 
 export function extractUserTimezone(content) {
   if (typeof content !== 'string' || !content.trim()) return undefined;
-  const match = content.match(/\*\*Timezone:\*\*\s*(.+)/i);
+  const match = content.match(/\*\*Timezone:\*\*[ \t]*([^\r\n]*)/i);
   const timezone = match?.[1]?.trim();
   return timezone || undefined;
 }

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -2220,6 +2220,7 @@ function resolveMemoryFilePath(args: Record<string, unknown>): string | null {
     normalizeMemoryFilePath(args.file_path) ||
     normalizeMemoryFilePath(args.path);
   if (direct) return direct;
+  if (args.file_path !== undefined || args.path !== undefined) return null;
 
   const target =
     typeof args.target === 'string' ? args.target.trim().toLowerCase() : '';
@@ -2231,7 +2232,12 @@ function resolveMemoryFilePath(args: Record<string, unknown>): string | null {
     return `memory/${date || currentDateStamp()}.md`;
   }
 
-  return 'MEMORY.md';
+  if (target) return null;
+  const action =
+    typeof args.action === 'string' ? args.action.trim().toLowerCase() : 'read';
+  return isMemoryWriteAction(action)
+    ? `memory/${currentDateStamp()}.md`
+    : 'MEMORY.md';
 }
 
 function listMemoryFiles(): string[] {
@@ -3131,6 +3137,11 @@ async function executeToolInternal(
         }
 
         if (action === 'write') {
+          if (args.confirm_overwrite !== true) {
+            return failTool(
+              'Error: memory write replaces the entire daily note. Set confirm_overwrite=true only to intentionally overwrite it; use append to save additional notes.',
+            );
+          }
           const content = typeof args.content === 'string' ? args.content : '';
           const limit = memoryCharLimit(relativePath);
           if (content.length > limit) {
@@ -4180,7 +4191,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
     function: {
       name: 'memory',
       description:
-        "Manage agent memory files. Read/search/list can access MEMORY.md, USER.md, and daily files at memory/YYYY-MM-DD.md. Write actions append/write/replace/remove are restricted to today's daily file so durable MEMORY.md rewrites flow only through dream consolidation.",
+        "Manage agent memory files. Read/search/list can access MEMORY.md, USER.md, and daily files at memory/YYYY-MM-DD.md. Omitted write targets default to today’s daily note. Prefer append; write replaces the entire note and requires confirm_overwrite=true. Write actions append/write/replace/remove are restricted to today's daily file so durable MEMORY.md rewrites flow only through dream consolidation.",
       parameters: {
         type: 'object',
         properties: {
@@ -4207,6 +4218,11 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
           content: {
             type: 'string',
             description: 'Text payload for append/write',
+          },
+          confirm_overwrite: {
+            type: 'boolean',
+            description:
+              'Required true for write: confirms replacing the entire daily note, including all earlier entries.',
           },
           old_text: {
             type: 'string',

--- a/docs/content/developer-guide/memory.md
+++ b/docs/content/developer-guide/memory.md
@@ -447,3 +447,15 @@ MEMORY.md changed during the model call.
 Locks are cooperative: shell commands and external editors do not participate.
 A crashed writer can leave a lock directory behind. Remove that directory only
 after verifying that no writer is running; locks are never stolen based on age.
+
+### Saving daily notes
+
+`memory append` without a target saves to today's `memory/YYYY-MM-DD.md`.
+Reads without a target use `MEMORY.md`. Prefer `append` to save additional notes;
+`write` replaces the entire daily note and requires `confirm_overwrite: true`.
+Explicit targets remain subject to the today-only write restriction.
+
+Daily filenames use the timezone in `USER.md`. An empty or invalid timezone uses
+the host's resolved timezone, which the gateway passes to Docker as `TZ`.
+Dynamic context states the exact daily-note filename even when the UTC date
+falls on a different day.

--- a/src/agent/conversation.ts
+++ b/src/agent/conversation.ts
@@ -1,6 +1,6 @@
 import os from 'node:os';
-
 import { DYNAMIC_CONTEXT_MESSAGE_PREFIX } from '../../container/shared/dynamic-context.js';
+import { currentDateStampInTimezone } from '../../container/shared/workspace-time.js';
 import { normalizeSkillConfigChannelKind } from '../channels/channel-registry.js';
 import { scheduleCloudMemorySync } from '../memory/cloud-memory.js';
 import {
@@ -71,6 +71,9 @@ export function buildDynamicContextMessage(
   if (agentId) {
     const contextFiles = loadStaticBootstrapFiles(agentId);
     const userTimezone = resolveUserTimezoneFromContextFiles(contextFiles);
+    lines.push(
+      `Daily note: memory/${currentDateStampInTimezone(userTimezone, now)}.md`,
+    );
     lines.push(`Current Date & Time: ${formatCurrentTime(userTimezone, now)}`);
 
     const dailyMemoryFiles = loadRecentDailyMemoryFiles(agentId, {

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -5,6 +5,7 @@
 import { type ChildProcess, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { resolveEffectiveTimezone } from '../../container/shared/workspace-time.js';
 import type {
   ExecutorRequest,
   ExecutorSessionHealthSnapshot,
@@ -763,6 +764,8 @@ function getOrSpawnContainer(
     `HYBRIDCLAW_BEHAVIOR_ANOMALY_TRAJECTORY_STORE_DIR=${CONTAINER_BEHAVIOR_ANOMALY_TRAJECTORY_STORE_DIR}`,
     '-e',
     `HYBRIDCLAW_AGENT_ID=${agentId}`,
+    '-e',
+    `TZ=${resolveEffectiveTimezone()}`,
     '-e',
     `HYBRIDCLAW_AGENT_WORKSPACE_ROOT=${CONTAINER_WORKSPACE_ROOT}`,
     '-e',

--- a/tests/container-runner.redaction.test.ts
+++ b/tests/container-runner.redaction.test.ts
@@ -668,6 +668,7 @@ test('ContainerExecutor injects gateway runtime env into docker launch', async (
     'HYBRIDCLAW_GATEWAY_URL=http://host.docker.internal:9090',
   );
   expect(runArgs).toContain('HYBRIDCLAW_GATEWAY_TOKEN=gateway-secret');
+  expect(runArgs).toContain(`TZ=${Intl.DateTimeFormat().resolvedOptions().timeZone}`);
 });
 
 test('ContainerExecutor stages the container node_modules symlink before docker launch', async () => {

--- a/tests/container.memory-tool.test.ts
+++ b/tests/container.memory-tool.test.ts
@@ -85,6 +85,22 @@ describe.sequential('container memory tool', () => {
     expect(fs.readFileSync(path.join(workspaceRoot, file_path), 'utf8')).toBe(content);
   });
 
+  test('defaults writes to today and requires explicit overwrite confirmation', async () => {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-defaults-'));
+    vi.stubEnv('HYBRIDCLAW_AGENT_WORKSPACE_ROOT', workspaceRoot);
+    const { executeTool } = await import('../container/src/tools.js');
+    const file = path.join(workspaceRoot, `memory/${currentLocalDateStamp()}.md`);
+    expect(await executeTool('memory', JSON.stringify({ action: 'append', content: 'keep me' }))).toContain('Appended');
+    for (const confirm_overwrite of [undefined, false, 'true']) {
+      expect(await executeTool('memory', JSON.stringify({ action: 'write', content: 'replacement', confirm_overwrite }))).toContain('confirm_overwrite=true');
+      expect(fs.readFileSync(file, 'utf8')).toContain('keep me');
+    }
+    expect(await executeTool('memory', JSON.stringify({ action: 'write', content: 'replacement', confirm_overwrite: true }))).toContain('Wrote');
+    expect(fs.readFileSync(file, 'utf8')).toBe('replacement');
+    expect(await executeTool('memory', JSON.stringify({ action: 'append', file_path: '../escape.md', content: 'bad' }))).toContain('Error:');
+    expect(fs.readFileSync(file, 'utf8')).toBe('replacement');
+  });
+
   test('memoizes USER.md timezone reads while the file is unchanged', async () => {
     workspaceRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), 'hybridclaw-memory-workspace-'),

--- a/tests/prompt-hooks-stability.test.ts
+++ b/tests/prompt-hooks-stability.test.ts
@@ -187,3 +187,11 @@ test('buildConversationContext appends dynamic context after unchanged history',
     vi.useRealTimers();
   }
 });
+
+ test('dynamic context names the user daily note across the UTC date boundary', async () => {
+   await createWorkspaceWithBootstrapFiles('timezone-agent');
+   const { buildDynamicContextMessage } = await import('../src/agent/conversation.js');
+   const message = buildDynamicContextMessage({ agentId: 'timezone-agent', now: new Date('2026-05-12T23:30:00Z') });
+   expect(message.content).toContain('Date (UTC): 2026-05-12');
+   expect(message.content).toContain('Daily note: memory/2026-05-13.md');
+ });

--- a/tests/workspace-time.test.ts
+++ b/tests/workspace-time.test.ts
@@ -1,0 +1,13 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { currentDateStampInTimezone, extractUserTimezone } from '../container/shared/workspace-time.js';
+afterEach(() => vi.unstubAllEnvs());
+test('empty timezone does not consume the next USER.md field', () => {
+  expect(extractUserTimezone('**Timezone:** \n**Notes:** example')).toBeUndefined();
+});
+test('blank and invalid user zones use inherited host TZ around midnight', () => {
+  vi.stubEnv('TZ', 'America/Los_Angeles');
+  const now = new Date('2026-09-08T00:30:00Z');
+  expect(currentDateStampInTimezone(undefined, now)).toBe('2026-09-07');
+  expect(currentDateStampInTimezone('Invalid/Zone', now)).toBe('2026-09-07');
+  expect(currentDateStampInTimezone('Europe/Berlin', now)).toBe('2026-09-08');
+});


### PR DESCRIPTION
Saving a note without a target now appends to today's daily file, while untargeted reads still use MEMORY.md. Whole-file `write` requires `confirm_overwrite: true`, and the schema explains that it erases earlier entries. Invalid explicit paths fail rather than silently falling back.

Docker inherits the host's resolved timezone via TZ, with USER.md still taking precedence. Blank timezone fields cannot consume the next line. Dynamic context names the daily file explicitly across UTC midnight.

Closes #1467. Stacked on #1497; merge that PR first.

Validation: 27 targeted tests passed, covering writes, overwrite confirmation, invalid paths, blank/invalid timezones, midnight context, Docker environment, prompt stability, and IPC. Root lint/typecheck, container lint, and full build passed. Live providers and a real Docker deployment were not exercised.

Risk notes: today's-note path restrictions and approval tiers remain intact. The inherited timezone affects newly launched containers; existing containers retain their launch environment. No gateway restart is performed by this change.
