### PR TITLE
feat(ratings): forward the rater's display name to HybridAI chat feedback

### DIFF
--- a/docs/content/channels/msteams.md
+++ b/docs/content/channels/msteams.md
@@ -182,7 +182,9 @@ Two ways to rate a HybridClaw answer from Teams:
 
 Ratings are stored per user and feed the same response-rating pipeline as the
 web console thumbs (audit trail, adaptive-skill feedback, and HybridAI chat
-feedback forwarding).
+feedback forwarding). The forwarded feedback carries the rater's Teams user id
+and display name so the HybridAI feedback board shows who rated an answer
+rather than the agent owner.
 
 Teams has no slash-command menu. In a team channel or group chat, mention the
 bot so the command reaches it, for example `@BotName /thumbs down Wrong total`.

--- a/src/gateway/gateway-service.ts
+++ b/src/gateway/gateway-service.ts
@@ -11439,6 +11439,7 @@ export async function handleGatewayCommand(
             sessionId: session.id,
             messageId,
             operatorUserId: String(req.userId || ''),
+            operatorDisplayName: req.username,
             rating,
             comment,
             sourceSurface,

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -1986,6 +1986,7 @@ async function startMSTeamsIntegration(): Promise<boolean> {
           sessionId: event.sessionId,
           messageId,
           operatorUserId: event.userId,
+          operatorDisplayName: event.username,
           addedRatings,
           removedRatings,
           sourceSurface: 'msteams',

--- a/src/gateway/response-ratings.ts
+++ b/src/gateway/response-ratings.ts
@@ -25,6 +25,12 @@ export interface SubmitResponseRatingInput {
   sessionId: string;
   messageId: number;
   operatorUserId: string;
+  /**
+   * Human-readable name of the rater (e.g. a Teams display name). Forwarded
+   * to HybridAI chat so the feedback board can show who rated instead of an
+   * opaque directory id; never used for identity matching.
+   */
+  operatorDisplayName?: string | null;
   rating: ResponseRatingValue | null;
   /** Optional free-text note, e.g. the expected answer for a thumbs-down. */
   comment?: string | null;
@@ -83,9 +89,11 @@ function warnHybridAIChatFeedbackForwardingFailed(
 }
 
 function resolveHybridAIChatFeedbackBrowserId(sessionId: string): string {
-  // HybridAI's feedback API requires a stable opaque browser_id. Web ratings
-  // are session-scoped and do not expose a separate browser fingerprint here,
-  // so use the HybridClaw session id rather than adding user-identifying data.
+  // HybridAI's feedback API requires a stable opaque browser_id. Ratings are
+  // session-scoped and expose no separate browser fingerprint, so use the
+  // HybridClaw session id. Note that channel DM session keys embed the peer
+  // id (e.g. `...:chat:dm:peer:<user id>`); the rater is sent explicitly as
+  // external_user_id anyway.
   return sessionId;
 }
 
@@ -93,6 +101,7 @@ async function forwardHybridAIChatFeedbackForRating(input: {
   sessionId: string;
   messageId: number;
   operatorUserId: string;
+  operatorDisplayName: string | null;
   rating: ResponseRatingValue;
   comment: string | null;
   target: ResponseRatingTarget;
@@ -118,6 +127,9 @@ async function forwardHybridAIChatFeedbackForRating(input: {
       ? `[${agentId}] ${input.target.assistant_content}`
       : input.target.assistant_content,
     external_user_id: input.operatorUserId,
+    ...(input.operatorDisplayName
+      ? { external_user_name: input.operatorDisplayName }
+      : {}),
     ...(input.rating === 'down' && input.comment
       ? { better_response: input.comment }
       : {}),
@@ -158,6 +170,7 @@ export function applyReactionRatingChanges(input: {
   sessionId: string;
   messageId: number;
   operatorUserId: string;
+  operatorDisplayName?: string | null;
   addedRatings: ResponseRatingValue[];
   removedRatings: ResponseRatingValue[];
   sourceSurface: string;
@@ -187,6 +200,7 @@ export function applyReactionRatingChanges(input: {
     sessionId: input.sessionId,
     messageId: input.messageId,
     operatorUserId: input.operatorUserId,
+    operatorDisplayName: input.operatorDisplayName,
     rating: next,
     sourceSurface: input.sourceSurface,
   });
@@ -198,6 +212,13 @@ export function submitResponseRating(
   const sessionId = input.sessionId.trim();
   if (!sessionId) throw new Error('Missing `sessionId`.');
   const operatorUserId = input.operatorUserId.trim() || 'web';
+  // Channels fall back to the raw user id as username; a name equal to the
+  // id adds nothing, so only forward genuinely human-readable labels.
+  const trimmedDisplayName = input.operatorDisplayName?.trim() || null;
+  const operatorDisplayName =
+    trimmedDisplayName && trimmedDisplayName !== operatorUserId
+      ? trimmedDisplayName
+      : null;
   const comment = input.rating ? input.comment?.trim() || null : null;
   const sourceSurface = input.sourceSurface?.trim().toLowerCase() || 'web';
   const target = getResponseRatingTarget({
@@ -268,6 +289,7 @@ export function submitResponseRating(
       sessionId,
       messageId: input.messageId,
       operatorUserId,
+      operatorDisplayName,
       rating: input.rating,
       comment,
       target,

--- a/tests/response-ratings.test.ts
+++ b/tests/response-ratings.test.ts
@@ -295,6 +295,51 @@ describe('response ratings', () => {
     });
   });
 
+  test('forwards the rater display name when it differs from the user id', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 201 });
+    vi.stubGlobal('fetch', fetchMock);
+    const service = await setup({
+      apiKey: 'hai-feedback-test-key',
+      hybridAIBaseUrl: 'https://hybridai.example/',
+      chatbotId: 'bot-feedback',
+    });
+
+    service.submitResponseRating({
+      sessionId: service.sessionId,
+      messageId: service.assistantMessageId,
+      operatorUserId: 'operator-a',
+      operatorDisplayName: '  Ada Lovelace  ',
+      rating: 'up',
+      sourceSurface: 'msteams',
+    });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    const [, first] = fetchMock.mock.calls[0] as [
+      string,
+      RequestInit & { body: string },
+    ];
+    expect(JSON.parse(first.body)).toMatchObject({
+      external_user_id: 'operator-a',
+      external_user_name: 'Ada Lovelace',
+    });
+
+    // Channels fall back to the raw id as username; that must not be sent
+    // as a display name.
+    service.submitResponseRating({
+      sessionId: service.sessionId,
+      messageId: service.assistantMessageId,
+      operatorUserId: 'operator-b',
+      operatorDisplayName: 'operator-b',
+      rating: 'down',
+      sourceSurface: 'msteams',
+    });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const [, second] = fetchMock.mock.calls[1] as [
+      string,
+      RequestInit & { body: string },
+    ];
+    expect(JSON.parse(second.body)).not.toHaveProperty('external_user_name');
+  });
+
   test('applies reaction rating changes with matching-removal semantics', async () => {
     const service = await setup();
     const base = {


### PR DESCRIPTION
## Why

Ratings from chat channels (Teams `/thumbs` and 👍/👎 reactions) reach the HybridAI feedback board with the rater's opaque directory id as `external_user_id`. The board cannot resolve that to a person, so every rating looks like it came from the agent owner.

## What

- `submitResponseRating` / `applyReactionRatingChanges` accept an optional `operatorDisplayName`.
- The `/thumbs` command passes the request username; the Teams reaction handler passes the reactor's username.
- The chat feedback payload gains `external_user_name` when a display name is present and differs from the user id (channels fall back to the raw id as username, which would add nothing).
- Corrected the stale comment on `resolveHybridAIChatFeedbackBrowserId`: DM session keys embed the peer id, so it was never free of user identifiers.
- Teams channel docs mention that forwarded feedback carries the rater's id and name.

## Tests

- new case: display name forwarded, id-equal name dropped
- existing payload assertions unchanged (no name → no field)