### PR TITLE
fix(voice): stop realtime responses playing over each other during consults

### DIFF
--- a/src/channels/voice/openai-realtime.ts
+++ b/src/channels/voice/openai-realtime.ts
@@ -67,6 +67,21 @@ function normalizeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
+// Responses the server opened without an id (older event shapes, tests) are
+// tracked under a synthetic key so cancel/accounting still balance.
+const ANONYMOUS_RESPONSE_PREFIX = 'anon:';
+
+function responseId(event: Record<string, unknown>): string {
+  return isRecord(event.response) ? normalizeString(event.response.id) : '';
+}
+
+/** Server-side VAD tuning; omitted fields keep the upstream defaults. */
+export interface RealtimeTurnDetection {
+  threshold?: number;
+  prefixPaddingMs?: number;
+  silenceDurationMs?: number;
+}
+
 export interface OpenAIRealtimeClientOptions {
   /** Realtime endpoint without the model query, e.g. from `resolveRealtimeConnection`. */
   url: string;
@@ -76,6 +91,7 @@ export interface OpenAIRealtimeClientOptions {
   audioFormat: RealtimeAudioFormat;
   instructions: string;
   tools: RealtimeFunctionTool[];
+  turnDetection?: RealtimeTurnDetection;
   callbacks: OpenAIRealtimeCallbacks;
   socketFactory?: RealtimeSocketFactory;
 }
@@ -88,12 +104,22 @@ const PENDING_AUDIO_LIMIT = 250;
 export class OpenAIRealtimeClient {
   private readonly socket: RealtimeSocket;
   private readonly callbacks: OpenAIRealtimeCallbacks;
-  private responseActive = false;
+  private readonly turnDetection: RealtimeTurnDetection;
+  // Every response the server has opened and not yet finished, by id. Out-of-
+  // band responses (`conversation: 'none'`) run concurrently with the
+  // conversation's own response, so a single boolean cannot describe "is the
+  // model talking" — and `response.cancel` without an id only ever stops the
+  // conversation one, leaving an out-of-band line playing over the caller.
+  private readonly activeResponseIds = new Set<string>();
+  private anonymousResponseCount = 0;
+  private autoResponse = true;
+  private ready = false;
   private closed = false;
   private pendingAudio: string[] = [];
 
   constructor(options: OpenAIRealtimeClientOptions) {
     this.callbacks = options.callbacks;
+    this.turnDetection = options.turnDetection || {};
     const factory = options.socketFactory || defaultSocketFactory;
     const url = `${options.url}?model=${encodeURIComponent(options.model)}`;
     this.socket = factory(url, {
@@ -110,7 +136,7 @@ export class OpenAIRealtimeClient {
             input: {
               format: options.audioFormat,
               transcription: { model: 'gpt-4o-mini-transcribe' },
-              turn_detection: { type: 'server_vad' },
+              turn_detection: this.turnDetectionPayload(),
             },
             output: {
               format: options.audioFormat,
@@ -145,7 +171,44 @@ export class OpenAIRealtimeClient {
   }
 
   get hasActiveResponse(): boolean {
-    return this.responseActive;
+    return this.activeResponseIds.size > 0;
+  }
+
+  /**
+   * Whether the server may open a response on its own when the caller stops
+   * speaking. Switched off while a function call is outstanding so caller
+   * noise or backchannels cannot spawn a second, guessed answer next to the
+   * reassurance line; the caller's words still land in the conversation and
+   * are answered once the tool output arrives.
+   */
+  setAutoResponse(enabled: boolean): void {
+    if (this.autoResponse === enabled) return;
+    this.autoResponse = enabled;
+    this.sendEvent({
+      type: 'session.update',
+      session: {
+        type: 'realtime',
+        audio: { input: { turn_detection: this.turnDetectionPayload() } },
+      },
+    });
+  }
+
+  private turnDetectionPayload(): Record<string, unknown> {
+    const tuning = this.turnDetection;
+    return {
+      type: 'server_vad',
+      ...(tuning.threshold !== undefined
+        ? { threshold: tuning.threshold }
+        : {}),
+      ...(tuning.prefixPaddingMs !== undefined
+        ? { prefix_padding_ms: tuning.prefixPaddingMs }
+        : {}),
+      ...(tuning.silenceDurationMs !== undefined
+        ? { silence_duration_ms: tuning.silenceDurationMs }
+        : {}),
+      create_response: this.autoResponse,
+      interrupt_response: true,
+    };
   }
 
   appendAudio(base64Audio: string): void {
@@ -187,10 +250,16 @@ export class OpenAIRealtimeClient {
     });
   }
 
+  /** Cancels every in-flight response, out-of-band ones included. */
   cancelResponse(): void {
-    if (!this.responseActive) return;
-    this.sendEvent({ type: 'response.cancel' });
-    this.responseActive = false;
+    for (const id of this.activeResponseIds) {
+      this.sendEvent(
+        id.startsWith(ANONYMOUS_RESPONSE_PREFIX)
+          ? { type: 'response.cancel' }
+          : { type: 'response.cancel', response_id: id },
+      );
+    }
+    this.activeResponseIds.clear();
   }
 
   sendFunctionCallOutput(callId: string, output: string): void {
@@ -252,16 +321,35 @@ export class OpenAIRealtimeClient {
     }
     const type = normalizeString(parsed.type);
     if (type === 'session.updated') {
-      this.callbacks.onReady();
+      // Later session.update round-trips (auto-response toggles) must not
+      // replay the greeting.
+      if (!this.ready) {
+        this.ready = true;
+        this.callbacks.onReady();
+      }
       return;
     }
     if (type === 'response.created') {
-      this.responseActive = true;
+      this.activeResponseIds.add(
+        responseId(parsed) ||
+          `${ANONYMOUS_RESPONSE_PREFIX}${++this.anonymousResponseCount}`,
+      );
       this.callbacks.onResponseCreated?.();
       return;
     }
     if (type === 'response.done') {
-      this.responseActive = false;
+      const id = responseId(parsed);
+      if (id && this.activeResponseIds.has(id)) {
+        this.activeResponseIds.delete(id);
+      } else {
+        // Unidentified completion: assume the oldest anonymous response.
+        for (const active of this.activeResponseIds) {
+          if (active.startsWith(ANONYMOUS_RESPONSE_PREFIX)) {
+            this.activeResponseIds.delete(active);
+            break;
+          }
+        }
+      }
       return;
     }
     if (type === 'response.output_audio.delta') {

--- a/src/channels/voice/realtime-bridge.ts
+++ b/src/channels/voice/realtime-bridge.ts
@@ -308,7 +308,7 @@ export class RealtimeCallBridge {
           ? ` It is currently busy with: ${this.consultActivity}.`
           : '';
         this.client.createOutOfBandResponse(
-          `The assistant is still working on the request.${activity} Briefly reassure the ${
+          `The assistant is still working on the request.${activity} You do not have its answer yet: do not guess, summarize, or invent any result. Briefly reassure the ${
             this.options.surface === 'phone' ? 'caller' : 'user'
           } in one short natural sentence. Do not call tools.`,
         );
@@ -348,6 +348,10 @@ export class RealtimeCallBridge {
     this.consultInFlight = true;
     this.consultActivity = null;
     this.options.onStateChange('thinking');
+    // Caller noise or a backchannel during the consult must not open a second
+    // response next to the reassurance line; what they say is still recorded
+    // and answered together with the tool output.
+    this.client.setAutoResponse(false);
     this.scheduleReassurance(CONSULT_REASSURE_FIRST_MS);
     void this.options
       .consultAgent(request, {
@@ -382,6 +386,7 @@ export class RealtimeCallBridge {
         if (this.closed || !output) {
           return;
         }
+        this.client.setAutoResponse(true);
         this.options.onStateChange('listening');
         this.client.sendFunctionCallOutput(callId, output);
       });

--- a/tests/voice.realtime-bridge.test.ts
+++ b/tests/voice.realtime-bridge.test.ts
@@ -538,3 +538,118 @@ test('phone calls layer voice.prompt over the shared speech settings', () => {
     instructions: 'Be brief.\nSprich Deutsch.',
   });
 });
+
+test('caller speech cancels every in-flight response, out-of-band ones included', () => {
+  const { socket, clears } = createBridge();
+  socket.open();
+  socket.serverEvent({
+    type: 'response.created',
+    response: { id: 'resp_conversation' },
+  });
+  socket.serverEvent({
+    type: 'response.created',
+    response: { id: 'resp_reassurance' },
+  });
+
+  socket.serverEvent({ type: 'input_audio_buffer.speech_started' });
+
+  expect(socket.sentOfType('response.cancel')).toEqual([
+    { type: 'response.cancel', response_id: 'resp_conversation' },
+    { type: 'response.cancel', response_id: 'resp_reassurance' },
+  ]);
+  expect(clears).toHaveLength(1);
+
+  // Both are gone; a repeat speech start has nothing left to cancel.
+  socket.serverEvent({ type: 'input_audio_buffer.speech_started' });
+  expect(socket.sentOfType('response.cancel')).toHaveLength(2);
+});
+
+test('a finished response no longer counts as active while another still plays', () => {
+  const { socket } = createBridge();
+  socket.open();
+  socket.serverEvent({ type: 'response.created', response: { id: 'a' } });
+  socket.serverEvent({ type: 'response.created', response: { id: 'b' } });
+  socket.serverEvent({ type: 'response.done', response: { id: 'a' } });
+
+  socket.serverEvent({ type: 'input_audio_buffer.speech_started' });
+  expect(socket.sentOfType('response.cancel')).toEqual([
+    { type: 'response.cancel', response_id: 'b' },
+  ]);
+});
+
+test('consults suspend auto-responses so caller noise cannot spawn a guessed answer', async () => {
+  let resolveConsult: (reply: string) => void = () => {};
+  const consultAgent = vi.fn(
+    () =>
+      new Promise<string>((resolve) => {
+        resolveConsult = resolve;
+      }),
+  );
+  const { socket } = createBridge({ consultAgent });
+  socket.open();
+  socket.serverEvent({ type: 'session.updated' });
+  expect(socket.sentOfType('response.create')).toHaveLength(1); // greeting
+
+  socket.serverEvent({
+    type: 'response.function_call_arguments.done',
+    call_id: 'call_1',
+    name: 'consult_agent',
+    arguments: JSON.stringify({ request: 'Open tasks this week?' }),
+  });
+  await Promise.resolve();
+
+  const turnDetectionOf = (event: Record<string, unknown>) =>
+    (
+      event.session as {
+        audio: { input: { turn_detection: Record<string, unknown> } };
+      }
+    ).audio.input.turn_detection;
+  const updates = socket.sentOfType('session.update');
+  expect(updates).toHaveLength(2);
+  expect(turnDetectionOf(updates[1])).toMatchObject({
+    type: 'server_vad',
+    create_response: false,
+    interrupt_response: true,
+  });
+
+  // The server acknowledges the toggle; that must not replay the greeting.
+  socket.serverEvent({ type: 'session.updated' });
+  expect(socket.sentOfType('response.create')).toHaveLength(1);
+
+  resolveConsult('Two open tasks.');
+  await flushAsync();
+
+  const after = socket.sentOfType('session.update');
+  expect(after).toHaveLength(3);
+  expect(turnDetectionOf(after[2])).toMatchObject({ create_response: true });
+  // Re-enabled before the tool output and its response.create go out.
+  const types = socket.sent.map((event) => event.type);
+  expect(types.lastIndexOf('session.update')).toBeLessThan(
+    types.lastIndexOf('conversation.item.create'),
+  );
+  expect(socket.sentOfType('response.create')).toHaveLength(2);
+});
+
+test('reassurance tells the model it has no answer yet', async () => {
+  vi.useFakeTimers();
+  try {
+    const consultAgent = vi.fn(() => new Promise<string>(() => {}));
+    const { socket } = createBridge({ consultAgent });
+    socket.open();
+    socket.serverEvent({
+      type: 'response.function_call_arguments.done',
+      call_id: 'call_1',
+      name: 'consult_agent',
+      arguments: JSON.stringify({ request: 'Slow request' }),
+    });
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(7_000);
+    const [reassurance] = socket.sentOfType('response.create');
+    expect(reassurance.response).toMatchObject({
+      conversation: 'none',
+      instructions: expect.stringContaining('do not guess'),
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+});


### PR DESCRIPTION
## Problem

On a phone call in realtime mode, while a `consult_agent` call is outstanding, two model responses could play at the same time: the out-of-band "still working" reassurance and a server-VAD auto-response triggered by any caller noise or backchannel ("mhm", "ja"). Their audio deltas were interleaved into the same playback queue, which the caller hears as garbled mumbling. Both responses were also free to invent a result the tool had not returned yet.

`response.cancel` without a `response_id` only stops the conversation's own response, so barge-in never reached an out-of-band line and it kept playing over the caller.

Observed on live calls: after two or three consults the assistant "stumbles" and turns into mumbling, then answers get cut mid-sentence.

## Fix

- `OpenAIRealtimeClient` tracks every open response by id and cancels each one explicitly on barge-in. `hasActiveResponse` is now correct with concurrent responses.
- `create_response` is switched off while a consult is in flight and back on right before the tool output is posted. The caller's words still land in the conversation and are answered together with the tool result.
- `onReady` fires only for the first `session.updated`, so the toggle round-trips do not replay the greeting.
- The reassurance instruction tells the model it has no answer yet and must not guess.
- The client accepts optional VAD tuning (`threshold`, `prefixPaddingMs`, `silenceDurationMs`); the phone surface will use it in a follow-up PR.

## Tests

Four new cases in `tests/voice.realtime-bridge.test.ts`: cancel of all in-flight responses by id, per-id active accounting, auto-response suspend/resume ordering around the tool output without re-greeting, and the no-guessing reassurance text. Existing voice suites pass; the two unit failures on `main` (eval-command, host-runner) are unrelated.