### PR TITLE
fix(memory): serialize workspace writes, safe daily notes, and lossless consolidation

### DIFF
--- a/container/shared/daily-memory.d.ts
+++ b/container/shared/daily-memory.d.ts
@@ -1,0 +1,6 @@
+export const DAILY_MEMORY_MAX_CHARS: number;
+export function truncateDailyMemoryText(
+  content: string,
+  maxChars?: number,
+): string;
+export function readDailyMemoryFile(filePath: string): string | null;

--- a/container/shared/daily-memory.js
+++ b/container/shared/daily-memory.js
@@ -1,0 +1,54 @@
+/**
+ * Daily-note intake uses the tool's character cap on both sides of the sandbox.
+ * Oversized external notes retain both ends; this does not set durable-memory budgets.
+ */
+import fs from 'node:fs';
+
+// Existing tool limit, shared on 2026-09-08 for issue #1466; configurable budgets deferred.
+export const DAILY_MEMORY_MAX_CHARS = 24_000;
+const MARKER = '\n...[truncated middle]...\n';
+
+export function truncateDailyMemoryText(
+  content,
+  maxChars = DAILY_MEMORY_MAX_CHARS,
+) {
+  if (content.length <= maxChars) return content;
+  if (maxChars <= MARKER.length) return MARKER.slice(0, maxChars);
+  const available = maxChars - MARKER.length;
+  const head = Math.ceil(available / 2);
+  const tail = Math.floor(available / 2);
+  return (
+    content.slice(0, head).replace(/[\uD800-\uDBFF]$/, '') +
+    MARKER +
+    (tail ? content.slice(-tail).replace(/^[\uDC00-\uDFFF]/, '') : '')
+  );
+}
+
+export function readDailyMemoryFile(filePath) {
+  let fd;
+  try {
+    fd = fs.openSync(filePath, 'r');
+    const size = fs.fstatSync(fd).size;
+    // UTF-8 can take up to four bytes per character. Bound allocation even
+    // for external files that bypass the memory tool's character limit.
+    const byteBudget = DAILY_MEMORY_MAX_CHARS * 4;
+    if (size <= byteBudget) {
+      const buffer = Buffer.alloc(size);
+      const count = fs.readSync(fd, buffer, 0, size, 0);
+      return truncateDailyMemoryText(buffer.toString('utf8', 0, count));
+    }
+    const head = Buffer.alloc(byteBudget / 2);
+    const tail = Buffer.alloc(byteBudget / 2);
+    const headRead = fs.readSync(fd, head, 0, head.length, 0);
+    const tailRead = fs.readSync(fd, tail, 0, tail.length, size - tail.length);
+    return truncateDailyMemoryText(
+      head.toString('utf8', 0, headRead).replace(/\uFFFD+$/, '') +
+        MARKER +
+        tail.toString('utf8', 0, tailRead).replace(/^\uFFFD+/, ''),
+    );
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
+}

--- a/container/shared/memory-file.d.ts
+++ b/container/shared/memory-file.d.ts
@@ -1,0 +1,3 @@
+export function lockMemoryFile(filePath: string): () => void;
+export function waitForMemoryFileLock(filePath: string): Promise<() => void>;
+export function writeMemoryFileAtomic(filePath: string, content: string): void;

--- a/container/shared/memory-file.js
+++ b/container/shared/memory-file.js
@@ -44,12 +44,13 @@ export async function waitForMemoryFileLock(filePath) {
 
 export function writeMemoryFileAtomic(filePath, content) {
   const temporary = `${filePath}.${randomUUID()}.tmp`;
+  let mode;
   try {
-    fs.writeFileSync(temporary, content, {
-      encoding: 'utf8',
-      flag: 'wx',
-      mode: 0o600,
-    });
+    mode = fs.statSync(filePath).mode & 0o777;
+  } catch {}
+  try {
+    fs.writeFileSync(temporary, content, { encoding: 'utf8', flag: 'wx' });
+    if (mode !== undefined) fs.chmodSync(temporary, mode);
     fs.renameSync(temporary, filePath);
   } finally {
     fs.rmSync(temporary, { force: true });

--- a/container/shared/memory-file.js
+++ b/container/shared/memory-file.js
@@ -1,0 +1,57 @@
+/**
+ * Cooperative memory-file transactions shared by host and container processes.
+ * Locks cover the entire read/modify/write; rename alone cannot prevent lost updates.
+ * This is not a workspace access policy and cannot serialize external editors.
+ */
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { setTimeout } from 'node:timers/promises';
+
+export function lockMemoryFile(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const lockPath = `${filePath}.lock`;
+  try {
+    fs.mkdirSync(lockPath);
+  } catch (err) {
+    if (err.code === 'EEXIST') {
+      throw new Error(
+        `Memory file is locked: ${filePath}. Retry later; after a crashed writer, remove the .lock directory only when no writer is running.`,
+      );
+    }
+    throw err;
+  }
+  return () => fs.rmdirSync(lockPath);
+}
+
+export async function waitForMemoryFileLock(filePath) {
+  // 5s/25ms (implementation decision, 2026-09-08, issue #1477): bound tool
+  // contention without blocking the event loop; automatic stale-lock stealing deferred.
+  const deadline = Date.now() + 5_000;
+  for (;;) {
+    try {
+      return lockMemoryFile(filePath);
+    } catch (err) {
+      if (
+        !err.message.startsWith('Memory file is locked:') ||
+        Date.now() >= deadline
+      )
+        throw err;
+      await setTimeout(25);
+    }
+  }
+}
+
+export function writeMemoryFileAtomic(filePath, content) {
+  const temporary = `${filePath}.${randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(temporary, content, {
+      encoding: 'utf8',
+      flag: 'wx',
+      mode: 0o600,
+    });
+    fs.renameSync(temporary, filePath);
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
+}

--- a/container/shared/workspace-time.js
+++ b/container/shared/workspace-time.js
@@ -71,7 +71,7 @@ function getTimezoneOffsetMs(timezone, date) {
 
 export function extractUserTimezone(content) {
   if (typeof content !== 'string' || !content.trim()) return undefined;
-  const match = content.match(/\*\*Timezone:\*\*\s*(.+)/i);
+  const match = content.match(/\*\*Timezone:\*\*[ \t]*([^\r\n]*)/i);
   const timezone = match?.[1]?.trim();
   return timezone || undefined;
 }

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -4,6 +4,10 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {
+  waitForMemoryFileLock,
+  writeMemoryFileAtomic,
+} from '../shared/memory-file.js';
+import {
   formatMessageToolChannelList,
   normalizeMessageToolChannelKinds,
 } from '../shared/message-tool-channels.js';
@@ -3099,79 +3103,89 @@ async function executeToolInternal(
         return `${relativePath}\n\n${content || '(empty)'}`;
       }
 
-      if (action === 'append') {
-        const content =
-          typeof args.content === 'string' ? args.content.trim() : '';
-        if (!content)
-          return failTool('Error: content is required for memory append');
+      const release = isMemoryWriteAction(action)
+        ? await waitForMemoryFileLock(filePath)
+        : undefined;
+      try {
+        if (action === 'append') {
+          const content =
+            typeof args.content === 'string' ? args.content.trim() : '';
+          if (!content)
+            return failTool('Error: content is required for memory append');
 
-        fs.mkdirSync(path.dirname(filePath), { recursive: true });
-        const existing = fs.existsSync(filePath)
-          ? fs.readFileSync(filePath, 'utf-8')
-          : '';
-        let next = existing.replace(/\s+$/, '');
-        if (next.length > 0) next += '\n\n';
-        next += `${content}\n`;
-        const limit = memoryCharLimit(relativePath);
-        if (next.length > limit) {
-          return failTool(
-            `Error: ${relativePath} would exceed ${limit} chars. Shorten content or remove older entries first.`,
-          );
+          fs.mkdirSync(path.dirname(filePath), { recursive: true });
+          const existing = fs.existsSync(filePath)
+            ? fs.readFileSync(filePath, 'utf-8')
+            : '';
+          let next = existing.replace(/\s+$/, '');
+          if (next.length > 0) next += '\n\n';
+          next += `${content}\n`;
+          const limit = memoryCharLimit(relativePath);
+          if (next.length > limit) {
+            return failTool(
+              `Error: ${relativePath} would exceed ${limit} chars. Shorten content or remove older entries first.`,
+            );
+          }
+          writeMemoryFileAtomic(filePath, next);
+          return `Appended ${content.length} chars to ${relativePath}`;
         }
-        fs.writeFileSync(filePath, next, 'utf-8');
-        return `Appended ${content.length} chars to ${relativePath}`;
-      }
 
-      if (action === 'write') {
-        const content = typeof args.content === 'string' ? args.content : '';
-        const limit = memoryCharLimit(relativePath);
-        if (content.length > limit) {
-          return failTool(
-            `Error: ${relativePath} exceeds ${limit} char limit.`,
-          );
+        if (action === 'write') {
+          const content = typeof args.content === 'string' ? args.content : '';
+          const limit = memoryCharLimit(relativePath);
+          if (content.length > limit) {
+            return failTool(
+              `Error: ${relativePath} exceeds ${limit} char limit.`,
+            );
+          }
+          fs.mkdirSync(path.dirname(filePath), { recursive: true });
+          writeMemoryFileAtomic(filePath, content);
+          return `Wrote ${content.length} chars to ${relativePath}`;
         }
-        fs.mkdirSync(path.dirname(filePath), { recursive: true });
-        fs.writeFileSync(filePath, content, 'utf-8');
-        return `Wrote ${content.length} chars to ${relativePath}`;
-      }
 
-      if (action === 'replace') {
-        const oldText = typeof args.old_text === 'string' ? args.old_text : '';
-        const newText = typeof args.new_text === 'string' ? args.new_text : '';
-        if (!oldText)
-          return failTool('Error: old_text is required for memory replace');
-        if (!fs.existsSync(filePath))
-          return failTool(`Error: File not found: ${relativePath}`);
-        const content = fs.readFileSync(filePath, 'utf-8');
-        if (!content.includes(oldText))
-          return failTool(`Error: old_text not found in ${relativePath}`);
-        const next = content.replace(oldText, newText);
-        const limit = memoryCharLimit(relativePath);
-        if (next.length > limit) {
-          return failTool(
-            `Error: replacement would exceed ${limit} chars for ${relativePath}.`,
-          );
+        if (action === 'replace') {
+          const oldText =
+            typeof args.old_text === 'string' ? args.old_text : '';
+          const newText =
+            typeof args.new_text === 'string' ? args.new_text : '';
+          if (!oldText)
+            return failTool('Error: old_text is required for memory replace');
+          if (!fs.existsSync(filePath))
+            return failTool(`Error: File not found: ${relativePath}`);
+          const content = fs.readFileSync(filePath, 'utf-8');
+          if (!content.includes(oldText))
+            return failTool(`Error: old_text not found in ${relativePath}`);
+          const next = content.replace(oldText, newText);
+          const limit = memoryCharLimit(relativePath);
+          if (next.length > limit) {
+            return failTool(
+              `Error: replacement would exceed ${limit} chars for ${relativePath}.`,
+            );
+          }
+          writeMemoryFileAtomic(filePath, next);
+          return `Updated ${relativePath}`;
         }
-        fs.writeFileSync(filePath, next, 'utf-8');
-        return `Updated ${relativePath}`;
-      }
 
-      if (action === 'remove') {
-        const oldText = typeof args.old_text === 'string' ? args.old_text : '';
-        if (!oldText)
-          return failTool('Error: old_text is required for memory remove');
-        if (!fs.existsSync(filePath))
-          return failTool(`Error: File not found: ${relativePath}`);
-        const content = fs.readFileSync(filePath, 'utf-8');
-        if (!content.includes(oldText))
-          return failTool(`Error: old_text not found in ${relativePath}`);
-        fs.writeFileSync(filePath, content.replace(oldText, ''), 'utf-8');
-        return `Removed matching text from ${relativePath}`;
-      }
+        if (action === 'remove') {
+          const oldText =
+            typeof args.old_text === 'string' ? args.old_text : '';
+          if (!oldText)
+            return failTool('Error: old_text is required for memory remove');
+          if (!fs.existsSync(filePath))
+            return failTool(`Error: File not found: ${relativePath}`);
+          const content = fs.readFileSync(filePath, 'utf-8');
+          if (!content.includes(oldText))
+            return failTool(`Error: old_text not found in ${relativePath}`);
+          writeMemoryFileAtomic(filePath, content.replace(oldText, ''));
+          return `Removed matching text from ${relativePath}`;
+        }
 
-      return failTool(
-        `Error: unknown memory action "${action}". Use read, append, write, replace, remove, list, or search.`,
-      );
+        return failTool(
+          `Error: unknown memory action "${action}". Use read, append, write, replace, remove, list, or search.`,
+        );
+      } finally {
+        release?.();
+      }
     }
 
     case 'message': {

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { DAILY_MEMORY_MAX_CHARS } from '../shared/daily-memory.js';
 import {
   waitForMemoryFileLock,
   writeMemoryFileAtomic,
@@ -2148,7 +2149,6 @@ const ROOT_MEMORY_CHAR_LIMITS: Record<string, number> = {
   'MEMORY.md': 12_000,
   'USER.md': 8_000,
 };
-const DAILY_MEMORY_CHAR_LIMIT = 24_000;
 
 function normalizeDateStamp(input: string): string | null {
   const trimmed = input.trim();
@@ -2260,7 +2260,7 @@ function listMemoryFiles(): string[] {
 }
 
 function memoryCharLimit(relativePath: string): number {
-  return ROOT_MEMORY_CHAR_LIMITS[relativePath] || DAILY_MEMORY_CHAR_LIMIT;
+  return ROOT_MEMORY_CHAR_LIMITS[relativePath] || DAILY_MEMORY_MAX_CHARS;
 }
 
 interface TranscriptRow {

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -2220,6 +2220,7 @@ function resolveMemoryFilePath(args: Record<string, unknown>): string | null {
     normalizeMemoryFilePath(args.file_path) ||
     normalizeMemoryFilePath(args.path);
   if (direct) return direct;
+  if (args.file_path !== undefined || args.path !== undefined) return null;
 
   const target =
     typeof args.target === 'string' ? args.target.trim().toLowerCase() : '';
@@ -2231,7 +2232,12 @@ function resolveMemoryFilePath(args: Record<string, unknown>): string | null {
     return `memory/${date || currentDateStamp()}.md`;
   }
 
-  return 'MEMORY.md';
+  if (target) return null;
+  const action =
+    typeof args.action === 'string' ? args.action.trim().toLowerCase() : 'read';
+  return isMemoryWriteAction(action)
+    ? `memory/${currentDateStamp()}.md`
+    : 'MEMORY.md';
 }
 
 function listMemoryFiles(): string[] {
@@ -3131,6 +3137,11 @@ async function executeToolInternal(
         }
 
         if (action === 'write') {
+          if (args.confirm_overwrite !== true) {
+            return failTool(
+              'Error: memory write replaces the entire daily note. Set confirm_overwrite=true only to intentionally overwrite it; use append to save additional notes.',
+            );
+          }
           const content = typeof args.content === 'string' ? args.content : '';
           const limit = memoryCharLimit(relativePath);
           if (content.length > limit) {
@@ -4180,7 +4191,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
     function: {
       name: 'memory',
       description:
-        "Manage agent memory files. Read/search/list can access MEMORY.md, USER.md, and daily files at memory/YYYY-MM-DD.md. Write actions append/write/replace/remove are restricted to today's daily file so durable MEMORY.md rewrites flow only through dream consolidation.",
+        "Manage agent memory files. Read/search/list can access MEMORY.md, USER.md, and daily files at memory/YYYY-MM-DD.md. Omitted write targets default to today’s daily note. Prefer append; write replaces the entire note and requires confirm_overwrite=true. Write actions append/write/replace/remove are restricted to today's daily file so durable MEMORY.md rewrites flow only through dream consolidation.",
       parameters: {
         type: 'object',
         properties: {
@@ -4207,6 +4218,11 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
           content: {
             type: 'string',
             description: 'Text payload for append/write',
+          },
+          confirm_overwrite: {
+            type: 'boolean',
+            description:
+              'Required true for write: confirms replacing the entire daily note, including all earlier entries.',
           },
           old_text: {
             type: 'string',

--- a/docs/content/developer-guide/memory.md
+++ b/docs/content/developer-guide/memory.md
@@ -433,3 +433,17 @@ skip parts of the native memory injection and compaction flow. Plugins that
 layer on top of native memory, such as additive external memory providers, do
 not change the built-in behavior described above unless they explicitly replace
 it.
+
+### Concurrent memory writes
+
+The memory tool and consolidation coordinate file updates through a sibling
+`<filename>.lock` directory shared by the host and container mount. The lock
+covers reading, validation, and atomic replacement, so independent chat,
+heartbeat, and scheduled sessions cannot silently overwrite each other's
+read/modify/write updates. Tools retry contention for up to five seconds;
+consolidation skips a busy file. Model cleanup discards its result if the source
+MEMORY.md changed during the model call.
+
+Locks are cooperative: shell commands and external editors do not participate.
+A crashed writer can leave a lock directory behind. Remove that directory only
+after verifying that no writer is running; locks are never stolen based on age.

--- a/docs/content/developer-guide/memory.md
+++ b/docs/content/developer-guide/memory.md
@@ -313,7 +313,7 @@ The values below describe the built-in defaults in the current codebase.
 | Limit | Default | Meaning |
 | --- | ---: | --- |
 | bootstrap file read cap | `20,000` chars per file | `MEMORY.md` and other bootstrap files are trimmed before prompt assembly |
-| current daily note prompt load | up to `20,000` chars | today's `memory/YYYY-MM-DD.md` is injected when present |
+| current daily note prompt load | up to `24,000` chars | today's `memory/YYYY-MM-DD.md` is injected when present |
 | prior daily note lookback | `7` days | complete prior notes are considered newest first |
 | prior daily note history budget | `12,000` chars | shared cap for prior notes; today's note has its own file cap |
 
@@ -459,3 +459,21 @@ Daily filenames use the timezone in `USER.md`. An empty or invalid timezone uses
 the host's resolved timezone, which the gateway passes to Docker as `TZ`.
 Dynamic context states the exact daily-note filename even when the UTC date
 falls on a different day.
+
+
+### Consolidation intake and preservation
+
+The memory tool, today's prompt note, and consolidation share a `24,000`
+character daily-file cap. Notes within the cap are read completely, including
+prose and entries after the sixth bullet. Oversized externally written notes
+retain their beginning and tail with a visible middle-truncation marker.
+Consolidation selects recent source notes within a separate `24,000` character
+input budget; older source files remain on disk.
+
+Model cleanup receives the existing memory document and replaces managed bullets
+under Facts, Decisions, and Patterns. Other headings, free text, and fenced
+examples are preserved verbatim. If the result exceeds the `12,000` character
+durable-file budget, deterministic consolidation is used instead of trimming
+operator content. Its digest prefers newest days; if the newest day alone is too
+large, both ends are retained with a truncation marker. Source daily files are
+never rewritten by consolidation.

--- a/docs/content/developer-guide/memory.md
+++ b/docs/content/developer-guide/memory.md
@@ -447,3 +447,15 @@ MEMORY.md changed during the model call.
 Locks are cooperative: shell commands and external editors do not participate.
 A crashed writer can leave a lock directory behind. Remove that directory only
 after verifying that no writer is running; locks are never stolen based on age.
+
+### Saving daily notes
+
+`memory append` without a target saves to today's `memory/YYYY-MM-DD.md`.
+Reads without a target use `MEMORY.md`. Prefer `append` to save additional notes;
+`write` replaces the entire daily note and requires `confirm_overwrite: true`.
+Explicit targets remain subject to the today-only write restriction.
+
+Daily filenames use the timezone in `USER.md`. An empty or invalid timezone uses
+the host's resolved timezone, which the gateway passes to Docker as `TZ`.
+Dynamic context states the exact daily-note filename even when the UTC date
+falls on a different day.

--- a/docs/content/developer-guide/memory.md
+++ b/docs/content/developer-guide/memory.md
@@ -124,8 +124,9 @@ Important properties:
 - the pre-compaction memory flush writes here before older history is
   summarized away
 - today's note is injected in full into the per-turn dynamic context block
-- up to seven prior daily notes are also loaded newest first, provided each
-  complete note fits within the shared 12,000-character history budget
+- up to seven prior daily notes are also loaded newest first within the shared
+  12,000-character history budget; a note larger than the remaining budget keeps
+  its beginning and tail with a visible middle-truncation marker
 - older notes beyond that window or budget are not loaded directly
 - older daily notes are later folded into `MEMORY.md` during dream
   consolidation
@@ -314,8 +315,8 @@ The values below describe the built-in defaults in the current codebase.
 | --- | ---: | --- |
 | bootstrap file read cap | `20,000` chars per file | `MEMORY.md` and other bootstrap files are trimmed before prompt assembly |
 | current daily note prompt load | up to `24,000` chars | today's `memory/YYYY-MM-DD.md` is injected when present |
-| prior daily note lookback | `7` days | complete prior notes are considered newest first |
-| prior daily note history budget | `12,000` chars | shared cap for prior notes; today's note has its own file cap |
+| prior daily note lookback | `7` days | prior notes are loaded newest first |
+| prior daily note history budget | `12,000` chars | shared cap for prior notes, head and tail retained when a note is truncated; today's note has its own file cap |
 
 ### Recent Session History
 
@@ -471,9 +472,12 @@ Consolidation selects recent source notes within a separate `24,000` character
 input budget; older source files remain on disk.
 
 Model cleanup receives the existing memory document and replaces managed bullets
-under Facts, Decisions, and Patterns. Other headings, free text, and fenced
-examples are preserved verbatim. If the result exceeds the `12,000` character
-durable-file budget, deterministic consolidation is used instead of trimming
-operator content. Its digest prefers newest days; if the newest day alone is too
-large, both ends are retained with a truncation marker. Source daily files are
-never rewritten by consolidation.
+under Facts, Decisions, and Patterns (heading case is ignored). Other headings,
+free text, and fenced examples are preserved verbatim; template placeholder
+lines are dropped once a section holds bullets and a single placeholder remains
+while it is empty. If the result exceeds the `12,000` character durable-file
+budget, deterministic consolidation is used instead of trimming operator
+content. Its digest gives every selected day a fair share of the remaining
+budget, so one large day is truncated at both ends rather than evicting smaller
+days; when even a shared budget is too small, the oldest days are dropped first.
+Source daily files are never rewritten by consolidation.

--- a/src/agent/conversation.ts
+++ b/src/agent/conversation.ts
@@ -1,6 +1,6 @@
 import os from 'node:os';
-
 import { DYNAMIC_CONTEXT_MESSAGE_PREFIX } from '../../container/shared/dynamic-context.js';
+import { currentDateStampInTimezone } from '../../container/shared/workspace-time.js';
 import { normalizeSkillConfigChannelKind } from '../channels/channel-registry.js';
 import { scheduleCloudMemorySync } from '../memory/cloud-memory.js';
 import {
@@ -71,6 +71,9 @@ export function buildDynamicContextMessage(
   if (agentId) {
     const contextFiles = loadStaticBootstrapFiles(agentId);
     const userTimezone = resolveUserTimezoneFromContextFiles(contextFiles);
+    lines.push(
+      `Daily note: memory/${currentDateStampInTimezone(userTimezone, now)}.md`,
+    );
     lines.push(`Current Date & Time: ${formatCurrentTime(userTimezone, now)}`);
 
     const dailyMemoryFiles = loadRecentDailyMemoryFiles(agentId, {

--- a/src/infra/container-runner.ts
+++ b/src/infra/container-runner.ts
@@ -5,6 +5,7 @@
 import { type ChildProcess, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { resolveEffectiveTimezone } from '../../container/shared/workspace-time.js';
 import type {
   ExecutorRequest,
   ExecutorSessionHealthSnapshot,
@@ -763,6 +764,8 @@ function getOrSpawnContainer(
     `HYBRIDCLAW_BEHAVIOR_ANOMALY_TRAJECTORY_STORE_DIR=${CONTAINER_BEHAVIOR_ANOMALY_TRAJECTORY_STORE_DIR}`,
     '-e',
     `HYBRIDCLAW_AGENT_ID=${agentId}`,
+    '-e',
+    `TZ=${resolveEffectiveTimezone()}`,
     '-e',
     `HYBRIDCLAW_AGENT_WORKSPACE_ROOT=${CONTAINER_WORKSPACE_ROOT}`,
     '-e',

--- a/src/memory/memory-consolidation.ts
+++ b/src/memory/memory-consolidation.ts
@@ -55,6 +55,19 @@ const MEMORY_FILE_MAX_CHARS = 12_000;
 const MODEL_MEMORY_ITEM_MAX_CHARS = 280;
 const MODEL_MEMORY_MAX_ITEMS_PER_SECTION = 18;
 const MEMORY_SECTION_NAMES = new Set(['Facts', 'Decisions', 'Patterns']);
+const MEMORY_SECTION_PLACEHOLDERS: Record<
+  keyof CanonicalMemorySections,
+  string
+> = {
+  facts:
+    "_(Key things you've discovered about the workspace, the user, the project.)_",
+  decisions:
+    '_(Important choices that were made. Record the "why" so you don\'t revisit them.)_',
+  patterns:
+    '_(Recurring things — how the user likes code formatted, common workflows, etc.)_',
+};
+const PLACEHOLDER_LINE_RE = /^\s*_\(.*\)_\s*$/;
+const DIGEST_MIN_TRUNCATED_CHARS = 600;
 const DEFAULT_MEMORY_TEMPLATE = `# MEMORY.md - Session Memory
 
 _Things you've learned across conversations. Update as you go._
@@ -104,6 +117,18 @@ const DAILY_DIGEST_PREFIX = [
   '_Auto-compiled from older `memory/YYYY-MM-DD.md` files._',
   '',
 ].join('\n');
+
+function canonicalMemorySectionName(heading: string): string | null {
+  const normalized = heading.trim().toLowerCase();
+  for (const name of MEMORY_SECTION_NAMES) {
+    if (name.toLowerCase() === normalized) return name;
+  }
+  return null;
+}
+
+function sectionKey(name: string): keyof CanonicalMemorySections {
+  return name.toLowerCase() as keyof CanonicalMemorySections;
+}
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -247,11 +272,8 @@ function extractCanonicalMemorySections(
     .split('\n')) {
     const headingMatch = /^##\s+(.+?)\s*$/.exec(line.trim());
     if (headingMatch) {
-      const sectionName = headingMatch[1]?.trim();
-      if (sectionName === 'Facts') activeSection = 'facts';
-      else if (sectionName === 'Decisions') activeSection = 'decisions';
-      else if (sectionName === 'Patterns') activeSection = 'patterns';
-      else activeSection = null;
+      const sectionName = canonicalMemorySectionName(headingMatch[1] || '');
+      activeSection = sectionName ? sectionKey(sectionName) : null;
       continue;
     }
 
@@ -284,8 +306,10 @@ function renderCanonicalMemoryDocument(
   sections: CanonicalMemorySections,
   existing: string,
 ): string {
-  const remaining = new Set(['Facts', 'Decisions', 'Patterns']);
-  let active = false;
+  const remaining = new Set(MEMORY_SECTION_NAMES);
+  const eol = existing.includes('\r\n') ? '\r\n' : '\n';
+  let activeKey: keyof CanonicalMemorySections | null = null;
+  let placeholderKept = false;
   let fence: string | null = null;
   const output: string[] = [];
   for (const line of existing
@@ -309,25 +333,69 @@ function renderCanonicalMemoryDocument(
     }
     const heading = /^(#{1,6})[ \t]+(.+?)\s*$/.exec(line);
     if (heading) {
-      active = heading[1] === '##' && MEMORY_SECTION_NAMES.has(heading[2]);
+      const name =
+        heading[1] === '##' ? canonicalMemorySectionName(heading[2]) : null;
       output.push(line);
-      if (active && remaining.delete(heading[2])) {
-        const key = heading[2].toLowerCase() as keyof CanonicalMemorySections;
+      activeKey = null;
+      placeholderKept = false;
+      if (name && remaining.delete(name)) {
+        activeKey = sectionKey(name);
         output.push(
-          `${line.endsWith('\n') ? '' : '\n'}${sections[key].map((item) => `- ${item}\n`).join('')}`,
+          `${line.endsWith('\n') ? '' : eol}${sections[activeKey]
+            .map((item) => `- ${item}${eol}`)
+            .join('')}`,
         );
       }
-    } else if (!active || !/^\s*[-*+]\s+/.test(line)) {
-      output.push(line);
+      continue;
     }
+    if (!activeKey) {
+      output.push(line);
+      continue;
+    }
+    if (/^\s*[-*+]\s+/.test(line)) continue;
+    if (PLACEHOLDER_LINE_RE.test(line)) {
+      if (sections[activeKey].length === 0 && !placeholderKept) {
+        placeholderKept = true;
+        output.push(line);
+      } else if (/^\r?\n$/.test(output.at(-1) || '')) {
+        output.pop();
+      }
+      continue;
+    }
+    output.push(line);
   }
   for (const title of remaining) {
-    const key = title.toLowerCase() as keyof CanonicalMemorySections;
-    output.push(
-      `\n\n## ${title}\n${sections[key].map((item) => `- ${item}\n`).join('')}`,
-    );
+    const key = sectionKey(title);
+    const body =
+      sections[key].length > 0
+        ? sections[key].map((item) => `- ${item}${eol}`).join('')
+        : `${eol}${MEMORY_SECTION_PLACEHOLDERS[key]}${eol}`;
+    output.push(`${eol}${eol}## ${title}${eol}${body}`);
   }
-  return output.join('');
+  return insertEmptySectionPlaceholders(output.join(''), sections, eol);
+}
+
+function insertEmptySectionPlaceholders(
+  document: string,
+  sections: CanonicalMemorySections,
+  eol: string,
+): string {
+  let result = document;
+  for (const title of MEMORY_SECTION_NAMES) {
+    const key = sectionKey(title);
+    if (sections[key].length > 0) continue;
+    const match = new RegExp(`^##[ \\t]+${title}[ \\t]*\\r?\\n`, 'im').exec(
+      result,
+    );
+    if (!match) continue;
+    const bodyStart = match.index + match[0].length;
+    const after = result.slice(bodyStart);
+    const nextHeading = after.search(/^#{1,6}[ \t]+/m);
+    const body = nextHeading === -1 ? after : after.slice(0, nextHeading);
+    if (body.trim()) continue;
+    result = `${result.slice(0, bodyStart)}${eol}${MEMORY_SECTION_PLACEHOLDERS[key]}${eol}${after}`;
+  }
+  return result;
 }
 
 function fitCanonicalMemoryDocument(
@@ -465,10 +533,7 @@ function dedupeMemorySections(memoryContent: string): string {
     const trimmed = line.trim();
     const headingMatch = /^##\s+(.+?)\s*$/.exec(trimmed);
     if (headingMatch) {
-      const sectionName = headingMatch[1]?.trim() || '';
-      activeSection = MEMORY_SECTION_NAMES.has(sectionName)
-        ? sectionName
-        : null;
+      activeSection = canonicalMemorySectionName(headingMatch[1] || '');
       seenBullets = new Set<string>();
       output.push(line);
       continue;
@@ -510,49 +575,59 @@ function buildMemoryContent(params: {
     return baseContent;
   }
 
-  const formattedEntries = params.entries.map(
-    (entry) => `### ${entry.date}\n${entry.summary}`,
-  );
-  let bodyLength = formattedEntries.reduce(
-    (total, entry, index) => total + entry.length + (index > 0 ? 2 : 0),
-    0,
-  );
   const fixedDigestLength =
     DAILY_DIGEST_PREFIX.length + DAILY_MEMORY_BLOCK_END.length + 2;
-  let firstEntryIndex = 0;
-
-  while (
-    firstEntryIndex < formattedEntries.length &&
-    fixedDigestLength + bodyLength > digestBudget
-  ) {
-    bodyLength -= formattedEntries[firstEntryIndex]?.length || 0;
-    if (firstEntryIndex < formattedEntries.length - 1) {
-      bodyLength -= 2;
-    }
-    firstEntryIndex += 1;
-  }
-
-  if (firstEntryIndex >= params.entries.length) {
-    const newest = params.entries.at(-1);
-    if (!newest) return baseContent;
-    const summaryBudget =
-      digestBudget - fixedDigestLength - `### ${newest.date}\n`.length;
-    if (summaryBudget <= 0) return baseContent;
-    return renderMemoryContent(
-      stripped,
-      buildDailyDigest([
-        {
-          date: newest.date,
-          summary: truncateDailyMemoryText(newest.summary, summaryBudget),
-        },
-      ]),
-    );
-  }
-
-  return renderMemoryContent(
-    stripped,
-    buildDailyDigest(params.entries.slice(firstEntryIndex)),
+  const fitted = allocateDigestEntries(
+    params.entries,
+    digestBudget - fixedDigestLength,
   );
+  if (fitted.length === 0) return baseContent;
+  return renderMemoryContent(stripped, buildDailyDigest(fitted));
+}
+
+function digestEntryHeader(entry: DailyMemoryEntry): string {
+  return `### ${entry.date}\n`;
+}
+
+function allocateDigestEntries(
+  entries: DailyMemoryEntry[],
+  budget: number,
+): DailyMemoryEntry[] {
+  let candidates = [...entries];
+  while (candidates.length > 0) {
+    let remaining = budget - 2 * (candidates.length - 1);
+    const ordered = [...candidates].sort(
+      (left, right) => left.summary.length - right.summary.length,
+    );
+    const allocated = new Map<DailyMemoryEntry, number>();
+    let fits = true;
+    for (let index = 0; index < ordered.length; index += 1) {
+      const entry = ordered[index] as DailyMemoryEntry;
+      const need = digestEntryHeader(entry).length + entry.summary.length;
+      const share = Math.floor(remaining / (ordered.length - index));
+      if (share < need && share < DIGEST_MIN_TRUNCATED_CHARS) {
+        fits = false;
+        break;
+      }
+      const take = Math.min(need, share);
+      allocated.set(entry, take);
+      remaining -= take;
+    }
+    if (fits) {
+      return candidates.map((entry) => {
+        const limit =
+          (allocated.get(entry) || 0) - digestEntryHeader(entry).length;
+        return limit >= entry.summary.length
+          ? entry
+          : {
+              date: entry.date,
+              summary: truncateDailyMemoryText(entry.summary, limit),
+            };
+      });
+    }
+    candidates = candidates.slice(1);
+  }
+  return [];
 }
 
 function collectDailyMemoryEntries(workspaceDir: string): DailyMemoryEntry[] {

--- a/src/memory/memory-consolidation.ts
+++ b/src/memory/memory-consolidation.ts
@@ -1,11 +1,17 @@
 /**
  * Consolidation owns durable MEMORY.md updates, unlike daily-note tool writes.
  * File transactions serialize cooperating writers; model results are committed only
- * if their input snapshot is still current. External editors do not take this lock.
+ * if their input snapshot is still current. Cleanup preserves non-managed text;
+ * external editors do not take this lock.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
+import {
+  DAILY_MEMORY_MAX_CHARS,
+  readDailyMemoryFile,
+  truncateDailyMemoryText,
+} from '../../container/shared/daily-memory.js';
 import {
   lockMemoryFile,
   writeMemoryFileAtomic,
@@ -44,10 +50,7 @@ export interface MemoryConsolidationReport {
 const DAILY_MEMORY_BLOCK_START = '<!-- BEGIN DAILY MEMORY DIGEST -->';
 const DAILY_MEMORY_BLOCK_END = '<!-- END DAILY MEMORY DIGEST -->';
 const DAILY_MEMORY_FILE_RE = /^(\d{4}-\d{2}-\d{2})\.md$/;
-const DAILY_MEMORY_DIGEST_MAX_CHARS = 6_000;
-const DAILY_MEMORY_FILE_MAX_CHARS = 4_000;
-const DAILY_MEMORY_SUMMARY_MAX_ITEMS = 6;
-const DAILY_MEMORY_LINE_MAX_CHARS = 220;
+const DAILY_MEMORY_DIGEST_MAX_CHARS = DAILY_MEMORY_MAX_CHARS;
 const MEMORY_FILE_MAX_CHARS = 12_000;
 const MODEL_MEMORY_ITEM_MAX_CHARS = 280;
 const MODEL_MEMORY_MAX_ITEMS_PER_SECTION = 18;
@@ -164,10 +167,7 @@ function addUniqueKey(seen: Set<string>, key: string): boolean {
   return true;
 }
 
-function truncateLine(
-  value: string,
-  maxChars = DAILY_MEMORY_LINE_MAX_CHARS,
-): string {
+function truncateLine(value: string, maxChars: number): string {
   const compact = compactWhitespace(value);
   if (compact.length <= maxChars) return compact;
   return `${compact.slice(0, maxChars - 3).trimEnd()}...`;
@@ -280,76 +280,62 @@ function countCanonicalMemoryItems(sections: CanonicalMemorySections): number {
   );
 }
 
-function renderMemorySection(
-  title: string,
-  items: string[],
-  placeholder: string,
-): string {
-  return [
-    `## ${title}`,
-    '',
-    items.length > 0
-      ? items.map((item) => `- ${item}`).join('\n')
-      : placeholder,
-  ].join('\n');
-}
-
 function renderCanonicalMemoryDocument(
   sections: CanonicalMemorySections,
+  existing: string,
 ): string {
-  return [
-    '# MEMORY.md - Session Memory',
-    '',
-    "_Things you've learned across conversations. Update as you go._",
-    '',
-    renderMemorySection(
-      'Facts',
-      sections.facts,
-      '_(No durable facts captured yet.)_',
-    ),
-    '',
-    renderMemorySection(
-      'Decisions',
-      sections.decisions,
-      '_(No durable decisions captured yet.)_',
-    ),
-    '',
-    renderMemorySection(
-      'Patterns',
-      sections.patterns,
-      '_(No recurring patterns captured yet.)_',
-    ),
-    '',
-    '---',
-    '',
-    'This is your persistent memory. Each session, read this first. Update it when you learn something worth remembering.',
-    '',
-  ].join('\n');
+  const remaining = new Set(['Facts', 'Decisions', 'Patterns']);
+  let active = false;
+  let fence: string | null = null;
+  const output: string[] = [];
+  for (const line of existing
+    .replace(DAILY_DIGEST_BLOCK_RE, '')
+    .match(/[^\n]*\n|[^\n]+$/g) || []) {
+    const fenceMatch = /^[ \t]*(`{3,}|~{3,})/.exec(line);
+    if (fence) {
+      output.push(line);
+      if (
+        fenceMatch &&
+        fenceMatch[1][0] === fence[0] &&
+        fenceMatch[1].length >= fence.length
+      )
+        fence = null;
+      continue;
+    }
+    if (fenceMatch) {
+      fence = fenceMatch[1];
+      output.push(line);
+      continue;
+    }
+    const heading = /^(#{1,6})[ \t]+(.+?)\s*$/.exec(line);
+    if (heading) {
+      active = heading[1] === '##' && MEMORY_SECTION_NAMES.has(heading[2]);
+      output.push(line);
+      if (active && remaining.delete(heading[2])) {
+        const key = heading[2].toLowerCase() as keyof CanonicalMemorySections;
+        output.push(
+          `${line.endsWith('\n') ? '' : '\n'}${sections[key].map((item) => `- ${item}\n`).join('')}`,
+        );
+      }
+    } else if (!active || !/^\s*[-*+]\s+/.test(line)) {
+      output.push(line);
+    }
+  }
+  for (const title of remaining) {
+    const key = title.toLowerCase() as keyof CanonicalMemorySections;
+    output.push(
+      `\n\n## ${title}\n${sections[key].map((item) => `- ${item}\n`).join('')}`,
+    );
+  }
+  return output.join('');
 }
 
 function fitCanonicalMemoryDocument(
   sections: CanonicalMemorySections,
+  existing: string,
 ): string | null {
-  const fitted: CanonicalMemorySections = {
-    facts: [...sections.facts],
-    decisions: [...sections.decisions],
-    patterns: [...sections.patterns],
-  };
-
-  let rendered = renderCanonicalMemoryDocument(fitted);
-  while (rendered.length > MEMORY_FILE_MAX_CHARS) {
-    const buckets: Array<keyof CanonicalMemorySections> = [
-      'patterns',
-      'facts',
-      'decisions',
-    ];
-    const target = buckets.find((key) => fitted[key].length > 0);
-    if (!target) return null;
-    fitted[target].pop();
-    rendered = renderCanonicalMemoryDocument(fitted);
-  }
-
-  return rendered;
+  const rendered = renderCanonicalMemoryDocument(sections, existing);
+  return rendered.length <= MEMORY_FILE_MAX_CHARS ? rendered : null;
 }
 
 function formatDailyEntriesForPrompt(entries: DailyMemoryEntry[]): string {
@@ -364,19 +350,7 @@ function buildModelCleanupPrompt(params: {
   entries: DailyMemoryEntry[];
   language?: string;
 }): string {
-  const sections = extractCanonicalMemorySections(params.existing);
-  const existingSummary =
-    countCanonicalMemoryItems(sections) > 0
-      ? [
-          '## Current durable memory',
-          '',
-          `Facts: ${sections.facts.length > 0 ? sections.facts.map((item) => `- ${item}`).join('\n') : 'None.'}`,
-          '',
-          `Decisions: ${sections.decisions.length > 0 ? sections.decisions.map((item) => `- ${item}`).join('\n') : 'None.'}`,
-          '',
-          `Patterns: ${sections.patterns.length > 0 ? sections.patterns.map((item) => `- ${item}`).join('\n') : 'None.'}`,
-        ].join('\n')
-      : '## Current durable memory\n\nNone.';
+  const existingSummary = `## Current durable memory\n\n${params.existing}`;
 
   return [
     'Rewrite the durable memory from these sources.',
@@ -440,7 +414,7 @@ async function rewriteMemoryContentWithModel(params: {
       fallbackReason: 'empty_model_output',
     };
   }
-  const content = fitCanonicalMemoryDocument(sections);
+  const content = fitCanonicalMemoryDocument(sections, params.existing);
   if (!content) {
     return {
       content: null,
@@ -454,30 +428,8 @@ async function rewriteMemoryContentWithModel(params: {
 }
 
 function summarizeDailyMemory(rawContent: string): string {
-  const trimmed = rawContent.trim();
-  if (!trimmed) return '';
-
-  const lines = trimmed
-    .replace(/\r/g, '')
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .filter((line, index) => !(index === 0 && line.startsWith('#')));
-  const seen = new Set<string>();
-  const items: string[] = [];
-
-  for (const line of lines) {
-    if (!/^([-*+]|\d+\.)\s+/.test(line) && !/^\[[ xX]\]\s+/.test(line)) {
-      continue;
-    }
-    const normalized = normalizeBullet(line);
-    const dedupeKey = normalized.toLowerCase();
-    if (!addUniqueKey(seen, dedupeKey)) continue;
-    items.push(`- ${truncateLine(normalized)}`);
-    if (items.length >= DAILY_MEMORY_SUMMARY_MAX_ITEMS) break;
-  }
-
-  return items.join('\n');
+  // Keep prose, long entries, and appended notes intact for model cleanup.
+  return rawContent.trim();
 }
 
 function buildDailyDigest(entries: DailyMemoryEntry[]): string {
@@ -581,34 +533,26 @@ function buildMemoryContent(params: {
   }
 
   if (firstEntryIndex >= params.entries.length) {
-    return baseContent;
+    const newest = params.entries.at(-1);
+    if (!newest) return baseContent;
+    const summaryBudget =
+      digestBudget - fixedDigestLength - `### ${newest.date}\n`.length;
+    if (summaryBudget <= 0) return baseContent;
+    return renderMemoryContent(
+      stripped,
+      buildDailyDigest([
+        {
+          date: newest.date,
+          summary: truncateDailyMemoryText(newest.summary, summaryBudget),
+        },
+      ]),
+    );
   }
 
   return renderMemoryContent(
     stripped,
     buildDailyDigest(params.entries.slice(firstEntryIndex)),
   );
-}
-
-function readDailyMemoryFile(filePath: string): string | null {
-  try {
-    const stats = fs.statSync(filePath);
-    if (stats.size <= 0) return '';
-    if (stats.size <= DAILY_MEMORY_FILE_MAX_CHARS) {
-      return fs.readFileSync(filePath, 'utf-8');
-    }
-
-    const fd = fs.openSync(filePath, 'r');
-    try {
-      const buffer = Buffer.alloc(DAILY_MEMORY_FILE_MAX_CHARS);
-      const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
-      return `${buffer.toString('utf8', 0, bytesRead)}\n...[truncated]`;
-    } finally {
-      fs.closeSync(fd);
-    }
-  } catch {
-    return null;
-  }
 }
 
 function collectDailyMemoryEntries(workspaceDir: string): DailyMemoryEntry[] {
@@ -634,7 +578,13 @@ function collectDailyMemoryEntries(workspaceDir: string): DailyMemoryEntry[] {
     if (!content.trim()) continue;
     const summary = summarizeDailyMemory(content);
     if (!summary) continue;
-    const entry = { date, summary };
+    const entry = {
+      date,
+      summary: truncateDailyMemoryText(
+        summary,
+        DAILY_MEMORY_DIGEST_MAX_CHARS - `### ${date}\n`.length,
+      ),
+    };
     const candidate = `### ${entry.date}\n${entry.summary}`;
     const nextSize = candidate.length + (selected.length > 0 ? 2 : 0);
     if (

--- a/src/memory/memory-consolidation.ts
+++ b/src/memory/memory-consolidation.ts
@@ -1,5 +1,15 @@
+/**
+ * Consolidation owns durable MEMORY.md updates, unlike daily-note tool writes.
+ * File transactions serialize cooperating writers; model results are committed only
+ * if their input snapshot is still current. External editors do not take this lock.
+ */
+
 import fs from 'node:fs';
 import path from 'node:path';
+import {
+  lockMemoryFile,
+  writeMemoryFileAtomic,
+} from '../../container/shared/memory-file.js';
 
 import {
   currentDateStampInTimezone,
@@ -683,15 +693,20 @@ export class MemoryConsolidationEngine {
       try {
         const entries = collectDailyMemoryEntries(workspaceDir);
         const memoryPath = path.join(workspaceDir, 'MEMORY.md');
-        const existing = fs.existsSync(memoryPath)
-          ? fs.readFileSync(memoryPath, 'utf-8')
-          : readMemoryTemplate();
-        const next = buildMemoryContent({ existing, entries });
-        dailyFilesCompiled += entries.length;
-        if (next === existing) continue;
-        fs.mkdirSync(path.dirname(memoryPath), { recursive: true });
-        fs.writeFileSync(memoryPath, next, 'utf-8');
-        workspacesUpdated += 1;
+        const release = lockMemoryFile(memoryPath);
+        try {
+          const existing = fs.existsSync(memoryPath)
+            ? fs.readFileSync(memoryPath, 'utf-8')
+            : readMemoryTemplate();
+          const next = buildMemoryContent({ existing, entries });
+          dailyFilesCompiled += entries.length;
+          if (next === existing) continue;
+          fs.mkdirSync(path.dirname(memoryPath), { recursive: true });
+          writeMemoryFileAtomic(memoryPath, next);
+          workspacesUpdated += 1;
+        } finally {
+          release();
+        }
       } catch (err) {
         logger.warn(
           { agentId: agent.id, workspaceDir, err },
@@ -772,9 +787,23 @@ export class MemoryConsolidationEngine {
         }
 
         if (next === existing) continue;
-        fs.mkdirSync(path.dirname(memoryPath), { recursive: true });
-        fs.writeFileSync(memoryPath, next, 'utf-8');
-        workspacesUpdated += 1;
+        const release = lockMemoryFile(memoryPath);
+        try {
+          const current = fs.existsSync(memoryPath)
+            ? fs.readFileSync(memoryPath, 'utf-8')
+            : null;
+          if (current !== (hasExistingMemory ? existing : null)) {
+            logger.warn(
+              { agentId: agent.id },
+              'Memory changed during cleanup; skipping stale rewrite',
+            );
+            continue;
+          }
+          writeMemoryFileAtomic(memoryPath, next);
+          workspacesUpdated += 1;
+        } finally {
+          release();
+        }
       } catch (err) {
         logger.warn(
           { agentId: agent.id, workspaceDir, err },

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -5,6 +5,7 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
+import { readDailyMemoryFile } from '../container/shared/daily-memory.js';
 import {
   currentDateStampInTimezone,
   extractUserTimezone,
@@ -912,7 +913,7 @@ export function loadDailyMemoryFile(
   const todayMemoryPath = path.join(wsDir, todayMemoryName);
   if (fs.existsSync(todayMemoryPath)) {
     try {
-      const raw = readBoundedWorkspaceTextFile(todayMemoryPath, MAX_FILE_CHARS);
+      const raw = readDailyMemoryFile(todayMemoryPath);
       if (raw == null) {
         throw new Error('Failed to read daily memory file');
       }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -5,7 +5,10 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
-import { readDailyMemoryFile } from '../container/shared/daily-memory.js';
+import {
+  readDailyMemoryFile,
+  truncateDailyMemoryText,
+} from '../container/shared/daily-memory.js';
 import {
   currentDateStampInTimezone,
   extractUserTimezone,
@@ -936,6 +939,7 @@ export function loadDailyMemoryFile(
 export const DAILY_MEMORY_LOOKBACK_DAYS = 7;
 /** Shared character budget for previous days' notes (today's note is separate). */
 export const DAILY_MEMORY_HISTORY_MAX_CHARS = 12_000;
+const DAILY_MEMORY_HISTORY_MIN_CHARS = 400;
 
 /**
  * Load today's daily memory note plus the notes of the previous
@@ -986,15 +990,17 @@ export function loadRecentDailyMemoryFiles(
     const filePath = path.join(wsDir, name);
     if (!fs.existsSync(filePath)) continue;
     try {
-      // Older notes are loaded whole or not at all; a truncated note would
-      // silently drop its newest (appended) entries. Stop at the first note
-      // that no longer fits so the prompt stays newest-first and complete.
-      if (fs.statSync(filePath).size > remaining) break;
-      const raw = readBoundedWorkspaceTextFile(filePath, remaining);
+      const raw = readDailyMemoryFile(filePath);
       const content = raw?.trim() || '';
       if (!content) continue;
-      result.push({ name, content });
-      remaining -= content.length;
+      if (
+        content.length > remaining &&
+        remaining < DAILY_MEMORY_HISTORY_MIN_CHARS
+      )
+        break;
+      const bounded = truncateDailyMemoryText(content, remaining);
+      result.push({ name, content: bounded });
+      remaining -= bounded.length;
     } catch (err) {
       logger.warn(
         { agentId, file: name, err },
@@ -1068,30 +1074,6 @@ export function resolveUserTimezoneFromContextFiles(
 ): string | undefined {
   const userFile = files.find((file) => file.name === 'USER.md');
   return extractUserTimezone(userFile?.content);
-}
-
-function readBoundedWorkspaceTextFile(
-  filePath: string,
-  maxChars: number,
-): string | null {
-  try {
-    const stats = fs.statSync(filePath);
-    if (stats.size <= 0) return '';
-    if (stats.size <= maxChars) {
-      return fs.readFileSync(filePath, 'utf-8');
-    }
-
-    const fd = fs.openSync(filePath, 'r');
-    try {
-      const buffer = Buffer.alloc(maxChars);
-      const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
-      return `${buffer.toString('utf8', 0, bytesRead)}\n...[truncated]`;
-    } finally {
-      fs.closeSync(fd);
-    }
-  } catch {
-    return null;
-  }
 }
 
 /**

--- a/tests/container-runner.redaction.test.ts
+++ b/tests/container-runner.redaction.test.ts
@@ -668,6 +668,7 @@ test('ContainerExecutor injects gateway runtime env into docker launch', async (
     'HYBRIDCLAW_GATEWAY_URL=http://host.docker.internal:9090',
   );
   expect(runArgs).toContain('HYBRIDCLAW_GATEWAY_TOKEN=gateway-secret');
+  expect(runArgs).toContain(`TZ=${Intl.DateTimeFormat().resolvedOptions().timeZone}`);
 });
 
 test('ContainerExecutor stages the container node_modules symlink before docker launch', async () => {

--- a/tests/container.memory-tool.test.ts
+++ b/tests/container.memory-tool.test.ts
@@ -69,6 +69,22 @@ describe.sequential('container memory tool', () => {
     ).toContain('- Durable fact.');
   });
 
+  test('concurrent appends keep every note and release locks after validation failures', async () => {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-appends-'));
+    vi.stubEnv('HYBRIDCLAW_AGENT_WORKSPACE_ROOT', workspaceRoot);
+    const { executeTool } = await import('../container/src/tools.js');
+    const file_path = `memory/${currentLocalDateStamp()}.md`;
+    const results = await Promise.all(Array.from({ length: 5 }, (_, index) =>
+      executeTool('memory', JSON.stringify({ action: 'append', file_path, content: `entry ${index}` }))));
+    expect(results.every(result => result.includes('Appended'))).toBe(true);
+    const content = fs.readFileSync(path.join(workspaceRoot, file_path), 'utf8');
+    for (let index = 0; index < 5; index++) expect(content).toContain(`entry ${index}`);
+    const failure = await executeTool('memory', JSON.stringify({ action: 'append', file_path, content: 'x'.repeat(24_000) }));
+    expect(failure).toContain('would exceed');
+    expect(fs.existsSync(path.join(workspaceRoot, `${file_path}.lock`))).toBe(false);
+    expect(fs.readFileSync(path.join(workspaceRoot, file_path), 'utf8')).toBe(content);
+  });
+
   test('memoizes USER.md timezone reads while the file is unchanged', async () => {
     workspaceRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), 'hybridclaw-memory-workspace-'),

--- a/tests/container.memory-tool.test.ts
+++ b/tests/container.memory-tool.test.ts
@@ -85,6 +85,22 @@ describe.sequential('container memory tool', () => {
     expect(fs.readFileSync(path.join(workspaceRoot, file_path), 'utf8')).toBe(content);
   });
 
+  test('defaults writes to today and requires explicit overwrite confirmation', async () => {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-defaults-'));
+    vi.stubEnv('HYBRIDCLAW_AGENT_WORKSPACE_ROOT', workspaceRoot);
+    const { executeTool } = await import('../container/src/tools.js');
+    const file = path.join(workspaceRoot, `memory/${currentLocalDateStamp()}.md`);
+    expect(await executeTool('memory', JSON.stringify({ action: 'append', content: 'keep me' }))).toContain('Appended');
+    for (const confirm_overwrite of [undefined, false, 'true']) {
+      expect(await executeTool('memory', JSON.stringify({ action: 'write', content: 'replacement', confirm_overwrite }))).toContain('confirm_overwrite=true');
+      expect(fs.readFileSync(file, 'utf8')).toContain('keep me');
+    }
+    expect(await executeTool('memory', JSON.stringify({ action: 'write', content: 'replacement', confirm_overwrite: true }))).toContain('Wrote');
+    expect(fs.readFileSync(file, 'utf8')).toBe('replacement');
+    expect(await executeTool('memory', JSON.stringify({ action: 'append', file_path: '../escape.md', content: 'bad' }))).toContain('Error:');
+    expect(fs.readFileSync(file, 'utf8')).toBe('replacement');
+  });
+
   test('memoizes USER.md timezone reads while the file is unchanged', async () => {
     workspaceRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), 'hybridclaw-memory-workspace-'),

--- a/tests/daily-memory.test.ts
+++ b/tests/daily-memory.test.ts
@@ -1,0 +1,30 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, expect, test } from 'vitest';
+import { DAILY_MEMORY_MAX_CHARS, readDailyMemoryFile, truncateDailyMemoryText } from '../container/shared/daily-memory.js';
+const directories: string[] = [];
+afterEach(() => { for (const directory of directories.splice(0)) fs.rmSync(directory, { recursive: true, force: true }); });
+function writeNote(content: string) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'daily-memory-'));
+  directories.push(directory);
+  const file = path.join(directory, 'note.md');
+  fs.writeFileSync(file, content);
+  return file;
+}
+test('reads the entire valid note in characters, including multibyte text', () => {
+  const text = '界'.repeat(DAILY_MEMORY_MAX_CHARS - 8) + '\nLatest.';
+  expect(readDailyMemoryFile(writeNote(text))).toBe(text);
+});
+test('oversized external notes retain their head and appended tail within the cap', () => {
+  const text = 'Beginning\n' + '😀'.repeat(70_000) + '\nLatest note.';
+  const content = readDailyMemoryFile(writeNote(text));
+  expect(content?.length).toBeLessThanOrEqual(DAILY_MEMORY_MAX_CHARS);
+  expect(content).toContain('Beginning');
+  expect(content).toContain('Latest note.');
+  expect(content).toContain('[truncated middle]');
+  expect(content).not.toContain('\uFFFD');
+});
+test('small truncation budgets remain bounded', () => {
+  for (let budget = 0; budget < 30; budget++) expect(truncateDailyMemoryText('x'.repeat(100), budget).length).toBeLessThanOrEqual(budget);
+});

--- a/tests/memory-consolidation.test.ts
+++ b/tests/memory-consolidation.test.ts
@@ -307,6 +307,26 @@ describe.sequential('memory consolidation', () => {
     );
   });
 
+  test('does not overwrite memory changed while the cleanup model runs', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-cleanup-race-'));
+    try {
+      const memoryPath = path.join(workspaceDir, 'MEMORY.md');
+      fs.writeFileSync(memoryPath, '## Facts\n- Original fact.\n');
+      const { MemoryConsolidationEngine } = await loadConsolidationModule(workspaceDir);
+      const { callAuxiliaryModel } = await import('../src/providers/auxiliary.js');
+      vi.mocked(callAuxiliaryModel).mockImplementationOnce(async () => {
+        fs.writeFileSync(memoryPath, '## Facts\n- Concurrent update.\n');
+        return { provider: 'hybridai', model: 'gpt-5-nano', content: JSON.stringify({ facts: ['Stale result'], decisions: [], patterns: [] }) };
+      });
+      const engine = new MemoryConsolidationEngine(makeBackend(), { decayRate: 0.1, staleAfterDays: 30, minConfidence: 0.1 });
+      expect((await engine.consolidateWithCleanup()).workspacesUpdated).toBe(0);
+      expect(fs.readFileSync(memoryPath, 'utf8')).toBe('## Facts\n- Concurrent update.\n');
+      expect(fs.existsSync(`${memoryPath}.lock`)).toBe(false);
+    } finally {
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   test('model-backed cleanup rewrites MEMORY.md without the daily digest block', async () => {
     const workspaceDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'hybridclaw-memory-consolidation-llm-'),

--- a/tests/memory-consolidation.test.ts
+++ b/tests/memory-consolidation.test.ts
@@ -897,4 +897,104 @@ describe.sequential('memory consolidation', () => {
       readSpy.mockRestore();
     }
   });
+
+  const cleanupEngine = async (workspaceDir: string, sections: Record<string, string[]>) => {
+    const { MemoryConsolidationEngine, currentDateStamp } = await loadConsolidationModule(workspaceDir);
+    const { callAuxiliaryModel } = await import('../src/providers/auxiliary.js');
+    const dailyDir = path.join(workspaceDir, 'memory');
+    fs.mkdirSync(dailyDir, { recursive: true });
+    const yesterday = currentDateStamp(new Date(Date.now() - 86400000));
+    fs.writeFileSync(path.join(dailyDir, `${yesterday}.md`), '- Learned something.\n');
+    vi.mocked(callAuxiliaryModel).mockResolvedValueOnce({ provider: 'hybridai', model: 'gpt-5-nano', content: JSON.stringify(sections) });
+    const engine = new MemoryConsolidationEngine(makeBackend(), { decayRate: 0.1, staleAfterDays: 7, minConfidence: 0.1 });
+    return engine.consolidateWithCleanup();
+  };
+
+  test('cleanup from the default template drops placeholders under populated sections only', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-template-'));
+    try {
+      const template = fs.readFileSync(path.join(process.cwd(), 'templates', 'MEMORY.md'), 'utf8');
+      const memoryPath = path.join(workspaceDir, 'MEMORY.md');
+      fs.writeFileSync(memoryPath, template);
+      expect((await cleanupEngine(workspaceDir, { facts: ['New fact.'], decisions: [], patterns: ['Prefers short replies.'] })).modelCleanups).toBe(1);
+      const result = fs.readFileSync(memoryPath, 'utf8');
+      expect(result).toContain('## Facts\n- New fact.\n\n## Decisions\n\n_(Important choices');
+      expect(result).not.toContain("_(Key things you've discovered");
+      expect(result).toContain('## Patterns\n- Prefers short replies.\n\n---\n');
+      expect(result).not.toContain('_(Recurring things');
+      expect(result.match(/_\(/g)?.length).toBe(1);
+      expect(result).toContain('This is your persistent memory.');
+    } finally { fs.rmSync(workspaceDir, { recursive: true, force: true }); }
+  });
+
+  test('cleanup from a CRLF template keeps line endings and a single placeholder for empty sections', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-template-crlf-'));
+    try {
+      const template = fs.readFileSync(path.join(process.cwd(), 'templates', 'MEMORY.md'), 'utf8').replace(/\n/g, '\r\n');
+      const memoryPath = path.join(workspaceDir, 'MEMORY.md');
+      fs.writeFileSync(memoryPath, template);
+      expect((await cleanupEngine(workspaceDir, { facts: ['New fact.'], decisions: [], patterns: [] })).modelCleanups).toBe(1);
+      const result = fs.readFileSync(memoryPath, 'utf8');
+      expect(result).toContain('## Facts\r\n- New fact.\r\n\r\n## Decisions\r\n\r\n_(Important choices');
+      expect(result).not.toContain("_(Key things you've discovered");
+      expect(result).toContain('## Patterns\r\n\r\n_(Recurring things');
+      expect(result.match(/_\(/g)?.length).toBe(2);
+      expect(result).not.toMatch(/[^\r]\n/);
+    } finally { fs.rmSync(workspaceDir, { recursive: true, force: true }); }
+  });
+
+  test('cleanup treats lowercase managed headings as managed without appending duplicates', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-lowercase-'));
+    try {
+      const memoryPath = path.join(workspaceDir, 'MEMORY.md');
+      fs.writeFileSync(memoryPath, '# Memory\n\n## facts\n- Old fact.\n\n## DECISIONS\n- Old decision.\n\n## Patterns\n- Old pattern.\n');
+      expect((await cleanupEngine(workspaceDir, { facts: ['New fact.'], decisions: ['New decision.'], patterns: ['New pattern.'] })).modelCleanups).toBe(1);
+      const result = fs.readFileSync(memoryPath, 'utf8');
+      expect(result).toBe('# Memory\n\n## facts\n- New fact.\n\n## DECISIONS\n- New decision.\n\n## Patterns\n- New pattern.\n');
+    } finally { fs.rmSync(workspaceDir, { recursive: true, force: true }); }
+  });
+
+  test('deterministic digest shares the budget so one large day does not evict small days', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-fair-share-'));
+    try {
+      const { MemoryConsolidationEngine, currentDateStamp } = await loadConsolidationModule(workspaceDir);
+      const dailyDir = path.join(workspaceDir, 'memory');
+      fs.mkdirSync(dailyDir);
+      const stamp = (days: number) => currentDateStamp(new Date(Date.now() - days * 86400000));
+      fs.writeFileSync(path.join(dailyDir, `${stamp(1)}.md`), 'Large day start.\n' + 'x'.repeat(20_000) + '\nLarge day end.\n');
+      fs.writeFileSync(path.join(dailyDir, `${stamp(2)}.md`), '- Small day two.\n');
+      fs.writeFileSync(path.join(dailyDir, `${stamp(3)}.md`), '- Small day three.\n');
+      const engine = new MemoryConsolidationEngine(makeBackend(), { decayRate: 0.1, staleAfterDays: 7, minConfidence: 0.1 });
+      expect(engine.consolidate().dailyFilesCompiled).toBe(3);
+      const result = fs.readFileSync(path.join(workspaceDir, 'MEMORY.md'), 'utf8');
+      expect(result.length).toBeLessThanOrEqual(12_000);
+      expect(result).toContain('- Small day two.');
+      expect(result).toContain('- Small day three.');
+      expect(result).toContain('Large day start.');
+      expect(result).toContain('Large day end.');
+      expect(result).toContain('[truncated middle]');
+      expect(result.indexOf(`### ${stamp(3)}`)).toBeLessThan(result.indexOf(`### ${stamp(1)}`));
+    } finally { fs.rmSync(workspaceDir, { recursive: true, force: true }); }
+  });
+
+  test('consolidate skips a workspace whose MEMORY.md lock is held', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-locked-'));
+    try {
+      const { MemoryConsolidationEngine, currentDateStamp } = await loadConsolidationModule(workspaceDir);
+      const { logger } = await import('../src/logger.js');
+      const dailyDir = path.join(workspaceDir, 'memory');
+      fs.mkdirSync(dailyDir);
+      fs.writeFileSync(path.join(dailyDir, `${currentDateStamp(new Date(Date.now() - 86400000))}.md`), '- Note.\n');
+      const memoryPath = path.join(workspaceDir, 'MEMORY.md');
+      fs.writeFileSync(memoryPath, '# Memory\n');
+      fs.mkdirSync(`${memoryPath}.lock`);
+      const engine = new MemoryConsolidationEngine(makeBackend(), { decayRate: 0.1, staleAfterDays: 7, minConfidence: 0.1 });
+      const report = engine.consolidate();
+      expect(report.workspacesUpdated).toBe(0);
+      expect(report.dailyFilesCompiled).toBe(0);
+      expect(fs.readFileSync(memoryPath, 'utf8')).toBe('# Memory\n');
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(expect.objectContaining({ workspaceDir }), expect.stringContaining('skipped a workspace'));
+      expect(fs.existsSync(`${memoryPath}.lock`)).toBe(true);
+    } finally { fs.rmSync(workspaceDir, { recursive: true, force: true }); }
+  });
 });

--- a/tests/memory-consolidation.test.ts
+++ b/tests/memory-consolidation.test.ts
@@ -176,7 +176,7 @@ describe.sequential('memory consolidation', () => {
     }
   });
 
-  test('ignores prose-only daily memory files instead of synthesizing digest bullets', async () => {
+  test('includes prose-only daily memory files without discarding paragraphs', async () => {
     const workspaceDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'hybridclaw-memory-consolidation-prose-'),
     );
@@ -210,9 +210,9 @@ describe.sequential('memory consolidation', () => {
     const report = engine.consolidate();
     const memoryPath = path.join(workspaceDir, 'MEMORY.md');
 
-    expect(report.dailyFilesCompiled).toBe(0);
-    expect(report.workspacesUpdated).toBe(0);
-    expect(fs.existsSync(memoryPath)).toBe(false);
+    expect(report.dailyFilesCompiled).toBe(1);
+    expect(report.workspacesUpdated).toBe(1);
+    expect(fs.readFileSync(memoryPath, 'utf8')).toContain('This is free-form prose without any bullet structure.\n\nIt should not be converted into a synthetic digest item.');
   });
 
   test('re-running consolidation replaces the managed digest instead of duplicating it', async () => {
@@ -405,6 +405,51 @@ describe.sequential('memory consolidation', () => {
     expect(memoryContent).toContain('Keep changes tightly scoped.');
     expect(memoryContent).toContain('User prefers concise replies.');
     expect(memoryContent).not.toContain('BEGIN DAILY MEMORY DIGEST');
+  });
+
+  test('cleanup sees long prose and late notes and preserves custom sections verbatim', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-preservation-'));
+    try {
+      const { MemoryConsolidationEngine, currentDateStamp } = await loadConsolidationModule(workspaceDir);
+      const { callAuxiliaryModel } = await import('../src/providers/auxiliary.js');
+      const memoryPath = path.join(workspaceDir, 'MEMORY.md');
+      const custom = '## Regeln\r\n\r\nCustom  spacing.\r\n- Keep this rule.\r\n\r\n```md\r\n## Facts\r\n- Example, not managed memory.\r\n```\r\n';
+      fs.writeFileSync(memoryPath, '# Operator title\nOpening free text.\n## Facts\n- Old fact.\nKeep this prose too.\n' + custom);
+      const dailyDir = path.join(workspaceDir, 'memory');
+      fs.mkdirSync(dailyDir);
+      const yesterday = currentDateStamp(new Date(Date.now() - 86400000));
+      const prose = 'Long prose ' + 'detail '.repeat(700) + 'important conclusion.';
+      const daily = Array.from({ length: 12 }, (_, i) => `- Entry ${i}`).join('\n') + '\n\n' + prose + '\n\nNewest appended fact.';
+      fs.writeFileSync(path.join(dailyDir, `${yesterday}.md`), daily);
+      vi.mocked(callAuxiliaryModel).mockResolvedValueOnce({ provider: 'hybridai', model: 'gpt-5-nano', content: JSON.stringify({ facts: ['New fact.'], decisions: [], patterns: [] }) });
+      const engine = new MemoryConsolidationEngine(makeBackend(), { decayRate: 0.1, staleAfterDays: 7, minConfidence: 0.1 });
+      expect((await engine.consolidateWithCleanup()).modelCleanups).toBe(1);
+      const prompt = JSON.stringify(vi.mocked(callAuxiliaryModel).mock.calls[0][0].messages);
+      expect(prompt).toContain('Entry 11');
+      expect(prompt).toContain(prose);
+      expect(prompt).toContain('Newest appended fact.');
+      const result = fs.readFileSync(memoryPath, 'utf8');
+      expect(result).toContain(custom);
+      expect(result).toContain('# Operator title\nOpening free text.\n');
+      expect(result).toContain('Keep this prose too.');
+      expect(result).toContain('- New fact.');
+      expect(result).not.toContain('- Old fact.');
+    } finally { fs.rmSync(workspaceDir, { recursive: true, force: true }); }
+  });
+
+  test('cleanup exceeding the file budget preserves operator content through fallback', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-preservation-budget-'));
+    try {
+      const { MemoryConsolidationEngine } = await loadConsolidationModule(workspaceDir);
+      const { callAuxiliaryModel } = await import('../src/providers/auxiliary.js');
+      const memoryPath = path.join(workspaceDir, 'MEMORY.md');
+      const custom = '# Memory\n\n## Regeln\n' + 'x'.repeat(11_900) + '\n';
+      fs.writeFileSync(memoryPath, custom);
+      vi.mocked(callAuxiliaryModel).mockResolvedValueOnce({ provider: 'hybridai', model: 'gpt-5-nano', content: JSON.stringify({ facts: ['y'.repeat(280)], decisions: [], patterns: [] }) });
+      const engine = new MemoryConsolidationEngine(makeBackend(), { decayRate: 0.1, staleAfterDays: 7, minConfidence: 0.1 });
+      expect((await engine.consolidateWithCleanup()).fallbacksUsed).toBe(1);
+      expect(fs.readFileSync(memoryPath, 'utf8')).toBe(custom);
+    } finally { fs.rmSync(workspaceDir, { recursive: true, force: true }); }
   });
 
   test('model-backed cleanup requests English output by default', async () => {
@@ -655,7 +700,7 @@ describe.sequential('memory consolidation', () => {
     const { MemoryConsolidationEngine, currentDateStamp } =
       await loadConsolidationModule(workspaceDir);
     const now = new Date();
-    const entries = Array.from({ length: 40 }, (_, index) => {
+    const entries = Array.from({ length: 120 }, (_, index) => {
       const date = new Date(now);
       date.setDate(date.getDate() - (index + 1));
       const stamp = currentDateStamp(date);
@@ -671,14 +716,14 @@ describe.sequential('memory consolidation', () => {
     const oldestEntry = entries.at(-1);
     expect(oldestEntry).toBeDefined();
 
-    const statSync = fs.statSync.bind(fs);
-    const statSpy = vi.spyOn(fs, 'statSync').mockImplementation((filePath) => {
+    const openSync = fs.openSync.bind(fs);
+    const openSpy = vi.spyOn(fs, 'openSync').mockImplementation((filePath, flags, mode) => {
       if (String(filePath) === oldestEntry?.filePath) {
         throw new Error(
           'Oldest file should not be touched after digest budget is full',
         );
       }
-      return statSync(filePath);
+      return openSync(filePath, flags, mode);
     });
 
     try {
@@ -696,13 +741,13 @@ describe.sequential('memory consolidation', () => {
 
       expect(report.dailyFilesCompiled).toBeGreaterThan(0);
       expect(memoryContent).toContain('Budget stop entry 1');
-      expect(memoryContent).not.toContain('Budget stop entry 40');
+      expect(memoryContent).not.toContain('Budget stop entry 120');
     } finally {
-      statSpy.mockRestore();
+      openSpy.mockRestore();
     }
   });
 
-  test('reads only a capped prefix for oversized daily memory files', async () => {
+  test('reads bounded head and tail for oversized daily memory files', async () => {
     const workspaceDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'hybridclaw-memory-consolidation-large-daily-'),
     );
@@ -717,7 +762,7 @@ describe.sequential('memory consolidation', () => {
     const largeDailyPath = path.join(dailyDir, `${olderStamp}.md`);
     fs.writeFileSync(
       largeDailyPath,
-      `- Oversized daily memory ${'x'.repeat(6_000)}\n`,
+      `- Oversized daily memory ${'x'.repeat(100_000)}\nNewest appended fact.\n`,
       'utf-8',
     );
 
@@ -746,6 +791,8 @@ describe.sequential('memory consolidation', () => {
 
       expect(report.dailyFilesCompiled).toBe(1);
       expect(memoryContent).toContain('Oversized daily memory');
+      expect(memoryContent).toContain('Newest appended fact.');
+      expect(memoryContent).toContain('[truncated middle]');
       expect(memoryContent).not.toContain(
         'Large daily file should not be fully read',
       );

--- a/tests/memory-file.test.ts
+++ b/tests/memory-file.test.ts
@@ -1,0 +1,57 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, expect, test, vi } from 'vitest';
+import { lockMemoryFile, writeMemoryFileAtomic } from '../container/shared/memory-file.js';
+
+const directories: string[] = [];
+function temporaryFile() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-transaction-'));
+  directories.push(directory);
+  return path.join(directory, 'note.md');
+}
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const directory of directories.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test('serializes read-modify-write across independent processes', async () => {
+  const file = temporaryFile();
+  const moduleUrl = new URL('../container/shared/memory-file.js', import.meta.url).href;
+  await Promise.all(Array.from({ length: 8 }, (_, index) => new Promise<void>((resolve, reject) => {
+    const child = spawn(process.execPath, ['--input-type=module', '-e', `
+      import fs from 'node:fs';
+      import { waitForMemoryFileLock, writeMemoryFileAtomic } from ${JSON.stringify(moduleUrl)};
+      const file = process.argv[1];
+      const release = await waitForMemoryFileLock(file);
+      try {
+        const before = fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
+        await new Promise(resolve => setTimeout(resolve, 10));
+        writeMemoryFileAtomic(file, before + process.argv[2] + '\\n');
+      } finally { release(); }
+    `, file, String(index)], { stdio: 'pipe' });
+    let error = '';
+    child.stderr.on('data', chunk => { error += chunk; });
+    child.on('error', reject);
+    child.on('exit', code => code === 0 ? resolve() : reject(new Error(error)));
+  })));
+  expect(fs.readFileSync(file, 'utf8').trim().split('\n').sort()).toEqual(['0','1','2','3','4','5','6','7']);
+});
+
+test('does not steal a held lock and permits acquisition after release', () => {
+  const file = temporaryFile();
+  const release = lockMemoryFile(file);
+  expect(() => lockMemoryFile(file)).toThrow('Memory file is locked');
+  release();
+  lockMemoryFile(file)();
+});
+
+test('failed rename preserves the original and removes the temporary file', () => {
+  const file = temporaryFile();
+  fs.writeFileSync(file, 'original');
+  vi.spyOn(fs, 'renameSync').mockImplementation(() => { throw new Error('rename failed'); });
+  expect(() => writeMemoryFileAtomic(file, 'replacement')).toThrow('rename failed');
+  expect(fs.readFileSync(file, 'utf8')).toBe('original');
+  expect(fs.readdirSync(path.dirname(file))).toEqual(['note.md']);
+});

--- a/tests/memory-file.test.ts
+++ b/tests/memory-file.test.ts
@@ -55,3 +55,16 @@ test('failed rename preserves the original and removes the temporary file', () =
   expect(fs.readFileSync(file, 'utf8')).toBe('original');
   expect(fs.readdirSync(path.dirname(file))).toEqual(['note.md']);
 });
+
+test('atomic write keeps the existing file mode', () => {
+  const file = temporaryFile();
+  fs.writeFileSync(file, 'original');
+  fs.chmodSync(file, 0o644);
+  writeMemoryFileAtomic(file, 'replacement');
+  expect(fs.statSync(file).mode & 0o777).toBe(0o644);
+  expect(fs.readFileSync(file, 'utf8')).toBe('replacement');
+  const fresh = path.join(path.dirname(file), 'fresh.md');
+  writeMemoryFileAtomic(fresh, 'new');
+  expect(fs.statSync(fresh).mode & 0o200).toBe(0o200);
+  expect(fs.statSync(fresh).mode & 0o044).toBe(0o044 & ~(process.umask() & 0o044));
+});

--- a/tests/prompt-hooks-stability.test.ts
+++ b/tests/prompt-hooks-stability.test.ts
@@ -187,3 +187,11 @@ test('buildConversationContext appends dynamic context after unchanged history',
     vi.useRealTimers();
   }
 });
+
+ test('dynamic context names the user daily note across the UTC date boundary', async () => {
+   await createWorkspaceWithBootstrapFiles('timezone-agent');
+   const { buildDynamicContextMessage } = await import('../src/agent/conversation.js');
+   const message = buildDynamicContextMessage({ agentId: 'timezone-agent', now: new Date('2026-05-12T23:30:00Z') });
+   expect(message.content).toContain('Date (UTC): 2026-05-12');
+   expect(message.content).toContain('Daily note: memory/2026-05-13.md');
+ });

--- a/tests/workspace-bootstrap.test.ts
+++ b/tests/workspace-bootstrap.test.ts
@@ -355,6 +355,26 @@ describe('workspace bootstrap lifecycle', () => {
     });
   });
 
+  test('daily prompt reads the tool cap and keeps the tail of oversized notes', async () => {
+    const homeDir = makeTempDir('hybridclaw-home-');
+    vi.stubEnv('HOME', homeDir);
+    const workspace = await import('../src/workspace.js');
+    const ipc = await import('../src/infra/ipc.js');
+    workspace.ensureBootstrapFiles('agent-test');
+    const workspaceDir = ipc.agentWorkspaceDir('agent-test');
+    const dailyPath = path.join(workspaceDir, 'memory', `${currentLocalDateStamp()}.md`);
+    fs.mkdirSync(path.dirname(dailyPath), { recursive: true });
+    const valid = 'Beginning\n' + '界'.repeat(23_970) + '\nNewest entry.';
+    fs.writeFileSync(dailyPath, valid);
+    expect(workspace.loadDailyMemoryFile('agent-test')?.content).toBe(valid);
+    fs.writeFileSync(dailyPath, 'Beginning\n' + 'x'.repeat(100_000) + '\nNewest entry.');
+    const content = workspace.loadDailyMemoryFile('agent-test')?.content;
+    expect(content).toContain('Beginning');
+    expect(content).toContain('Newest entry.');
+    expect(content).toContain('[truncated middle]');
+    expect(content?.length).toBeLessThanOrEqual(24_000);
+  });
+
   test('loads the previous days of daily memory notes, newest first, within budget', async () => {
     const homeDir = makeTempDir('hybridclaw-home-');
     const unrelatedCwd = makeTempDir('hybridclaw-cwd-');

--- a/tests/workspace-bootstrap.test.ts
+++ b/tests/workspace-bootstrap.test.ts
@@ -444,6 +444,30 @@ describe('workspace bootstrap lifecycle', () => {
     ]);
   });
 
+  test('prior daily notes keep their tail when truncated to the history budget', async () => {
+    const homeDir = makeTempDir('hybridclaw-home-');
+    vi.stubEnv('HOME', homeDir);
+    const workspace = await import('../src/workspace.js');
+    const ipc = await import('../src/infra/ipc.js');
+    workspace.ensureBootstrapFiles('agent-test');
+    const memoryDir = path.join(ipc.agentWorkspaceDir('agent-test'), 'memory');
+    fs.mkdirSync(memoryDir, { recursive: true });
+    const now = new Date();
+    const stampDaysAgo = (days: number): string => {
+      const date = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+      return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+    };
+    fs.writeFileSync(path.join(memoryDir, `${stampDaysAgo(1)}.md`), 'Beginning\n' + 'x'.repeat(100_000) + '\nNewest entry.');
+    fs.writeFileSync(path.join(memoryDir, `${stampDaysAgo(2)}.md`), '- two days ago\n');
+    const files = workspace.loadRecentDailyMemoryFiles('agent-test', { now });
+    expect(files.map((file) => file.name)).toEqual([`memory/${stampDaysAgo(1)}.md`]);
+    const content = files[0]?.content || '';
+    expect(content).toContain('Beginning');
+    expect(content).toContain('Newest entry.');
+    expect(content).toContain('[truncated middle]');
+    expect(content.length).toBeLessThanOrEqual(workspace.DAILY_MEMORY_HISTORY_MAX_CHARS);
+  });
+
   test('omits the default HEARTBEAT.md from bootstrap context', async () => {
     const homeDir = makeTempDir('hybridclaw-home-');
     const unrelatedCwd = makeTempDir('hybridclaw-cwd-');

--- a/tests/workspace-time.test.ts
+++ b/tests/workspace-time.test.ts
@@ -1,0 +1,13 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { currentDateStampInTimezone, extractUserTimezone } from '../container/shared/workspace-time.js';
+afterEach(() => vi.unstubAllEnvs());
+test('empty timezone does not consume the next USER.md field', () => {
+  expect(extractUserTimezone('**Timezone:** \n**Notes:** example')).toBeUndefined();
+});
+test('blank and invalid user zones use inherited host TZ around midnight', () => {
+  vi.stubEnv('TZ', 'America/Los_Angeles');
+  const now = new Date('2026-09-08T00:30:00Z');
+  expect(currentDateStampInTimezone(undefined, now)).toBe('2026-09-07');
+  expect(currentDateStampInTimezone('Invalid/Zone', now)).toBe('2026-09-07');
+  expect(currentDateStampInTimezone('Europe/Berlin', now)).toBe('2026-09-08');
+});


### PR DESCRIPTION
Combines three stacked memory fixes into one PR (formerly #1497, #1498, #1499).

Closes #1477. Closes #1467. Closes #1466.

## Serialize concurrent workspace memory writes (#1477)

Concurrent chat, heartbeat, and scheduled sessions share an agent workspace. Memory updates now take a cross-process file lock across read/modify/write and publish with atomic rename, preventing lost appends and partial reads. Model consolidation rejects a rewrite when MEMORY.md changed during its model call.

Locks coordinate the memory tool and consolidation, not arbitrary shell writes or external editors. Busy tools retry for five seconds; consolidation skips contention. Locks left by crashed writers require manual removal after verifying the writer has stopped; no age-based lock stealing.

## Safe, timezone-consistent daily note saves (#1467)

Saving a note without a target now appends to today's daily file, while untargeted reads still use MEMORY.md. Whole-file `write` requires `confirm_overwrite: true`, and the schema explains that it erases earlier entries. Invalid explicit paths fail rather than silently falling back.

Docker inherits the host's resolved timezone via TZ, with USER.md still taking precedence. Blank timezone fields cannot consume the next line. Dynamic context names the daily file explicitly across UTC midnight. The inherited timezone affects newly launched containers; existing containers retain their launch environment.

## Preserve daily notes and custom consolidation sections (#1466)

Consolidation receives complete daily notes up to the same 24,000-character cap used by the memory tool and today's prompt loader. Prose, long entries, and notes after the sixth bullet reach the model. Oversized external files use bounded head-and-tail reads with a visible truncation marker.

Cleanup replaces only managed bullets under Facts, Decisions, and Patterns, preserving custom headings, free text, and fenced examples verbatim. Over-budget model output falls back without trimming operator content. The deterministic digest retains the newest day even when that day needs head-and-tail truncation; source daily files remain intact.

Remaining limits: the combined consolidation intake is bounded at 24,000 characters and durable MEMORY.md at 12,000. Older source notes remain on disk. Model output remains a concise semantic summary, so this does not promise lossless archival in MEMORY.md. Prior-day prompt history keeps its existing seven-day/12,000-character policy.

## Validation

Targeted suites: memory tool, memory-file locking (separate-process contention, failed rename), consolidation (18 tests incl. over-budget preservation), workspace-time, daily-memory, workspace bootstrap, container-runner env, prompt-hooks stability, and IPC. Root lint/typecheck, container lint, and full build passed. Live provider tests and a real Docker deployment were not run; memory path restrictions and approval tiers are unchanged.


## Follow-up after review

- Atomic memory writes keep the existing file mode instead of forcing `0600`, so a root-run gateway no longer locks the sandbox out of MEMORY.md after consolidation.
- Model cleanup drops the template placeholder lines once a managed section holds bullets and keeps exactly one placeholder while it is empty; CRLF documents keep their line endings.
- Managed headings match case-insensitively (`## facts` is Facts), so cleanup no longer appends duplicate sections.
- Prior-day notes in the prompt loader use the shared head-and-tail reader, so an oversized note keeps its newest entries with the middle-truncation marker.
- The deterministic digest gives each selected day a fair share of the remaining budget; a single large day is truncated rather than evicting smaller days, and the oldest days are dropped only when the shared budget is too small.
- New tests: file-mode preservation, cleanup from the default template (LF and CRLF), lowercase headings, fair-share digest, locked-workspace skip, and tail retention for prior-day notes.
