### PR TITLE
fix(memory): preserve daily notes and custom consolidation sections

### DIFF
--- a/container/shared/daily-memory.d.ts
+++ b/container/shared/daily-memory.d.ts
@@ -1,0 +1,6 @@
+export const DAILY_MEMORY_MAX_CHARS: number;
+export function truncateDailyMemoryText(
+  content: string,
+  maxChars?: number,
+): string;
+export function readDailyMemoryFile(filePath: string): string | null;

--- a/container/shared/daily-memory.js
+++ b/container/shared/daily-memory.js
@@ -1,0 +1,54 @@
+/**
+ * Daily-note intake uses the tool's character cap on both sides of the sandbox.
+ * Oversized external notes retain both ends; this does not set durable-memory budgets.
+ */
+import fs from 'node:fs';
+
+// Existing tool limit, shared on 2026-09-08 for issue #1466; configurable budgets deferred.
+export const DAILY_MEMORY_MAX_CHARS = 24_000;
+const MARKER = '\n...[truncated middle]...\n';
+
+export function truncateDailyMemoryText(
+  content,
+  maxChars = DAILY_MEMORY_MAX_CHARS,
+) {
+  if (content.length <= maxChars) return content;
+  if (maxChars <= MARKER.length) return MARKER.slice(0, maxChars);
+  const available = maxChars - MARKER.length;
+  const head = Math.ceil(available / 2);
+  const tail = Math.floor(available / 2);
+  return (
+    content.slice(0, head).replace(/[\uD800-\uDBFF]$/, '') +
+    MARKER +
+    (tail ? content.slice(-tail).replace(/^[\uDC00-\uDFFF]/, '') : '')
+  );
+}
+
+export function readDailyMemoryFile(filePath) {
+  let fd;
+  try {
+    fd = fs.openSync(filePath, 'r');
+    const size = fs.fstatSync(fd).size;
+    // UTF-8 can take up to four bytes per character. Bound allocation even
+    // for external files that bypass the memory tool's character limit.
+    const byteBudget = DAILY_MEMORY_MAX_CHARS * 4;
+    if (size <= byteBudget) {
+      const buffer = Buffer.alloc(size);
+      const count = fs.readSync(fd, buffer, 0, size, 0);
+      return truncateDailyMemoryText(buffer.toString('utf8', 0, count));
+    }
+    const head = Buffer.alloc(byteBudget / 2);
+    const tail = Buffer.alloc(byteBudget / 2);
+    const headRead = fs.readSync(fd, head, 0, head.length, 0);
+    const tailRead = fs.readSync(fd, tail, 0, tail.length, size - tail.length);
+    return truncateDailyMemoryText(
+      head.toString('utf8', 0, headRead).replace(/\uFFFD+$/, '') +
+        MARKER +
+        tail.toString('utf8', 0, tailRead).replace(/^\uFFFD+/, ''),
+    );
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
+}

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { DAILY_MEMORY_MAX_CHARS } from '../shared/daily-memory.js';
 import {
   waitForMemoryFileLock,
   writeMemoryFileAtomic,
@@ -2148,7 +2149,6 @@ const ROOT_MEMORY_CHAR_LIMITS: Record<string, number> = {
   'MEMORY.md': 12_000,
   'USER.md': 8_000,
 };
-const DAILY_MEMORY_CHAR_LIMIT = 24_000;
 
 function normalizeDateStamp(input: string): string | null {
   const trimmed = input.trim();
@@ -2260,7 +2260,7 @@ function listMemoryFiles(): string[] {
 }
 
 function memoryCharLimit(relativePath: string): number {
-  return ROOT_MEMORY_CHAR_LIMITS[relativePath] || DAILY_MEMORY_CHAR_LIMIT;
+  return ROOT_MEMORY_CHAR_LIMITS[relativePath] || DAILY_MEMORY_MAX_CHARS;
 }
 
 interface TranscriptRow {

--- a/docs/content/developer-guide/memory.md
+++ b/docs/content/developer-guide/memory.md
@@ -313,7 +313,7 @@ The values below describe the built-in defaults in the current codebase.
 | Limit | Default | Meaning |
 | --- | ---: | --- |
 | bootstrap file read cap | `20,000` chars per file | `MEMORY.md` and other bootstrap files are trimmed before prompt assembly |
-| current daily note prompt load | up to `20,000` chars | today's `memory/YYYY-MM-DD.md` is injected when present |
+| current daily note prompt load | up to `24,000` chars | today's `memory/YYYY-MM-DD.md` is injected when present |
 | prior daily note lookback | `7` days | complete prior notes are considered newest first |
 | prior daily note history budget | `12,000` chars | shared cap for prior notes; today's note has its own file cap |
 
@@ -459,3 +459,21 @@ Daily filenames use the timezone in `USER.md`. An empty or invalid timezone uses
 the host's resolved timezone, which the gateway passes to Docker as `TZ`.
 Dynamic context states the exact daily-note filename even when the UTC date
 falls on a different day.
+
+
+### Consolidation intake and preservation
+
+The memory tool, today's prompt note, and consolidation share a `24,000`
+character daily-file cap. Notes within the cap are read completely, including
+prose and entries after the sixth bullet. Oversized externally written notes
+retain their beginning and tail with a visible middle-truncation marker.
+Consolidation selects recent source notes within a separate `24,000` character
+input budget; older source files remain on disk.
+
+Model cleanup receives the existing memory document and replaces managed bullets
+under Facts, Decisions, and Patterns. Other headings, free text, and fenced
+examples are preserved verbatim. If the result exceeds the `12,000` character
+durable-file budget, deterministic consolidation is used instead of trimming
+operator content. Its digest prefers newest days; if the newest day alone is too
+large, both ends are retained with a truncation marker. Source daily files are
+never rewritten by consolidation.

--- a/src/memory/memory-consolidation.ts
+++ b/src/memory/memory-consolidation.ts
@@ -1,11 +1,17 @@
 /**
  * Consolidation owns durable MEMORY.md updates, unlike daily-note tool writes.
  * File transactions serialize cooperating writers; model results are committed only
- * if their input snapshot is still current. External editors do not take this lock.
+ * if their input snapshot is still current. Cleanup preserves non-managed text;
+ * external editors do not take this lock.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
+import {
+  DAILY_MEMORY_MAX_CHARS,
+  readDailyMemoryFile,
+  truncateDailyMemoryText,
+} from '../../container/shared/daily-memory.js';
 import {
   lockMemoryFile,
   writeMemoryFileAtomic,
@@ -44,10 +50,7 @@ export interface MemoryConsolidationReport {
 const DAILY_MEMORY_BLOCK_START = '<!-- BEGIN DAILY MEMORY DIGEST -->';
 const DAILY_MEMORY_BLOCK_END = '<!-- END DAILY MEMORY DIGEST -->';
 const DAILY_MEMORY_FILE_RE = /^(\d{4}-\d{2}-\d{2})\.md$/;
-const DAILY_MEMORY_DIGEST_MAX_CHARS = 6_000;
-const DAILY_MEMORY_FILE_MAX_CHARS = 4_000;
-const DAILY_MEMORY_SUMMARY_MAX_ITEMS = 6;
-const DAILY_MEMORY_LINE_MAX_CHARS = 220;
+const DAILY_MEMORY_DIGEST_MAX_CHARS = DAILY_MEMORY_MAX_CHARS;
 const MEMORY_FILE_MAX_CHARS = 12_000;
 const MODEL_MEMORY_ITEM_MAX_CHARS = 280;
 const MODEL_MEMORY_MAX_ITEMS_PER_SECTION = 18;
@@ -164,10 +167,7 @@ function addUniqueKey(seen: Set<string>, key: string): boolean {
   return true;
 }
 
-function truncateLine(
-  value: string,
-  maxChars = DAILY_MEMORY_LINE_MAX_CHARS,
-): string {
+function truncateLine(value: string, maxChars: number): string {
   const compact = compactWhitespace(value);
   if (compact.length <= maxChars) return compact;
   return `${compact.slice(0, maxChars - 3).trimEnd()}...`;
@@ -280,76 +280,62 @@ function countCanonicalMemoryItems(sections: CanonicalMemorySections): number {
   );
 }
 
-function renderMemorySection(
-  title: string,
-  items: string[],
-  placeholder: string,
-): string {
-  return [
-    `## ${title}`,
-    '',
-    items.length > 0
-      ? items.map((item) => `- ${item}`).join('\n')
-      : placeholder,
-  ].join('\n');
-}
-
 function renderCanonicalMemoryDocument(
   sections: CanonicalMemorySections,
+  existing: string,
 ): string {
-  return [
-    '# MEMORY.md - Session Memory',
-    '',
-    "_Things you've learned across conversations. Update as you go._",
-    '',
-    renderMemorySection(
-      'Facts',
-      sections.facts,
-      '_(No durable facts captured yet.)_',
-    ),
-    '',
-    renderMemorySection(
-      'Decisions',
-      sections.decisions,
-      '_(No durable decisions captured yet.)_',
-    ),
-    '',
-    renderMemorySection(
-      'Patterns',
-      sections.patterns,
-      '_(No recurring patterns captured yet.)_',
-    ),
-    '',
-    '---',
-    '',
-    'This is your persistent memory. Each session, read this first. Update it when you learn something worth remembering.',
-    '',
-  ].join('\n');
+  const remaining = new Set(['Facts', 'Decisions', 'Patterns']);
+  let active = false;
+  let fence: string | null = null;
+  const output: string[] = [];
+  for (const line of existing
+    .replace(DAILY_DIGEST_BLOCK_RE, '')
+    .match(/[^\n]*\n|[^\n]+$/g) || []) {
+    const fenceMatch = /^[ \t]*(`{3,}|~{3,})/.exec(line);
+    if (fence) {
+      output.push(line);
+      if (
+        fenceMatch &&
+        fenceMatch[1][0] === fence[0] &&
+        fenceMatch[1].length >= fence.length
+      )
+        fence = null;
+      continue;
+    }
+    if (fenceMatch) {
+      fence = fenceMatch[1];
+      output.push(line);
+      continue;
+    }
+    const heading = /^(#{1,6})[ \t]+(.+?)\s*$/.exec(line);
+    if (heading) {
+      active = heading[1] === '##' && MEMORY_SECTION_NAMES.has(heading[2]);
+      output.push(line);
+      if (active && remaining.delete(heading[2])) {
+        const key = heading[2].toLowerCase() as keyof CanonicalMemorySections;
+        output.push(
+          `${line.endsWith('\n') ? '' : '\n'}${sections[key].map((item) => `- ${item}\n`).join('')}`,
+        );
+      }
+    } else if (!active || !/^\s*[-*+]\s+/.test(line)) {
+      output.push(line);
+    }
+  }
+  for (const title of remaining) {
+    const key = title.toLowerCase() as keyof CanonicalMemorySections;
+    output.push(
+      `\n\n## ${title}\n${sections[key].map((item) => `- ${item}\n`).join('')}`,
+    );
+  }
+  return output.join('');
 }
 
 function fitCanonicalMemoryDocument(
   sections: CanonicalMemorySections,
+  existing: string,
 ): string | null {
-  const fitted: CanonicalMemorySections = {
-    facts: [...sections.facts],
-    decisions: [...sections.decisions],
-    patterns: [...sections.patterns],
-  };
-
-  let rendered = renderCanonicalMemoryDocument(fitted);
-  while (rendered.length > MEMORY_FILE_MAX_CHARS) {
-    const buckets: Array<keyof CanonicalMemorySections> = [
-      'patterns',
-      'facts',
-      'decisions',
-    ];
-    const target = buckets.find((key) => fitted[key].length > 0);
-    if (!target) return null;
-    fitted[target].pop();
-    rendered = renderCanonicalMemoryDocument(fitted);
-  }
-
-  return rendered;
+  const rendered = renderCanonicalMemoryDocument(sections, existing);
+  return rendered.length <= MEMORY_FILE_MAX_CHARS ? rendered : null;
 }
 
 function formatDailyEntriesForPrompt(entries: DailyMemoryEntry[]): string {
@@ -364,19 +350,7 @@ function buildModelCleanupPrompt(params: {
   entries: DailyMemoryEntry[];
   language?: string;
 }): string {
-  const sections = extractCanonicalMemorySections(params.existing);
-  const existingSummary =
-    countCanonicalMemoryItems(sections) > 0
-      ? [
-          '## Current durable memory',
-          '',
-          `Facts: ${sections.facts.length > 0 ? sections.facts.map((item) => `- ${item}`).join('\n') : 'None.'}`,
-          '',
-          `Decisions: ${sections.decisions.length > 0 ? sections.decisions.map((item) => `- ${item}`).join('\n') : 'None.'}`,
-          '',
-          `Patterns: ${sections.patterns.length > 0 ? sections.patterns.map((item) => `- ${item}`).join('\n') : 'None.'}`,
-        ].join('\n')
-      : '## Current durable memory\n\nNone.';
+  const existingSummary = `## Current durable memory\n\n${params.existing}`;
 
   return [
     'Rewrite the durable memory from these sources.',
@@ -440,7 +414,7 @@ async function rewriteMemoryContentWithModel(params: {
       fallbackReason: 'empty_model_output',
     };
   }
-  const content = fitCanonicalMemoryDocument(sections);
+  const content = fitCanonicalMemoryDocument(sections, params.existing);
   if (!content) {
     return {
       content: null,
@@ -454,30 +428,8 @@ async function rewriteMemoryContentWithModel(params: {
 }
 
 function summarizeDailyMemory(rawContent: string): string {
-  const trimmed = rawContent.trim();
-  if (!trimmed) return '';
-
-  const lines = trimmed
-    .replace(/\r/g, '')
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .filter((line, index) => !(index === 0 && line.startsWith('#')));
-  const seen = new Set<string>();
-  const items: string[] = [];
-
-  for (const line of lines) {
-    if (!/^([-*+]|\d+\.)\s+/.test(line) && !/^\[[ xX]\]\s+/.test(line)) {
-      continue;
-    }
-    const normalized = normalizeBullet(line);
-    const dedupeKey = normalized.toLowerCase();
-    if (!addUniqueKey(seen, dedupeKey)) continue;
-    items.push(`- ${truncateLine(normalized)}`);
-    if (items.length >= DAILY_MEMORY_SUMMARY_MAX_ITEMS) break;
-  }
-
-  return items.join('\n');
+  // Keep prose, long entries, and appended notes intact for model cleanup.
+  return rawContent.trim();
 }
 
 function buildDailyDigest(entries: DailyMemoryEntry[]): string {
@@ -581,34 +533,26 @@ function buildMemoryContent(params: {
   }
 
   if (firstEntryIndex >= params.entries.length) {
-    return baseContent;
+    const newest = params.entries.at(-1);
+    if (!newest) return baseContent;
+    const summaryBudget =
+      digestBudget - fixedDigestLength - `### ${newest.date}\n`.length;
+    if (summaryBudget <= 0) return baseContent;
+    return renderMemoryContent(
+      stripped,
+      buildDailyDigest([
+        {
+          date: newest.date,
+          summary: truncateDailyMemoryText(newest.summary, summaryBudget),
+        },
+      ]),
+    );
   }
 
   return renderMemoryContent(
     stripped,
     buildDailyDigest(params.entries.slice(firstEntryIndex)),
   );
-}
-
-function readDailyMemoryFile(filePath: string): string | null {
-  try {
-    const stats = fs.statSync(filePath);
-    if (stats.size <= 0) return '';
-    if (stats.size <= DAILY_MEMORY_FILE_MAX_CHARS) {
-      return fs.readFileSync(filePath, 'utf-8');
-    }
-
-    const fd = fs.openSync(filePath, 'r');
-    try {
-      const buffer = Buffer.alloc(DAILY_MEMORY_FILE_MAX_CHARS);
-      const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
-      return `${buffer.toString('utf8', 0, bytesRead)}\n...[truncated]`;
-    } finally {
-      fs.closeSync(fd);
-    }
-  } catch {
-    return null;
-  }
 }
 
 function collectDailyMemoryEntries(workspaceDir: string): DailyMemoryEntry[] {
@@ -634,7 +578,13 @@ function collectDailyMemoryEntries(workspaceDir: string): DailyMemoryEntry[] {
     if (!content.trim()) continue;
     const summary = summarizeDailyMemory(content);
     if (!summary) continue;
-    const entry = { date, summary };
+    const entry = {
+      date,
+      summary: truncateDailyMemoryText(
+        summary,
+        DAILY_MEMORY_DIGEST_MAX_CHARS - `### ${date}\n`.length,
+      ),
+    };
     const candidate = `### ${entry.date}\n${entry.summary}`;
     const nextSize = candidate.length + (selected.length > 0 ? 2 : 0);
     if (

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -5,6 +5,7 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
+import { readDailyMemoryFile } from '../container/shared/daily-memory.js';
 import {
   currentDateStampInTimezone,
   extractUserTimezone,
@@ -912,7 +913,7 @@ export function loadDailyMemoryFile(
   const todayMemoryPath = path.join(wsDir, todayMemoryName);
   if (fs.existsSync(todayMemoryPath)) {
     try {
-      const raw = readBoundedWorkspaceTextFile(todayMemoryPath, MAX_FILE_CHARS);
+      const raw = readDailyMemoryFile(todayMemoryPath);
       if (raw == null) {
         throw new Error('Failed to read daily memory file');
       }

--- a/tests/daily-memory.test.ts
+++ b/tests/daily-memory.test.ts
@@ -1,0 +1,30 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, expect, test } from 'vitest';
+import { DAILY_MEMORY_MAX_CHARS, readDailyMemoryFile, truncateDailyMemoryText } from '../container/shared/daily-memory.js';
+const directories: string[] = [];
+afterEach(() => { for (const directory of directories.splice(0)) fs.rmSync(directory, { recursive: true, force: true }); });
+function writeNote(content: string) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'daily-memory-'));
+  directories.push(directory);
+  const file = path.join(directory, 'note.md');
+  fs.writeFileSync(file, content);
+  return file;
+}
+test('reads the entire valid note in characters, including multibyte text', () => {
+  const text = '界'.repeat(DAILY_MEMORY_MAX_CHARS - 8) + '\nLatest.';
+  expect(readDailyMemoryFile(writeNote(text))).toBe(text);
+});
+test('oversized external notes retain their head and appended tail within the cap', () => {
+  const text = 'Beginning\n' + '😀'.repeat(70_000) + '\nLatest note.';
+  const content = readDailyMemoryFile(writeNote(text));
+  expect(content?.length).toBeLessThanOrEqual(DAILY_MEMORY_MAX_CHARS);
+  expect(content).toContain('Beginning');
+  expect(content).toContain('Latest note.');
+  expect(content).toContain('[truncated middle]');
+  expect(content).not.toContain('\uFFFD');
+});
+test('small truncation budgets remain bounded', () => {
+  for (let budget = 0; budget < 30; budget++) expect(truncateDailyMemoryText('x'.repeat(100), budget).length).toBeLessThanOrEqual(budget);
+});

--- a/tests/memory-consolidation.test.ts
+++ b/tests/memory-consolidation.test.ts
@@ -176,7 +176,7 @@ describe.sequential('memory consolidation', () => {
     }
   });
 
-  test('ignores prose-only daily memory files instead of synthesizing digest bullets', async () => {
+  test('includes prose-only daily memory files without discarding paragraphs', async () => {
     const workspaceDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'hybridclaw-memory-consolidation-prose-'),
     );
@@ -210,9 +210,9 @@ describe.sequential('memory consolidation', () => {
     const report = engine.consolidate();
     const memoryPath = path.join(workspaceDir, 'MEMORY.md');
 
-    expect(report.dailyFilesCompiled).toBe(0);
-    expect(report.workspacesUpdated).toBe(0);
-    expect(fs.existsSync(memoryPath)).toBe(false);
+    expect(report.dailyFilesCompiled).toBe(1);
+    expect(report.workspacesUpdated).toBe(1);
+    expect(fs.readFileSync(memoryPath, 'utf8')).toContain('This is free-form prose without any bullet structure.\n\nIt should not be converted into a synthetic digest item.');
   });
 
   test('re-running consolidation replaces the managed digest instead of duplicating it', async () => {
@@ -405,6 +405,51 @@ describe.sequential('memory consolidation', () => {
     expect(memoryContent).toContain('Keep changes tightly scoped.');
     expect(memoryContent).toContain('User prefers concise replies.');
     expect(memoryContent).not.toContain('BEGIN DAILY MEMORY DIGEST');
+  });
+
+  test('cleanup sees long prose and late notes and preserves custom sections verbatim', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-preservation-'));
+    try {
+      const { MemoryConsolidationEngine, currentDateStamp } = await loadConsolidationModule(workspaceDir);
+      const { callAuxiliaryModel } = await import('../src/providers/auxiliary.js');
+      const memoryPath = path.join(workspaceDir, 'MEMORY.md');
+      const custom = '## Regeln\r\n\r\nCustom  spacing.\r\n- Keep this rule.\r\n\r\n```md\r\n## Facts\r\n- Example, not managed memory.\r\n```\r\n';
+      fs.writeFileSync(memoryPath, '# Operator title\nOpening free text.\n## Facts\n- Old fact.\nKeep this prose too.\n' + custom);
+      const dailyDir = path.join(workspaceDir, 'memory');
+      fs.mkdirSync(dailyDir);
+      const yesterday = currentDateStamp(new Date(Date.now() - 86400000));
+      const prose = 'Long prose ' + 'detail '.repeat(700) + 'important conclusion.';
+      const daily = Array.from({ length: 12 }, (_, i) => `- Entry ${i}`).join('\n') + '\n\n' + prose + '\n\nNewest appended fact.';
+      fs.writeFileSync(path.join(dailyDir, `${yesterday}.md`), daily);
+      vi.mocked(callAuxiliaryModel).mockResolvedValueOnce({ provider: 'hybridai', model: 'gpt-5-nano', content: JSON.stringify({ facts: ['New fact.'], decisions: [], patterns: [] }) });
+      const engine = new MemoryConsolidationEngine(makeBackend(), { decayRate: 0.1, staleAfterDays: 7, minConfidence: 0.1 });
+      expect((await engine.consolidateWithCleanup()).modelCleanups).toBe(1);
+      const prompt = JSON.stringify(vi.mocked(callAuxiliaryModel).mock.calls[0][0].messages);
+      expect(prompt).toContain('Entry 11');
+      expect(prompt).toContain(prose);
+      expect(prompt).toContain('Newest appended fact.');
+      const result = fs.readFileSync(memoryPath, 'utf8');
+      expect(result).toContain(custom);
+      expect(result).toContain('# Operator title\nOpening free text.\n');
+      expect(result).toContain('Keep this prose too.');
+      expect(result).toContain('- New fact.');
+      expect(result).not.toContain('- Old fact.');
+    } finally { fs.rmSync(workspaceDir, { recursive: true, force: true }); }
+  });
+
+  test('cleanup exceeding the file budget preserves operator content through fallback', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-preservation-budget-'));
+    try {
+      const { MemoryConsolidationEngine } = await loadConsolidationModule(workspaceDir);
+      const { callAuxiliaryModel } = await import('../src/providers/auxiliary.js');
+      const memoryPath = path.join(workspaceDir, 'MEMORY.md');
+      const custom = '# Memory\n\n## Regeln\n' + 'x'.repeat(11_900) + '\n';
+      fs.writeFileSync(memoryPath, custom);
+      vi.mocked(callAuxiliaryModel).mockResolvedValueOnce({ provider: 'hybridai', model: 'gpt-5-nano', content: JSON.stringify({ facts: ['y'.repeat(280)], decisions: [], patterns: [] }) });
+      const engine = new MemoryConsolidationEngine(makeBackend(), { decayRate: 0.1, staleAfterDays: 7, minConfidence: 0.1 });
+      expect((await engine.consolidateWithCleanup()).fallbacksUsed).toBe(1);
+      expect(fs.readFileSync(memoryPath, 'utf8')).toBe(custom);
+    } finally { fs.rmSync(workspaceDir, { recursive: true, force: true }); }
   });
 
   test('model-backed cleanup requests English output by default', async () => {
@@ -655,7 +700,7 @@ describe.sequential('memory consolidation', () => {
     const { MemoryConsolidationEngine, currentDateStamp } =
       await loadConsolidationModule(workspaceDir);
     const now = new Date();
-    const entries = Array.from({ length: 40 }, (_, index) => {
+    const entries = Array.from({ length: 120 }, (_, index) => {
       const date = new Date(now);
       date.setDate(date.getDate() - (index + 1));
       const stamp = currentDateStamp(date);
@@ -671,14 +716,14 @@ describe.sequential('memory consolidation', () => {
     const oldestEntry = entries.at(-1);
     expect(oldestEntry).toBeDefined();
 
-    const statSync = fs.statSync.bind(fs);
-    const statSpy = vi.spyOn(fs, 'statSync').mockImplementation((filePath) => {
+    const openSync = fs.openSync.bind(fs);
+    const openSpy = vi.spyOn(fs, 'openSync').mockImplementation((filePath, flags, mode) => {
       if (String(filePath) === oldestEntry?.filePath) {
         throw new Error(
           'Oldest file should not be touched after digest budget is full',
         );
       }
-      return statSync(filePath);
+      return openSync(filePath, flags, mode);
     });
 
     try {
@@ -696,13 +741,13 @@ describe.sequential('memory consolidation', () => {
 
       expect(report.dailyFilesCompiled).toBeGreaterThan(0);
       expect(memoryContent).toContain('Budget stop entry 1');
-      expect(memoryContent).not.toContain('Budget stop entry 40');
+      expect(memoryContent).not.toContain('Budget stop entry 120');
     } finally {
-      statSpy.mockRestore();
+      openSpy.mockRestore();
     }
   });
 
-  test('reads only a capped prefix for oversized daily memory files', async () => {
+  test('reads bounded head and tail for oversized daily memory files', async () => {
     const workspaceDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'hybridclaw-memory-consolidation-large-daily-'),
     );
@@ -717,7 +762,7 @@ describe.sequential('memory consolidation', () => {
     const largeDailyPath = path.join(dailyDir, `${olderStamp}.md`);
     fs.writeFileSync(
       largeDailyPath,
-      `- Oversized daily memory ${'x'.repeat(6_000)}\n`,
+      `- Oversized daily memory ${'x'.repeat(100_000)}\nNewest appended fact.\n`,
       'utf-8',
     );
 
@@ -746,6 +791,8 @@ describe.sequential('memory consolidation', () => {
 
       expect(report.dailyFilesCompiled).toBe(1);
       expect(memoryContent).toContain('Oversized daily memory');
+      expect(memoryContent).toContain('Newest appended fact.');
+      expect(memoryContent).toContain('[truncated middle]');
       expect(memoryContent).not.toContain(
         'Large daily file should not be fully read',
       );

--- a/tests/workspace-bootstrap.test.ts
+++ b/tests/workspace-bootstrap.test.ts
@@ -355,6 +355,26 @@ describe('workspace bootstrap lifecycle', () => {
     });
   });
 
+  test('daily prompt reads the tool cap and keeps the tail of oversized notes', async () => {
+    const homeDir = makeTempDir('hybridclaw-home-');
+    vi.stubEnv('HOME', homeDir);
+    const workspace = await import('../src/workspace.js');
+    const ipc = await import('../src/infra/ipc.js');
+    workspace.ensureBootstrapFiles('agent-test');
+    const workspaceDir = ipc.agentWorkspaceDir('agent-test');
+    const dailyPath = path.join(workspaceDir, 'memory', `${currentLocalDateStamp()}.md`);
+    fs.mkdirSync(path.dirname(dailyPath), { recursive: true });
+    const valid = 'Beginning\n' + '界'.repeat(23_970) + '\nNewest entry.';
+    fs.writeFileSync(dailyPath, valid);
+    expect(workspace.loadDailyMemoryFile('agent-test')?.content).toBe(valid);
+    fs.writeFileSync(dailyPath, 'Beginning\n' + 'x'.repeat(100_000) + '\nNewest entry.');
+    const content = workspace.loadDailyMemoryFile('agent-test')?.content;
+    expect(content).toContain('Beginning');
+    expect(content).toContain('Newest entry.');
+    expect(content).toContain('[truncated middle]');
+    expect(content?.length).toBeLessThanOrEqual(24_000);
+  });
+
   test('loads the previous days of daily memory notes, newest first, within budget', async () => {
     const homeDir = makeTempDir('hybridclaw-home-');
     const unrelatedCwd = makeTempDir('hybridclaw-cwd-');


### PR DESCRIPTION
Consolidation receives complete daily notes up to the same 24,000-character cap used by the memory tool and today's prompt loader. Prose, long entries, and notes after the sixth bullet reach the model. Oversized external files use bounded head-and-tail reads with a visible truncation marker.

Cleanup replaces only managed bullets under Facts, Decisions, and Patterns, preserving custom headings, free text, and fenced examples verbatim. Over-budget model output falls back without trimming operator content. The deterministic digest retains the newest day even when that day needs head-and-tail truncation; source daily files remain intact.

Closes #1466. Stacked on #1498, which depends on #1497; merge in that order.

Validation: 78 targeted tests passed across ten suites, followed by the expanded 18-test consolidation suite including an additional over-budget preservation test (79 distinct tests total). Root lint/typecheck, container lint, full build, and final root unused/type checks passed. Tests cover complete multibyte notes, large-file tails, prose, late entries, custom sections, fenced examples, budget boundaries, workspace loading, concurrent writes, and IPC. Live provider tests were skipped because model cleanup is covered with deterministic responses; a real Docker deployment was not run locally.

Remaining limits: the combined consolidation intake is bounded at 24,000 characters and durable MEMORY.md at 12,000. Older source notes remain on disk. Model output remains a concise semantic summary, so this does not promise lossless archival in MEMORY.md. Prior-day prompt history keeps its existing seven-day/12,000-character policy.
