### PR TITLE
fix: simplify action honesty and preserve tool outcomes

### DIFF
--- a/container/shared/tool-history.js
+++ b/container/shared/tool-history.js
@@ -45,10 +45,20 @@ export function validateToolHistory(value) {
   const messages = [];
   const pending = new Set();
   for (const message of value) {
+    let content = message?.content;
+    if (
+      message?.role === 'assistant' &&
+      Array.isArray(content) &&
+      content.every(
+        (part) => part?.type === 'text' && typeof part.text === 'string',
+      )
+    ) {
+      content = content.map((part) => part.text).join('\n');
+    }
     if (
       !message ||
       typeof message !== 'object' ||
-      !(message.content === null || typeof message.content === 'string')
+      !(content === null || typeof content === 'string')
     ) {
       throw new Error('Invalid tool history message.');
     }
@@ -77,7 +87,7 @@ export function validateToolHistory(value) {
       }
       const next = {
         role: 'assistant',
-        content: message.content,
+        content,
         tool_calls: message.tool_calls.map((call) => ({
           id: call.id,
           type: 'function',

--- a/container/src/codex-app-server.ts
+++ b/container/src/codex-app-server.ts
@@ -1,3 +1,8 @@
+/**
+ * The app-server bridge retains completed native tool exchanges for gateway
+ * persistence. Approval and sandbox events remain audit metadata, never tool
+ * success; replay supplies context without re-executing historical actions.
+ */
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
@@ -11,6 +16,7 @@ import {
   readString as readUnknownString,
 } from './codex-app-utils.js';
 import { withToolActivityHeartbeat } from './tool-activity-heartbeat.js';
+import { TurnToolHistory } from './turn-tool-history.js';
 import type {
   ChatMessage,
   ContainerInput,
@@ -41,6 +47,7 @@ interface CodexProjection {
   textDeltas: string[];
   agentMessages: string[];
   toolExecutions: ToolExecution[];
+  toolHistory: TurnToolHistory;
   toolsUsed: Set<string>;
   tokenUsage: TokenUsageStats;
   approvalEvents: ToolExecution[];
@@ -144,9 +151,21 @@ export function buildCodexTurnText(messages: ChatMessage[]): string {
   const prior = messages
     .filter((message) => message.role !== 'system' && message !== latest)
     .map((message) => {
-      const content = stringifyContent(message.content).trim();
+      const content = [
+        stringifyContent(message.content).trim(),
+        ...(message.tool_calls || []).map(
+          (call) =>
+            `Tool call (${call.id}): ${call.function.name} ${call.function.arguments}`,
+        ),
+      ]
+        .filter(Boolean)
+        .join('\n');
       if (!content) return '';
-      return `${message.role}: ${content}`;
+      const label =
+        message.role === 'tool'
+          ? `Tool result (${message.tool_call_id})`
+          : message.role;
+      return `${label}: ${content}`;
     })
     .filter(Boolean);
 
@@ -213,6 +232,35 @@ function appendToolExecution(
 ): void {
   projection.toolExecutions.push(execution);
   projection.toolsUsed.add(execution.name);
+  if (
+    !['codex.command', 'codex.patch', 'codex.mcp', 'codex.tool'].includes(
+      execution.name,
+    )
+  )
+    return;
+  const callId = randomUUID();
+  const args =
+    execution.name === 'codex.command'
+      ? JSON.stringify({ command: execution.arguments })
+      : execution.name === 'codex.patch'
+        ? JSON.stringify({ changes: JSON.parse(execution.arguments) })
+        : execution.arguments;
+  projection.toolHistory.recordAssistant({
+    role: 'assistant',
+    content: null,
+    tool_calls: [
+      {
+        id: callId,
+        type: 'function',
+        function: { name: execution.name, arguments: args },
+      },
+    ],
+  });
+  projection.toolHistory.recordResult({
+    role: 'tool',
+    tool_call_id: callId,
+    content: `Tool ${execution.isError ? 'failed' : 'completed'}:\n${execution.result}`,
+  });
 }
 
 function projectionToolsUsed(projection: CodexProjection): string[] {
@@ -493,7 +541,9 @@ export function projectCodexThreadItem(
       arguments: readString(item, 'command'),
       result: readString(item, 'aggregatedOutput'),
       durationMs: readNumber(item, 'durationMs') ?? 0,
-      isError: readString(item, 'status') !== 'completed',
+      isError:
+        readString(item, 'status') !== 'completed' ||
+        (readNumber(item, 'exitCode') ?? 0) !== 0,
     });
     return;
   }
@@ -503,7 +553,7 @@ export function projectCodexThreadItem(
       arguments: JSON.stringify(item.changes ?? []),
       result: readString(item, 'status') || 'file change completed',
       durationMs: 0,
-      isError: readString(item, 'status') === 'failed',
+      isError: !['completed', 'applied'].includes(readString(item, 'status')),
     });
     return;
   }
@@ -521,6 +571,7 @@ export function projectCodexThreadItem(
       durationMs: readNumber(item, 'durationMs') ?? 0,
       isError:
         item.success === false ||
+        (isRecord(item.result) && item.result.isError === true) ||
         readString(item, 'status') === 'failed' ||
         Boolean(item.error),
     });
@@ -899,12 +950,13 @@ function parseTurnError(error: Record<string, unknown>): string {
   );
 }
 
-function createProjection(): CodexProjection {
+function createProjection(sessionId: string): CodexProjection {
   return {
     threadId: null,
     textDeltas: [],
     agentMessages: [],
     toolExecutions: [],
+    toolHistory: new TurnToolHistory(sessionId),
     toolsUsed: new Set<string>(),
     tokenUsage: emptyTokenUsage(),
     approvalEvents: [],
@@ -1003,6 +1055,7 @@ function outputFromProjection(
       result: completed.pendingApproval.prompt,
       toolsUsed: projectionToolsUsed(completed),
       toolExecutions,
+      ...finishToolHistory(completed),
       tokenUsage: completed.tokenUsage,
       pendingApproval: completed.pendingApproval,
       effectiveUserPrompt,
@@ -1014,6 +1067,7 @@ function outputFromProjection(
       result: resultText || null,
       toolsUsed: projectionToolsUsed(completed),
       toolExecutions,
+      ...finishToolHistory(completed),
       tokenUsage: completed.tokenUsage,
       error: completed.error,
       effectiveUserPrompt,
@@ -1024,8 +1078,21 @@ function outputFromProjection(
     result: resultText || '',
     toolsUsed: projectionToolsUsed(completed),
     toolExecutions,
+    ...finishToolHistory(completed),
     tokenUsage: completed.tokenUsage,
     effectiveUserPrompt,
+  };
+}
+
+function finishToolHistory(
+  projection: CodexProjection,
+): Pick<ContainerOutput, 'toolHistory' | 'toolHistoryForReplay'> {
+  return {
+    toolHistory: projection.toolHistory.finish('App-server turn ended.'),
+    toolHistoryForReplay: projection.toolHistory.finish(
+      'App-server turn ended.',
+      true,
+    ),
   };
 }
 
@@ -1042,6 +1109,7 @@ function errorOutputFromProjection(
       ...projection.toolExecutions,
       ...projection.approvalEvents,
     ],
+    ...finishToolHistory(projection),
     tokenUsage: projection.tokenUsage,
     error: error instanceof Error ? error.message : String(error),
     effectiveUserPrompt,
@@ -1062,6 +1130,8 @@ export async function resumePendingCodexAppServerApproval(
   pendingCodexApprovals.delete(params.sessionId);
   const directive = parseApprovalDirective(latestUserText(params.messages));
   if (!directive) return null;
+  // Exchanges before the approval prompt were persisted with that earlier turn.
+  pending.projection.toolHistory = new TurnToolHistory(params.sessionId);
   try {
     respondToCodexApproval(pending, directive);
     const next = await waitWithActivity(pending.client, params.onActivity);
@@ -1155,7 +1225,7 @@ export async function runCodexAppServerTurn(
     pendingCodexApprovals.delete(params.sessionId);
   }
   const effectiveUserPrompt = buildCodexTurnText(params.messages);
-  const projection = createProjection();
+  const projection = createProjection(params.sessionId);
   const client = new CodexAppServerClient(projection, params);
   let keepClientOpen = false;
   try {

--- a/container/src/tools.ts
+++ b/container/src/tools.ts
@@ -1332,7 +1332,12 @@ async function callGatewayMessageAction(
     );
   }
 
-  if (parsed) return JSON.stringify(parsed, null, 2);
+  if (parsed) {
+    const output = JSON.stringify(parsed, null, 2);
+    if (parsed.ok === false || parsed.success === false)
+      return failTool(output);
+    return output;
+  }
   return rawText || JSON.stringify({ ok: true }, null, 2);
 }
 
@@ -4265,7 +4270,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
     function: {
       name: 'memory',
       description:
-        "Manage agent memory files. Read/search/list can access MEMORY.md, USER.md, and daily files at memory/YYYY-MM-DD.md. Omitted write targets default to today’s daily note. Prefer append; write replaces the entire note and requires confirm_overwrite=true. Write actions append/write/replace/remove are restricted to today's daily file so durable MEMORY.md rewrites flow only through dream consolidation.",
+        "Manage agent memory files. Persist new standing rules and preferences with append before confirming they were saved; acknowledging them in prose does not persist them. Read/search/list can access MEMORY.md, USER.md, and daily files at memory/YYYY-MM-DD.md. Omitted write targets default to today’s daily note. Prefer append; write replaces the entire note and requires confirm_overwrite=true. Write actions append/write/replace/remove are restricted to today's daily file so durable MEMORY.md rewrites flow only through dream consolidation.",
       parameters: {
         type: 'object',
         properties: {
@@ -5372,7 +5377,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
         '- "list": show all scheduled tasks\n' +
         '- "add": create a task. Provide execution instruction in "prompt" (or aliases "message"/"text"), plus one schedule field: "at" (ISO-8601 one-shot), "at_seconds" (one-shot seconds from now), "cron" (recurring 5-field cron expression, evaluated in the user timezone from USER.md, or in "tz" when given), or "every" (recurring interval seconds). Optional "channel" overrides where the generated result is delivered. In web chat and heartbeat sessions "channel" is required because task output cannot be delivered there.\n' +
         '- "remove": delete a task by taskId\n' +
-        'The "prompt" is what the model will receive when the task fires. Use an explicit instruction (not the original user sentence). If you set "channel", describe the content to generate for that destination instead of telling the model to send it itself. A success result means the task is saved and returns its id; an Error result means nothing was scheduled. Quote the id and schedule from the result when confirming to the user.',
+        'The "prompt" is what the model will receive when the task fires. Use an explicit instruction (not the original user sentence). If you set "channel", describe the content to generate for that destination instead of telling the model to send it itself. Writing to memory or HEARTBEAT.md does not schedule a task. A successful add saves the task and returns its id; use existing results or list to confirm an earlier task instead of adding it again. Quote the id, schedule, timezone, and delivery channel from the result when confirming.',
       parameters: {
         type: 'object',
         properties: {

--- a/docs/content/developer-guide/memory.md
+++ b/docs/content/developer-guide/memory.md
@@ -146,6 +146,16 @@ the exchange on its owning message preserves pairs during pagination, session
 forks, deletion, and compaction. Existing rows without tool history remain
 ordinary chat messages; audit events are not used to reconstruct them.
 
+Action confirmations can use earlier tool results. Missing or compacted evidence
+means the outcome is unknown, not that an action never happened. Confirming an
+existing action does not require executing it again.
+
+The optional Codex app-server runtime retains completed command, file-change,
+MCP, and dynamic-tool exchanges too. Its next-turn transcript includes call
+names, arguments, IDs, and results. Approval and sandbox events stay in the
+audit metadata and do not count as completed tools. Anthropic text-block arrays
+are normalized for storage while native signed content stays intact.
+
 Individual results are capped at 16,000 characters before entering model
 context. Larger results include a reference to the full result in the agent's
 `.session-transcripts/<session>.jsonl` file, which is written when the turn

--- a/src/agent/prompt-hooks.ts
+++ b/src/agent/prompt-hooks.ts
@@ -1,3 +1,8 @@
+/**
+ * Prompt hooks compose stable guidance; tool results, including prior turns,
+ * supply action evidence. Unlike approval policy, prose here cannot authorize
+ * execution or establish that an action succeeded.
+ */
 import type { ChannelInfo, ChannelKind } from '../channels/channel.js';
 import {
   getChannelByContextId,
@@ -482,15 +487,8 @@ function buildSafetyHook(context: PromptHookContext): string {
     '## Runtime Safety Guardrails',
     'Follow TRUST_MODEL.md and SECURITY.md boundaries, and use the least-privilege tools possible.',
     '',
-    '## Action Honesty (mandatory)',
-    'An action exists only if a tool call in the current turn returned a success result. Never say something was saved, written, scheduled, sent, delivered, or configured unless the corresponding tool result in this turn confirms it. If you did not call the tool, say the action has not been done yet.',
-    'If a tool result starts with "Error:", contains "ok":false, or otherwise reports a failure, tell the user what failed. Do not paraphrase a failure into success, and do not invent delivery confirmations, receipts, or sender details that the tool result does not contain.',
-    "When the user states standing rules, preferences, or instructions to remember: first write them with the `memory` tool (append to today's daily note), then confirm and name the file you wrote to. Acknowledging rules in prose persists nothing.",
-    'Any promise of a future or recurring delivery (briefings, reports, reminders, check-ins) requires a successful `cron` "add" tool result in the same turn. Quote the schedule and delivery channel from that result. Writing a schedule into memory or HEARTBEAT.md does not schedule anything.',
-    '`cron` expressions are evaluated in the user timezone from USER.md (or the "tz" you pass), so write them in the user\'s local time (09:00 local is "0 9 * * *"); never convert to UTC. Quote the timezone from the tool result when confirming.',
-    'Scheduled task output cannot be delivered into the web chat. When the current session is web chat, always pass an explicit "channel" (a configured messaging channel or an email address) to `cron` "add"; if none is available, say so instead of scheduling.',
-    'Outbound messages are always sent from the account HybridClaw is connected with. You cannot choose a different sender number or address, so never claim a message was sent from a specific number.',
-    'Reply in the language the user writes in.',
+    '## Action Honesty',
+    'Base action claims on available tool results, including earlier turns. Distinguish pending, failed, queued, sent, and confirmed delivery. If evidence is missing, say what is unknown. Do not repeat completed actions merely to confirm them.',
     '',
     ...(toolsSummary ? [toolsSummary, ''] : []),
     '## Tool Call Style',
@@ -738,6 +736,7 @@ function buildRuntimeHook(context: PromptHookContext): string {
     // keep brevity guidance in both the identity layer and the always-on runtime
     // layer so prompt modes that omit one still retain concise-answer steering.
     'Default response style: brief and direct. Lead with the answer, skip filler, and expand only when depth, risk, tradeoffs, or structured deliverables require it.',
+    'Reply in the language the user writes in.',
     'For structured documents, extracted fields, and comparisons, prefer complete field coverage over extreme brevity.',
     'Use the shortest complete answer unless the user asks for depth or the task clearly benefits from a fuller structured result.',
     ...(channelInstructions

--- a/src/gateway/chat-result.ts
+++ b/src/gateway/chat-result.ts
@@ -1,3 +1,8 @@
+/**
+ * Reply fallbacks report structured execution outcomes, never status inferred
+ * from arbitrary tool content. Unlike the worker, this module only presents
+ * completed results; it neither executes actions nor grants approvals.
+ */
 import { isSilentReply, stripSilentToken } from '../agent/silent-reply.js';
 import { getSessionById } from '../memory/db.js';
 import {
@@ -160,34 +165,7 @@ function isMessageSendExecution(
 function isFailedExecution(
   execution: NonNullable<GatewayChatResult['toolExecutions']>[number],
 ): boolean {
-  if (execution.blocked || execution.isError) return true;
-  const resultObj = parseJsonObject(execution.result);
-  return resultObj?.ok === false || resultObj?.success === false;
-}
-
-/**
- * True when at least one `message` send in this turn actually succeeded.
- * Failed, blocked, or `ok:false` sends do not count: the silent-reply token
- * must never be rendered as "Message sent." when nothing was sent.
- */
-export function hasMessageSendToolExecution(
-  result: GatewayChatResult,
-): boolean {
-  if (!Array.isArray(result.toolExecutions)) return false;
-  return result.toolExecutions.some(
-    (execution) =>
-      isMessageSendExecution(execution) && !isFailedExecution(execution),
-  );
-}
-
-export function hasFailedMessageSendToolExecution(
-  result: GatewayChatResult,
-): boolean {
-  if (!Array.isArray(result.toolExecutions)) return false;
-  return result.toolExecutions.some(
-    (execution) =>
-      isMessageSendExecution(execution) && isFailedExecution(execution),
-  );
+  return execution.blocked === true || execution.isError === true;
 }
 
 export function fallbackResultFromTools(result: GatewayChatResult): string {
@@ -196,7 +174,7 @@ export function fallbackResultFromTools(result: GatewayChatResult): string {
     : [];
   for (let i = executions.length - 1; i >= 0; i -= 1) {
     const execution = executions[i];
-    if (execution.isError) continue;
+    if (isFailedExecution(execution)) continue;
     const text = String(execution.result || '').trim();
     if (!text) continue;
     return text;
@@ -215,7 +193,7 @@ export function normalizePlaceholderToolReply(
     : [];
   for (let i = executions.length - 1; i >= 0; i -= 1) {
     const execution = executions[i];
-    if (execution.isError) continue;
+    if (isFailedExecution(execution)) continue;
     const toolName = String(execution.name || '')
       .trim()
       .toLowerCase();
@@ -241,16 +219,28 @@ export function normalizeSilentMessageSendReply(
   result: GatewayChatResult,
 ): GatewayChatResult {
   if (result.status !== 'success') return result;
-  const sentByMessageTool = hasMessageSendToolExecution(result);
   const rawResult = result.result || '';
-  // When the model went silent after a send that failed, surface the failure
-  // instead of a generic placeholder; the user must not see "Message sent.".
   const silentFallback = (): string => {
-    if (sentByMessageTool) return 'Message sent.';
-    if (hasFailedMessageSendToolExecution(result)) {
-      return summarizePlaceholderToolFailure(result) ?? 'Message send failed.';
-    }
-    return fallbackResultFromTools(result);
+    const sends = (result.toolExecutions || []).filter(isMessageSendExecution);
+    if (!sends.length) return fallbackResultFromTools(result);
+    const successful = sends.filter(
+      (execution) => !isFailedExecution(execution),
+    );
+    const queued = successful.filter((execution) => {
+      const count = parseJsonObject(execution.result)?.queued;
+      return typeof count === 'number' && count > 0;
+    });
+    const failure = summarizePlaceholderToolFailure({
+      ...result,
+      toolExecutions: sends,
+    });
+    return [
+      successful.length > queued.length ? 'Message sent.' : '',
+      queued.length ? 'Message queued for delivery.' : '',
+      failure,
+    ]
+      .filter(Boolean)
+      .join(' ');
   };
   if (isSilentReply(rawResult)) {
     return {

--- a/src/gateway/gateway-http-server.ts
+++ b/src/gateway/gateway-http-server.ts
@@ -220,7 +220,6 @@ import {
 } from './chat-approval.js';
 import {
   filterChatResultForSession,
-  hasMessageSendToolExecution,
   normalizePendingApprovalReply,
   normalizePlaceholderToolReply,
   normalizeSilentMessageSendReply,
@@ -3785,12 +3784,6 @@ async function handleApiChatStream(
           delta: bufferedDelta,
           outputPresentation: assistantBubblePresentation,
         });
-      }
-      if (streamFilter.isSilent() && hasMessageSendToolExecution(result)) {
-        result = {
-          ...result,
-          result: 'Message sent.',
-        };
       }
     }
     const filteredResult = filterChatResultForSession(

--- a/src/gateway/openai-compatible.ts
+++ b/src/gateway/openai-compatible.ts
@@ -29,7 +29,6 @@ import { buildSessionKey } from '../session/session-key.js';
 import type { ChatMessage } from '../types/api.js';
 import { ensureBootstrapFiles, resetWorkspace } from '../workspace.js';
 import {
-  hasMessageSendToolExecution,
   normalizePendingApprovalReply,
   normalizePlaceholderToolReply,
   normalizeSilentMessageSendReply,
@@ -772,10 +771,6 @@ async function handleOpenAICompatibleStreamingChat(
           content: buffered,
         }),
       );
-    }
-
-    if (streamFilter.isSilent() && hasMessageSendToolExecution(result)) {
-      result.result = 'Message sent.';
     }
 
     const finalText = typeof result.result === 'string' ? result.result : '';

--- a/tests/chat-result.test.ts
+++ b/tests/chat-result.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
 import {
-  hasMessageSendToolExecution,
   normalizePendingApprovalReply,
   normalizePlaceholderToolReply,
   normalizeSilentMessageSendReply,
@@ -78,6 +77,21 @@ describe('normalizePlaceholderToolReply', () => {
       ],
     });
 
+    expect(normalizePlaceholderToolReply(result)).toBe(result);
+  });
+
+  test('does not interpret successfully read file content as an execution failure', () => {
+    const result = makeResult({
+      toolsUsed: ['read'],
+      toolExecutions: [
+        {
+          name: 'read',
+          arguments: '{"path":"fixture.json"}',
+          result: '{"ok":false,"success":false,"error":"example failure"}',
+          isError: false,
+        },
+      ],
+    });
     expect(normalizePlaceholderToolReply(result)).toBe(result);
   });
 
@@ -172,7 +186,6 @@ describe('normalizeSilentMessageSendReply', () => {
         },
       ],
     });
-    expect(hasMessageSendToolExecution(failed)).toBe(false);
     const result = normalizeSilentMessageSendReply(failed);
     expect(result.result).not.toBe('Message sent.');
     expect(result.result).toContain('message failed');
@@ -188,14 +201,65 @@ describe('normalizeSilentMessageSendReply', () => {
           name: 'message',
           arguments: '{"action":"send","to":"+491234567890","content":"hi"}',
           result: JSON.stringify({ ok: false, error: 'rate limited' }),
-          isError: false,
+          isError: true,
         },
       ],
     });
-    expect(hasMessageSendToolExecution(failed)).toBe(false);
     expect(normalizeSilentMessageSendReply(failed).result).not.toBe(
       'Message sent.',
     );
+  });
+
+  test.each([
+    'failed',
+    'blocked',
+  ])('preserves a %s send alongside a successful send', (outcome) => {
+    const result = normalizeSilentMessageSendReply(
+      makeResult({
+        result: silentToken,
+        toolExecutions: [
+          {
+            name: 'message',
+            arguments: '{"action":"send","channelId":"first@example.com"}',
+            result: '{"ok":true}',
+            isError: false,
+          },
+          {
+            name: 'message',
+            arguments: '{"action":"send","channelId":"second@example.com"}',
+            result: '{"ok":false,"error":"rate limited"}',
+            isError: outcome === 'failed',
+            blocked: outcome === 'blocked',
+            blockedReason:
+              outcome === 'blocked' ? 'approval denied' : undefined,
+          },
+        ],
+      }),
+    );
+    expect(result.result).toContain('Message sent.');
+    expect(result.result).toContain('message failed:');
+    expect(result.result).toContain(
+      outcome === 'blocked' ? 'approval denied' : 'rate limited',
+    );
+  });
+
+  test('reports queued delivery without claiming a message was sent', () => {
+    const result = normalizeSilentMessageSendReply(
+      makeResult({
+        result: silentToken,
+        toolExecutions: [
+          {
+            name: 'message',
+            arguments: '{"action":"send","channelId":"tui"}',
+            result:
+              '{"ok":true,"action":"send","transport":"local","queued":1,"dropped":0}',
+            isError: false,
+          },
+        ],
+      }),
+    );
+    expect(result.result).toBe('Message queued for delivery.');
+    expect(normalizeSilentMessageSendReply(result)).toEqual(result);
   });
 });
 

--- a/tests/codex-app-runtime.test.ts
+++ b/tests/codex-app-runtime.test.ts
@@ -1,5 +1,10 @@
 import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
+import { TurnToolHistory } from '../container/src/turn-tool-history.js';
+import {
+  expandStoredMessage,
+  sanitizeToolHistory,
+} from '../src/session/tool-history.js';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
   buildCodexApprovalResponseForDirective,
@@ -30,6 +35,7 @@ describe('Codex app-server runtime helpers', () => {
       textDeltas: [],
       agentMessages: [],
       toolExecutions: [],
+      toolHistory: new TurnToolHistory('session-test'),
       toolsUsed: new Set<string>(),
       tokenUsage: {
         modelCalls: 1,
@@ -111,6 +117,18 @@ describe('Codex app-server runtime helpers', () => {
           });
           setTimeout(() => {
             writeJsonLine(child, {
+              method: 'item/completed',
+              params: {
+                item: {
+                  type: 'commandExecution',
+                  command: `echo before-${index}`,
+                  aggregatedOutput: `before-${index}`,
+                  status: 'completed',
+                  exitCode: 0,
+                },
+              },
+            });
+            writeJsonLine(child, {
               id: approvalRequestId,
               method: 'item/commandExecution/requestApproval',
               params: { command: `echo ${index}` },
@@ -119,6 +137,18 @@ describe('Codex app-server runtime helpers', () => {
           return true;
         }
         if (message.id === approvalRequestId && message.result) {
+          writeJsonLine(child, {
+            method: 'item/completed',
+            params: {
+              item: {
+                type: 'commandExecution',
+                command: `echo ${index}`,
+                aggregatedOutput: String(index),
+                status: 'completed',
+                exitCode: 0,
+              },
+            },
+          });
           writeJsonLine(child, {
             method: 'item/completed',
             params: {
@@ -153,6 +183,34 @@ describe('Codex app-server runtime helpers', () => {
         { role: 'user', content: 'third' },
       ]),
     ).toContain('Current user request:\nthird');
+  });
+
+  test('replays call names, arguments and result ids even with empty assistant content', () => {
+    const messages = [
+      {
+        role: 'assistant' as const,
+        content: null,
+        tool_calls: [
+          {
+            id: 'write-a',
+            type: 'function' as const,
+            function: {
+              name: 'write',
+              arguments: '{"path":"report.txt","content":"42"}',
+            },
+          },
+        ],
+      },
+      { role: 'tool' as const, tool_call_id: 'write-a', content: 'Success' },
+      { role: 'user' as const, content: 'Which file did you save?' },
+    ];
+    const before = structuredClone(messages);
+    const prompt = buildCodexTurnText(messages);
+    expect(prompt).toContain(
+      'Tool call (write-a): write {"path":"report.txt","content":"42"}',
+    );
+    expect(prompt).toContain('Tool result (write-a): Success');
+    expect(messages).toEqual(before);
   });
 
   test('registers the HybridClaw callback MCP server with transient context', () => {
@@ -337,6 +395,9 @@ describe('Codex app-server runtime helpers', () => {
 
     expect(first.pendingApproval?.approvalId).toBeTruthy();
     expect(second.pendingApproval?.approvalId).toBeTruthy();
+    expect(first.toolHistory).toHaveLength(2);
+    expect(JSON.stringify(first.toolHistory)).toContain('before-0');
+    expect(JSON.stringify(first.toolHistory)).not.toContain('codex.approval');
     expect(
       await resumePendingCodexAppServerApproval({
         sessionId: 'session-c',
@@ -365,6 +426,14 @@ describe('Codex app-server runtime helpers', () => {
 
     expect(resumedFirst?.result).toBe('approved-0');
     expect(resumedSecond?.result).toBe('approved-1');
+    expect(resumedFirst?.toolHistory).toHaveLength(2);
+    expect(resumedFirst?.toolHistoryForReplay).toEqual(
+      resumedFirst?.toolHistory,
+    );
+    expect(JSON.stringify(resumedFirst?.toolHistory)).not.toContain('before-0');
+    expect(JSON.stringify(resumedSecond?.toolHistory)).not.toContain(
+      'before-1',
+    );
     expect(
       spawn.mock.calls.filter(([, args]) => args[0] === '--version'),
     ).toHaveLength(1);
@@ -441,6 +510,63 @@ describe('Codex app-server runtime helpers', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  test('retains completed native exchanges when the app-server exits before finishing', async () => {
+    vi.resetModules();
+    const spawn = vi.fn((_command: string, args: string[]) => {
+      const child = createMockChild();
+      if (args[0] === '--version') {
+        queueMicrotask(() => child.emit('exit', 0));
+        return child;
+      }
+      child.stdin.write = vi.fn((line: string) => {
+        const message = JSON.parse(line);
+        if (message.method === 'initialize')
+          writeJsonLine(child, { id: message.id, result: {} });
+        if (message.method === 'thread/start')
+          writeJsonLine(child, {
+            id: message.id,
+            result: { thread: { id: 'thread-error' } },
+          });
+        if (message.method === 'turn/start') {
+          writeJsonLine(child, {
+            id: message.id,
+            result: { turn: { status: 'in_progress' } },
+          });
+          setTimeout(() => {
+            writeJsonLine(child, {
+              method: 'item/completed',
+              params: {
+                item: {
+                  type: 'commandExecution',
+                  command: 'echo saved',
+                  aggregatedOutput: 'saved',
+                  status: 'completed',
+                  exitCode: 0,
+                },
+              },
+            });
+            child.emit('exit', 1);
+          }, 0);
+        }
+        return true;
+      });
+      return child;
+    });
+    vi.doMock('node:child_process', () => ({ spawn }));
+    const { runCodexAppServerTurn } = await import(
+      '../container/src/codex-app-server.js'
+    );
+    const output = await runCodexAppServerTurn({
+      sessionId: 'session-error',
+      messages: [{ role: 'user', content: 'Run the command' }],
+      model: 'openai-codex/gpt-5.4',
+    });
+    expect(output.status).toBe('error');
+    expect(output.toolHistory).toHaveLength(2);
+    expect(JSON.stringify(output.toolHistory)).toContain('echo saved');
+    expect(output.toolHistoryForReplay).toEqual(output.toolHistory);
   });
 
   test('migrates user MCP servers without embedding sensitive environment values', () => {
@@ -559,6 +685,85 @@ describe('Codex app-server runtime helpers', () => {
       isError: false,
     });
     expect(projection.toolExecutions[1]?.arguments).toContain('src/index.ts');
+    const history = projection.toolHistory.finish('Done');
+    const replay = expandStoredMessage({
+      role: 'assistant',
+      content: 'Done',
+      tool_history_json: JSON.stringify(history),
+    });
+    const prompt = buildCodexTurnText([
+      ...replay,
+      { role: 'user', content: 'What did you do?' },
+    ]);
+    expect(prompt).toContain('codex.command {"command":"npm test"}');
+    expect(prompt).toContain('src/index.ts');
+    expect(history.filter((message) => message.role === 'tool')).toHaveLength(
+      2,
+    );
+  });
+
+  test('retains failed command and MCP outcomes explicitly in native tool history', () => {
+    const projection = makeProjection();
+    projectCodexThreadItem(projection, {
+      type: 'commandExecution',
+      command: 'test -f missing.txt',
+      aggregatedOutput: '',
+      status: 'completed',
+      exitCode: 1,
+    });
+    projectCodexThreadItem(projection, {
+      type: 'mcpToolCall',
+      server: 'example',
+      tool: 'lookup',
+      arguments: {},
+      status: 'completed',
+      result: {
+        isError: true,
+        content: [{ type: 'text', text: 'Unavailable' }],
+      },
+    });
+    expect(
+      projection.toolExecutions.every((execution) => execution.isError),
+    ).toBe(true);
+    const history = projection.toolHistory.finish('Done');
+    for (const message of history.filter((entry) => entry.role === 'tool')) {
+      expect(message.content).toMatch(/^Tool failed:\n/);
+    }
+  });
+
+  test('native tool history remains credential-redactable at the gateway boundary', () => {
+    const projection = makeProjection();
+    projectCodexThreadItem(projection, {
+      type: 'mcpToolCall',
+      server: 'example',
+      tool: 'lookup',
+      arguments: { api_key: 'test-key' },
+      result: { api_key: 'test-result-key', value: 'visible' },
+      status: 'completed',
+    });
+    const sanitized = sanitizeToolHistory(
+      projection.toolHistory.finish('Done'),
+    );
+    const serialized = JSON.stringify(sanitized);
+    expect(serialized).not.toContain('test-key');
+    expect(serialized).not.toContain('test-result-key');
+    expect(serialized).toContain('visible');
+  });
+
+  test.each([
+    'failed',
+    'declined',
+  ])('does not record a %s file change as successful', (status) => {
+    const projection = makeProjection();
+    projectCodexThreadItem(projection, {
+      type: 'fileChange',
+      changes: [{ path: 'report.txt' }],
+      status,
+    });
+    expect(projection.toolExecutions[0].isError).toBe(true);
+    expect(projection.toolHistory.finish('Done')[1].content).toBe(
+      `Tool failed:\n${status}`,
+    );
   });
 
   test('projects Codex MCP and dynamic tool items into HybridClaw tool executions', () => {
@@ -613,5 +818,6 @@ describe('Codex app-server runtime helpers', () => {
     expect(projection.toolExecutions[1]?.arguments).toContain(
       'workspace-write',
     );
+    expect(projection.toolHistory.finish('Done')).toEqual([]);
   });
 });

--- a/tests/container.anthropic-provider.test.ts
+++ b/tests/container.anthropic-provider.test.ts
@@ -4,6 +4,7 @@ import {
   callAnthropicProviderStream,
 } from '../container/src/providers/anthropic.js';
 import type { ChatMessage, ToolDefinition } from '../container/src/types.js';
+import { TurnToolHistory } from '../container/src/turn-tool-history.js';
 
 function makeEventStreamResponse(chunks: string[]): Response {
   const encoder = new TextEncoder();
@@ -47,6 +48,57 @@ afterEach(() => {
 });
 
 describe('Anthropic container provider', () => {
+  test('persists a multi-block tool response without losing native content or call pairing', async () => {
+    const nativeContent = [
+      { type: 'text', text: 'Reading the report.' },
+      { type: 'text', text: 'Using the requested filename.' },
+      {
+        type: 'tool_use',
+        id: 'read-a',
+        name: 'read',
+        input: { path: 'report.txt' },
+      },
+    ];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              id: 'msg_multi',
+              model: 'claude-sonnet-4-6',
+              role: 'assistant',
+              stop_reason: 'tool_use',
+              content: nativeContent,
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          ),
+      ),
+    );
+    const response = await callAnthropicProvider(baseArgs);
+    const recorder = new TurnToolHistory('session-a');
+    const message: ChatMessage = {
+      ...response.choices[0].message,
+      role: 'assistant',
+    };
+    recorder.recordAssistant(message);
+    const result = recorder.recordResult({
+      role: 'tool',
+      tool_call_id: 'read-a',
+      content: '42',
+    });
+    recorder.retain([message, result]);
+    for (const forReplay of [false, true]) {
+      const saved = recorder.finish('Turn ended', forReplay);
+      expect(saved[0].content).toBe(
+        'Reading the report.\nUsing the requested filename.',
+      );
+      expect(saved[0].anthropic_content).toEqual(nativeContent);
+      expect(saved[0].tool_calls?.[0].id).toBe(saved[1].tool_call_id);
+      expect(saved[1].content).toBe('42');
+    }
+    expect(message.content).toEqual(nativeContent.slice(0, 2));
+  });
   test('sets an inference timeout signal on non-streaming API requests', async () => {
     const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
     const fetchMock = vi.fn(

--- a/tests/container.message-tool-normalization.test.ts
+++ b/tests/container.message-tool-normalization.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import {
   executeTool,
+  executeToolWithMetadata,
   getMessageToolDescription,
   setGatewayContext,
   setSessionContext,
@@ -59,6 +60,24 @@ describe.sequential('container message tool normalization', () => {
     >;
     expect(payload.action).toBe('send');
     expect(payload.channelId).toBe(CHANNEL_ID);
+  });
+
+  test.each([
+    { ok: false },
+    { success: false },
+  ])('marks a rejected HTTP 200 message response as failed: %j', async (status) => {
+    mockGatewayFetch({ ...status, error: 'rate limited' });
+    setGatewayContext('http://gateway.local', 'test-key', '');
+    const result = await executeToolWithMetadata(
+      'message',
+      JSON.stringify({
+        action: 'send',
+        channelId: 'email:user@example.com',
+        content: 'test message',
+      }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain('rate limited');
   });
 
   test('strips discord: prefix from channel target before gateway call', async () => {

--- a/tests/gateway-http-server.test.ts
+++ b/tests/gateway-http-server.test.ts
@@ -12555,6 +12555,67 @@ describe('gateway HTTP server', () => {
     });
   });
 
+  test.each([
+    ['/api/chat', 'queued'],
+    ['/api/chat', 'partial'],
+    ['/v1/chat/completions', 'queued'],
+    ['/v1/chat/completions', 'partial'],
+  ])('preserves %s streaming send outcome: %s', async (url, outcome) => {
+    const state = await importFreshHealth();
+    state.handleGatewayMessage.mockImplementationOnce(
+      async ({ onTextDelta }: { onTextDelta?: (delta: string) => void }) => {
+        onTextDelta?.('__MESSAGE_SEND_HANDLED__');
+        return {
+          status: 'success' as const,
+          result: '__MESSAGE_SEND_HANDLED__',
+          toolsUsed: ['message'],
+          toolExecutions: [
+            {
+              name: 'message',
+              arguments: '{"action":"send"}',
+              result:
+                outcome === 'queued' ? '{"ok":true,"queued":1}' : '{"ok":true}',
+              isError: false,
+            },
+            ...(outcome === 'partial'
+              ? [
+                  {
+                    name: 'message',
+                    arguments: '{"action":"send"}',
+                    result: '{"ok":false,"error":"rate limited"}',
+                    isError: true,
+                  },
+                ]
+              : []),
+          ],
+        };
+      },
+    );
+    const req = makeRequest({
+      method: 'POST',
+      url,
+      body:
+        url === '/api/chat'
+          ? { content: 'send this', stream: true }
+          : {
+              model: 'gpt-5',
+              stream: true,
+              messages: [{ role: 'user', content: 'send this' }],
+            },
+    });
+    const res = makeResponse();
+    state.handler(req as never, res as never);
+    await waitForResponse(res, (next) => next.writableEnded);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).not.toContain('__MESSAGE_SEND_HANDLED__');
+    expect(res.body).toContain(
+      outcome === 'queued'
+        ? 'Message queued for delivery.'
+        : 'message failed: rate limited.',
+    );
+    if (outcome === 'queued') expect(res.body).not.toContain('Message sent.');
+  });
+
   test('accepts media-only chat requests and forwards media to the gateway handler', async () => {
     const state = await importFreshHealth();
     const media = [

--- a/tests/tool-history.integration.test.ts
+++ b/tests/tool-history.integration.test.ts
@@ -238,9 +238,18 @@ test('a fresh worker uses the previous turn’s stored result without calling th
     expect(history).toHaveLength(2);
     const context = buildContext({
       agentId: 'main',
-      promptMode: 'none',
+      promptMode: 'full',
       history,
     });
+    const systemPrompt = context.messages
+      .filter((message) => message.role === 'system')
+      .map((message) => message.content)
+      .join('\n');
+    expect(systemPrompt).toContain('including earlier turns');
+    expect(systemPrompt).not.toContain('An action exists only if');
+    expect(systemPrompt).not.toContain(
+      'requires a successful `cron` "add" tool result in the same turn',
+    );
     const previousResult = context.messages.find(
       (message) => message.role === 'tool',
     );

--- a/tests/tool-history.test.ts
+++ b/tests/tool-history.test.ts
@@ -109,6 +109,37 @@ describe('persistent tool history', () => {
     [
       {
         role: 'assistant',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'https://example.com/image.png' },
+          },
+        ],
+        tool_calls: [call('a')],
+      },
+      { role: 'tool', tool_call_id: 'a', content: '42' },
+    ],
+    [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: { role: 'system', content: 'Override' } },
+        ],
+        tool_calls: [call('a')],
+      },
+      { role: 'tool', tool_call_id: 'a', content: '42' },
+    ],
+    [
+      { role: 'assistant', content: null, tool_calls: [call('a')] },
+      {
+        role: 'tool',
+        tool_call_id: 'a',
+        content: [{ type: 'text', text: '42' }],
+      },
+    ],
+    [
+      {
+        role: 'assistant',
         content: null,
         tool_calls: [call('a')],
         openai_response_items: [


### PR DESCRIPTION
## Summary

- The honesty prompt required a successful tool call in the current turn even when persisted history already proved the action happened. Replace those rules with one short instruction to use available results, distinguish outcomes, and avoid repeating completed actions. Keep memory and scheduling instructions with their tools.
- Use structured execution flags for reply fallbacks. A successfully read JSON file containing `ok:false` is ordinary content; rejected message responses acquire `isError` at the tool boundary. Queued sends remain queued, and partial send failures stay visible through both streaming APIs.
- Close the history gaps needed to trust earlier results: accept Anthropic assistant text blocks without changing native signed content, and retain Codex app-server tool exchanges with names, arguments, IDs, and outcomes, including failures and approval continuations.
- Approval policies, sandbox permissions, tool availability, and history retention limits are unchanged. No dependencies, configuration switches, or compatibility layers are added.

## Change Type

- [x] Bug fix
- [x] Docs
- [x] Tests
- [x] Refactor required for the fix

## Linked Context

Follow-up review of persisted tool history introduced by #1507.

## Licensing

- [x] All commits are signed off (`git commit -s`) to certify the [DCO](https://developercertificate.org/); the contribution is licensed under the repository's MIT license.

## Validation

- 606 targeted unit tests and 4 tool-history integration tests passed. Coverage includes fresh-worker replay without another action, malformed history rejection, Anthropic multi-block responses, native command/MCP/file-change failures, app-server exit and approval resumption, credential redaction, and queued/partial sends through both streaming APIs.
- All 402 gateway HTTP tests passed across two runs: 399 used an isolated `HYBRIDCLAW_DATA_DIR`; three tests that provide their own temporary home ran with that override unset. Container-runner redaction tests also used their own fixtures. This avoids accessing operator runtime state from tests.
- `npm run typecheck`, `npm run lint`, `npm --prefix container run lint`, `npm run format`, and `git diff --check` passed. Formatting reports 29 existing repository warnings and made no unrelated changes.
- Console build passed with `npm --workspace console run build -- --configLoader runner`; root and container builds passed with `npm --ignore-scripts run build`. The console was built separately because the default Vite config loader tries to write through the shared dependency directory in this worktree.
- Skipped the full repository suite, Docker image build, and credentialed live-provider tests; the relevant worker/IPC paths use deterministic fixtures, and there are no dependency or Docker packaging changes.

## Docs And Config Impact

- [x] Developer memory/history documentation updated
- No configuration or workspace bootstrap changes.

## Risk Notes

Gateway presentation and container-to-gateway history boundaries are touched. The main failure modes are reporting an unsuccessful action as complete, losing evidence after an approval or process exit, and persisting invalid call/result pairs. Boundary and failure-mode tests cover these cases. Error detection moves to the message tool's response boundary; arbitrary tool content no longer determines execution status. Approval and sandbox events remain audit metadata and never become evidence of tool success.

Native tool arguments/results can contain credentials. They use the existing gateway history sanitizer; a regression test verifies credential values are redacted while ordinary result data remains visible. This PR does not change credential resolution, authorization, or the redaction policy. Live provider behavior remains subject to the existing tool-event adapters and is not exercised here.

## Evidence

- [x] New and updated regression coverage for the review findings
