### PR TITLE
fix(voice): stop realtime responses overlapping and make turn detection configurable

### DIFF
--- a/console/src/generated/settings-registry.ts
+++ b/console/src/generated/settings-registry.ts
@@ -2566,6 +2566,36 @@ export const GENERATED_SETTINGS_REGISTRY: ReadonlyArray<GeneratedSettingEntry> =
       defaultValue: 'auto',
     },
     {
+      path: 'speech.realtime.turnDetection.eagerness',
+      section: 'speech',
+      kind: 'string',
+      defaultValue: 'auto',
+    },
+    {
+      path: 'speech.realtime.turnDetection.prefixPaddingMs',
+      section: 'speech',
+      kind: 'string',
+      defaultValue: null,
+    },
+    {
+      path: 'speech.realtime.turnDetection.silenceDurationMs',
+      section: 'speech',
+      kind: 'string',
+      defaultValue: null,
+    },
+    {
+      path: 'speech.realtime.turnDetection.threshold',
+      section: 'speech',
+      kind: 'string',
+      defaultValue: null,
+    },
+    {
+      path: 'speech.realtime.turnDetection.type',
+      section: 'speech',
+      kind: 'string',
+      defaultValue: 'server_vad',
+    },
+    {
       path: 'speech.realtime.voice',
       section: 'speech',
       kind: 'string',

--- a/docs/content/reference/configuration.md
+++ b/docs/content/reference/configuration.md
@@ -279,6 +279,14 @@ saved revision history directly.
   calls, web console voice mode, and plugin realtime sessions:
   `speech.realtime.model`, `speech.realtime.voice`,
   `speech.realtime.greeting`, and `speech.realtime.instructions`.
+  `speech.realtime.turnDetection` configures upstream turn taking:
+  `type` (`server_vad`, the default, or `semantic_vad`), and for
+  `server_vad` the optional `threshold` (0–1), `prefixPaddingMs`, and
+  `silenceDurationMs` (`null`, the default, keeps the upstream value); for
+  `semantic_vad` the `eagerness` (`auto`, `low`, `medium`, `high`). Calibrate
+  these from the `Realtime speech segment` gateway log events of real calls
+  (segment length, whether it interrupted a playing response, transcript
+  size) rather than by guesswork.
   `speech.realtime.provider` selects the backend: `auto` (the default:
   HybridAI when a HybridAI credential is present, otherwise OpenAI), `openai`
   (requires an `OPENAI_API_KEY`), or `hybridai` (the HybridAI platform's

--- a/src/channels/voice/openai-realtime.ts
+++ b/src/channels/voice/openai-realtime.ts
@@ -32,13 +32,20 @@ export interface RealtimeFunctionCall {
   arguments: string;
 }
 
+export interface RealtimeSpeechBoundary {
+  /** Position in the input audio buffer, ms since the session started. */
+  audioMs: number;
+  /** Conversation item the utterance becomes; keys the later transcript. */
+  itemId: string;
+}
+
 export interface OpenAIRealtimeCallbacks {
   onReady: () => void;
   onAudioDelta: (base64Audio: string) => void;
-  onSpeechStarted: () => void;
-  onSpeechStopped?: () => void;
+  onSpeechStarted: (boundary: RealtimeSpeechBoundary) => void;
+  onSpeechStopped?: (boundary: RealtimeSpeechBoundary) => void;
   onResponseCreated?: () => void;
-  onInputTranscript: (transcript: string) => void;
+  onInputTranscript: (transcript: string, itemId: string) => void;
   onOutputTranscript: (transcript: string) => void;
   onFunctionCall: (call: RealtimeFunctionCall) => void;
   onError: (message: string) => void;
@@ -67,6 +74,10 @@ function normalizeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
+function normalizeNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
 // Responses the server opened without an id (older event shapes, tests) are
 // tracked under a synthetic key so cancel/accounting still balance.
 const ANONYMOUS_RESPONSE_PREFIX = 'anon:';
@@ -75,11 +86,15 @@ function responseId(event: Record<string, unknown>): string {
   return isRecord(event.response) ? normalizeString(event.response.id) : '';
 }
 
-/** Server-side VAD tuning; omitted fields keep the upstream defaults. */
+/** Upstream turn detection; omitted fields keep the upstream defaults. */
 export interface RealtimeTurnDetection {
+  type?: 'server_vad' | 'semantic_vad';
+  /** `server_vad` only. */
   threshold?: number;
   prefixPaddingMs?: number;
   silenceDurationMs?: number;
+  /** `semantic_vad` only. */
+  eagerness?: 'auto' | 'low' | 'medium' | 'high';
 }
 
 export interface OpenAIRealtimeClientOptions {
@@ -195,6 +210,14 @@ export class OpenAIRealtimeClient {
 
   private turnDetectionPayload(): Record<string, unknown> {
     const tuning = this.turnDetection;
+    if (tuning.type === 'semantic_vad') {
+      return {
+        type: 'semantic_vad',
+        ...(tuning.eagerness ? { eagerness: tuning.eagerness } : {}),
+        create_response: this.autoResponse,
+        interrupt_response: true,
+      };
+    }
     return {
       type: 'server_vad',
       ...(tuning.threshold !== undefined
@@ -360,17 +383,26 @@ export class OpenAIRealtimeClient {
       return;
     }
     if (type === 'input_audio_buffer.speech_started') {
-      this.callbacks.onSpeechStarted();
+      this.callbacks.onSpeechStarted({
+        audioMs: normalizeNumber(parsed.audio_start_ms),
+        itemId: normalizeString(parsed.item_id),
+      });
       return;
     }
     if (type === 'input_audio_buffer.speech_stopped') {
-      this.callbacks.onSpeechStopped?.();
+      this.callbacks.onSpeechStopped?.({
+        audioMs: normalizeNumber(parsed.audio_end_ms),
+        itemId: normalizeString(parsed.item_id),
+      });
       return;
     }
     if (type === 'conversation.item.input_audio_transcription.completed') {
       const transcript = normalizeString(parsed.transcript).trim();
       if (transcript) {
-        this.callbacks.onInputTranscript(transcript);
+        this.callbacks.onInputTranscript(
+          transcript,
+          normalizeString(parsed.item_id),
+        );
       }
       return;
     }

--- a/src/channels/voice/openai-realtime.ts
+++ b/src/channels/voice/openai-realtime.ts
@@ -67,6 +67,21 @@ function normalizeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
+// Responses the server opened without an id (older event shapes, tests) are
+// tracked under a synthetic key so cancel/accounting still balance.
+const ANONYMOUS_RESPONSE_PREFIX = 'anon:';
+
+function responseId(event: Record<string, unknown>): string {
+  return isRecord(event.response) ? normalizeString(event.response.id) : '';
+}
+
+/** Server-side VAD tuning; omitted fields keep the upstream defaults. */
+export interface RealtimeTurnDetection {
+  threshold?: number;
+  prefixPaddingMs?: number;
+  silenceDurationMs?: number;
+}
+
 export interface OpenAIRealtimeClientOptions {
   /** Realtime endpoint without the model query, e.g. from `resolveRealtimeConnection`. */
   url: string;
@@ -76,6 +91,7 @@ export interface OpenAIRealtimeClientOptions {
   audioFormat: RealtimeAudioFormat;
   instructions: string;
   tools: RealtimeFunctionTool[];
+  turnDetection?: RealtimeTurnDetection;
   callbacks: OpenAIRealtimeCallbacks;
   socketFactory?: RealtimeSocketFactory;
 }
@@ -88,12 +104,22 @@ const PENDING_AUDIO_LIMIT = 250;
 export class OpenAIRealtimeClient {
   private readonly socket: RealtimeSocket;
   private readonly callbacks: OpenAIRealtimeCallbacks;
-  private responseActive = false;
+  private readonly turnDetection: RealtimeTurnDetection;
+  // Every response the server has opened and not yet finished, by id. Out-of-
+  // band responses (`conversation: 'none'`) run concurrently with the
+  // conversation's own response, so a single boolean cannot describe "is the
+  // model talking" — and `response.cancel` without an id only ever stops the
+  // conversation one, leaving an out-of-band line playing over the caller.
+  private readonly activeResponseIds = new Set<string>();
+  private anonymousResponseCount = 0;
+  private autoResponse = true;
+  private ready = false;
   private closed = false;
   private pendingAudio: string[] = [];
 
   constructor(options: OpenAIRealtimeClientOptions) {
     this.callbacks = options.callbacks;
+    this.turnDetection = options.turnDetection || {};
     const factory = options.socketFactory || defaultSocketFactory;
     const url = `${options.url}?model=${encodeURIComponent(options.model)}`;
     this.socket = factory(url, {
@@ -110,7 +136,7 @@ export class OpenAIRealtimeClient {
             input: {
               format: options.audioFormat,
               transcription: { model: 'gpt-4o-mini-transcribe' },
-              turn_detection: { type: 'server_vad' },
+              turn_detection: this.turnDetectionPayload(),
             },
             output: {
               format: options.audioFormat,
@@ -145,7 +171,44 @@ export class OpenAIRealtimeClient {
   }
 
   get hasActiveResponse(): boolean {
-    return this.responseActive;
+    return this.activeResponseIds.size > 0;
+  }
+
+  /**
+   * Whether the server may open a response on its own when the caller stops
+   * speaking. Switched off while a function call is outstanding so caller
+   * noise or backchannels cannot spawn a second, guessed answer next to the
+   * reassurance line; the caller's words still land in the conversation and
+   * are answered once the tool output arrives.
+   */
+  setAutoResponse(enabled: boolean): void {
+    if (this.autoResponse === enabled) return;
+    this.autoResponse = enabled;
+    this.sendEvent({
+      type: 'session.update',
+      session: {
+        type: 'realtime',
+        audio: { input: { turn_detection: this.turnDetectionPayload() } },
+      },
+    });
+  }
+
+  private turnDetectionPayload(): Record<string, unknown> {
+    const tuning = this.turnDetection;
+    return {
+      type: 'server_vad',
+      ...(tuning.threshold !== undefined
+        ? { threshold: tuning.threshold }
+        : {}),
+      ...(tuning.prefixPaddingMs !== undefined
+        ? { prefix_padding_ms: tuning.prefixPaddingMs }
+        : {}),
+      ...(tuning.silenceDurationMs !== undefined
+        ? { silence_duration_ms: tuning.silenceDurationMs }
+        : {}),
+      create_response: this.autoResponse,
+      interrupt_response: true,
+    };
   }
 
   appendAudio(base64Audio: string): void {
@@ -187,10 +250,16 @@ export class OpenAIRealtimeClient {
     });
   }
 
+  /** Cancels every in-flight response, out-of-band ones included. */
   cancelResponse(): void {
-    if (!this.responseActive) return;
-    this.sendEvent({ type: 'response.cancel' });
-    this.responseActive = false;
+    for (const id of this.activeResponseIds) {
+      this.sendEvent(
+        id.startsWith(ANONYMOUS_RESPONSE_PREFIX)
+          ? { type: 'response.cancel' }
+          : { type: 'response.cancel', response_id: id },
+      );
+    }
+    this.activeResponseIds.clear();
   }
 
   sendFunctionCallOutput(callId: string, output: string): void {
@@ -252,16 +321,35 @@ export class OpenAIRealtimeClient {
     }
     const type = normalizeString(parsed.type);
     if (type === 'session.updated') {
-      this.callbacks.onReady();
+      // Later session.update round-trips (auto-response toggles) must not
+      // replay the greeting.
+      if (!this.ready) {
+        this.ready = true;
+        this.callbacks.onReady();
+      }
       return;
     }
     if (type === 'response.created') {
-      this.responseActive = true;
+      this.activeResponseIds.add(
+        responseId(parsed) ||
+          `${ANONYMOUS_RESPONSE_PREFIX}${++this.anonymousResponseCount}`,
+      );
       this.callbacks.onResponseCreated?.();
       return;
     }
     if (type === 'response.done') {
-      this.responseActive = false;
+      const id = responseId(parsed);
+      if (id && this.activeResponseIds.has(id)) {
+        this.activeResponseIds.delete(id);
+      } else {
+        // Unidentified completion: assume the oldest anonymous response.
+        for (const active of this.activeResponseIds) {
+          if (active.startsWith(ANONYMOUS_RESPONSE_PREFIX)) {
+            this.activeResponseIds.delete(active);
+            break;
+          }
+        }
+      }
       return;
     }
     if (type === 'response.output_audio.delta') {

--- a/src/channels/voice/realtime-bridge.ts
+++ b/src/channels/voice/realtime-bridge.ts
@@ -43,7 +43,6 @@ const CONSULT_BUSY_OUTPUT =
 const CONSULT_REASSURE_FIRST_MS = 7_000;
 const CONSULT_REASSURE_INTERVAL_MS = 12_000;
 
-
 export type RealtimeBridgeState = 'listening' | 'speaking' | 'thinking';
 
 export type RealtimeSurface = 'phone' | 'web';

--- a/src/channels/voice/realtime-bridge.ts
+++ b/src/channels/voice/realtime-bridge.ts
@@ -308,7 +308,7 @@ export class RealtimeCallBridge {
           ? ` It is currently busy with: ${this.consultActivity}.`
           : '';
         this.client.createOutOfBandResponse(
-          `The assistant is still working on the request.${activity} Briefly reassure the ${
+          `The assistant is still working on the request.${activity} You do not have its answer yet: do not guess, summarize, or invent any result. Briefly reassure the ${
             this.options.surface === 'phone' ? 'caller' : 'user'
           } in one short natural sentence. Do not call tools.`,
         );
@@ -348,6 +348,10 @@ export class RealtimeCallBridge {
     this.consultInFlight = true;
     this.consultActivity = null;
     this.options.onStateChange('thinking');
+    // Caller noise or a backchannel during the consult must not open a second
+    // response next to the reassurance line; what they say is still recorded
+    // and answered together with the tool output.
+    this.client.setAutoResponse(false);
     this.scheduleReassurance(CONSULT_REASSURE_FIRST_MS);
     void this.options
       .consultAgent(request, {
@@ -382,6 +386,7 @@ export class RealtimeCallBridge {
         if (this.closed || !output) {
           return;
         }
+        this.client.setAutoResponse(true);
         this.options.onStateChange('listening');
         this.client.sendFunctionCallOutput(callId, output);
       });

--- a/src/channels/voice/realtime-bridge.ts
+++ b/src/channels/voice/realtime-bridge.ts
@@ -18,6 +18,7 @@
  */
 import type {
   RuntimeSpeechRealtimeConfig,
+  RuntimeSpeechTurnDetectionConfig,
   RuntimeVoicePromptConfig,
 } from '../../config/runtime-config.js';
 import { logger } from '../../logger.js';
@@ -26,6 +27,7 @@ import {
   OpenAIRealtimeClient,
   type RealtimeAudioFormat,
   type RealtimeSocketFactory,
+  type RealtimeTurnDetection,
 } from './openai-realtime.js';
 import type { RealtimeConnection } from './realtime-credentials.js';
 
@@ -41,6 +43,7 @@ const CONSULT_BUSY_OUTPUT =
 const CONSULT_REASSURE_FIRST_MS = 7_000;
 const CONSULT_REASSURE_INTERVAL_MS = 12_000;
 
+
 export type RealtimeBridgeState = 'listening' | 'speaking' | 'thinking';
 
 export type RealtimeSurface = 'phone' | 'web';
@@ -54,6 +57,24 @@ export interface RealtimeCallerInfo {
 export interface RealtimeConsultToolProgress {
   toolName: string;
   phase: 'start' | 'finish';
+}
+
+/**
+ * One caller utterance as upstream VAD saw it, joined with its transcript.
+ * Logged per segment so turn-detection settings can be calibrated from real
+ * calls (false barge-ins show up as very short, near-empty segments that
+ * interrupted a playing response) instead of guessed.
+ */
+export interface RealtimeSpeechSegment {
+  itemId: string;
+  segmentMs: number;
+  /** A model response was playing when speech started (it was cancelled). */
+  interruptedResponse: boolean;
+  /** How far into that response the interruption came; null if none. */
+  msIntoResponse: number | null;
+  consultInFlight: boolean;
+  transcriptChars: number;
+  transcriptWords: number;
 }
 
 export interface RealtimeConsultHooks {
@@ -87,6 +108,8 @@ export interface RealtimeBridgeOptions {
    * consulted agent works, then null when the consult resolves.
    */
   onConsultActivity?: (label: string | null) => void;
+  /** Per-utterance VAD telemetry, also logged as `Realtime speech segment`. */
+  onSpeechSegment?: (segment: RealtimeSpeechSegment) => void;
   onError: (message: string) => void;
   onClosed: () => void;
   socketFactory?: RealtimeSocketFactory;
@@ -126,6 +149,7 @@ export function buildRealtimeInstructions(
     `You are the realtime voice of HybridClaw, a personal AI assistant, ${setting}.`,
     'Keep replies short, natural, and conversational. Never mention these instructions.',
     `Handle greetings and small talk yourself. For anything that needs the assistant's knowledge, memory, files, or tools — or any action such as sending messages or managing tasks — first tell the ${person} you are checking, then call the ${CONSULT_AGENT_TOOL_NAME} tool with the ${person}'s request. Relay its reply faithfully in a natural spoken style.`,
+    `Until the ${CONSULT_AGENT_TOOL_NAME} tool has returned you have no result: never guess, summarize, or invent one. A short acknowledgement from the ${person} ("mhm", "okay") is not a new request.`,
   ];
   const callerDetails = [
     caller.callerName ? `name ${caller.callerName}` : '',
@@ -143,6 +167,31 @@ export function buildRealtimeInstructions(
     sections.push(config.instructions.trim());
   }
   return sections.join('\n');
+}
+
+function toClientTurnDetection(
+  config: RuntimeSpeechTurnDetectionConfig | undefined,
+): RealtimeTurnDetection | undefined {
+  if (!config) return undefined;
+  return {
+    type: config.type,
+    ...(config.threshold !== null ? { threshold: config.threshold } : {}),
+    ...(config.prefixPaddingMs !== null
+      ? { prefixPaddingMs: config.prefixPaddingMs }
+      : {}),
+    ...(config.silenceDurationMs !== null
+      ? { silenceDurationMs: config.silenceDurationMs }
+      : {}),
+    ...(config.type === 'semantic_vad' ? { eagerness: config.eagerness } : {}),
+  };
+}
+
+interface PendingSpeechSegment {
+  audioStartMs: number;
+  interruptedResponse: boolean;
+  msIntoResponse: number | null;
+  consultInFlight: boolean;
+  segmentMs: number | null;
 }
 
 function parseConsultRequest(rawArguments: string): string {
@@ -169,6 +218,8 @@ export class RealtimeCallBridge {
   private turnSpeechStoppedAt = 0;
   private turnResponseCreatedAt = 0;
   private turnFirstAudioPending = false;
+  // Utterances awaiting their transcript, keyed by conversation item id.
+  private readonly pendingSegments = new Map<string, PendingSpeechSegment>();
 
   constructor(options: RealtimeBridgeOptions) {
     this.options = options;
@@ -178,6 +229,7 @@ export class RealtimeCallBridge {
       model: options.config.model,
       voice: options.config.voice,
       audioFormat: options.audioFormat,
+      turnDetection: toClientTurnDetection(options.config.turnDetection),
       instructions: buildRealtimeInstructions(
         options.config,
         options.caller,
@@ -229,25 +281,44 @@ export class RealtimeCallBridge {
             );
           });
         },
-        onSpeechStopped: () => {
+        onSpeechStopped: (boundary) => {
           this.turnSpeechStoppedAt = Date.now();
           this.turnFirstAudioPending = false;
+          const pending = this.pendingSegments.get(boundary.itemId);
+          if (pending) {
+            pending.segmentMs = Math.max(
+              0,
+              boundary.audioMs - pending.audioStartMs,
+            );
+          }
         },
         onResponseCreated: () => {
           if (!this.turnSpeechStoppedAt) return;
           this.turnResponseCreatedAt = Date.now();
           this.turnFirstAudioPending = true;
         },
-        onSpeechStarted: () => {
+        onSpeechStarted: (boundary) => {
           this.callerSpeaking = true;
+          const interruptedResponse = this.client.hasActiveResponse;
+          this.recordSpeechStart(boundary.itemId, {
+            audioStartMs: boundary.audioMs,
+            interruptedResponse,
+            msIntoResponse:
+              interruptedResponse && this.turnResponseCreatedAt
+                ? Date.now() - this.turnResponseCreatedAt
+                : null,
+            consultInFlight: this.consultInFlight,
+            segmentMs: null,
+          });
           this.options.onStateChange('listening');
           this.client.cancelResponse();
           void this.options.clearPlayback().catch(() => {
             // The transport is gone; the close handler tears the session down.
           });
         },
-        onInputTranscript: (transcript) => {
+        onInputTranscript: (transcript, itemId) => {
           this.callerSpeaking = false;
+          this.completeSpeechSegment(itemId, transcript);
           this.options.onTranscript('caller', transcript);
         },
         onOutputTranscript: (transcript) => {
@@ -282,6 +353,37 @@ export class RealtimeCallBridge {
     this.client.sendUserText(
       `The caller pressed the keypad digit "${normalized}".`,
     );
+  }
+
+  private recordSpeechStart(
+    itemId: string,
+    segment: PendingSpeechSegment,
+  ): void {
+    if (this.pendingSegments.size >= 32) {
+      const oldest = this.pendingSegments.keys().next().value;
+      if (oldest !== undefined) this.pendingSegments.delete(oldest);
+    }
+    this.pendingSegments.set(itemId, segment);
+  }
+
+  private completeSpeechSegment(itemId: string, transcript: string): void {
+    const pending = this.pendingSegments.get(itemId);
+    if (!pending) return;
+    this.pendingSegments.delete(itemId);
+    const segment: RealtimeSpeechSegment = {
+      itemId,
+      segmentMs: pending.segmentMs ?? 0,
+      interruptedResponse: pending.interruptedResponse,
+      msIntoResponse: pending.msIntoResponse,
+      consultInFlight: pending.consultInFlight,
+      transcriptChars: transcript.length,
+      transcriptWords: transcript.split(/\s+/).filter(Boolean).length,
+    };
+    logger.info(
+      { surface: this.options.surface, ...segment },
+      'Realtime speech segment',
+    );
+    this.options.onSpeechSegment?.(segment);
   }
 
   close(): void {

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -695,12 +695,33 @@ export interface RuntimeVoiceConfig {
  * mode, and plugin realtime sessions alike. Future speech-output settings
  * (TTS, dictation) belong here too.
  */
+export type RuntimeSpeechTurnDetectionType = 'server_vad' | 'semantic_vad';
+export type RuntimeSpeechVadEagerness = 'auto' | 'low' | 'medium' | 'high';
+
+/**
+ * Upstream turn detection for realtime sessions. Every numeric field is
+ * `null` by default so the upstream defaults apply; set them only from
+ * measured call data (see the `Realtime speech segment` log events).
+ */
+export interface RuntimeSpeechTurnDetectionConfig {
+  type: RuntimeSpeechTurnDetectionType;
+  /** `server_vad` only, 0..1 — higher means less sensitive to quiet audio. */
+  threshold: number | null;
+  /** `server_vad` only — audio kept before detected speech, in ms. */
+  prefixPaddingMs: number | null;
+  /** `server_vad` only — silence that ends a turn, in ms. */
+  silenceDurationMs: number | null;
+  /** `semantic_vad` only. */
+  eagerness: RuntimeSpeechVadEagerness;
+}
+
 export interface RuntimeSpeechRealtimeConfig {
   provider: RuntimeSpeechRealtimeProvider;
   model: string;
   voice: string;
   greeting: string;
   instructions: string;
+  turnDetection?: RuntimeSpeechTurnDetectionConfig;
 }
 
 export interface RuntimeSpeechConfig {
@@ -1828,6 +1849,13 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
       voice: 'marin',
       greeting: 'Hello! How can I help you today?',
       instructions: '',
+      turnDetection: {
+        type: 'server_vad',
+        threshold: null,
+        prefixPaddingMs: null,
+        silenceDurationMs: null,
+        eagerness: 'auto',
+      },
     },
   },
   imessage: {
@@ -4201,7 +4229,63 @@ function normalizeSpeechConfig(
         fallback.realtime.instructions,
         { allowEmpty: true },
       ),
+      turnDetection: normalizeSpeechTurnDetection(
+        rawRealtime.turnDetection,
+        fallback.realtime.turnDetection ||
+          DEFAULT_RUNTIME_CONFIG.speech.realtime.turnDetection!,
+      ),
     },
+  };
+}
+
+function normalizeBoundedNumberOrNull(
+  value: unknown,
+  fallback: number | null,
+  min: number,
+  max: number,
+): number | null {
+  if (value === null) return null;
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  return value < min || value > max ? fallback : value;
+}
+
+function normalizeSpeechTurnDetection(
+  value: unknown,
+  fallback: RuntimeSpeechTurnDetectionConfig,
+): RuntimeSpeechTurnDetectionConfig {
+  const raw = isRecord(value) ? value : {};
+  const type =
+    raw.type === 'server_vad' || raw.type === 'semantic_vad'
+      ? raw.type
+      : fallback.type;
+  const eagerness =
+    raw.eagerness === 'auto' ||
+    raw.eagerness === 'low' ||
+    raw.eagerness === 'medium' ||
+    raw.eagerness === 'high'
+      ? raw.eagerness
+      : fallback.eagerness;
+  return {
+    type,
+    threshold: normalizeBoundedNumberOrNull(
+      raw.threshold,
+      fallback.threshold,
+      0,
+      1,
+    ),
+    prefixPaddingMs: normalizeBoundedNumberOrNull(
+      raw.prefixPaddingMs,
+      fallback.prefixPaddingMs,
+      0,
+      5_000,
+    ),
+    silenceDurationMs: normalizeBoundedNumberOrNull(
+      raw.silenceDurationMs,
+      fallback.silenceDurationMs,
+      0,
+      5_000,
+    ),
+    eagerness,
   };
 }
 

--- a/tests/runtime-config.migration-logging.test.ts
+++ b/tests/runtime-config.migration-logging.test.ts
@@ -329,6 +329,13 @@ describe('runtime config migration logging', () => {
       voice: 'cedar',
       greeting: 'Hi there!',
       instructions: 'Be brief.',
+      turnDetection: {
+        type: 'server_vad',
+        threshold: null,
+        prefixPaddingMs: null,
+        silenceDurationMs: null,
+        eagerness: 'auto',
+      },
     });
     expect(stored.speech.realtime.provider).toBe('openai');
     expect(stored.voice.realtime).toBeUndefined();

--- a/tests/voice.realtime-bridge.test.ts
+++ b/tests/voice.realtime-bridge.test.ts
@@ -653,3 +653,130 @@ test('reassurance tells the model it has no answer yet', async () => {
     vi.useRealTimers();
   }
 });
+
+test('turn detection follows speech.realtime.turnDetection; unset fields keep upstream defaults', () => {
+  const turnDetectionOf = (socket: FakeRealtimeSocket) =>
+    (
+      socket.sentOfType('session.update')[0].session as {
+        audio: { input: { turn_detection: Record<string, unknown> } };
+      }
+    ).audio.input.turn_detection;
+
+  const untouched = createBridge();
+  untouched.socket.open();
+  expect(turnDetectionOf(untouched.socket)).toEqual({
+    type: 'server_vad',
+    create_response: true,
+    interrupt_response: true,
+  });
+
+  const tuned = createBridge({
+    config: {
+      ...REALTIME_CONFIG,
+      turnDetection: {
+        type: 'server_vad',
+        threshold: 0.7,
+        prefixPaddingMs: null,
+        silenceDurationMs: 800,
+        eagerness: 'auto',
+      },
+    },
+  });
+  tuned.socket.open();
+  expect(turnDetectionOf(tuned.socket)).toEqual({
+    type: 'server_vad',
+    threshold: 0.7,
+    silence_duration_ms: 800,
+    create_response: true,
+    interrupt_response: true,
+  });
+
+  const semantic = createBridge({
+    config: {
+      ...REALTIME_CONFIG,
+      turnDetection: {
+        type: 'semantic_vad',
+        threshold: 0.7,
+        prefixPaddingMs: null,
+        silenceDurationMs: null,
+        eagerness: 'low',
+      },
+    },
+  });
+  semantic.socket.open();
+  expect(turnDetectionOf(semantic.socket)).toEqual({
+    type: 'semantic_vad',
+    eagerness: 'low',
+    create_response: true,
+    interrupt_response: true,
+  });
+});
+
+test('each caller utterance is reported as a speech segment with barge-in context', () => {
+  const segments: Array<Record<string, unknown>> = [];
+  const { socket } = createBridge({
+    onSpeechSegment: (segment) => {
+      segments.push(segment as unknown as Record<string, unknown>);
+    },
+  });
+  socket.open();
+
+  // A backchannel while the model talks: short, interrupts the response.
+  socket.serverEvent({ type: 'response.created', response: { id: 'r1' } });
+  socket.serverEvent({
+    type: 'input_audio_buffer.speech_started',
+    audio_start_ms: 4_000,
+    item_id: 'item_a',
+  });
+  socket.serverEvent({
+    type: 'input_audio_buffer.speech_stopped',
+    audio_end_ms: 4_260,
+    item_id: 'item_a',
+  });
+  socket.serverEvent({
+    type: 'conversation.item.input_audio_transcription.completed',
+    item_id: 'item_a',
+    transcript: 'Mhm.',
+  });
+
+  // A real question into silence.
+  socket.serverEvent({
+    type: 'input_audio_buffer.speech_started',
+    audio_start_ms: 9_000,
+    item_id: 'item_b',
+  });
+  socket.serverEvent({
+    type: 'input_audio_buffer.speech_stopped',
+    audio_end_ms: 11_400,
+    item_id: 'item_b',
+  });
+  socket.serverEvent({
+    type: 'conversation.item.input_audio_transcription.completed',
+    item_id: 'item_b',
+    transcript: 'Wie hoch ist der Umsatz mit Claas?',
+  });
+
+  expect(segments).toEqual([
+    expect.objectContaining({
+      itemId: 'item_a',
+      segmentMs: 260,
+      interruptedResponse: true,
+      consultInFlight: false,
+      transcriptChars: 4,
+      transcriptWords: 1,
+    }),
+    expect.objectContaining({
+      itemId: 'item_b',
+      segmentMs: 2_400,
+      interruptedResponse: false,
+      msIntoResponse: null,
+      transcriptWords: 7,
+    }),
+  ]);
+});
+
+test('instructions forbid inventing a result before the consult returns', () => {
+  const text = buildRealtimeInstructions(REALTIME_CONFIG, CALLER);
+  expect(text).toContain('never guess, summarize, or invent one');
+  expect(text).toContain('not a new request');
+});

--- a/tests/voice.realtime-bridge.test.ts
+++ b/tests/voice.realtime-bridge.test.ts
@@ -538,3 +538,118 @@ test('phone calls layer voice.prompt over the shared speech settings', () => {
     instructions: 'Be brief.\nSprich Deutsch.',
   });
 });
+
+test('caller speech cancels every in-flight response, out-of-band ones included', () => {
+  const { socket, clears } = createBridge();
+  socket.open();
+  socket.serverEvent({
+    type: 'response.created',
+    response: { id: 'resp_conversation' },
+  });
+  socket.serverEvent({
+    type: 'response.created',
+    response: { id: 'resp_reassurance' },
+  });
+
+  socket.serverEvent({ type: 'input_audio_buffer.speech_started' });
+
+  expect(socket.sentOfType('response.cancel')).toEqual([
+    { type: 'response.cancel', response_id: 'resp_conversation' },
+    { type: 'response.cancel', response_id: 'resp_reassurance' },
+  ]);
+  expect(clears).toHaveLength(1);
+
+  // Both are gone; a repeat speech start has nothing left to cancel.
+  socket.serverEvent({ type: 'input_audio_buffer.speech_started' });
+  expect(socket.sentOfType('response.cancel')).toHaveLength(2);
+});
+
+test('a finished response no longer counts as active while another still plays', () => {
+  const { socket } = createBridge();
+  socket.open();
+  socket.serverEvent({ type: 'response.created', response: { id: 'a' } });
+  socket.serverEvent({ type: 'response.created', response: { id: 'b' } });
+  socket.serverEvent({ type: 'response.done', response: { id: 'a' } });
+
+  socket.serverEvent({ type: 'input_audio_buffer.speech_started' });
+  expect(socket.sentOfType('response.cancel')).toEqual([
+    { type: 'response.cancel', response_id: 'b' },
+  ]);
+});
+
+test('consults suspend auto-responses so caller noise cannot spawn a guessed answer', async () => {
+  let resolveConsult: (reply: string) => void = () => {};
+  const consultAgent = vi.fn(
+    () =>
+      new Promise<string>((resolve) => {
+        resolveConsult = resolve;
+      }),
+  );
+  const { socket } = createBridge({ consultAgent });
+  socket.open();
+  socket.serverEvent({ type: 'session.updated' });
+  expect(socket.sentOfType('response.create')).toHaveLength(1); // greeting
+
+  socket.serverEvent({
+    type: 'response.function_call_arguments.done',
+    call_id: 'call_1',
+    name: 'consult_agent',
+    arguments: JSON.stringify({ request: 'Open tasks this week?' }),
+  });
+  await Promise.resolve();
+
+  const turnDetectionOf = (event: Record<string, unknown>) =>
+    (
+      event.session as {
+        audio: { input: { turn_detection: Record<string, unknown> } };
+      }
+    ).audio.input.turn_detection;
+  const updates = socket.sentOfType('session.update');
+  expect(updates).toHaveLength(2);
+  expect(turnDetectionOf(updates[1])).toMatchObject({
+    type: 'server_vad',
+    create_response: false,
+    interrupt_response: true,
+  });
+
+  // The server acknowledges the toggle; that must not replay the greeting.
+  socket.serverEvent({ type: 'session.updated' });
+  expect(socket.sentOfType('response.create')).toHaveLength(1);
+
+  resolveConsult('Two open tasks.');
+  await flushAsync();
+
+  const after = socket.sentOfType('session.update');
+  expect(after).toHaveLength(3);
+  expect(turnDetectionOf(after[2])).toMatchObject({ create_response: true });
+  // Re-enabled before the tool output and its response.create go out.
+  const types = socket.sent.map((event) => event.type);
+  expect(types.lastIndexOf('session.update')).toBeLessThan(
+    types.lastIndexOf('conversation.item.create'),
+  );
+  expect(socket.sentOfType('response.create')).toHaveLength(2);
+});
+
+test('reassurance tells the model it has no answer yet', async () => {
+  vi.useFakeTimers();
+  try {
+    const consultAgent = vi.fn(() => new Promise<string>(() => {}));
+    const { socket } = createBridge({ consultAgent });
+    socket.open();
+    socket.serverEvent({
+      type: 'response.function_call_arguments.done',
+      call_id: 'call_1',
+      name: 'consult_agent',
+      arguments: JSON.stringify({ request: 'Slow request' }),
+    });
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(7_000);
+    const [reassurance] = socket.sentOfType('response.create');
+    expect(reassurance.response).toMatchObject({
+      conversation: 'none',
+      instructions: expect.stringContaining('do not guess'),
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+});


### PR DESCRIPTION
Combines the concurrent-response fix (formerly #1502) with configurable turn detection and speech-segment telemetry (formerly #1503).

## Problem

On a phone call in realtime mode, while a `consult_agent` call is outstanding, two model responses could play at the same time: the out-of-band "still working" reassurance and a server-VAD auto-response triggered by any caller noise or backchannel ("mhm", "ja"). Their audio deltas were interleaved into the same playback queue, which the caller hears as garbled mumbling. Both responses were also free to invent a result the tool had not returned yet.

`response.cancel` without a `response_id` only stops the conversation's own response, so barge-in never reached an out-of-band line and it kept playing over the caller.

Separately, phone calls run with the upstream server-VAD defaults, which assume a close headset mic. On a PSTN leg, line noise, speakerphone echo and caller backchannels trip speech detection; every false trigger cancels the answer mid-sentence and clears playback, so callers hear fragments followed by silence.

Observed on live calls: after two or three consults the assistant "stumbles" and turns into mumbling, then answers get cut mid-sentence.

## Fix: concurrent responses

- `OpenAIRealtimeClient` tracks every open response by id and cancels each one explicitly on barge-in. `hasActiveResponse` is now correct with concurrent responses.
- `create_response` is switched off while a consult is in flight and back on right before the tool output is posted. The caller's words still land in the conversation and are answered together with the tool result.
- `onReady` fires only for the first `session.updated`, so the toggle round-trips do not replay the greeting.
- The reassurance instruction tells the model it has no answer yet and must not guess; short acknowledgements are not new requests.

## Fix: configurable turn detection and telemetry

- `speech.realtime.turnDetection`: `type` (`server_vad`, default, or `semantic_vad`), `threshold`, `prefixPaddingMs`, `silenceDurationMs` (each `null` by default, keeping the upstream value), and `eagerness` for semantic VAD. Documented in the configuration reference.
- The realtime client parses `audio_start_ms` / `audio_end_ms` / `item_id` on the speech boundary events and forwards the transcript's `item_id`.
- The bridge logs one `Realtime speech segment` event per caller utterance: segment length, whether a response was playing when speech started and how far into it, whether a consult was in flight, and transcript size. Surfaces can also receive it via `onSpeechSegment`. False barge-ins show up as short segments with one-word transcripts that interrupted a response.

## Calibration plan

Run a handful of real calls on the default settings, count the false-barge-in segments per minute of bot speech, then repeat with `semantic_vad` and with a raised `threshold` / `silenceDurationMs`, and set the config from the numbers.

## Tests

`tests/voice.realtime-bridge.test.ts`: cancel of all in-flight responses by id, per-id active accounting, auto-response suspend/resume ordering around the tool output without re-greeting, the no-guessing reassurance text, speech-segment reporting, and the instruction text. `tests/runtime-config.migration-logging.test.ts`: config normalization (upstream defaults, tuned server VAD, semantic VAD payloads). Voice and runtime-config suites pass.
